### PR TITLE
fix(security): validate cross-workspace FKs on attachments + project BOM entries

### DIFF
--- a/backend/app/api/_helpers.py
+++ b/backend/app/api/_helpers.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from fastapi import HTTPException, status
+from sqlalchemy import select
+
+
+def assert_in_workspace(
+    db,
+    Model: Any,
+    id_: UUID,
+    workspace_id: UUID,
+    *,
+    label: str | None = None,
+) -> Any:
+    """Look up a workspace-owned row by id, scoped to the current workspace.
+
+    Returns the row on success; raises 404 if it does not exist *or* belongs
+    to a different workspace. This is the only correct way to validate an
+    ID accepted from a request body / path / query — `db.get(Model, id)`
+    cannot express the workspace filter and lets a foreign-workspace UUID
+    through to writes that reference it.
+    """
+    row = db.execute(
+        select(Model).where(Model.id == id_, Model.workspace_id == workspace_id)
+    ).scalar_one_or_none()
+    if row is None:
+        name = label or getattr(Model, "__tablename__", "row")
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail=f"{name} not found")
+    return row

--- a/backend/app/api/routes/attachments.py
+++ b/backend/app/api/routes/attachments.py
@@ -10,6 +10,7 @@ from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile, s
 from fastapi.responses import FileResponse
 from sqlalchemy import select
 
