### PR TITLE
fix(stock): TOCTOU advisory lock + non-negative balance trigger (BE CRIT-1)

### DIFF
--- a/backend/alembic/versions/0013_stock_nonneg_trigger.py
+++ b/backend/alembic/versions/0013_stock_nonneg_trigger.py
@@ -1,0 +1,87 @@
+"""stock_entries non-negative balance trigger
+
+Revision ID: 0013
+Revises: 0012
+Create Date: 2026-05-02
+
+Defense-in-depth for BE CRIT-1 (stock TOCTOU). The append-only ledger
+design's whole rationale is that current_stock = SUM(quantity_delta)
+can never go negative. Two concurrent operators consuming from the
+same lot can both pass the per-request availability check before
+either writes (the read-then-write window is unguarded). The service
+layer now takes a `pg_advisory_xact_lock` on (workspace, part) which
+serialises writes; this trigger is the database-side fall-back.
+
+Behaviour:
+- Fires AFTER INSERT FOR EACH ROW on stock_entries.
+- Re-aggregates SUM(quantity_delta) for the (workspace_id, part_id,
+  lot_id, storage_location_id, status) tuple including the new row.
+- If the sum is negative, raises and rolls back the transaction.
+
+Caveats:
+- Trigger uses `IS NOT DISTINCT FROM` so NULL lot_id / storage_location_id
+  match each other (per existing aggregation semantics in
+  app.domain.stock.service.current_quantity).
+- Filters by `status` so reservations and on_hand are tracked
+  independently (a positive on_hand entry does not mask a negative
+  reserved sum, and vice versa).
+- Does NOT validate existing rows at upgrade time. If prod already
+  has rows summing negative for any tuple (e.g. due to a past CRIT-1
+  incident), this migration upgrades cleanly but the FIRST insert to
+  that tuple after deploy will fail with the trigger error. Run the
+  pre-deploy verification query in the PR description to catch this
+  before it surprises someone.
+"""
+from alembic import op
+
+
+revision = "0013"
+down_revision = "0012"
+branch_labels = None
+depends_on = None
+
+
+_FUNCTION_SQL = """
+CREATE OR REPLACE FUNCTION check_stock_nonneg() RETURNS TRIGGER AS $$
+DECLARE
+    total NUMERIC;
+BEGIN
+    SELECT COALESCE(SUM(quantity_delta), 0)
+      INTO total
+      FROM stock_entries
+     WHERE workspace_id = NEW.workspace_id
+       AND part_id = NEW.part_id
+       AND status = NEW.status
+       AND lot_id IS NOT DISTINCT FROM NEW.lot_id
+       AND storage_location_id IS NOT DISTINCT FROM NEW.storage_location_id;
+
+    IF total < 0 THEN
+        RAISE EXCEPTION
+            'cumulative stock balance would be negative (%); '
+            'workspace=% part=% lot=% storage=% status=%',
+            total, NEW.workspace_id, NEW.part_id,
+            NEW.lot_id, NEW.storage_location_id, NEW.status
+            USING ERRCODE = 'check_violation';
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+"""
+
+
+def upgrade() -> None:
+    op.execute(_FUNCTION_SQL)
+    op.execute(
+        """
+        CREATE TRIGGER ck_stock_nonneg
+        AFTER INSERT ON stock_entries
+        FOR EACH ROW
+        EXECUTE FUNCTION check_stock_nonneg();
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TRIGGER IF EXISTS ck_stock_nonneg ON stock_entries;")
+    op.execute("DROP FUNCTION IF EXISTS check_stock_nonneg();")

--- a/backend/app/domain/stock/service.py
+++ b/backend/app/domain/stock/service.py
@@ -6,7 +6,7 @@ from decimal import Decimal
 from typing import Iterable
 from uuid import UUID
 
-from sqlalchemy import and_, func, or_, select
+from sqlalchemy import and_, func, or_, select, text
 from sqlalchemy.orm import Session
 
 from app.domain.lots.models import Lot
@@ -32,6 +32,30 @@ def _now() -> datetime:
 
 def _belongs(obj, workspace_id: UUID) -> bool:
     return obj is not None and obj.workspace_id == workspace_id
+
+
+def _lock_for_stock_write(db: Session, *, workspace_id: UUID, part_id: UUID) -> None:
+    """Serialise concurrent stock writes on the same (workspace, part).
+
+    The append-only ledger has a TOCTOU race: two concurrent operators
+    consuming from the same lot both read available=N from
+    `current_quantity()`, both pass `qty <= available`, then both insert
+    a -qty row — the lot ends up at -qty (BE CRIT-1).
+
+    `pg_advisory_xact_lock` takes a session-level lock keyed on a
+    bigint hash of (workspace_id, part_id). The lock is released
+    automatically at COMMIT or ROLLBACK. Two transactions targeting
+    the same tuple serialise: the second waits for the first to
+    finish, then re-reads `current_quantity` against the updated
+    state. The 0013 trigger is the database-side fall-back if the
+    lock is ever bypassed (e.g. raw SQL outside the service layer).
+    """
+    # UUID's __str__ is stable RFC 4122 canonical form, so the same
+    # (workspace_id, part_id) pair always hashes to the same int8 lock id.
+    db.execute(
+        text("SELECT pg_advisory_xact_lock(hashtextextended(:k, 0))"),
+        {"k": f"{workspace_id}:{part_id}"},
+    )
 
 
 def current_quantity(
@@ -225,6 +249,7 @@ def remove_stock(
     user_id: UUID | None,
     payload: RemoveStockIn,
 ) -> StockEntry:
+    _lock_for_stock_write(db, workspace_id=workspace_id, part_id=payload.part_id)
     part = db.get(Part, payload.part_id)
     if not _belongs(part, workspace_id):
         raise StockError("part not found")
@@ -274,6 +299,7 @@ def move_stock(
     user_id: UUID | None,
     payload: MoveStockIn,
 ) -> tuple[StockEntry, StockEntry]:
+    _lock_for_stock_write(db, workspace_id=workspace_id, part_id=payload.part_id)
     part = db.get(Part, payload.part_id)
     if not _belongs(part, workspace_id):
         raise StockError("part not found")
@@ -391,6 +417,7 @@ def adjust_stock(
     user_id: UUID | None,
     payload: AdjustStockIn,
 ) -> StockEntry | None:
+    _lock_for_stock_write(db, workspace_id=workspace_id, part_id=payload.part_id)
     part = db.get(Part, payload.part_id)
     if not _belongs(part, workspace_id):
         raise StockError("part not found")

--- a/backend/tests/test_stock_concurrency.py
+++ b/backend/tests/test_stock_concurrency.py
@@ -1,0 +1,215 @@
+"""Tests for the stock TOCTOU + non-negative-balance fix (BE CRIT-1).
+
+Two layers:
+1. Service-layer advisory lock keyed on (workspace, part) — serialises
+   concurrent writes so the read-then-write race window can't be hit.
+2. Database-side AFTER INSERT trigger that re-aggregates the per-tuple
+   sum and rolls back if it would go negative — defense in depth.
+
+The trigger is the cleaner test target (deterministic, no concurrency
+needed). The advisory lock is verified via a threaded concurrency test
+that's mostly a smoke check — the load-bearing guarantee is the trigger.
+"""
+from __future__ import annotations
+
+import threading
+import time
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+
+from app.main import app
+
+
+def _signup(c: TestClient) -> str:
+    r = c.post(
+        "/api/auth/signup",
+        json={"email": f"u-{uuid.uuid4().hex[:8]}@x.com", "name": "u", "password": "password123"},
+    )
+    assert r.status_code == 200, r.text
+    return r.json()["data"]["workspace_id"]
+
+
+@pytest.fixture
+def authed():
+    c = TestClient(app)
+    _signup(c)
+    return c
+
+
+def _create_storage(c, name="Bin"):
+    r = c.post("/api/storage", json={"name": name})
+    assert r.status_code in (200, 201)
+    return r.json()["data"]["id"]
+
+
+def _create_part(c, name="P"):
+    r = c.post("/api/parts", json={"name": name, "part_type": "local"})
+    assert r.status_code in (200, 201)
+    return r.json()["data"]["id"]
+
+
+def _add_stock(c, part_id, qty, storage_id, lot_name="L"):
+    r = c.post(
+        "/api/stock/add",
+        json={
+            "part_id": part_id,
+            "quantity": qty,
+            "storage_location_id": storage_id,
+            "lot": {"name": lot_name},
+        },
+    )
+    assert r.status_code in (200, 201), r.text
+    return r.json()["data"]
+
+
+# ---------------------------------------------------------------------------
+# Trigger — direct SQL insert that would push the per-tuple sum negative.
+# Bypasses the service layer (no advisory lock acquired) so this purely
+# tests the database-side guarantee.
+# ---------------------------------------------------------------------------
+
+
+def test_trigger_blocks_negative_balance_via_direct_sql(authed):
+    """Add 100 to a lot via the API, then attempt to write a -150 row
+    via raw SQL. The trigger fires on insert and rolls back."""
+    part_id = _create_part(authed, "P1")
+    storage_id = _create_storage(authed, "B1")
+    entry = _add_stock(authed, part_id, 100, storage_id)
+    lot_id = entry["lot_id"]
+    workspace_id = authed.get("/api/auth/me").json()["data"]["workspaces"][0]["id"]
+
+    from app.infra.db import SessionLocal
+
+    with SessionLocal() as s:
+        # Bypass the service layer — write a raw SQL INSERT that would
+        # take the (workspace, part, lot, storage, status='on_hand') sum
+        # to -50. Trigger should reject.
+        with pytest.raises(Exception) as exc_info:
+            s.execute(
+                text(
+                    """
+                    INSERT INTO stock_entries
+                        (id, workspace_id, part_id, lot_id, storage_location_id,
+                         quantity_delta, status, operation_type, occurred_at, created_at)
+                    VALUES
+                        (:id, :ws, :part, :lot, :sl, -150, 'on_hand', 'remove', NOW(), NOW())
+                    """
+                ),
+                {
+                    "id": str(uuid.uuid4()),
+                    "ws": workspace_id,
+                    "part": part_id,
+                    "lot": lot_id,
+                    "sl": storage_id,
+                },
+            )
+            s.commit()
+        # Trigger raises with our custom message; SQLAlchemy wraps it as
+        # IntegrityError. Either the message or check_violation is fine
+        # to pin.
+        err = str(exc_info.value).lower()
+        assert "negative" in err or "check" in err, exc_info.value
+
+
+def test_trigger_allows_non_negative_balance(authed):
+    """Sanity check: a -50 write against a 100-piece lot succeeds via
+    raw SQL (with the right tuple). Confirms the trigger isn't
+    rejecting legitimate writes."""
+    part_id = _create_part(authed, "P2")
+    storage_id = _create_storage(authed, "B2")
+    entry = _add_stock(authed, part_id, 100, storage_id)
+    lot_id = entry["lot_id"]
+    workspace_id = authed.get("/api/auth/me").json()["data"]["workspaces"][0]["id"]
+
+    from app.infra.db import SessionLocal
+
+    with SessionLocal() as s:
+        s.execute(
+            text(
+                """
+                INSERT INTO stock_entries
+                    (id, workspace_id, part_id, lot_id, storage_location_id,
+                     quantity_delta, status, operation_type, occurred_at, created_at)
+                VALUES
+                    (:id, :ws, :part, :lot, :sl, -50, 'on_hand', 'remove', NOW(), NOW())
+                """
+            ),
+            {
+                "id": str(uuid.uuid4()),
+                "ws": workspace_id,
+                "part": part_id,
+                "lot": lot_id,
+                "sl": storage_id,
+            },
+        )
+        s.commit()
+
+    summary = authed.get(f"/api/parts/{part_id}/stock").json()["data"]
+    total = summary["total_on_hand"]
+    assert total == 50
+
+
+# ---------------------------------------------------------------------------
+# Advisory lock — concurrent removes from the same lot.
+#
+# Two threads each fire `POST /api/stock/remove` for 60 of a 100-piece
+# lot. Without the lock, both pass `current_quantity >= 60` and both
+# write -60 (lot goes to -20). With the lock, the second blocks on
+# the first's commit, then re-checks and sees `current_quantity = 40`
+# (or its own 100 if the first failed) and returns 400 "insufficient
+# stock". Net guarantee: no negative balance regardless of which path
+# the two threads end up on.
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_removes_cannot_both_drain_below_zero(authed):
+    part_id = _create_part(authed, "P3")
+    storage_id = _create_storage(authed, "B3")
+    entry = _add_stock(authed, part_id, 100, storage_id)
+    lot_id = entry["lot_id"]
+
+    # Each thread uses its own TestClient instance to get an independent
+    # SQLAlchemy connection (TestClient per-call wraps a new ASGI loop).
+    cookie = next(c for c in authed.cookies.jar)
+
+    results: list[int] = []
+    barrier = threading.Barrier(2)
+
+    def do_remove():
+        c = TestClient(app)
+        c.cookies.set(cookie.name, cookie.value, domain=cookie.domain, path=cookie.path)
+        barrier.wait()  # both threads ready before either fires
+        r = c.post(
+            "/api/stock/remove",
+            json={
+                "part_id": part_id,
+                "quantity": 60,
+                "storage_location_id": storage_id,
+                "lot_id": lot_id,
+            },
+        )
+        results.append(r.status_code)
+
+    t1 = threading.Thread(target=do_remove)
+    t2 = threading.Thread(target=do_remove)
+    t1.start()
+    t2.start()
+    t1.join(timeout=10)
+    t2.join(timeout=10)
+
+    # Whatever combination of (200, 400) or (200, 500) we end up with,
+    # the load-bearing assertion is: the lot's net quantity is never
+    # negative. Could be 40 (one succeeded), or 100 (one failed before
+    # write, retry exhausted).
+    assert len(results) == 2
+    successes = sum(1 for s in results if s in (200, 201))
+    assert successes <= 1, f"both removes succeeded: {results}"
+
+    summary = authed.get(f"/api/parts/{part_id}/stock").json()["data"]
+    total = summary["total_on_hand"]
+    assert total >= 0, f"lot went negative: {total}; results={results}"
+    # And specifically: either 40 (one removed) or 100 (none removed).
+    assert total in (40, 100), f"unexpected total {total}; results={results}"


### PR DESCRIPTION
## ⚠️ DO NOT MERGE WITHOUT RUNNING THE PRE-DEPLOY CHECKLIST BELOW ⚠️

This is a Class 2 schema migration. Per the plan's review-process table, merge requires a pre-deploy `pg_dump` and operator-side verification queries. The deploy is auto on merge.

## Summary

Tier C, PR #6 of the comprehensive remediation plan. Closes the 2026-04-30 review's highest-stakes data-integrity finding.

The append-only ledger's whole rationale is `current_stock = SUM(quantity_delta) ≥ 0`, but nothing in the service or schema enforced it. Two concurrent operators consuming from the same lot both pass `current_quantity` before either writes — both insert `-qty` rows, the lot goes to `-qty`.

## Two-layer fix

### 1. Service-layer advisory lock per (workspace, part)

`_lock_for_stock_write` issues `pg_advisory_xact_lock(hashtextextended(<key>, 0))` keyed on a stable string of the UUIDs. Lock held until `COMMIT`/`ROLLBACK`. Acquired at the top of `remove_stock` / `move_stock` / `adjust_stock` (not `add_stock` — pure positive deltas can't go negative). Two transactions on the same `(workspace, part)` serialise.

### 2. Database AFTER INSERT trigger as defense in depth

Migration `0013_stock_nonneg_trigger.py` adds `check_stock_nonneg()` and wires it `AFTER INSERT FOR EACH ROW ON stock_entries`. Re-aggregates the per-tuple sum and raises if it would go negative. `IS NOT DISTINCT FROM` handles NULL=NULL correctly. Catches any future path that bypasses the service-layer lock (raw SQL, etc.).

Uses the existing `ix_stock_ws_part_status` index from migration `0001`; no new index needed.

## Tests

- `test_trigger_blocks_negative_balance_via_direct_sql` — raw SQL drives the per-tuple sum below zero; trigger fires.
- `test_trigger_allows_non_negative_balance` — negative control.
- `test_concurrent_removes_cannot_both_drain_below_zero` — two threaded removes of 60 against a 100-piece lot. Asserts final balance ∈ {40, 100} (never negative) and at most one request returns 200.

**Full backend suite: 227/227** (was 224, +3 new).

## Review

`alembic-migration-reviewer` subagent on the diff: **✅ ready to merge**. Verified chain integrity, lock placement, hash collision risk, downgrade correctness, status-filter semantics.

## Pre-deploy checklist (operator-side, before merging)

**Mandatory:**

1. `pg_dump` per `docs/deployment.md#backups`. Standard hygiene for any schema change.
2. Scan prod for any pre-existing tuple that already sums negative — those would weaponise the trigger on the next insert. Run on prod:
   ```sql
   SELECT workspace_id, part_id, lot_id, storage_location_id, status,
          SUM(quantity_delta) AS total
     FROM stock_entries
    GROUP BY workspace_id, part_id, lot_id, storage_location_id, status
   HAVING SUM(quantity_delta) < 0;
   ```
   Expected: zero rows. If any rows surface, write a corrective `adjust` entry per offending tuple **before** merging — otherwise the next remove on that lot fails mysteriously.
3. Confirm the supporting index exists:
   ```sql
   SELECT 1 FROM pg_indexes
    WHERE tablename = 'stock_entries' AND indexname = 'ix_stock_ws_part_status';
   ```

**Optional but recommended:**

4. Tail Sentry for `check_violation` errors in the first hour post-deploy. Any hit means a service path that bypasses the lock and writes faster than the read — investigate immediately.

## Test plan

- [x] `pytest tests/test_stock_concurrency.py` → 3/3 pass
- [x] Full backend suite → 227/227
- [x] `alembic-migration-reviewer` subagent → ✅ ready to merge
- [ ] **Pre-deploy: pg_dump captured, timestamped**
- [ ] **Pre-deploy: SELECT for negative-sum tuples — zero rows**
- [ ] **Pre-deploy: index ix_stock_ws_part_status present**
- [ ] Post-deploy: trigger a deliberate concurrent-remove via two browsers; balance stays ≥ 0
- [ ] Post-deploy: tail Sentry for `check_violation` for 1 hour; expect zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)