### PR TITLE
fix(security): close remaining cross-workspace FK leaks + custom_fields source

### DIFF
--- a/backend/app/api/_helpers.py
+++ b/backend/app/api/_helpers.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from functools import lru_cache
 from typing import Any
 from uuid import UUID
 
@@ -30,3 +31,48 @@ def assert_in_workspace(
         name = label or getattr(Model, "__tablename__", "row")
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail=f"{name} not found")
     return row
+
+
+# Allow-list of (object_type → SQLAlchemy model) for the polymorphic
+# (object_type, object_id) tables: attachments, custom_fields, tag_links.
+# Adding a new entry here is the safe way to let a new resource accept
+# attachments / custom fields / tag links — without it, callers cannot
+# reference the new object type and the cross-tenant write guard remains
+# load-bearing.
+@lru_cache(maxsize=1)
+def _polymorphic_resolvers() -> dict[str, Any]:
+    # Lazy + cached: keeps the API layer from creating a hard import-time
+    # dependency on the parts domain, and avoids rebuilding the dict on
+    # every attachment upload / custom-field write / tag link. Adding a
+    # new entry requires a process restart — that's fine, this list is
+    # static at deploy time.
+    from app.domain.parts.models import Part
+
+    return {
+        "part": Part,
+    }
+
+
+def assert_polymorphic_in_workspace(
+    db,
+    object_type: str,
+    object_id: UUID,
+    workspace_id: UUID,
+) -> Any:
+    """Resolve a polymorphic (object_type, object_id) reference against the
+    current workspace.
+
+    Raises 400 on unknown object_type, 404 on not-found-or-cross-workspace.
+    The cross-tenant write guard on attachments / custom_fields / tag_links
+    is load-bearing — a missing call here lets a caller in workspace B
+    write rows tagged with B's workspace_id but pointing at an object_id
+    owned by workspace A.
+    """
+    resolvers = _polymorphic_resolvers()
+    Model = resolvers.get(object_type)
+    if Model is None:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            detail=f"unknown object_type: {object_type}",
+        )
+    return assert_in_workspace(db, Model, object_id, workspace_id, label=object_type)

--- a/backend/app/api/routes/attachments.py
+++ b/backend/app/api/routes/attachments.py
@@ -10,7 +10,7 @@ from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile, s
 from fastapi.responses import FileResponse
 from sqlalchemy import select
 
