### PR TITLE
fix(security): /api/sentry-tunnel rate-limit + body cap (Sec CRIT-5)

### DIFF
--- a/backend/app/api/routes/sentry_tunnel.py
+++ b/backend/app/api/routes/sentry_tunnel.py
@@ -11,10 +11,15 @@ Security posture:
 * No auth gate — Sentry's SDK is unauthenticated by design (the public DSN
   is the identifier, ingest.sentry.io accepts any envelope tagged with a
   valid project key).
-* Host allow-list against `SENTRY_DSN`. Without it, this endpoint would be
-  an open egress to anywhere Sentry-shaped — we cap it to our own DSN's
-  host + project id.
-* No rate-limit. Sentry SDKs do their own rate-limiting client-side.
+* Host allow-list against `SENTRY_DSN` / `VITE_SENTRY_DSN`. Without it,
+  this endpoint would be an open egress to anywhere Sentry-shaped — we
+  cap it to our own DSN's host + project id.
+* Rate-limited to 60/min/IP (Sec CRIT-5). Real Sentry SDKs do their own
+  client-side rate limiting and never hit this; the limit only catches
+  abuse, not legitimate traffic.
+* Body cap at SENTRY_TUNNEL_MAX_BYTES (200 KiB default). Envelopes are
+  streamed and the running byte count is checked per chunk, so an
+  oversize body is rejected before the full payload buffers in RAM.
 """
 from __future__ import annotations
 
@@ -25,6 +30,7 @@ import httpx
 from fastapi import APIRouter, HTTPException, Request, Response, status
 
 from app.core.config import settings
+from app.core.ratelimit import limiter
 
 
 router = APIRouter()
@@ -53,6 +59,7 @@ def _allowed_endpoints() -> list[tuple[str, str]]:
 
 
 @router.post("/sentry-tunnel")
+@limiter.limit("60/minute")
 async def sentry_tunnel(request: Request) -> Response:
     allowed = _allowed_endpoints()
     if not allowed:
@@ -60,7 +67,23 @@ async def sentry_tunnel(request: Request) -> Response:
         # soft 204 so SDK retries don't hammer the route.
         return Response(status_code=status.HTTP_204_NO_CONTENT)
 
-    envelope = await request.body()
+    # Streaming-bounded body read. `await request.body()` would buffer
+    # the entire payload in RAM with no upper bound — a single curl loop
+    # could pump arbitrary bytes through this worker. Iterating the
+    # stream lets us 413 the moment we cross the cap.
+    max_bytes = settings().SENTRY_TUNNEL_MAX_BYTES
+    chunks: list[bytes] = []
+    total = 0
+    async for chunk in request.stream():
+        total += len(chunk)
+        if total > max_bytes:
+            raise HTTPException(
+                status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                detail=f"envelope exceeds {max_bytes} bytes",
+            )
+        chunks.append(chunk)
+    envelope = b"".join(chunks)
+
     if not envelope:
         raise HTTPException(status_code=400, detail="empty envelope")
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -22,6 +22,14 @@ class Settings(BaseSettings):
     # bigger PDFs that fail with 413 are the operator's signal to
     # compress or to bump this number.
     MAX_UPLOAD_BYTES: int = 10 * 1024 * 1024
+    # Maximum size of a single Sentry envelope forwarded through
+    # /api/sentry-tunnel, in bytes. Default 200 KiB. Real envelopes from
+    # the React SDK are typically <50 KiB; this caps abuse without
+    # truncating legitimate replays. The route is unauthenticated by
+    # design (Sentry SDKs don't carry a session), so without this cap
+    # the tunnel is an open ingress that anyone on the internet can
+    # use to pump arbitrary bytes through this worker.
+    SENTRY_TUNNEL_MAX_BYTES: int = 200 * 1024
     CORS_ORIGINS: str = "http://localhost:5173"
     # Sentry. Empty string → SDK is not initialised (no events sent, no
     # network egress, no performance overhead). Populate in .env.prod

--- a/backend/tests/test_sentry_tunnel.py
+++ b/backend/tests/test_sentry_tunnel.py
@@ -1,0 +1,175 @@
+"""Tests for the /api/sentry-tunnel hardening (Sec CRIT-5).
+
+The route is unauthenticated by design (Sentry SDKs don't carry a session
+cookie). What we pin here:
+- 204 short-circuit when no DSN is configured (no upstream egress).
+- 400 on empty / malformed / DSN-missing envelopes.
+- 403 on a DSN that doesn't match the server's allow-list.
+- 413 when the envelope exceeds SENTRY_TUNNEL_MAX_BYTES.
+- The route declares the slowapi rate-limit decorator (slowapi is
+  disabled in non-prod env, so we don't trip the limit at runtime in
+  tests — we verify the wiring instead).
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# 204 short-circuit when no DSN is configured.
+# ---------------------------------------------------------------------------
+
+
+def test_sentry_tunnel_returns_204_when_no_dsn_configured(client, monkeypatch):
+    """No DSN on the server → 204 No Content. SDK retries see this as a
+    soft acknowledgement and back off."""
+    from app.core.config import settings
+
+    monkeypatch.setenv("SENTRY_DSN", "")
+    monkeypatch.setenv("VITE_SENTRY_DSN", "")
+    settings.cache_clear()
+    try:
+        r = client.post("/api/sentry-tunnel", content=b"anything")
+        assert r.status_code == 204, r.text
+    finally:
+        settings.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Body-cap (Sec CRIT-5)
+# ---------------------------------------------------------------------------
+
+
+def test_sentry_tunnel_rejects_oversize_envelope(client, monkeypatch):
+    """Force a 1 KiB cap, send 2 KiB → 413."""
+    from app.core.config import settings
+
+    # A configured DSN is required to reach the size-check path.
+    monkeypatch.setenv("VITE_SENTRY_DSN", "https://abc@o123.ingest.sentry.io/456")
+    monkeypatch.setenv("SENTRY_TUNNEL_MAX_BYTES", "1024")
+    settings.cache_clear()
+    try:
+        r = client.post("/api/sentry-tunnel", content=b"X" * 2048)
+        assert r.status_code == 413, r.text
+    finally:
+        settings.cache_clear()
+
+
+def test_sentry_tunnel_accepts_envelope_at_cap_boundary(client, monkeypatch):
+    """A body exactly at the cap should pass the size check (and then
+    fail downstream on the malformed envelope header — that's fine,
+    we're only verifying the cap is inclusive of the boundary, not
+    that arbitrary bytes are valid envelopes)."""
+    from app.core.config import settings
+
+    monkeypatch.setenv("VITE_SENTRY_DSN", "https://abc@o123.ingest.sentry.io/456")
+    monkeypatch.setenv("SENTRY_TUNNEL_MAX_BYTES", "1024")
+    settings.cache_clear()
+    try:
+        r = client.post("/api/sentry-tunnel", content=b"X" * 1024)
+        # Size check passes (would have been 413 if cap was exclusive);
+        # next step is parsing the envelope header which fails as 400.
+        assert r.status_code == 400, r.text
+        assert "envelope" in (r.json().get("status", {}).get("message") or "").lower()
+    finally:
+        settings.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# DSN allow-list — pre-existing behaviour, pinned here to prevent regression
+# ---------------------------------------------------------------------------
+
+
+def test_sentry_tunnel_rejects_empty_envelope(client, monkeypatch):
+    from app.core.config import settings
+
+    monkeypatch.setenv("VITE_SENTRY_DSN", "https://abc@o123.ingest.sentry.io/456")
+    settings.cache_clear()
+    try:
+        r = client.post("/api/sentry-tunnel", content=b"")
+        assert r.status_code == 400, r.text
+    finally:
+        settings.cache_clear()
+
+
+def test_sentry_tunnel_rejects_malformed_header(client, monkeypatch):
+    from app.core.config import settings
+
+    monkeypatch.setenv("VITE_SENTRY_DSN", "https://abc@o123.ingest.sentry.io/456")
+    settings.cache_clear()
+    try:
+        r = client.post("/api/sentry-tunnel", content=b"not-json\nrest")
+        assert r.status_code == 400, r.text
+    finally:
+        settings.cache_clear()
+
+
+def test_sentry_tunnel_rejects_dsn_mismatch(client, monkeypatch):
+    """Envelope claims a DSN that's not in the server's allow-list →
+    403. Without this, the route is an open egress to any Sentry-shaped
+    URL the client cares to put in an envelope header."""
+    from app.core.config import settings
+
+    monkeypatch.setenv("VITE_SENTRY_DSN", "https://abc@o123.ingest.sentry.io/456")
+    settings.cache_clear()
+    try:
+        # Foreign DSN (different host + project_id).
+        envelope_header = json.dumps(
+            {"dsn": "https://xyz@o999.ingest.sentry.io/000"}
+        )
+        body = envelope_header.encode() + b"\n{}"
+        r = client.post("/api/sentry-tunnel", content=body)
+        assert r.status_code == 403, r.text
+    finally:
+        settings.cache_clear()
+
+
+def test_sentry_tunnel_rejects_envelope_missing_dsn(client, monkeypatch):
+    from app.core.config import settings
+
+    monkeypatch.setenv("VITE_SENTRY_DSN", "https://abc@o123.ingest.sentry.io/456")
+    settings.cache_clear()
+    try:
+        envelope_header = json.dumps({"event_id": "abc"})  # no `dsn`
+        body = envelope_header.encode() + b"\n{}"
+        r = client.post("/api/sentry-tunnel", content=body)
+        assert r.status_code == 400, r.text
+    finally:
+        settings.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Rate-limit wiring
+# ---------------------------------------------------------------------------
+
+
+def test_sentry_tunnel_route_has_rate_limit_decorator():
+    """slowapi's `enabled=False` outside prod means we can't trip the
+    limit in tests, but we can verify the decorator was applied — its
+    presence is the load-bearing check."""
+    from app.api.routes.sentry_tunnel import sentry_tunnel
+
+    # slowapi attaches a `limiter_kwargs` attribute on the wrapped
+    # callable. The exact attribute name is internal; check for any of
+    # the public-facing markers slowapi uses across versions.
+    markers = ("limiter_kwargs", "_limiter", "limit")
+    has_marker = any(hasattr(sentry_tunnel, m) for m in markers)
+    # If none of the markers are present, fall back to a less precise
+    # but still strong signal: the function's repr should reference
+    # slowapi at some level after decoration.
+    if not has_marker:
+        wrapped = getattr(sentry_tunnel, "__wrapped__", sentry_tunnel)
+        assert wrapped is not sentry_tunnel, (
+            "expected @limiter.limit to wrap sentry_tunnel — none of "
+            f"{markers} found and __wrapped__ unset"
+        )


