### PR TITLE
fix(security): attachment XSS + filename + size hardening (Sec CRIT-1 / CRIT-2)

### DIFF
--- a/backend/app/api/routes/attachments.py
+++ b/backend/app/api/routes/attachments.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import re
 import uuid as uuidlib
 from uuid import UUID
 
@@ -10,7 +11,7 @@ from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile, s
 from fastapi.responses import FileResponse
 from sqlalchemy import select
 
-from app.api._helpers import assert_polymorphic_in_workspace
+from app.api._helpers import assert_in_workspace, assert_polymorphic_in_workspace
 from app.core.config import settings
 from app.core.deps import (
     CurrentUser,
@@ -24,6 +25,66 @@ from app.domain.attachments.models import Attachment
 from app.infra.db import get_db
 
 router = APIRouter()
+
+
+# Allow-list of MIME types we accept on upload, with the canonical
+# extension we use for the stored filename. SVG is intentionally excluded
+# — sanitising it correctly is a research project, and the only place we
+# render inline is the browser (no scoped iframe / sandbox), so any
+# escape becomes a same-origin XSS. PNG / JPEG / WebP / PDF cover every
+# real use case here (part photos, datasheets, lot images).
+_ALLOWED_MIMES: dict[str, str] = {
+    "image/png": "png",
+    "image/jpeg": "jpg",
+    "image/webp": "webp",
+    "application/pdf": "pdf",
+}
+
+
+def _detect_mime(header: bytes) -> str | None:
+    """Return the canonical MIME if `header` matches one of the allowed
+    formats, else None. Magic-byte sniff defeats the `evil.html declared
+    image/png` upload — the declared Content-Type is never trusted on
+    its own.
+
+    Reference signatures:
+    - PNG  89 50 4E 47 0D 0A 1A 0A
+    - JPEG FF D8 FF
+    - WebP "RIFF" at 0..3, "WEBP" at 8..11 (variable-length size in 4..7)
+    - PDF  25 50 44 46 2D ("%PDF-")
+    """
+    if header.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "image/png"
+    if header.startswith(b"\xff\xd8\xff"):
+        return "image/jpeg"
+    if len(header) >= 12 and header[:4] == b"RIFF" and header[8:12] == b"WEBP":
+        return "image/webp"
+    if header.startswith(b"%PDF-"):
+        return "application/pdf"
+    return None
+
+
+_FILENAME_RE = re.compile(r"[^A-Za-z0-9._-]+")
+
+
+def _safe_filename(name: str | None, mime: str) -> str:
+    """Sanitise the user-supplied filename for storage and Content-
+    Disposition. The extension is always derived from the validated MIME
+    so a `.html` suffix on a PNG can never make it back to the browser.
+
+    - Strip any client-supplied extension (we replace it with the canonical one).
+    - Replace anything outside [A-Za-z0-9._-] with `_`.
+    - Cap at 80 chars (matches the existing `withDownloadName` helper on
+      the FE — keeps Save-As dialogs sane).
+    - Empty / all-stripped → `attachment-<8-hex>.<ext>`.
+    """
+    ext = _ALLOWED_MIMES[mime]
+    base = (name or "").rsplit(".", 1)[0]
+    base = _FILENAME_RE.sub("_", base).strip("._-")
+    if not base:
+        base = f"attachment-{uuidlib.uuid4().hex[:8]}"
+    base = base[:80]
+    return f"{base}.{ext}"
 
 
 def _serialize(a: Attachment) -> dict:
@@ -49,20 +110,59 @@ async def upload(
     ws=Depends(get_current_workspace),
     user=Depends(get_current_user),
 ):
+    # Caller must own (or be a member of) the workspace AND the polymorphic
+    # target object must exist in this workspace. Stops cross-tenant writes
+    # before any disk I/O happens.
     assert_polymorphic_in_workspace(db, object_type, object_id, ws.id)
-    storage_key = f"{ws.id}/{uuidlib.uuid4()}-{file.filename}"
+
+    # Streaming-bounded read: read at most MAX_UPLOAD_BYTES + 1 to detect
+    # over-cap, then reject. Starlette's UploadFile is spooled, so the
+    # extra byte stays in the spool — never lands in active memory beyond
+    # what we explicitly read here.
+    max_bytes = settings().MAX_UPLOAD_BYTES
+    contents = await file.read(max_bytes + 1)
+    if len(contents) > max_bytes:
+        raise HTTPException(
+            status_code=413,
+            detail=f"upload exceeds {max_bytes} bytes",
+        )
+    if not contents:
+        raise HTTPException(status_code=400, detail="empty upload")
+
+    # Validate the bytes against the allow-list and confirm the declared
+    # Content-Type matches reality. The declared MIME is never trusted on
+    # its own — `evil.html` with `Content-Type: image/png` would pass the
+    # allow-list check but fail the magic-byte check.
+    actual_mime = _detect_mime(contents[:16])
+    if actual_mime is None:
+        raise HTTPException(
+            status_code=415,
+            detail="unsupported file type — allowed: PNG, JPEG, WebP, PDF",
+        )
+    if file.content_type and file.content_type != actual_mime:
+        raise HTTPException(
+            status_code=415,
+            detail=(
+                f"declared content-type ({file.content_type}) does not match "
+                f"actual content ({actual_mime})"
+            ),
+        )
+
+    safe_name = _safe_filename(file.filename, actual_mime)
+    storage_key = f"{ws.id}/{uuidlib.uuid4()}-{safe_name}"
     abs_path = os.path.join(settings().UPLOAD_DIR, storage_key)
     os.makedirs(os.path.dirname(abs_path), exist_ok=True)
-    contents = await file.read()
     with open(abs_path, "wb") as f:
         f.write(contents)
     a = Attachment(
         workspace_id=ws.id,
         object_type=object_type,
         object_id=object_id,
-        file_name=file.filename or "upload",
+        # Store the SANITIZED name + DETECTED MIME — never echo back what
+        # the client sent. Subsequent downloads serve the sanitized form.
+        file_name=safe_name,
         file_type=file_type,
-        mime_type=file.content_type,
+        mime_type=actual_mime,
         size_bytes=len(contents),
         storage_key=storage_key,
         uploaded_by=user.id,
@@ -90,18 +190,33 @@ def list_for_object(object_type: str, object_id: UUID, db: DbSession, ws: Curren
 
 @router.get("/{attachment_id}/download")
 def download(attachment_id: UUID, db: DbSession, ws: CurrentWorkspace):
-    a = db.get(Attachment, attachment_id)
-    if not a or a.workspace_id != ws.id:
-        raise HTTPException(status_code=404, detail="attachment not found")
+    a = assert_in_workspace(db, Attachment, attachment_id, ws.id, label="attachment")
     abs_path = os.path.join(settings().UPLOAD_DIR, a.storage_key)
-    return FileResponse(abs_path, media_type=a.mime_type or "application/octet-stream", filename=a.file_name)
+    # Legacy attachments (uploaded before this PR's allow-list landed) may
+    # carry NULL or non-allow-listed mime_types. Serve them as
+    # `application/octet-stream` so the browser cannot inline-render an
+    # `evil.svg` or `evil.html` from before the allow-list. New uploads
+    # have a canonical MIME — the conditional collapses for them.
+    served_mime = (
+        a.mime_type
+        if a.mime_type in _ALLOWED_MIMES
+        else "application/octet-stream"
+    )
+    # Force Content-Disposition: attachment regardless of MIME — even an
+    # allow-listed image won't render inline this way. Pre-empts any
+    # future MIME-allow-list expansion accidentally re-introducing the
+    # inline-render vector.
+    return FileResponse(
+        abs_path,
+        media_type=served_mime,
+        filename=a.file_name,
+        content_disposition_type="attachment",
+    )
 
 
 @router.delete("/{attachment_id}")
 def delete(attachment_id: UUID, db: DbSession, ws: CurrentWorkspace):
-    a = db.get(Attachment, attachment_id)
-    if not a or a.workspace_id != ws.id:
-        raise HTTPException(status_code=404, detail="attachment not found")
+    a = assert_in_workspace(db, Attachment, attachment_id, ws.id, label="attachment")
     abs_path = os.path.join(settings().UPLOAD_DIR, a.storage_key)
     try:
         os.remove(abs_path)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -14,6 +14,14 @@ class Settings(BaseSettings):
     SESSION_COOKIE_NAME: str = "stockmgr_session"
     SESSION_LIFETIME_DAYS: int = 30
     UPLOAD_DIR: str = "/data/uploads"
+    # Per-upload size cap. nginx (in web container) and Apache (in front)
+    # both cap at 25 MiB, but FastAPI must enforce its own cap so a
+    # direct hit on the backend port — or any future change to those
+    # proxy limits — doesn't let a single request consume unbounded
+    # memory. 10 MiB is plenty for part photos and most datasheets;
+    # bigger PDFs that fail with 413 are the operator's signal to
+    # compress or to bump this number.
+    MAX_UPLOAD_BYTES: int = 10 * 1024 * 1024
     CORS_ORIGINS: str = "http://localhost:5173"
     # Sentry. Empty string → SDK is not initialised (no events sent, no
     # network egress, no performance overhead). Populate in .env.prod

--- a/backend/tests/test_attachments.py
+++ b/backend/tests/test_attachments.py
@@ -8,6 +8,18 @@ from fastapi.testclient import TestClient
 from app.main import app
 
 
+# Magic-byte prefixes for the allow-listed types. The rest of the file
+# can be arbitrary bytes — _detect_mime only inspects the first 16 bytes.
+PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+JPEG_MAGIC = b"\xff\xd8\xff\xe0"
+WEBP_MAGIC = b"RIFF\x10\x00\x00\x00WEBP"
+PDF_MAGIC = b"%PDF-1.4\n"
+
+
+def _png(payload: bytes = b"data") -> bytes:
+    return PNG_MAGIC + payload
+
+
 def _signup(c: TestClient, email: str | None = None) -> str:
     email = email or f"u-{uuid.uuid4().hex[:8]}@x.com"
     r = c.post(
@@ -31,19 +43,28 @@ def _make_part(c: TestClient) -> str:
     ).json()["data"]["id"]
 
 
+# ---------------------------------------------------------------------------
+# Happy path — upload / list / download / delete on the new MIME allow-list
+# ---------------------------------------------------------------------------
+
+
 def test_upload_list_download_delete(authed):
     part_id = _make_part(authed)
+    body = _png(b"hello")
     r = authed.post(
         "/api/attachments",
-        files={"file": ("test.txt", b"hello", "text/plain")},
+        files={"file": ("photo.png", body, "image/png")},
         data={"object_type": "part", "object_id": part_id, "file_type": "datasheet"},
     )
     assert r.status_code == 201, r.text
     a = r.json()["data"]
-    assert a["file_name"] == "test.txt"
+    # Filename is stored AS sanitized — same input here, plus the canonical
+    # extension derived from the validated MIME.
+    assert a["file_name"] == "photo.png"
     assert a["object_type"] == "part"
     assert a["file_type"] == "datasheet"
-    assert a["size_bytes"] == 5
+    assert a["mime_type"] == "image/png"
+    assert a["size_bytes"] == len(body)
     aid = a["id"]
 
     listed = authed.get(f"/api/attachments/by-object/part/{part_id}").json()["data"]
@@ -52,7 +73,12 @@ def test_upload_list_download_delete(authed):
 
     dl = authed.get(f"/api/attachments/{aid}/download")
     assert dl.status_code == 200
-    assert dl.content == b"hello"
+    assert dl.content == body
+    # Download must always use Content-Disposition: attachment so even
+    # an allow-listed image cannot be inline-rendered as part of an XSS.
+    cd = dl.headers.get("content-disposition", "").lower()
+    assert "attachment" in cd, cd
+    assert "filename=" in cd, cd
 
     rd = authed.delete(f"/api/attachments/{aid}")
     assert rd.status_code == 200
@@ -63,7 +89,7 @@ def test_workspace_isolation(authed):
     part_id = _make_part(authed)
     a = authed.post(
         "/api/attachments",
-        files={"file": ("a.txt", b"secret", "text/plain")},
+        files={"file": ("a.png", _png(b"secret"), "image/png")},
         data={"object_type": "part", "object_id": part_id, "file_type": "other"},
     ).json()["data"]
     aid = a["id"]
@@ -85,3 +111,238 @@ def test_workspace_isolation(authed):
     # Owner workspace still has it
     still = authed.get(f"/api/attachments/by-object/part/{part_id}").json()["data"]
     assert len(still) == 1
+
+
+# ---------------------------------------------------------------------------
+# MIME allow-list — Sec CRIT-1 (stored XSS via uploaded SVG / HTML)
+# ---------------------------------------------------------------------------
+
+
+def test_upload_rejects_text_html(authed):
+    part_id = _make_part(authed)
+    r = authed.post(
+        "/api/attachments",
+        files={"file": ("evil.html", b"<script>alert(1)</script>", "text/html")},
+        data={"object_type": "part", "object_id": part_id, "file_type": "other"},
+    )
+    assert r.status_code == 415, r.text
+
+
+def test_upload_rejects_svg(authed):
+    """SVG is excluded from the allow-list because correctly sanitising
+    embedded JS, event handlers, foreign-objects, etc. is research-grade."""
+    part_id = _make_part(authed)
+    svg = b"<svg xmlns='http://www.w3.org/2000/svg'><script>alert(1)</script></svg>"
+    r = authed.post(
+        "/api/attachments",
+        files={"file": ("photo.svg", svg, "image/svg+xml")},
+        data={"object_type": "part", "object_id": part_id, "file_type": "other"},
+    )
+    assert r.status_code == 415, r.text
+
+
+def test_upload_rejects_text_plain(authed):
+    part_id = _make_part(authed)
+    r = authed.post(
+        "/api/attachments",
+        files={"file": ("note.txt", b"hello", "text/plain")},
+        data={"object_type": "part", "object_id": part_id, "file_type": "other"},
+    )
+    assert r.status_code == 415, r.text
+
+
+def test_upload_rejects_magic_byte_mismatch(authed):
+    """`Content-Type: image/png` declared but actual content is HTML —
+    must reject. Defeats the canonical evil.html-as-PNG attack."""
+    part_id = _make_part(authed)
+    r = authed.post(
+        "/api/attachments",
+        files={"file": ("photo.png", b"<html><script>alert(1)</script>", "image/png")},
+        data={"object_type": "part", "object_id": part_id, "file_type": "other"},
+    )
+    assert r.status_code == 415, r.text
+
+
+def test_upload_rejects_declared_mime_mismatch(authed):
+    """Bytes are a real PNG, but the client declares JPEG. Even though
+    the bytes are safe, mismatched declarations are an attempt to
+    confuse the type-resolution path — reject defensively."""
+    part_id = _make_part(authed)
+    r = authed.post(
+        "/api/attachments",
+        files={"file": ("photo.jpg", _png(b"data"), "image/jpeg")},
+        data={"object_type": "part", "object_id": part_id, "file_type": "other"},
+    )
+    assert r.status_code == 415, r.text
+
+
+def test_upload_accepts_pdf(authed):
+    part_id = _make_part(authed)
+    r = authed.post(
+        "/api/attachments",
+        files={"file": ("ds.pdf", PDF_MAGIC + b"body", "application/pdf")},
+        data={"object_type": "part", "object_id": part_id, "file_type": "datasheet"},
+    )
+    assert r.status_code == 201, r.text
+    assert r.json()["data"]["mime_type"] == "application/pdf"
+
+
+def test_upload_accepts_webp(authed):
+    part_id = _make_part(authed)
+    r = authed.post(
+        "/api/attachments",
+        files={"file": ("photo.webp", WEBP_MAGIC + b"body", "image/webp")},
+        data={"object_type": "part", "object_id": part_id, "file_type": "other"},
+    )
+    assert r.status_code == 201, r.text
+    assert r.json()["data"]["mime_type"] == "image/webp"
+
+
+def test_upload_accepts_jpeg(authed):
+    part_id = _make_part(authed)
+    r = authed.post(
+        "/api/attachments",
+        files={"file": ("photo.jpg", JPEG_MAGIC + b"body", "image/jpeg")},
+        data={"object_type": "part", "object_id": part_id, "file_type": "other"},
+    )
+    assert r.status_code == 201, r.text
+    assert r.json()["data"]["mime_type"] == "image/jpeg"
+
+
+def test_upload_rejects_empty_file(authed):
+    part_id = _make_part(authed)
+    r = authed.post(
+        "/api/attachments",
+        files={"file": ("empty.png", b"", "image/png")},
+        data={"object_type": "part", "object_id": part_id, "file_type": "other"},
+    )
+    assert r.status_code == 400, r.text
+
+
+# ---------------------------------------------------------------------------
+# Size cap — Sec CRIT-2 (auth-required OOM via unbounded `await file.read()`)
+# ---------------------------------------------------------------------------
+
+
+def test_upload_rejects_over_size_cap(authed, monkeypatch):
+    """Force a 10 KiB cap via env override so the test is fast, then
+    upload 20 KiB and assert 413."""
+    from app.core.config import settings
+
+    monkeypatch.setenv("MAX_UPLOAD_BYTES", str(10 * 1024))
+    settings.cache_clear()
+    try:
+        part_id = _make_part(authed)
+        big = _png(b"X" * (20 * 1024))
+        r = authed.post(
+            "/api/attachments",
+            files={"file": ("big.png", big, "image/png")},
+            data={"object_type": "part", "object_id": part_id, "file_type": "other"},
+        )
+        assert r.status_code == 413, r.text
+    finally:
+        monkeypatch.delenv("MAX_UPLOAD_BYTES", raising=False)
+        settings.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Filename sanitization — path traversal, control chars, mixed extensions
+# ---------------------------------------------------------------------------
+
+
+def test_upload_sanitizes_path_traversal_filename(authed):
+    part_id = _make_part(authed)
+    r = authed.post(
+        "/api/attachments",
+        files={"file": ("../../etc/passwd.png", _png(b"data"), "image/png")},
+        data={"object_type": "part", "object_id": part_id, "file_type": "other"},
+    )
+    assert r.status_code == 201, r.text
+    name = r.json()["data"]["file_name"]
+    # Slashes and dots must be stripped/replaced; canonical extension reasserted.
+    assert "/" not in name
+    assert ".." not in name
+    assert name.endswith(".png")
+    # The visible string must contain something derived from the input.
+    assert "passwd" in name or "etc" in name or name.startswith("attachment-")
+
+
+def test_upload_synthesises_filename_when_input_strips_to_empty(authed):
+    """A filename that's all special chars (e.g. `~/`, `///`, `...`)
+    sanitises to empty. The fallback synthesises an `attachment-<hex>.<ext>`
+    name rather than 500'ing or producing a bare-extension filename."""
+    part_id = _make_part(authed)
+    r = authed.post(
+        "/api/attachments",
+        files={"file": ("///", _png(b"data"), "image/png")},
+        data={"object_type": "part", "object_id": part_id, "file_type": "other"},
+    )
+    assert r.status_code == 201, r.text
+    name = r.json()["data"]["file_name"]
+    assert name.startswith("attachment-")
+    assert name.endswith(".png")
+
+
+def test_upload_overrides_extension_to_match_mime(authed):
+    """The user names their file `evil.html` but the bytes + declared
+    type are PNG. Stored extension must be `.png`, not `.html`."""
+    part_id = _make_part(authed)
+    r = authed.post(
+        "/api/attachments",
+        files={"file": ("evil.html", _png(b"data"), "image/png")},
+        data={"object_type": "part", "object_id": part_id, "file_type": "other"},
+    )
+    assert r.status_code == 201, r.text
+    name = r.json()["data"]["file_name"]
+    assert name.endswith(".png")
+    assert ".html" not in name
+
+
+# ---------------------------------------------------------------------------
+# Download Content-Disposition — even with allow-listed MIMEs, force download
+# ---------------------------------------------------------------------------
+
+
+def test_download_forces_attachment_disposition(authed):
+    part_id = _make_part(authed)
+    a = authed.post(
+        "/api/attachments",
+        files={"file": ("photo.png", _png(b"data"), "image/png")},
+        data={"object_type": "part", "object_id": part_id, "file_type": "other"},
+    ).json()["data"]
+    dl = authed.get(f"/api/attachments/{a['id']}/download")
+    assert dl.status_code == 200
+    cd = dl.headers.get("content-disposition", "").lower()
+    assert cd.startswith("attachment"), cd
+    # No matter what MIME is served, the browser sees an explicit "save"
+    # rather than "render inline" — the XSS-via-image-tag escape is closed.
+    assert "inline" not in cd
+
+
+def test_download_legacy_unsupported_mime_falls_back_to_octet_stream(authed):
+    """Pre-existing prod attachments uploaded before the allow-list
+    landed may carry `mime_type='text/html'` or NULL. Download must
+    still work but serve them as `application/octet-stream` so the
+    browser cannot inline-render them."""
+    part_id = _make_part(authed)
+    a = authed.post(
+        "/api/attachments",
+        files={"file": ("photo.png", _png(b"data"), "image/png")},
+        data={"object_type": "part", "object_id": part_id, "file_type": "other"},
+    ).json()["data"]
+
+    # Backdoor: rewrite the stored mime_type to a legacy value to simulate
+    # an attachment that predates this PR.
+    from sqlalchemy import update
+    from app.domain.attachments.models import Attachment
+    from app.infra.db import SessionLocal
+
+    with SessionLocal() as s:
+        s.execute(update(Attachment).where(Attachment.id == uuid.UUID(a["id"])).values(mime_type="text/html"))
+        s.commit()
+
+    dl = authed.get(f"/api/attachments/{a['id']}/download")
+    assert dl.status_code == 200
+    assert dl.headers.get("content-type", "").startswith("application/octet-stream")
+    cd = dl.headers.get("content-disposition", "").lower()
+    assert cd.startswith("attachment")


### PR DESCRIPTION
## Summary

Tier C, PR #4 of the comprehensive remediation plan. Closes the 2026-04-30 review's two highest-impact attachment-related CRITs.

## CRIT-1 — stored XSS via uploaded SVG/HTML

**Before**: upload accepted any Content-Type + any filename + any size; download served the attacker-controlled MIME and filename back via `FileResponse` with default disposition. An attacker uploading `evil.svg` with `Content-Type: image/svg+xml` could plant a same-origin XSS that any workspace member would execute on view.

**After**:
- Strict MIME allow-list: `{image/png, image/jpeg, image/webp, application/pdf}`. SVG is intentionally excluded — sanitising embedded JS / event handlers / foreign-objects is research-grade; operators upload PNG/JPEG/WebP for photos and PDF for datasheets.
- Magic-byte sniff (first 16 bytes) defeats `evil.html declared image/png`.
- Declared-vs-actual content-type matching rejects intentional mismatches.
- Filename sanitized to `[A-Za-z0-9._-]{1,80}` with the extension derived from the validated MIME — `evil.html` is stored as `evil.png` (canonical extension reasserted).
- Download forces `Content-Disposition: attachment` regardless of MIME.
- Legacy attachments with non-allow-listed MIME types fall back to `application/octet-stream` on download (back-compat without exposing the inline-render vector).

## CRIT-2 — auth-required OOM via unbounded `await file.read()`

**Before**: entire upload buffered into RAM before validation. nginx + Apache cap at 25 MiB but the FastAPI handler had no enforcement of its own.

**After**: new `MAX_UPLOAD_BYTES` setting (default 10 MiB; env-tunable). Upload reads at most `MAX_UPLOAD_BYTES + 1` — anything larger 413s before disk I/O. Empty uploads also rejected (400).

## Pattern alignment

`download` and `delete` switched from `db.get(Attachment, id)` + manual ws-check to the `assert_in_workspace` helper established by PR #2 — same semantics, consistent style.

## Tests

**17 cases** in `tests/test_attachments.py` (replacing the previous 2):
- Allow-list: PNG/JPEG/WebP/PDF accept; HTML/SVG/text/plain reject; magic-byte mismatch reject; declared-MIME mismatch reject; empty reject.
- Size cap: env-controlled 10 KiB cap → 413 on 20 KiB upload.
- Filename sanitization: path-traversal → safe; empty → synthesised; mismatched extension → MIME-derived.
- Download: `Content-Disposition: attachment` always; legacy non-allow-listed MIME → `application/octet-stream` fallback.
- Workspace isolation: cross-workspace download/delete still 404.

**Full backend suite: 209/209 passing** (was 194 before, +15 new).

## Review

`/security-review` skill on the diff: **zero findings above the 0.7 confidence threshold**. Path traversal in `_safe_filename`, polyglot bypass, Content-Disposition header injection, and legacy `mime_type=None` fallback all investigated and dismissed with rationale.

## Test plan

- [x] `pytest tests/test_attachments.py` → 17/17 pass
- [x] Full backend suite → 209/209 pass
- [x] `/security-review` skill → no findings
- [ ] **Pre-deploy DB query** to estimate legacy mime_type fallout:
      `psql ... -c "SELECT count(*), array_agg(DISTINCT mime_type) FROM attachments WHERE mime_type IS NULL OR mime_type NOT IN ('image/png','image/jpeg','image/webp','application/pdf')"`. Any rows surface here will serve as `application/octet-stream` after deploy — they remain downloadable but not preview-able. Acceptable.
- [ ] **Post-deploy smoke**: upload PNG via UI → 201; upload SVG → 415; existing prod PNG/PDF attachments still downloadable.

## Notable

- **Behavior change for new uploads**: only PNG/JPEG/WebP/PDF accepted; text files / arbitrary binaries rejected. If users have been uploading `.txt` notes or zip files, they'll now get 415. Add to allow-list if needed.
- **Behavior change for downloads**: `Content-Disposition: attachment` is now forced. Browsers will always download instead of inline-rendering. PartInfo's existing inline image render via the `/api/parts/assets/...` path is unaffected (different endpoint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)