+from app.api._helpers import assert_in_workspace
 from app.core.config import settings
 from app.core.deps import (
     CurrentUser,
@@ -20,7 +21,17 @@ from app.core.deps import (
 )
 from app.core.responses import ok
 from app.domain.attachments.models import Attachment
+from app.domain.parts.models import Part
 from app.infra.db import get_db
+
+
+# Registry of (object_type → SQLAlchemy model). Add a new entry here only when
+# a new workspace-owned resource starts accepting attachments. The registry is
+# the cross-tenant write guardrail on /attachments — without it, a caller in
+# workspace B could attach a file to an object_id owned by workspace A.
+_OBJECT_RESOLVERS: dict[str, type] = {
+    "part": Part,
+}
 
 router = APIRouter()
 
@@ -48,6 +59,10 @@ async def upload(
     ws=Depends(get_current_workspace),
     user=Depends(get_current_user),
 ):
+    Model = _OBJECT_RESOLVERS.get(object_type)
+    if Model is None:
+        raise HTTPException(status_code=400, detail=f"unknown object_type: {object_type}")
+    assert_in_workspace(db, Model, object_id, ws.id, label=object_type)
     storage_key = f"{ws.id}/{uuidlib.uuid4()}-{file.filename}"
     abs_path = os.path.join(settings().UPLOAD_DIR, storage_key)
     os.makedirs(os.path.dirname(abs_path), exist_ok=True)

--- a/backend/app/api/routes/projects.py
+++ b/backend/app/api/routes/projects.py
@@ -7,8 +7,10 @@ from fastapi import APIRouter, HTTPException, status
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy import or_, select
 
+from app.api._helpers import assert_in_workspace
 from app.core.deps import CurrentUser, CurrentWorkspace, DbSession
 from app.core.responses import ok
+from app.domain.parts.models import Part
 from app.domain.projects import bom_import as bom
 from app.domain.projects.models import Project, ProjectEntry
 from app.domain.projects.schemas import (
@@ -133,6 +135,10 @@ def list_entries(project_id: UUID, db: DbSession, ws: CurrentWorkspace):
 @router.post("/{project_id}/entries")
 def add_entry(project_id: UUID, payload: BomEntryIn, db: DbSession, ws: CurrentWorkspace, user: CurrentUser):
     p = _get(db, ws.id, project_id)
+    if payload.part_id is not None:
+        assert_in_workspace(db, Part, payload.part_id, ws.id, label="part")
+    if payload.meta_part_id is not None:
+        assert_in_workspace(db, Part, payload.meta_part_id, ws.id, label="part")
     next_idx = (
         db.execute(
             select(ProjectEntry.order_index)
@@ -170,7 +176,12 @@ def patch_entry(project_id: UUID, entry_id: UUID, payload: BomEntryPatch, db: Db
     e = db.get(ProjectEntry, entry_id)
     if not e or e.workspace_id != ws.id or e.project_id != p.id:
         raise HTTPException(status_code=404, detail="entry not found")
-    for k, v in payload.model_dump(exclude_unset=True).items():
+    data = payload.model_dump(exclude_unset=True)
+    if data.get("part_id") is not None:
+        assert_in_workspace(db, Part, data["part_id"], ws.id, label="part")
+    if data.get("meta_part_id") is not None:
+        assert_in_workspace(db, Part, data["meta_part_id"], ws.id, label="part")
+    for k, v in data.items():
         setattr(e, k, v)
     e.updated_by = user.id
     db.commit()

--- a/backend/tests/test_workspace_isolation.py
+++ b/backend/tests/test_workspace_isolation.py
@@ -33,3 +33,82 @@ def test_workspace_isolation():
     # User B trying to GET it directly → 404
     r = b.get(f"/api/parts/{part_id}")
     assert r.status_code == 404
+
+
+def test_attachments_reject_cross_workspace_object_id():
+    """Polymorphic write check on /attachments. Without it, a caller in
+    workspace B can attach a file keyed to a part_id owned by workspace A —
+    the FK enforces existence, not access."""
+    a = TestClient(app)
+    b = TestClient(app)
+    _signup(a, f"a-{uuid.uuid4().hex[:6]}@x.com")
+    _signup(b, f"b-{uuid.uuid4().hex[:6]}@x.com")
+
+    # A creates a part
+    r = a.post("/api/parts", json={"name": "A's part", "part_type": "local"})
+    assert r.status_code in (200, 201)
+    part_a = r.json()["data"]["id"]
+
+    # B tries to attach a file to A's part_id — must 404
+    files = {"file": ("s.txt", b"secret", "text/plain")}
+    data = {"object_type": "part", "object_id": part_a, "file_type": "other"}
+    r = b.post("/api/attachments", data=data, files=files)
+    assert r.status_code == 404, r.text
+
+    # And A's by-object listing for that part is still empty (no leak the other way).
+    r = a.get(f"/api/attachments/by-object/part/{part_a}")
+    assert r.status_code == 200
+    assert r.json()["data"] == []
+
+
+def test_project_entry_rejects_cross_workspace_part_id():
+    """Adding/patching a BOM entry must not accept a part_id from another
+    workspace. Without this, A could embed B's part UUID in their BOM and
+    leak it through downstream joins (build consume, BOM-shortage report)."""
+    a = TestClient(app)
+    b = TestClient(app)
+    _signup(a, f"a-{uuid.uuid4().hex[:6]}@x.com")
+    _signup(b, f"b-{uuid.uuid4().hex[:6]}@x.com")
+
+    # B owns a secret part
+    r = b.post("/api/parts", json={"name": "B-Secret", "part_type": "local"})
+    assert r.status_code in (200, 201)
+    secret = r.json()["data"]["id"]
+
+    # A creates a project
+    r = a.post("/api/projects", json={"name": "P"})
+    assert r.status_code in (200, 201)
+    proj = r.json()["data"]["id"]
+
+    # A tries to attach B's part directly — must 404
+    r = a.post(
+        f"/api/projects/{proj}/entries",
+        json={"entry_type": "part", "part_id": secret, "quantity": 1},
+    )
+    assert r.status_code == 404, r.text
+
+    # A also can't smuggle it in via meta_part_id
+    r = a.post(
+        f"/api/projects/{proj}/entries",
+        json={"entry_type": "meta_part", "meta_part_id": secret, "quantity": 1},
+    )
+    assert r.status_code == 404, r.text
+
+    # A creates a legitimate unmatched entry, then tries to patch in B's part — must 404
+    r = a.post(
+        f"/api/projects/{proj}/entries",
+        json={"entry_type": "unmatched", "name": "x", "quantity": 1},
+    )
+    assert r.status_code in (200, 201)
+    entry = r.json()["data"]["id"]
+
+    r = a.patch(f"/api/projects/{proj}/entries/{entry}", json={"part_id": secret})
+    assert r.status_code == 404, r.text
+
+    r = a.patch(f"/api/projects/{proj}/entries/{entry}", json={"meta_part_id": secret})
+    assert r.status_code == 404, r.text
+
+    # And the existing /match endpoint still rejects the same vector (regression
+    # pin — it was already correct, this asserts it stays that way).
+    r = a.post(f"/api/projects/{proj}/entries/{entry}/match", json={"part_id": secret})
+    assert r.status_code == 404, r.text


### PR DESCRIPTION
## Summary

Two active cross-workspace data-leak paths discovered by the workspace-isolation audit on 2026-05-01:

1. **`POST /api/attachments`** accepted `(object_type, object_id)` from the form body and wrote the row without verifying the referenced object belonged to `ws`. A caller in workspace B could attach a file keyed to a part UUID owned by workspace A.
2. **`POST/PATCH /api/projects/{id}/entries`** accepted `part_id` and `meta_part_id` from the body and persisted them to `ProjectEntry` with no workspace check. A workspace-A user could embed a workspace-B part UUID in their BOM, leaking that part through downstream joins (reports / bom-shortage, build consume).

The DB FK enforces existence, not access — workspace isolation in this codebase is enforced **in code**, not the database (see `docs/ARCHITECTURE.md`).

## Changes

- New shared helper `backend/app/api/_helpers.py::assert_in_workspace` — the canonical replacement for `db.get(Model, id)` followed by a manual `workspace_id` check.
- `attachments.py` upload: small `_OBJECT_RESOLVERS` allow-list (`{"part": Part}` for now; extend when new resources start accepting attachments) + `assert_in_workspace` before write. Unknown `object_type` returns 400.
- `projects.py` `add_entry` + `patch_entry`: validate `part_id` and `meta_part_id` against `Part` scoped to `ws.id`, matching the pre-existing pattern in `match_entry`.
- `tests/test_workspace_isolation.py`: regression coverage for both leaks plus a pin on the already-correct `/match` path.

Defense-in-depth gaps in `stock`, `builds`, `custom_fields`, `tags` will be a follow-up PR using the same `assert_in_workspace` helper.

## Test plan

- [x] `pytest tests/test_workspace_isolation.py tests/test_attachments.py tests/test_bom_import.py` — all 7 pass.
- [x] Full backend suite — 175/175 pass.
- [x] Manual smoke after deploy: upload an attachment to a part as a member; create a BOM entry with a valid local part_id; both should still work.
- [ ] Manual confirm: with two browser sessions in different workspaces, A creating an attachment for B's part_id returns 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)