-from app.api._helpers import assert_in_workspace
+from app.api._helpers import assert_polymorphic_in_workspace
 from app.core.config import settings
 from app.core.deps import (
     CurrentUser,
@@ -21,17 +21,7 @@ from app.core.deps import (
 )
 from app.core.responses import ok
 from app.domain.attachments.models import Attachment
-from app.domain.parts.models import Part
 from app.infra.db import get_db
-
-
-# Registry of (object_type → SQLAlchemy model). Add a new entry here only when
-# a new workspace-owned resource starts accepting attachments. The registry is
-# the cross-tenant write guardrail on /attachments — without it, a caller in
-# workspace B could attach a file to an object_id owned by workspace A.
-_OBJECT_RESOLVERS: dict[str, type] = {
-    "part": Part,
-}
 
 router = APIRouter()
 
@@ -59,10 +49,7 @@ async def upload(
     ws=Depends(get_current_workspace),
     user=Depends(get_current_user),
 ):
-    Model = _OBJECT_RESOLVERS.get(object_type)
-    if Model is None:
-        raise HTTPException(status_code=400, detail=f"unknown object_type: {object_type}")
-    assert_in_workspace(db, Model, object_id, ws.id, label=object_type)
+    assert_polymorphic_in_workspace(db, object_type, object_id, ws.id)
     storage_key = f"{ws.id}/{uuidlib.uuid4()}-{file.filename}"
     abs_path = os.path.join(settings().UPLOAD_DIR, storage_key)
     os.makedirs(os.path.dirname(abs_path), exist_ok=True)

--- a/backend/app/api/routes/custom_fields.py
+++ b/backend/app/api/routes/custom_fields.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-from typing import Literal
 from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, status
 from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import select
 
+from app.api._helpers import assert_in_workspace, assert_polymorphic_in_workspace
 from app.core.deps import CurrentUser, CurrentWorkspace, DbSession
 from app.core.responses import ok
 from app.domain.custom_fields.models import CustomField
@@ -21,11 +21,6 @@ class CustomFieldIn(BaseModel):
     object_id: UUID
     key: str = Field(min_length=1, max_length=256)
     value: str | None = Field(default=None, max_length=1024)
-    # Hint for the upsert. Defaults to "manual" — provider data is written
-    # via app.api.routes.parts.refresh_from_provider, which sets source
-    # directly. The frontend doesn't pass this; it's here so the provider
-    # path can reuse this surface if it ever needs to.
-    source: Literal["provider", "manual", "override"] = "manual"
 
 
 def _serialize(r: CustomField) -> dict:
@@ -62,9 +57,19 @@ def create_or_update(payload: CustomFieldIn, db: DbSession, ws: CurrentWorkspace
     * existing.source='override' and the new value matches
       existing.original_value → revert to 'provider', clear
       original_value.
-    * existing.source='manual' or no existing row → plain upsert at
-      payload.source (default 'manual').
+    * existing.source='manual' or no existing row → plain upsert as 'manual'.
+
+    `source` is server-controlled — provider rows are only ever written
+    through the refresh-from-provider path in
+    domain/parts/services/provider.py. Without this guard a caller could
+    POST {source: "provider"} and forge a provider-origin row.
     """
+    # Polymorphic FK validation: object_id must name a row in the current
+    # workspace, and object_type must be a known resource. Without this
+    # guard a caller in workspace B can store custom fields keyed to a
+    # part_id owned by workspace A.
+    assert_polymorphic_in_workspace(db, payload.object_type, payload.object_id, ws.id)
+
     existing = (
         db.execute(
             select(CustomField)
@@ -96,11 +101,6 @@ def create_or_update(payload: CustomFieldIn, db: DbSession, ws: CurrentWorkspace
         else:
             # manual or provider-write-with-same-value
             existing.value = new_value
-            if existing.source == "manual" and payload.source == "provider":
-                # Edge case: a provider path is back-filling a row that
-                # was previously stored as manual (e.g. legacy rows
-                # before this migration). Trust the explicit source.
-                existing.source = "provider"
         existing.updated_by = user.id
         db.commit()
         return ok(_serialize(existing))
@@ -111,7 +111,7 @@ def create_or_update(payload: CustomFieldIn, db: DbSession, ws: CurrentWorkspace
         object_id=payload.object_id,
         key=payload.key,
         value=new_value,
-        source=payload.source,
+        source="manual",
         created_by=user.id,
         updated_by=user.id,
     )
@@ -122,8 +122,12 @@ def create_or_update(payload: CustomFieldIn, db: DbSession, ws: CurrentWorkspace
 
 @router.delete("/{cf_id}")
 def delete(cf_id: UUID, db: DbSession, ws: CurrentWorkspace):
-    row = db.get(CustomField, cf_id)
-    if row and row.workspace_id == ws.id:
+    row = db.execute(
+        select(CustomField)
+        .where(CustomField.id == cf_id)
+        .where(CustomField.workspace_id == ws.id)
+    ).scalar_one_or_none()
+    if row is not None:
         db.delete(row)
         db.commit()
     return ok(None, "deleted")
@@ -133,9 +137,7 @@ def delete(cf_id: UUID, db: DbSession, ws: CurrentWorkspace):
 def restore_override(cf_id: UUID, db: DbSession, ws: CurrentWorkspace, user: CurrentUser):
     """Reverts an `override` row back to `provider`, restoring the saved
     `original_value` as the live value. 400 if the row isn't an override."""
-    row = db.get(CustomField, cf_id)
-    if not row or row.workspace_id != ws.id:
-        raise HTTPException(status_code=404, detail="row not found")
+    row = assert_in_workspace(db, CustomField, cf_id, ws.id, label="row")
     if row.source != "override":
         raise HTTPException(
             status_code=400,

--- a/backend/app/api/routes/parts.py
+++ b/backend/app/api/routes/parts.py
@@ -11,6 +11,7 @@ from fastapi.responses import FileResponse
 from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import or_, select
 
+from app.api._helpers import assert_in_workspace
 from app.api.routes._activity import build_activity
 from app.core.config import settings
 from app.core.deps import CurrentUser, CurrentWorkspace, DbSession
@@ -28,6 +29,7 @@ from app.domain.stock.service import (
     stock_summary_for_part,
     total_for_part,
 )
+from app.domain.storage.models import StorageLocation
 from app.domain.workspaces.models import Workspace
 
 router = APIRouter()
@@ -258,6 +260,16 @@ def create_part(payload: PartIn, db: DbSession, ws: CurrentWorkspace, user: Curr
                 },
             )
 
+    # default_storage_location_id is caller-supplied; it must point at a
+    # storage row in this workspace. Without this guard a caller in
+    # workspace B can persist a foreign storage UUID as the default for one
+    # of their parts (existence-oracle + foot-gun for downstream lookups).
+    if payload.default_storage_location_id is not None:
+        assert_in_workspace(
+            db, StorageLocation, payload.default_storage_location_id, ws.id,
+            label="storage location",
+        )
+
     p = Part(
         workspace_id=ws.id,
         part_type=payload.part_type,
@@ -322,6 +334,15 @@ def patch_part(part_id: UUID, payload: PartPatch, db: DbSession, ws: CurrentWork
         and data["description"] != p.description
     ):
         p.description_locally_edited = True
+
+    # default_storage_location_id is caller-supplied via the generic setattr
+    # loop below; must validate it before assignment. None clears the FK,
+    # which is allowed without lookup.
+    if data.get("default_storage_location_id") is not None:
+        assert_in_workspace(
+            db, StorageLocation, data["default_storage_location_id"], ws.id,
+            label="storage location",
+        )
 
     for k, v in data.items():
         setattr(p, k, v)
@@ -824,6 +845,21 @@ def bulk_import_from_scan(
                 "error": "empty MPN",
             })
             continue
+
+        # Per-row workspace validation of caller-supplied storage. Without
+        # this, the Part is committed with `default_storage_location_id`
+        # pointing at a foreign workspace's row (existence-oracle + downstream
+        # foot-gun). Same fix as create_part / patch_part — surface the
+        # failure as `invalid` so the rest of the batch still runs.
+        if row.storage_location_id is not None:
+            sl = db.get(StorageLocation, row.storage_location_id)
+            if sl is None or sl.workspace_id != ws.id:
+                out_rows.append({
+                    "mpn": mpn,
+                    "status": "invalid",
+                    "error": "storage location not found in workspace",
+                })
+                continue
 
         # Bag re-scan recognition — same physical bag scanned again.
         # The first import wrote bag_signature on the resulting

--- a/backend/app/api/routes/tags.py
+++ b/backend/app/api/routes/tags.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, status
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy import select
 
+from app.api._helpers import assert_in_workspace, assert_polymorphic_in_workspace
 from app.core.deps import CurrentUser, CurrentWorkspace, DbSession
 from app.core.responses import ok
 from app.domain.tags.models import Tag, TagLink
@@ -44,9 +45,11 @@ class TagLinkIn(BaseModel):
 
 @router.post("/links", status_code=status.HTTP_201_CREATED)
 def link(payload: TagLinkIn, db: DbSession, ws: CurrentWorkspace, user: CurrentUser):
-    tag = db.get(Tag, payload.tag_id)
-    if not tag or tag.workspace_id != ws.id:
-        raise HTTPException(status_code=404, detail="tag not found")
+    tag = assert_in_workspace(db, Tag, payload.tag_id, ws.id, label="tag")
+    # Polymorphic FK validation: object_id must name a row in the current
+    # workspace, and object_type must be a known resource. Without this
+    # guard a caller in workspace B can tag a part_id owned by workspace A.
+    assert_polymorphic_in_workspace(db, payload.object_type, payload.object_id, ws.id)
     existing = (
         db.execute(
             select(TagLink)
@@ -75,8 +78,12 @@ def link(payload: TagLinkIn, db: DbSession, ws: CurrentWorkspace, user: CurrentU
 
 @router.delete("/links/{link_id}")
 def unlink(link_id: UUID, db: DbSession, ws: CurrentWorkspace):
-    row = db.get(TagLink, link_id)
-    if row and row.workspace_id == ws.id:
+    row = db.execute(
+        select(TagLink)
+        .where(TagLink.id == link_id)
+        .where(TagLink.workspace_id == ws.id)
+    ).scalar_one_or_none()
+    if row is not None:
         db.delete(row)
         db.commit()
     return ok(None, "deleted")

--- a/backend/app/domain/builds/service.py
+++ b/backend/app/domain/builds/service.py
@@ -293,6 +293,21 @@ def consume(
                 )
                 raise BuildError(f"part {line.part_id} is not {kind} for entry {e.id}")
 
+        # Validate caller-supplied lot / storage against the workspace
+        # BEFORE the availability check. current_quantity is ws-filtered so
+        # a foreign lot/storage is masked as "0 available" — that's defense
+        # in depth, not a contract. Validating here keeps the failure mode
+        # explicit and prevents a future refactor of current_quantity from
+        # silently re-opening a write-side cross-workspace FK leak.
+        if line.lot_id is not None:
+            lot = db.get(Lot, line.lot_id)
+            if lot is None or lot.workspace_id != workspace_id:
+                raise BuildError(f"lot {line.lot_id} not in workspace")
+        if line.storage_location_id is not None:
+            sl = db.get(StorageLocation, line.storage_location_id)
+            if sl is None or sl.workspace_id != workspace_id:
+                raise BuildError(f"storage {line.storage_location_id} not in workspace")
+
         # Verify stock available
         avail = current_quantity(
             db,

--- a/backend/app/domain/stock/service.py
+++ b/backend/app/domain/stock/service.py
@@ -227,6 +227,19 @@ def remove_stock(
     part = db.get(Part, payload.part_id)
     if not _belongs(part, workspace_id):
         raise StockError("part not found")
+    # Validate caller-supplied FK targets against the workspace BEFORE the
+    # availability check. current_quantity is workspace-filtered, so a
+    # foreign lot/storage is masked as "0 available" — that's defense in
+    # depth, not a contract. Validating here also keeps the failure mode
+    # explicit ("lot not found", not "insufficient stock").
+    if payload.storage_location_id is not None:
+        storage = db.get(StorageLocation, payload.storage_location_id)
+        if not _belongs(storage, workspace_id):
+            raise StockError("storage location not found")
+    if payload.lot_id is not None:
+        lot = db.get(Lot, payload.lot_id)
+        if not _belongs(lot, workspace_id):
+            raise StockError("lot not found")
     available = current_quantity(
         db,
         workspace_id=workspace_id,
@@ -270,6 +283,22 @@ def move_stock(
         raise StockError("destination is archived")
     if dest.is_full:
         raise StockError("destination is full")
+
+    # Validate caller-supplied source FKs against the workspace. Same
+    # defense-in-depth rationale as remove_stock — current_quantity ws-filter
+    # would mask a foreign source as "0 available" but the failure should
+    # name the real cause.
+    if payload.source_storage_location_id is not None:
+        src_storage = db.get(StorageLocation, payload.source_storage_location_id)
+        if not _belongs(src_storage, workspace_id):
+            raise StockError("source storage not found")
+    if payload.source_lot_id is not None:
+        # If split_lot is true the same id is re-fetched + checked below for
+        # the new-lot copy; this still validates the workspace boundary up
+        # front so a foreign source-lot fails with a clear message.
+        src_lot = db.get(Lot, payload.source_lot_id)
+        if not _belongs(src_lot, workspace_id):
+            raise StockError("source lot not found")
 
     available = current_quantity(
         db,
@@ -364,6 +393,20 @@ def adjust_stock(
     part = db.get(Part, payload.part_id)
     if not _belongs(part, workspace_id):
         raise StockError("part not found")
+    # Active leak fix: adjust writes a positive delta = (actual_quantity - 0)
+    # when the (lot, storage) tuple resolves to 0 stock — which is exactly
+    # what foreign FKs would return through current_quantity's ws filter.
+    # Without this validation, an A-workspace caller can persist a positive
+    # StockEntry in workspace A whose lot_id / storage_location_id point at
+    # workspace B's rows.
+    if payload.storage_location_id is not None:
+        storage = db.get(StorageLocation, payload.storage_location_id)
+        if not _belongs(storage, workspace_id):
+            raise StockError("storage location not found")
+    if payload.lot_id is not None:
+        lot = db.get(Lot, payload.lot_id)
+        if not _belongs(lot, workspace_id):
+            raise StockError("lot not found")
     current = current_quantity(
         db,
         workspace_id=workspace_id,

--- a/backend/tests/test_bulk_delete.py
+++ b/backend/tests/test_bulk_delete.py
@@ -99,16 +99,16 @@ def test_list_parts_includes_image_url(authed):
     thumbnail without a per-row custom_field fetch."""
     pid = _create(authed, "Resistor", mpn="RC0402JR-070R")
     # Backdoor: write the custom_field directly via the API.
-    authed.post(
+    r = authed.post(
         "/api/custom-fields",
         json={
             "object_type": "part",
             "object_id": pid,
             "key": "image_url",
             "value": "/api/parts/assets/abc/image.png",
-            "source": "manual",
         },
     )
+    assert r.status_code in (200, 201), r.text
     listed = authed.get("/api/parts").json()["data"]
     row = next(r for r in listed if r["id"] == pid)
     assert row["image_url"] == "/api/parts/assets/abc/image.png"

--- a/backend/tests/test_workspace_isolation.py
+++ b/backend/tests/test_workspace_isolation.py
@@ -112,3 +112,350 @@ def test_project_entry_rejects_cross_workspace_part_id():
     # pin — it was already correct, this asserts it stays that way).
     r = a.post(f"/api/projects/{proj}/entries/{entry}/match", json={"part_id": secret})
     assert r.status_code == 404, r.text
+
+
+# ---------------------------------------------------------------------------
+# Helpers for the cross-tenant FK validation tests below.
+# ---------------------------------------------------------------------------
+
+
+def _two_workspaces():
+    a = TestClient(app)
+    b = TestClient(app)
+    _signup(a, f"a-{uuid.uuid4().hex[:6]}@x.com")
+    _signup(b, f"b-{uuid.uuid4().hex[:6]}@x.com")
+    return a, b
+
+
+def _create_part(c: TestClient, name: str = "P") -> str:
+    r = c.post("/api/parts", json={"name": name, "part_type": "local"})
+    assert r.status_code in (200, 201), r.text
+    return r.json()["data"]["id"]
+
+
+def _create_storage(c: TestClient, name: str = "Bin") -> str:
+    r = c.post("/api/storage", json={"name": name})
+    assert r.status_code in (200, 201), r.text
+    return r.json()["data"]["id"]
+
+
+def _add_stock(
+    c: TestClient,
+    *,
+    part_id: str,
+    storage_id: str | None = None,
+    quantity: int = 5,
+    lot_name: str = "L",
+) -> dict:
+    body: dict = {"part_id": part_id, "quantity": quantity, "lot": {"name": lot_name}}
+    if storage_id:
+        body["storage_location_id"] = storage_id
+    r = c.post("/api/stock/add", json=body)
+    assert r.status_code in (200, 201), r.text
+    return r.json()["data"]
+
+
+# ---------------------------------------------------------------------------
+# custom_fields: cross-workspace polymorphic write + source-forge attempt
+# ---------------------------------------------------------------------------
+
+
+def test_custom_fields_reject_cross_workspace_object_id():
+    """POST /api/custom-fields validates (object_type, object_id) against
+    the caller's workspace. Without this, B can attach attributes to A's
+    part — own-ws row + foreign object_id pollutes the cross-tenant graph."""
+    a, b = _two_workspaces()
+    part_a = _create_part(a, "A-secret")
+
+    r = b.post(
+        "/api/custom-fields",
+        json={"object_type": "part", "object_id": part_a, "key": "k", "value": "v"},
+    )
+    assert r.status_code == 404, r.text
+
+
+def test_custom_fields_unknown_object_type_returns_400():
+    """The polymorphic registry is the cross-tenant guardrail. Unknown
+    object_types must reject with 400 — not silently store an unscoped row."""
+    a, _b = _two_workspaces()
+    part_a = _create_part(a)
+    r = a.post(
+        "/api/custom-fields",
+        json={"object_type": "lot", "object_id": part_a, "key": "k", "value": "v"},
+    )
+    assert r.status_code == 400, r.text
+
+
+def test_custom_fields_source_cannot_be_forged():
+    """A caller posting `source: "provider"` would forge a provider-origin
+    row, defeating the override/restore UX. The field must be rejected by
+    Pydantic (extra='forbid'), so the response is 422 Unprocessable Entity."""
+    a, _b = _two_workspaces()
+    part = _create_part(a)
+    r = a.post(
+        "/api/custom-fields",
+        json={
+            "object_type": "part",
+            "object_id": part,
+            "key": "k",
+            "value": "v",
+            "source": "provider",
+        },
+    )
+    assert r.status_code == 422, r.text
+
+
+# ---------------------------------------------------------------------------
+# tags: cross-workspace polymorphic write
+# ---------------------------------------------------------------------------
+
+
+def test_tags_reject_cross_workspace_object_id_on_link():
+    """POST /api/tags/links validates (object_type, object_id) against the
+    caller's workspace. Without this, B can label A's part_id."""
+    a, b = _two_workspaces()
+    part_a = _create_part(a, "A-secret")
+    tag_b = b.post("/api/tags", json={"name": "Hot"}).json()["data"]["id"]
+    r = b.post(
+        "/api/tags/links",
+        json={"tag_id": tag_b, "object_type": "part", "object_id": part_a},
+    )
+    assert r.status_code == 404, r.text
+
+
+# ---------------------------------------------------------------------------
+# stock service: cross-workspace lot/storage on adjust/remove/move.
+# adjust_stock was the active leak — `delta = actual_qty - 0` persists a
+# positive entry referencing the foreign FK. remove + move are defense in
+# depth (today: current_quantity returns 0, raises insufficient).
+# ---------------------------------------------------------------------------
+
+
+def test_stock_adjust_rejects_foreign_lot_and_storage():
+    a, b = _two_workspaces()
+    storage_a = _create_storage(a, "A-bin")
+    part_a = _create_part(a, "A-part")
+    lot_a = _add_stock(a, part_id=part_a, storage_id=storage_a, quantity=5)["lot_id"]
+
+    part_b = _create_part(b, "B-part")
+
+    # B passes A's lot_id — must 422 "lot not found", not silently persist.
+    r = b.post(
+        "/api/stock/adjust",
+        json={
+            "part_id": part_b,
+            "lot_id": lot_a,
+            "actual_quantity": 99,
+        },
+    )
+    assert r.status_code == 400, r.text
+
+    # B passes A's storage_id — same.
+    r = b.post(
+        "/api/stock/adjust",
+        json={
+            "part_id": part_b,
+            "storage_location_id": storage_a,
+            "actual_quantity": 99,
+        },
+    )
+    assert r.status_code == 400, r.text
+
+
+def test_stock_remove_rejects_foreign_lot_and_storage():
+    a, b = _two_workspaces()
+    storage_a = _create_storage(a, "A-bin")
+    part_a = _create_part(a, "A-part")
+    lot_a = _add_stock(a, part_id=part_a, storage_id=storage_a, quantity=5)["lot_id"]
+
+    part_b = _create_part(b, "B-part")
+    _add_stock(b, part_id=part_b, quantity=10)
+
+    r = b.post(
+        "/api/stock/remove",
+        json={"part_id": part_b, "quantity": 1, "lot_id": lot_a},
+    )
+    assert r.status_code == 400, r.text
+
+    r = b.post(
+        "/api/stock/remove",
+        json={"part_id": part_b, "quantity": 1, "storage_location_id": storage_a},
+    )
+    assert r.status_code == 400, r.text
+
+
+def test_stock_move_rejects_foreign_source():
+    a, b = _two_workspaces()
+    storage_a = _create_storage(a, "A-bin")
+    part_a = _create_part(a, "A-part")
+    lot_a = _add_stock(a, part_id=part_a, storage_id=storage_a, quantity=5)["lot_id"]
+
+    part_b = _create_part(b, "B-part")
+    storage_b1 = _create_storage(b, "B-bin1")
+    storage_b2 = _create_storage(b, "B-bin2")
+    _add_stock(b, part_id=part_b, storage_id=storage_b1, quantity=5)
+
+    # B tries to move using A's source_storage_location_id
+    r = b.post(
+        "/api/stock/move",
+        json={
+            "part_id": part_b,
+            "quantity": 1,
+            "source_storage_location_id": storage_a,
+            "destination_storage_location_id": storage_b2,
+        },
+    )
+    assert r.status_code == 400, r.text
+
+    # B tries to move using A's source_lot_id
+    r = b.post(
+        "/api/stock/move",
+        json={
+            "part_id": part_b,
+            "quantity": 1,
+            "source_lot_id": lot_a,
+            "destination_storage_location_id": storage_b2,
+        },
+    )
+    assert r.status_code == 400, r.text
+
+
+# ---------------------------------------------------------------------------
+# parts.default_storage_location_id on create / patch / bulk-import-from-scan
+# ---------------------------------------------------------------------------
+
+
+def test_parts_create_rejects_foreign_default_storage():
+    a, b = _two_workspaces()
+    storage_a = _create_storage(a)
+
+    r = b.post(
+        "/api/parts",
+        json={
+            "name": "X",
+            "part_type": "local",
+            "default_storage_location_id": storage_a,
+        },
+    )
+    assert r.status_code == 404, r.text
+
+
+def test_parts_patch_rejects_foreign_default_storage():
+    a, b = _two_workspaces()
+    storage_a = _create_storage(a)
+    part_b = _create_part(b)
+
+    r = b.patch(
+        f"/api/parts/{part_b}",
+        json={"default_storage_location_id": storage_a},
+    )
+    assert r.status_code == 404, r.text
+
+
+def test_parts_bulk_import_rejects_foreign_storage():
+    """bulk-import-from-scan must validate row.storage_location_id against
+    the caller's workspace BEFORE creating the part. The whole-batch loop
+    keeps running; only the offending row is reported as `invalid`."""
+    a, b = _two_workspaces()
+    storage_a = _create_storage(a)
+
+    # B has to have a provider configured for bulk-import to even reach the
+    # row-validation step (the endpoint short-circuits if no provider). Use
+    # the "none" path — set parts_provider to mouser and a fake key just
+    # so the configuration check passes; the foreign-storage validation
+    # fires before the provider lookup.
+    r = b.patch(
+        "/api/workspaces/current",
+        json={"parts_provider": "mouser", "parts_provider_api_key": "x" * 36},
+    )
+    assert r.status_code == 200, r.text
+
+    r = b.post(
+        "/api/parts/bulk-import-from-scan",
+        json={
+            "rows": [
+                # Row 1: foreign storage — must be marked invalid, not block the loop.
+                {
+                    "mpn": "RC0402-1K",
+                    "storage_location_id": storage_a,
+                    "quantity": 1,
+                },
+                # Row 2: no storage at all — proves the per-row independence;
+                # mpn won't resolve (fake key, no real provider) so it ends as
+                # lookup_failed, but it MUST run rather than be skipped because
+                # row 1 failed.
+                {"mpn": "RC0402-2K", "quantity": 1},
+            ]
+        },
+    )
+    # Endpoint returns 200 with per-row outcomes.
+    assert r.status_code == 200, r.text
+    out = r.json()["data"]["rows"]
+    assert len(out) == 2
+    assert out[0]["status"] == "invalid"
+    assert "storage" in (out[0].get("error") or "").lower()
+    # Row 2 was processed (per-row independence) and reached the provider,
+    # which fails because the API key is fake — but the loop did NOT abort
+    # on row 1.
+    assert out[1]["status"] == "lookup_failed"
+
+
+# ---------------------------------------------------------------------------
+# builds.consume: cross-workspace lot / storage on a consume line.
+# Defense in depth — current_quantity ws-filter would return 0 today,
+# blocking the write. Pinned so a future refactor can't reopen the leak.
+# ---------------------------------------------------------------------------
+
+
+def test_builds_consume_rejects_foreign_lot_and_storage():
+    a, b = _two_workspaces()
+    storage_b = _create_storage(b, "B-bin")
+    part_b = _create_part(b, "B-part")
+    lot_b = _add_stock(b, part_id=part_b, storage_id=storage_b, quantity=5)["lot_id"]
+
+    # A sets up a project + entry pointing at A's part, then a build.
+    storage_a = _create_storage(a, "A-bin")
+    part_a = _create_part(a, "A-part")
+    _add_stock(a, part_id=part_a, storage_id=storage_a, quantity=10)
+
+    proj_a = a.post("/api/projects", json={"name": "P"}).json()["data"]["id"]
+    entry = a.post(
+        f"/api/projects/{proj_a}/entries",
+        json={"entry_type": "part", "part_id": part_a, "quantity": 1},
+    ).json()["data"]["id"]
+    build_a = a.post(
+        "/api/builds",
+        json={"name": "B1", "project_id": proj_a, "quantity": 1},
+    ).json()["data"]["id"]
+
+    # A's build, A's entry, A's part — but the line claims B's lot. Must reject.
+    r = a.post(
+        f"/api/builds/{build_a}/consume",
+        json={
+            "lines": [
+                {
+                    "project_entry_id": entry,
+                    "part_id": part_a,
+                    "lot_id": lot_b,
+                    "quantity": 1,
+                }
+            ]
+        },
+    )
+    assert r.status_code == 400, r.text
+
+    # And likewise for storage_location_id.
+    r = a.post(
+        f"/api/builds/{build_a}/consume",
+        json={
+            "lines": [
+                {
+                    "project_entry_id": entry,
+                    "part_id": part_a,
+                    "storage_location_id": storage_b,
+                    "quantity": 1,
+                }
+            ]
+        },
+    )
+    assert r.status_code == 400, r.text


### PR DESCRIPTION
## Summary

Tier A of the comprehensive review remediation (`/home/matyas/.claude/plans/linked-cooking-raccoon.md`). Closes the remainder of the prior-review **Sec HIGH-3** (cross-workspace IDOR on create paths) plus one new finding from today's audit: `CustomFieldIn.source` was client-controlled and let callers forge `source='provider'` rows.

PR #1 (merged) closed `attachments.upload` and `projects.add_entry/patch_entry`. This PR closes everything else of the same shape — `custom_fields`, `tags`, `stock` (active leak in `adjust_stock`), `builds`, `parts.default_storage_location_id` — using the `assert_in_workspace` / new `assert_polymorphic_in_workspace` helpers.

## What changes

### Polymorphic write guards
- `custom_fields.create_or_update`: validate `(object_type, object_id)` against `ws.id` before write. Drop `source` from `CustomFieldIn` (force `'manual'` server-side; provider writes go through `domain/parts/services/provider.py` only).
- `tags.link`: validate `(object_type, object_id)` before `TagLink` write.
- `attachments`: switched from local `_OBJECT_RESOLVERS` registry to the shared helper.
- Replaces 4 `db.get(WorkspaceOwned, id)` + manual ws-check sites (CLAUDE.md flags this pattern as fragile) with `assert_in_workspace` in `custom_fields` and `tags`.

### Service-layer FK validation
- `stock.adjust_stock` — **was the active leak.** `delta = actual_quantity - 0` persisted a positive `StockEntry` with foreign FKs (`current_quantity`'s ws-filter masked the cross-workspace lookup as 0 stock, so the adjust computed a positive delta against unverified lot/storage).
- `stock.remove_stock` + `stock.move_stock` — defense in depth. Today blocked by `current_quantity`'s ws-filter; pinned so a future refactor of that filter can't reopen the leak.
- `builds.consume` — same defense-in-depth on per-line `lot_id` / `storage_location_id`.

### `default_storage_location_id` validation
- `parts.create_part` and `parts.patch_part`: validate before persist.
- `parts.bulk_import_from_scan`: validate per-row at the top of the loop; foreign storage → `status='invalid'`, batch continues.

### Helper (`backend/app/api/_helpers.py`)
- `assert_polymorphic_in_workspace(db, object_type, object_id, ws_id)` — resolves a polymorphic FK against the caller's workspace using a registry of known object types. Returns 400 on unknown type, 404 on cross-workspace.
- Registry is `@lru_cache`'d to avoid rebuilding on every API call.

## Tests

- 11 new cases in `test_workspace_isolation.py` covering every changed surface — the polymorphic 404 path, the `source` 422-forge rejection, and per-row independence on bulk-import.
- One pre-existing test in `test_bulk_delete.py` updated to drop the now-forbidden `source` field from its custom-field create POST body.

**Full backend suite: 186/186 passing** (was 175 before).

## Review

- Independent pass by the `workspace-isolation-checker` subagent on the diff: **✅ ready to merge**. Three minor cosmetic items raised; two addressed (`lru_cache`, per-row independence test). One left for a follow-up sweep (replacing `db.get` patterns in `attachments.download/delete` for uniformity).

## Test plan

- [x] `pytest tests/test_workspace_isolation.py` → 14/14 pass.
- [x] Full backend suite → 186/186 pass.
- [ ] Manual smoke after deploy: typical workflows still work — add custom field on a part, tag a part, add/remove/move/adjust stock with valid IDs, BOM build consume.
- [ ] Cross-tenant smoke: as user A, every formerly-leaky endpoint with B's IDs → expected 404/400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)