### PR TITLE
fix(security): hardening batch — cookie / non-root / dockerignore / sourcemaps / openapi / sentry-pii / gha-pins

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,65 @@
+# Build context exclusions. Without this the docker daemon receives the
+# entire repo (was 263 MB with web/node_modules + .git + dist), which
+# slows every rebuild and risks shipping local secrets via incidental
+# COPY-* layers. Listed here at the repo root because docker-compose's
+# `context: .` for the web build is the worst offender.
+
+# Version control
+.git
+.gitignore
+.gitattributes
+
+# Environments and secrets — must NEVER enter a build context.
+.env
+.env.*
+!.env.example
+deploy/.env*
+!deploy/.env.prod.example
+
+# Python build artifacts and venvs
+__pycache__/
+*.py[cod]
+*$py.class
+*.egg-info/
+*.egg
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+.tox/
+.coverage
+.coverage.*
+htmlcov/
+.venv*/
+venv*/
+*.venv/
+
+# Node / Vite
+node_modules/
+dist/
+.vite/
+*.tsbuildinfo
+
+# IDE / OS noise
+.idea/
+.vscode/
+*.swp
+.DS_Store
+Thumbs.db
+
+# Local Claude tooling — not a runtime concern
+.claude/
+.remember/
+
+# Past review artifacts — kept locally, never shipped
+review-*/
+
+# Top-level docs / READMEs (not needed at runtime)
+*.md
+!web/index.html
+
+# Old static-bundle graveyard — see PR #16 in the remediation plan
+barcodeReader/
+
+# Misc local files
+*.log
+uploads/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,13 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
+# Default token scope for the workflow. Tighter than the repo default,
+# prevents a malicious dependency in test code from using the auto-issued
+# GITHUB_TOKEN to push commits / open PRs / edit issues. Override per-job
+# when a step needs more (none currently do).
+permissions:
+  contents: read
+
 jobs:
   backend-tests:
     runs-on: ubuntu-latest
@@ -31,9 +38,13 @@ jobs:
           --health-retries 10
 
     steps:
-      - uses: actions/checkout@v4
+      # SHA-pin every action so a tag-rewrite attack can't substitute a
+      # malicious version. Comments record the human-readable tag the SHA
+      # was resolved from on 2026-05-01; bump via
+      # `gh api repos/<owner>/<repo>/git/refs/tags/<tag>`.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.12"
           cache: pip
@@ -54,9 +65,9 @@ jobs:
   web-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: "20"
           cache: npm
@@ -80,10 +91,16 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: [backend-tests, web-build]
     runs-on: ubuntu-latest
+    # Environment association. Today this just scopes any environment-level
+    # secrets we add later; if a "Required reviewers" protection rule is
+    # configured for `production` in the repo's GitHub Settings → Environments,
+    # this job will pause for human approval before each deploy. See
+    # docs/deployment.md → "Optional: gate deploys behind a human reviewer".
+    environment: production
 
     steps:
       - name: SSH deploy
-        uses: appleboy/ssh-action@v1.0.3
+        uses: appleboy/ssh-action@029f5b4aeeeb58fdfe1410a5d17f967dacf36262  # v1.0.3
         with:
           host: ${{ secrets.DEPLOY_HOST }}
           username: ${{ secrets.DEPLOY_USER }}

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -6,14 +6,30 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /app
 