### PR DESCRIPTION
## Summary

Tier C, PR #5 of the comprehensive remediation plan.

`/api/sentry-tunnel` is unauthenticated by design (Sentry SDKs don't carry a session) and has been host-allow-listed against the configured DSNs, but until now had no rate limit and no body cap. `await request.body()` buffered the entire payload in RAM with no upper bound — anyone on the internet could pump arbitrary bytes through this worker.

## Changes

- **Rate limit**: `@limiter.limit("60/minute")` per IP. Real Sentry SDKs do their own client-side rate limiting and never hit this; the limit only catches abuse. Reuses the existing slowapi wiring established in `auth.py`.
- **Body cap**: new `SENTRY_TUNNEL_MAX_BYTES` setting (default 200 KiB; env-tunable). Body is read via `async for chunk in request.stream()`; running byte count triggers 413 the moment the cap is crossed. Real envelopes are typically <50 KiB.

The pre-existing DSN allow-list (host + project_id matched against `SENTRY_DSN` / `VITE_SENTRY_DSN`) is preserved unchanged.

## Tests

8 cases in `tests/test_sentry_tunnel.py`:
- 204 short-circuit when no DSN configured
- 413 when body exceeds cap; cap boundary is inclusive
- 400 on empty / malformed-header / missing-DSN envelopes
- 403 on foreign DSN
- Decorator presence (slowapi's `enabled=False` outside prod means we can't trip the limit at runtime; the wiring is what we pin)

**Full backend suite: 217/217** (was 209, +8 new).

## Review

`/security-review` skill: **zero findings above the 0.7 confidence threshold**. Streaming-mid-raise cleanup, URL injection in `upstream` formatting, decorator placement, and degenerate `SENTRY_TUNNEL_MAX_BYTES` values investigated and dismissed.

## Test plan

- [x] `pytest tests/test_sentry_tunnel.py` → 8/8
- [x] Full suite → 217/217
- [x] `/security-review` → no findings
- [ ] Post-deploy: trigger a deliberate frontend error in prod, confirm Sentry event arrives via tunnel (no regression on legitimate path)
- [ ] Post-deploy: `curl -X POST -H "Content-Type: application/octet-stream" --data-binary "@/dev/zero" -o /dev/null -w "%{http_code}\n" --max-time 10 https://parts.matescb.cz/api/sentry-tunnel | head -c 1024` should return 413 (or eventually 429 after enough rapid-fire attempts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)