### PR TITLE
fix(correctness): bulk_import_from_scan transactional + per-row savepoints (BE CRIT-6)

### DIFF
--- a/backend/app/api/routes/parts.py
+++ b/backend/app/api/routes/parts.py
@@ -822,8 +822,20 @@ def bulk_import_from_scan(
     user: CurrentUser,
 ):
     """Materialise scanned bag rows into Parts (+ optional initial stock).
-    Each row is independent — duplicates / no-match outcomes are returned
-    inline rather than aborting the batch."""
+
+    Each row is independent — both at the result-shape level (duplicates /
+    no-match outcomes are returned inline rather than aborting the batch)
+    AND at the database level: every row that does writes is wrapped in a
+    SAVEPOINT (`db.begin_nested()`) so an unexpected exception mid-row
+    (IntegrityError on a unique constraint, asset-fetch network error,
+    anything we didn't anticipate) rolls back ONLY that row's writes
+    without losing the rest of the batch. The outer transaction commits
+    every surviving savepoint at the end. Without this, a single uncaught
+    exception in row N would discard rows 1..N-1's writes — which the
+    operator already saw acknowledged in the per-row outcome list — and
+    the audit trail would diverge from what was actually persisted (Sec
+    CRIT-6).
+    """
     provider = make_provider(
         ws.parts_provider,
         ws.parts_provider_api_key,
@@ -903,10 +915,20 @@ def bulk_import_from_scan(
             })
             continue
 
-        # Provider lookup.
+        # Provider lookup. Provider classes already convert HTTP / parse
+        # errors into `{"found": False, "message": "..."}`, so this
+        # `except Exception` is a belt-and-braces guard against
+        # programming errors. We capture to Sentry instead of silently
+        # swallowing — the row still resolves with `lookup_failed` so
+        # the operator sees something, but ops aren't blind to the bug.
         try:
             lookup = provider.lookup_mpn(mpn)
-        except Exception as exc:  # provider should swallow these — belt+braces
+        except Exception as exc:
+            try:  # local import keeps this path zero-cost when SENTRY_DSN is empty
+                import sentry_sdk
+                sentry_sdk.capture_exception(exc)
+            except Exception:
+                pass
             out_rows.append({
                 "mpn": mpn,
                 "status": "lookup_failed",
@@ -929,113 +951,29 @@ def bulk_import_from_scan(
         if len(name) > 300:
             name = name[:300]
 
-        p = Part(
-            workspace_id=ws.id,
-            part_type="linked",
-            name=name,
-            manufacturer=(r.get("manufacturer") or None),
-            mpn=(r.get("mpn") or mpn),
-            description=(r.get("description") or None),
-            footprint=(r.get("footprint") or None),
-            attrition_percentage=0,
-            attrition_min_quantity=0,
-            default_storage_location_id=row.storage_location_id,
-            default_storage_mandatory=False,
-            serialized=False,
-            linked_provider=provider.name,
-            linked_external_id=(r.get("mpn") or mpn),
-            last_refresh_at=datetime.now(timezone.utc),
-            description_locally_edited=False,
-            created_by=user.id,
-            updated_by=user.id,
-        )
-        db.add(p)
-        db.flush()  # assign p.id for the custom_fields below
-
-        # Materialise spec rows + image/datasheet as `source='provider'`,
-        # mirroring the refresh-from-provider path. Skip empties.
-        for s in (r.get("specs") or []):
-            key = (s.get("key") or "").strip()
-            value = (s.get("value") or "").strip()
-            if not key or not value:
-                continue
-            db.add(CustomField(
-                workspace_id=ws.id,
-                object_type="part",
-                object_id=p.id,
-                key=key,
-                value=value,
-                source="provider",
-                created_by=user.id,
-                updated_by=user.id,
-            ))
-        # Download image + datasheet locally so we don't depend on the
-        # provider's CDN at render time. Failed downloads fall back to
-        # the original URL so the worst case is unchanged from before.
-        if r.get("image_url"):
-            local = fetch_provider_asset(r["image_url"], str(ws.id), "image")
-            db.add(CustomField(
-                workspace_id=ws.id,
-                object_type="part",
-                object_id=p.id,
-                key="image_url",
-                value=local or r["image_url"],
-                source="provider",
-                created_by=user.id,
-                updated_by=user.id,
-            ))
-        if r.get("datasheet_url"):
-            local = fetch_provider_asset(r["datasheet_url"], str(ws.id), "datasheet")
-            db.add(CustomField(
-                workspace_id=ws.id,
-                object_type="part",
-                object_id=p.id,
-                key="datasheet_url",
-                value=local or r["datasheet_url"],
-                source="provider",
-                created_by=user.id,
-                updated_by=user.id,
-            ))
-
-        # Initial stock entry — when the bag's Q field carries a count
-        # (or the operator entered one), the part lands on-hand right
-        # away. Storage location is optional: when present, the entry is
-        # filed there; when absent, it's recorded with no location so the
-        # operator can move/file it later from the Stock view. This
-        # mirrors how a freshly-arrived bag actually exists physically:
-        # you have it in hand, the count is on the label, the bin
-        # assignment can happen later.
-        qty_added = 0
-        stock_error: str | None = None
-        if row.quantity and row.quantity > 0:
-            # Build a Lot row only when the bag carried any traceability
-            # info. Without it, add_stock makes a bare stock entry with
-            # no associated lot — same as the manual stock-add flow.
-            lot_payload: LotInput | None = None
-            if row.lot_name or row.lot_serial:
-                lot_payload = LotInput(
-                    name=row.lot_name,
-                    serial_number=row.lot_serial,
+        # Wrap every write for this row in a savepoint. If anything
+        # below this line raises (IntegrityError on the partial-unique
+        # MPN constraint, asset-fetch raising mid-flight, fetch_provider_asset
+        # crashing, anything else unanticipated) — only this row rolls
+        # back. Other rows in the batch keep their writes.
+        try:
+            with db.begin_nested():
+                p, qty_added, stock_error = _import_one_scan_row(
+                    db, ws=ws, user=user, row=row, mpn=mpn,
+                    provider_name=provider.name, lookup_result=r,
                 )
+        except Exception as exc:
             try:
-                add_stock(
-                    db,
-                    workspace_id=ws.id,
-                    user_id=user.id,
-                    payload=AddStockIn(
-                        part_id=p.id,
-                        quantity=row.quantity,
-                        storage_location_id=row.storage_location_id,
-                        lot=lot_payload,
-                        comments=row.comments,
-                        bag_signature=row.bag_signature,
-                    ),
-                )
-                qty_added = row.quantity
-            except StockError as exc:
-                # Don't fail the whole row — the part is created, but
-                # surface the stock issue so the UI can flag it.
-                stock_error = str(exc)
+                import sentry_sdk
+                sentry_sdk.capture_exception(exc)
+            except Exception:
+                pass
+            out_rows.append({
+                "mpn": mpn,
+                "status": "row_failed",
+                "error": f"{type(exc).__name__}: {exc}",
+            })
+            continue
 
         out_rows.append({
             "mpn": mpn,
@@ -1052,8 +990,139 @@ def bulk_import_from_scan(
         "bag_rescan":     sum(1 for r in out_rows if r["status"] == "bag_rescan"),
         "lookup_failed":  sum(1 for r in out_rows if r["status"] == "lookup_failed"),
         "invalid":        sum(1 for r in out_rows if r["status"] == "invalid"),
+        "row_failed":     sum(1 for r in out_rows if r["status"] == "row_failed"),
     }
     return ok({"rows": out_rows, "summary": summary, "provider": provider.name})
+
+
+def _import_one_scan_row(
+    db,
+    *,
+    ws,
+    user,
+    row,
+    mpn: str,
+    provider_name: str,
+    lookup_result: dict,
+):
+    """Write the Part + provider custom_fields + initial stock for a
+    single bulk-import row, INSIDE a caller-managed savepoint. Returns
+    (part, qty_added, stock_error). Raises on any unanticipated DB
+    failure — the caller's `with db.begin_nested():` rolls back this
+    row only.
+    """
+    r = lookup_result
+    name = (r.get("description") or "").strip() or mpn
+    if len(name) > 300:
+        name = name[:300]
+
+    p = Part(
+        workspace_id=ws.id,
+        part_type="linked",
+        name=name,
+        manufacturer=(r.get("manufacturer") or None),
+        mpn=(r.get("mpn") or mpn),
+        description=(r.get("description") or None),
+        footprint=(r.get("footprint") or None),
+        attrition_percentage=0,
+        attrition_min_quantity=0,
+        default_storage_location_id=row.storage_location_id,
+        default_storage_mandatory=False,
+        serialized=False,
+        linked_provider=provider_name,
+        linked_external_id=(r.get("mpn") or mpn),
+        last_refresh_at=datetime.now(timezone.utc),
+        description_locally_edited=False,
+        created_by=user.id,
+        updated_by=user.id,
+    )
+    db.add(p)
+    db.flush()  # assign p.id for the custom_fields below
+
+    # Materialise spec rows + image/datasheet as `source='provider'`,
+    # mirroring the refresh-from-provider path. Skip empties.
+    for s in (r.get("specs") or []):
+        key = (s.get("key") or "").strip()
+        value = (s.get("value") or "").strip()
+        if not key or not value:
+            continue
+        db.add(CustomField(
+            workspace_id=ws.id,
+            object_type="part",
+            object_id=p.id,
+            key=key,
+            value=value,
+            source="provider",
+            created_by=user.id,
+            updated_by=user.id,
+        ))
+    # Download image + datasheet locally so we don't depend on the
+    # provider's CDN at render time. Failed downloads fall back to
+    # the original URL so the worst case is unchanged from before.
+    if r.get("image_url"):
+        local = fetch_provider_asset(r["image_url"], str(ws.id), "image")
+        db.add(CustomField(
+            workspace_id=ws.id,
+            object_type="part",
+            object_id=p.id,
+            key="image_url",
+            value=local or r["image_url"],
+            source="provider",
+            created_by=user.id,
+            updated_by=user.id,
+        ))
+    if r.get("datasheet_url"):
+        local = fetch_provider_asset(r["datasheet_url"], str(ws.id), "datasheet")
+        db.add(CustomField(
+            workspace_id=ws.id,
+            object_type="part",
+            object_id=p.id,
+            key="datasheet_url",
+            value=local or r["datasheet_url"],
+            source="provider",
+            created_by=user.id,
+            updated_by=user.id,
+        ))
+
+    # Initial stock entry — when the bag's Q field carries a count
+    # (or the operator entered one), the part lands on-hand right
+    # away. Storage location is optional: when present, the entry is
+    # filed there; when absent, it's recorded with no location so the
+    # operator can move/file it later from the Stock view.
+    qty_added = 0
+    stock_error: str | None = None
+    if row.quantity and row.quantity > 0:
+        lot_payload: LotInput | None = None
+        if row.lot_name or row.lot_serial:
+            lot_payload = LotInput(
+                name=row.lot_name,
+                serial_number=row.lot_serial,
+            )
+        try:
+            add_stock(
+                db,
+                workspace_id=ws.id,
+                user_id=user.id,
+                payload=AddStockIn(
+                    part_id=p.id,
+                    quantity=row.quantity,
+                    storage_location_id=row.storage_location_id,
+                    lot=lot_payload,
+                    comments=row.comments,
+                    bag_signature=row.bag_signature,
+                ),
+            )
+            qty_added = row.quantity
+        except StockError as exc:
+            # Don't fail the whole row — the part is created, but surface
+            # the stock issue so the UI can flag it. StockError is
+            # caught here (inside the savepoint) rather than letting it
+            # bubble out, because we don't want a stock-add failure to
+            # roll back the Part + provider specs the operator already
+            # sees as "created" in the response.
+            stock_error = str(exc)
+
+    return p, qty_added, stock_error
 
 
 class QuickRemoveBagIn(BaseModel):

--- a/backend/tests/test_bulk_import_from_scan.py
+++ b/backend/tests/test_bulk_import_from_scan.py
@@ -335,12 +335,110 @@ def test_bulk_import_mixed_batch_returns_per_row_status(authed, monkeypatch):
         "bag_rescan": 0,
         "lookup_failed": 1,
         "invalid": 0,
+        "row_failed": 0,
     }
 
 
 # ---------------------------------------------------------------------------
 # Top-level error paths
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Per-row savepoints (Sec CRIT-6) — a single row's unanticipated write
+# failure must not roll back the rest of the batch.
+# ---------------------------------------------------------------------------
+
+
+def test_bulk_import_row_failure_does_not_roll_back_other_rows(authed, monkeypatch):
+    """Force the second row's write step to raise something OTHER than
+    StockError (which is caught inline), then verify rows 1 and 3
+    persisted while row 2 was savepoint-rolled-back."""
+    monkeypatch.setattr(
+        "app.domain.parts.providers.mouser._post_mouser",
+        lambda url, payload: _stub_mouser_response(
+            mpn=payload["SearchByPartRequest"]["mouserPartNumber"]
+        ),
+    )
+
+    # Trigger a mid-row failure on row 2. We patch the per-row helper
+    # to raise on its second invocation — easier than crafting a
+    # legitimate IntegrityError mid-flight, and exercises the same
+    # savepoint-rollback path.
+    import app.api.routes.parts as parts_mod
+
+    real_helper = parts_mod._import_one_scan_row
+    call_count = {"n": 0}
+
+    def flaky_helper(*args, **kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == 2:
+            raise RuntimeError("simulated mid-row crash")
+        return real_helper(*args, **kwargs)
+
+    monkeypatch.setattr(parts_mod, "_import_one_scan_row", flaky_helper)
+
+    r = authed.post(
+        "/api/parts/bulk-import-from-scan",
+        json={
+            "rows": [
+                {"mpn": "RC0402JR-070R", "quantity": 1},
+                {"mpn": "RC0402JR-070K", "quantity": 1},
+                {"mpn": "RC0402JR-070M", "quantity": 1},
+            ]
+        },
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()["data"]
+    statuses = [row["status"] for row in body["rows"]]
+    assert statuses == ["created", "row_failed", "created"]
+    assert body["summary"]["row_failed"] == 1
+    assert body["summary"]["created"] == 2
+
+    # Surviving rows must actually be in the DB — not just claimed
+    # in the response.
+    listed = authed.get("/api/parts").json()["data"]
+    mpns = {p["mpn"] for p in listed}
+    assert "RC0402JR-070R" in mpns
+    assert "RC0402JR-070M" in mpns
+    # Row 2's MPN must NOT be in the DB (savepoint rolled back).
+    assert "RC0402JR-070K" not in mpns
+
+
+def test_bulk_import_provider_exception_does_not_abort_batch(authed, monkeypatch):
+    """Pre-existing behaviour: a provider exception on one row marks
+    that row lookup_failed, the rest of the batch still processes.
+    Pinned here to prevent regression from the savepoint refactor."""
+    call_count = {"n": 0}
+
+    def flaky_post(url, payload):
+        call_count["n"] += 1
+        mpn = payload["SearchByPartRequest"]["mouserPartNumber"]
+        if call_count["n"] == 2:
+            raise RuntimeError("simulated provider crash")
+        return _stub_mouser_response(mpn=mpn)
+
+    monkeypatch.setattr("app.domain.parts.providers.mouser._post_mouser", flaky_post)
+
+    r = authed.post(
+        "/api/parts/bulk-import-from-scan",
+        json={
+            "rows": [
+                {"mpn": "RC0402JR-070R"},
+                {"mpn": "RC0402JR-070K"},
+                {"mpn": "RC0402JR-070M"},
+            ]
+        },
+    )
+    assert r.status_code == 200, r.text
+    statuses = [row["status"] for row in r.json()["data"]["rows"]]
+    # Mouser provider catches RuntimeError internally and returns
+    # `{"found": False, "message": "..."}`, so the row resolves as
+    # `lookup_failed` rather than `row_failed`. Either way, the
+    # surrounding batch keeps processing — that's the load-bearing pin.
+    assert statuses[0] == "created"
+    assert statuses[1] == "lookup_failed"
+    assert statuses[2] == "created"
 
 
 def test_bulk_import_fails_when_no_provider_configured():


### PR DESCRIPTION
## Summary

Tier C, PR #7 of the comprehensive remediation plan.

**Before**: bulk-import wrote Part + custom_fields + Lot + StockEntry on the shared session and `db.commit()` once at the end. Any uncaught exception mid-loop made FastAPI roll back the entire transaction. The operator had already seen rows 1..N-1 acknowledged in the per-row outcome list — but in fact none landed. Hot path on a barcode scanner.

**After**: every row's writes wrap in `with db.begin_nested():` (SAVEPOINT). On exception inside the savepoint, only that row rolls back; the loop captures the exception, records `status="row_failed"`, sends to Sentry, and continues. The outer transaction commits every surviving savepoint.

## Changes

- Body of each row's writes extracted to `_import_one_scan_row(...)` helper.
- Loop wraps the helper call in `db.begin_nested()`.
- Catches `Exception` from the savepoint, records `row_failed`, sends to Sentry, continues.
- Provider-call's bare `except Exception` (which converts unanticipated provider crashes to `lookup_failed`) now also captures to Sentry — preserves row-resilience while making ops aware of the bug class.
- New `row_failed` outcome in the summary dict.
- StockError still caught inline (creates the part, surfaces `stock_error` on the row response) — that's a surface concern, not a savepoint concern.

## Tests

- `test_bulk_import_row_failure_does_not_roll_back_other_rows` — monkeypatches the per-row helper to raise on the second invocation; asserts rows 1 and 3 land in the DB while row 2 rolled back.
- `test_bulk_import_provider_exception_does_not_abort_batch` — pins the pre-existing "provider crash on one row → that row lookup_failed, others continue" behaviour through the savepoint refactor.
- `test_bulk_import_mixed_batch_returns_per_row_status` — updated to include the new `row_failed: 0` summary key.

**Full backend suite: 219/219** (was 217, +2 new).

## Review

Code review only — no schema, no auth, no migration. Savepoint refactor is localised to one endpoint.

## Test plan

- [x] `pytest tests/test_bulk_import_from_scan.py` → 14/14
- [x] Full suite → 219/219
- [ ] Post-deploy: scan a stack of bags, intentionally break one (e.g., scan a malformed barcode mid-batch); operator's per-row outcome should match DB state exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)