+# `gosu` lets the entrypoint chown the upload volume as root (required
+# the first time a fresh named volume is mounted on top of /data/uploads,
+# or after upgrading from a previous image that ran as root) and then
+# drop privileges before exec'ing uvicorn. Without it the runtime would
+# either stay root forever (Sec HIGH-2 / Infra CRIT-3) or fail to write
+# to a root-owned upload volume.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        build-essential libpq-dev curl \
-    && rm -rf /var/lib/apt/lists/*
+        build-essential libpq-dev curl gosu \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd -r -u 1000 -m -d /home/appuser appuser \
+    && mkdir -p /data/uploads \
+    && chown -R appuser:appuser /data
 
 COPY pyproject.toml ./
 RUN pip install --upgrade pip && pip install -e .
 
 COPY . .
 
+# /app stays root-owned (read-only at runtime; appuser doesn't need to
+# mutate the source tree). USER is intentionally NOT set here — the
+# compose `command:` starts as root so it can chown /data on first
+# mount, then `gosu appuser` drops privileges before exec'ing uvicorn.
+
 EXPOSE 8000
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+# Default for direct `docker run`. Compose overrides with the alembic +
+# gosu + uvicorn one-liner; see docker-compose.prod.yml.
+CMD ["sh", "-c", "chown -R appuser:appuser /data 2>/dev/null || true; exec gosu appuser uvicorn app.main:app --host 0.0.0.0 --port 8000"]

--- a/backend/app/api/routes/workspaces.py
+++ b/backend/app/api/routes/workspaces.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, Depends, HTTPException, Response, status
 from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import select
 
+from app.core.config import settings
 from app.core.deps import CurrentUser, CurrentWorkspace, DbSession, require_role
 from app.core.responses import ok
 from app.domain.users.models import User
@@ -224,11 +225,19 @@ def remove_member(member_id: UUID, db: DbSession, ws: CurrentWorkspace, user: Cu
 
 @router.post("/{workspace_id}/switch")
 def switch_workspace(workspace_id: str, response: Response):
+    # Hardened cookie attributes (Sec CRIT-3 in 2026-04-30 review):
+    # - httponly: the SPA reads the active workspace from localStorage, never
+    #   from this cookie, so JS access is unnecessary and an XSS vector.
+    # - secure in prod: cookie may not be sent over plain HTTP. Dev runs
+    #   over HTTP so we keep it permissive there.
+    # - samesite=lax: blocks cross-site sub-request cookie attachment, so a
+    #   victim cannot be silently switched to another workspace from a
+    #   different origin.
     response.set_cookie(
         key="stockmgr_workspace",
         value=workspace_id,
-        httponly=False,
-        secure=False,
+        httponly=True,
+        secure=settings().APP_ENV == "prod",
         samesite="lax",
         max_age=365 * 24 * 3600,
         path="/",

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,6 +6,36 @@ from fastapi import Depends, FastAPI, HTTPException
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 
+
+# Top-level (testable) Sentry event scrubber. Runs as `before_send` so the
+# event is mutated before it leaves the worker. We have to scrub here
+# rather than rely on Sentry's defaults because:
+# - PATCH /api/workspaces/current carries the workspace's plaintext
+#   provider API keys + scanner license key in the body. A 5xx during
+#   that PATCH would otherwise ship those credentials to Sentry.
+# - POST /api/workspaces/{id}/switch carries the target workspace_id —
+#   tenant-identifying, low value to triage.
+# - Cookie / Authorization / X-Workspace-Id headers are tenant- or
+#   session-identifying. Sentry redacts `Cookie` by default, but we
+#   strip explicitly so we don't depend on the SDK's redaction list.
+def _scrub_event(event, _hint):
+    request = event.get("request")
+    if not isinstance(request, dict):
+        return event
+    headers = request.get("headers")
+    if isinstance(headers, dict):
+        drop = {"cookie", "authorization", "x-workspace-id"}
+        for k in list(headers.keys()):
+            if k.lower() in drop:
+                headers.pop(k, None)
+    url = (request.get("url") or "").lower()
+    method = (request.get("method") or "").upper()
+    if method in ("PATCH", "POST") and "/api/workspaces" in url:
+        if request.pop("data", None) is not None:
+            request["body_redacted"] = True
+    return event
+
+
 # Initialise Sentry BEFORE FastAPI is imported, per the SDK's docs — its
 # auto-instrumentation patches starlette / FastAPI on first import. No-ops
 # entirely when SENTRY_DSN is empty (dev / unset prod), so this stays
@@ -23,12 +53,12 @@ def _init_sentry() -> None:
         environment=cfg.APP_ENV,
         release=cfg.SENTRY_RELEASE or None,
         traces_sample_rate=cfg.SENTRY_TRACES_SAMPLE_RATE,
-        # Per the Sentry FastAPI wizard. Sends request headers and the
-        # user IP. Cookies are redacted automatically; if a particular
-        # header (e.g. Authorization) needs scrubbing, add a
-        # before_send hook here. Flip to False if you want strict
-        # data-minimisation.
+        # `send_default_pii=True` ships user IP + request headers + body.
+        # Combined with the `before_send` scrubber below, this is the
+        # right balance: triage gets enough context, plaintext credentials
+        # never reach Sentry.
         send_default_pii=True,
+        before_send=_scrub_event,
         integrations=[
             StarletteIntegration(transaction_style="endpoint"),
             FastApiIntegration(transaction_style="endpoint"),
@@ -63,7 +93,18 @@ from app.core.config import settings
 from app.core.deps import require_member_for_writes
 from app.core.responses import http_exception_handler, validation_exception_handler
 
-app = FastAPI(title="Parts Inventory & Production Manager", version="0.1.0")
+_is_prod = settings().APP_ENV == "prod"
+
+app = FastAPI(
+    title="Parts Inventory & Production Manager",
+    version="0.1.0",
+    # Disable OpenAPI surface in prod — the schema is a free attacker
+    # roadmap to every endpoint, parameter shape, and response. Kept on
+    # in dev where the interactive playground is useful.
+    docs_url=None if _is_prod else "/docs",
+    redoc_url=None if _is_prod else "/redoc",
+    openapi_url=None if _is_prod else "/openapi.json",
+)
 
 # Rate limiter wired before CORS so 429 responses still get the right headers.
 from slowapi import _rate_limit_exceeded_handler  # noqa: E402

--- a/backend/tests/test_security_hardening.py
+++ b/backend/tests/test_security_hardening.py
@@ -1,0 +1,157 @@
+"""Regression tests for the Tier B security hardening batch.
+
+Pins:
+- workspace-switch cookie attributes (httponly + samesite + secure-in-prod)
+- OpenAPI docs are reachable in dev (the prod-disable path is verified by
+  the constructor logic; we don't reload the module in tests)
+- Sentry `before_send` scrubber strips request body on workspace settings
+  PATCH/switch and strips tenant-identifying headers
+"""
+from __future__ import annotations
+
+import uuid
+
+from fastapi.testclient import TestClient
+
+from app.main import _scrub_event, app
+
+
+def _signup(c: TestClient) -> str:
+    email = f"sec-{uuid.uuid4().hex[:6]}@x.com"
+    r = c.post("/api/auth/signup", json={"email": email, "name": "u", "password": "password123"})
+    assert r.status_code == 200, r.text
+    return r.json()["data"]["workspace_id"]
+
+
+# ---------------------------------------------------------------------------
+# Workspace cookie hardening (Sec CRIT-3 in 2026-04-30 review)
+# ---------------------------------------------------------------------------
+
+
+def test_workspace_switch_sets_hardened_cookie_attributes():
+    c = TestClient(app)
+    ws_id = _signup(c)
+    r = c.post(f"/api/workspaces/{ws_id}/switch")
+    assert r.status_code == 200, r.text
+    set_cookie = r.headers.get("set-cookie", "")
+    assert set_cookie, "expected a Set-Cookie header"
+    lower = set_cookie.lower()
+    # httponly: blocks JS read of the cookie. Reverses Sec CRIT-3.
+    assert "httponly" in lower, f"missing HttpOnly: {set_cookie}"
+    # samesite=lax: blocks cross-site cookie attachment on non-GET.
+    assert "samesite=lax" in lower, f"missing SameSite=Lax: {set_cookie}"
+    # In test env APP_ENV defaults to "dev" so Secure is correctly absent.
+    # The prod path (`Secure` set when APP_ENV == "prod") is exercised by
+    # reading the route's logic — covered by code review, not this test.
+
+
+# ---------------------------------------------------------------------------
+# OpenAPI surface (Sec MED-1)
+# ---------------------------------------------------------------------------
+
+
+def test_openapi_docs_enabled_in_dev():
+    """In test env APP_ENV defaults to 'dev' so /docs is mounted. The prod
+    path (`docs_url=None` when APP_ENV=='prod') is set at FastAPI()
+    construction; we don't module-reload here. If a later refactor moves
+    the gate, this test catches the dev-side regression."""
+    c = TestClient(app)
+    r = c.get("/docs")
+    assert r.status_code == 200, r.text
+    r = c.get("/openapi.json")
+    assert r.status_code == 200, r.text
+
+
+# ---------------------------------------------------------------------------
+# Sentry before_send scrubber (Sec HIGH-1)
+# ---------------------------------------------------------------------------
+
+
+def test_scrubber_strips_patch_body_on_workspace_settings():
+    event = {
+        "request": {
+            "method": "PATCH",
+            "url": "https://parts.matescb.cz/api/workspaces/current",
+            "data": '{"parts_provider_api_key": "SECRET"}',
+            "headers": {"Content-Type": "application/json"},
+        },
+    }
+    out = _scrub_event(event, None)
+    assert "data" not in out["request"]
+    assert out["request"].get("body_redacted") is True
+
+
+def test_scrubber_strips_post_body_on_workspace_switch():
+    event = {
+        "request": {
+            "method": "POST",
+            "url": "https://parts.matescb.cz/api/workspaces/abc/switch",
+            "data": "anything",
+            "headers": {},
+        },
+    }
+    out = _scrub_event(event, None)
+    assert "data" not in out["request"]
+
+
+def test_scrubber_keeps_body_on_unrelated_endpoint():
+    event = {
+        "request": {
+            "method": "POST",
+            "url": "https://parts.matescb.cz/api/parts",
+            "data": '{"name": "Cap"}',
+            "headers": {},
+        },
+    }
+    out = _scrub_event(event, None)
+    # Non-workspace POSTs keep their body — this is normal triage data.
+    assert out["request"]["data"] == '{"name": "Cap"}'
+
+
+def test_scrubber_strips_sensitive_headers():
+    event = {
+        "request": {
+            "method": "GET",
+            "url": "https://parts.matescb.cz/api/parts",
+            "headers": {
+                "Cookie": "session=abc; stockmgr_workspace=xyz",
+                "Authorization": "Bearer foo",
+                "X-Workspace-Id": "00000000-0000-0000-0000-000000000000",
+                "User-Agent": "Mozilla/5.0",
+                "Content-Type": "application/json",
+            },
+        },
+    }
+    out = _scrub_event(event, None)
+    headers = out["request"]["headers"]
+    assert "Cookie" not in headers
+    assert "Authorization" not in headers
+    assert "X-Workspace-Id" not in headers
+    # Non-sensitive headers kept for triage value.
+    assert headers["User-Agent"] == "Mozilla/5.0"
+    assert headers["Content-Type"] == "application/json"
+
+
+def test_scrubber_strips_lowercased_headers_too():
+    """Sentry's HTTPx integration sometimes lowercases header names."""
+    event = {
+        "request": {
+            "method": "GET",
+            "url": "https://parts.matescb.cz/api/parts",
+            "headers": {
+                "cookie": "session=abc",
+                "authorization": "Bearer foo",
+            },
+        },
+    }
+    out = _scrub_event(event, None)
+    assert "cookie" not in out["request"]["headers"]
+    assert "authorization" not in out["request"]["headers"]
+
+
+def test_scrubber_handles_event_without_request():
+    """Some Sentry events are diagnostic / breadcrumb-only. Don't crash."""
+    out = _scrub_event({"message": "hello"}, None)
+    assert out == {"message": "hello"}
+    out = _scrub_event({"request": "not a dict"}, None)
+    assert out["request"] == "not a dict"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -72,7 +72,19 @@ services:
     # Single-line so YAML's folded-scalar rules don't break shell tokens
     # across argv boundaries (uvicorn was missing --proxy-headers
     # because the YAML kept the newline before it intact).
-    command: ["sh", "-c", "alembic upgrade head && exec uvicorn app.main:app --host 0.0.0.0 --port 8000 --workers 1 --proxy-headers --forwarded-allow-ips=*"]
+    #
+    # Boot sequence:
+    #   1. chown the upload volume to appuser. Idempotent — cheap when
+    #      already correct, fixes ownership the first time a fresh named
+    #      volume is mounted (Docker preserves the image's path ownership
+    #      on first creation) or when migrating from a previous root-only
+    #      image. Runs as root because the compose container's USER is
+    #      unset by design (see backend/Dockerfile).
+    #   2. exec gosu appuser <inner shell>. Drops privileges to UID 1000
+    #      for the rest of the process tree. From this point uvicorn and
+    #      alembic both run unprivileged.
+    #   3. alembic upgrade head, then exec uvicorn. Identical to before.
+    command: ["sh", "-c", "chown -R appuser:appuser /data 2>/dev/null || true; exec gosu appuser sh -c 'alembic upgrade head && exec uvicorn app.main:app --host 0.0.0.0 --port 8000 --workers 1 --proxy-headers --forwarded-allow-ips=*'"]
 
   web:
     build:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -231,6 +231,38 @@ If the VPS host key ever rotates (rebuild, key regeneration), pin the new
 fingerprint via the action's `fingerprint:` input — capture it on the host
 with `ssh-keygen -lf /etc/ssh/ssh_host_ed25519_key.pub`.
 
+### Action SHA pins
+
+All third-party actions are SHA-pinned in `ci.yml`, with a comment recording
+the human-readable tag the SHA was resolved from. Bump them with:
+
+```bash
+gh api repos/actions/checkout/git/refs/tags/v4 --jq .object.sha
+gh api repos/actions/setup-python/git/refs/tags/v5 --jq .object.sha
+gh api repos/actions/setup-node/git/refs/tags/v4 --jq .object.sha
+gh api repos/appleboy/ssh-action/git/refs/tags/v1.0.3 --jq .object.sha
+```
+
+Replace the SHA in the `uses:` line; keep the tag in the trailing comment.
+Pin-bumps are normal-stream PRs (no special review gate); only bump on a
+genuine version intent.
+
+### Optional: gate deploys behind a human reviewer
+
+The `deploy` job has `environment: production` set. By default this just
+scopes any environment-level secrets we add later. If you want a manual
+"approve this deploy" step before each prod push:
+
+1. GitHub UI → Settings → Environments → New environment → name `production`.
+2. Add a "Required reviewers" rule and list the trusted approvers
+   (typically just your own account).
+3. Optional: "Wait timer" if you want a cooling-off period before the
+   approval prompt fires.
+
+After this, every push to `main` that passes CI will pause at the deploy
+step and email the listed reviewers. Approving the run resumes the SSH
+deploy. Skip this if you'd rather keep the current friction-free flow.
+
 ## Operations
 
 All commands below assume you're SSH'd into the VPS. If you don't have a

--- a/web/.dockerignore
+++ b/web/.dockerignore
@@ -1,0 +1,20 @@
+# Build context exclusions for `docker build web/` invocations.
+# Mirrors the repo-root .dockerignore for the web subtree, in case the
+# build is ever invoked with `context: web/` instead of the current
+# `context: .`.
+
+node_modules/
+dist/
+.vite/
+*.tsbuildinfo
+.env
+.env.*
+!.env.example
+.git
+__pycache__/
+.pytest_cache/
+.idea/
+.vscode/
+*.log
+*.swp
+.DS_Store

--- a/web/Dockerfile.prod
+++ b/web/Dockerfile.prod
@@ -48,8 +48,14 @@ FROM nginx:alpine AS runtime
 # Replace the default site with our SPA-aware config (try_files → index.html).
 COPY deploy/nginx-web.conf /etc/nginx/conf.d/default.conf
 
-# Static bundle.
+# Static bundle. Strip sourcemaps from the served image — they're
+# already uploaded to Sentry by sentryVitePlugin during the build, and
+# Vite's `sourcemap: "hidden"` only suppresses the //# sourceMappingURL
+# comment at the bottom of the JS, not the .map files themselves.
+# Leaving them under /assets/*.map exposes the original source to anyone
+# who can guess the bundle hash (Infra CRIT-5).
 COPY --from=build /app/dist /usr/share/nginx/html
+RUN find /usr/share/nginx/html -name '*.map' -delete
 
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/web/src/instrument.ts
+++ b/web/src/instrument.ts
@@ -41,6 +41,32 @@ Sentry.init({
   // Per the wizard. Sends user IP + request headers; cookies are
   // redacted automatically. Flip to false for stricter data minimisation.
   sendDefaultPii: true,
+  // Strip request bodies on workspace settings PATCH/switch (carry
+  // plaintext provider API keys + scanner license key) and a few
+  // tenant-identifying headers. Sentry redacts Cookie by default, but
+  // we don't depend on the default redaction list.
+  beforeSend(event) {
+    const req = event.request;
+    if (req) {
+      if (req.headers) {
+        const drop = new Set(["cookie", "authorization", "x-workspace-id"]);
+        for (const k of Object.keys(req.headers)) {
+          if (drop.has(k.toLowerCase())) {
+            delete (req.headers as Record<string, unknown>)[k];
+          }
+        }
+      }
+      const url = (req.url ?? "").toLowerCase();
+      const method = (req.method ?? "").toUpperCase();
+      if ((method === "PATCH" || method === "POST") && url.includes("/api/workspaces")) {
+        if (req.data !== undefined) {
+          delete req.data;
+          (req as Record<string, unknown>).body_redacted = true;
+        }
+      }
+    }
+    return event;
+  },
   integrations: [
     // Hooks-based router integration: we use <BrowserRouter> + <Routes>
     // (not createBrowserRouter), so we hand React Router's hooks to


### PR DESCRIPTION
## Summary

Tier B of the comprehensive remediation plan. Seven low-risk config changes that individually are trivial but collectively shift the security posture meaningfully. Each item maps to a finding from the 2026-04-30 review.

## What changes

### Workspace cookie hardening — `Sec CRIT-3`
`switch_workspace` now sets `httponly=True`, `secure=APP_ENV=='prod'`, `samesite=lax`. Backwards-compatible — existing browser cookies stay valid; next `/switch` overwrites with the hardened flags.

### Backend non-root runtime — `Sec HIGH-2 / Infra CRIT-3`
`gosu` + appuser uid 1000 + idempotent `chown /data` on every container start. `USER` intentionally unset; the compose `command:` starts as root, chowns the upload volume (handles fresh-mount and root-owned-legacy cases), then `exec gosu appuser` into the alembic+uvicorn shell. Runtime is unprivileged from that point.

### `.dockerignore` — `Infra HIGH-5`
Drops build context from ~263 MB to ~10 MB; stops shipping local `.env` and `.git` into the daemon. New at repo root and `web/`.

### Source-map filter — `Infra CRIT-5`
`web/Dockerfile.prod` runs `find /usr/share/nginx/html -name '*.map' -delete` after the dist COPY. Sentry already has them via the build-time upload; serving them publicly would expose original source.

### OpenAPI surface disabled in prod — `Sec MED-1`
`FastAPI(docs_url=None, redoc_url=None, openapi_url=None)` when `APP_ENV=='prod'`. Dev still has `/docs`.

### Sentry `before_send` scrubber — `Sec HIGH-1`
Top-level `_scrub_event` in backend and matching `beforeSend` in frontend. Strips request body on PATCH/POST under `/api/workspaces/*` (carries plaintext provider keys + scanner license) and strips `Cookie` / `Authorization` / `X-Workspace-Id` headers from every event.

### GHA SHA-pin + permissions + environment — `Infra CRIT-4`
All actions pinned by SHA with the tag in a trailing comment. `permissions: contents: read` at workflow scope. `environment: production` on the deploy job is strictly additive today; if a "Required reviewers" rule is later configured in the GitHub UI, it gates every deploy on human approval. `docs/deployment.md` updated to document the SHA-bump procedure and the optional approval-gate.

## Tests

- **8 new cases** in `tests/test_security_hardening.py` covering cookie attributes, OpenAPI dev-path, and Sentry scrubber (including lowercased-header and no-request-shape edges).
- **Full backend suite: 194/194** (was 186 before).
- Frontend `tsc -b`: clean.

## Review

`/security-review` skill on the diff: **zero findings above the 0.7 confidence threshold.** Each potential concern (gosu/chown TOCTOU, scrubber URL-case bypass, cookie session-fixation, source-map find-delete scope, .dockerignore exclusions, SHA-pin correctness) was investigated and dismissed with rationale.

## Test plan

- [x] `pytest tests/test_security_hardening.py` → 8/8 pass
- [x] Full backend suite → 194/194 pass
- [x] `tsc -b` → clean
- [x] `/security-review` skill → no findings
- [ ] **Post-deploy verification** — login still works in browser; workspace switch sets the new cookie attributes (verify in DevTools → Application → Cookies); `https://parts.matescb.cz/api/docs` returns 404; an attempt to fetch any `/assets/*.map` URL returns 404.
- [ ] **Container audit** — `docker exec stockmanager-backend-1 whoami` returns `appuser`; uvicorn process tree runs unprivileged; an upload via the UI persists to `/data/uploads/<ws_id>/`.

## Notable caveats

- The `gosu`+chown approach assumes the upload volume is on a regular filesystem (no special acl). If POSIX ACLs were ever applied, the chown would still complete but might lose ACLs.
- `environment: production` association takes effect immediately. Today there's no protection rule, so deploys aren't gated. If the user later adds a "Required reviewers" rule (per `docs/deployment.md`), all deploys after that point pause for approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)