### PR TITLE
fix(scanner): memoize props + ref-based dep avoidance to stop SDK churn (FE CRIT-2 / MED-9)

### DIFF
--- a/web/src/components/scanner/ScanditScanner.tsx
+++ b/web/src/components/scanner/ScanditScanner.tsx
@@ -42,6 +42,17 @@ export default function ScanditScanner({ licenseKey, onScan, className, symbolog
     text: "Initializing…",
   });
 
+  // Refs hold the latest props so the SDK init effect can read them at
+  // event time without subscribing to them in its dep array. Without
+  // this, every parent re-render with a fresh `onScan` closure or
+  // `symbologies` array tore the SDK down (`DataCaptureContext.dispose`)
+  // and reloaded the multi-MB wasm — visible camera stutter or full
+  // soft-lock under any state churn (FE CRIT-2 in the 2026-04-30 review).
+  const onScanRef = useRef(onScan);
+  useEffect(() => { onScanRef.current = onScan; }, [onScan]);
+  const symbologiesRef = useRef(symbologies);
+  useEffect(() => { symbologiesRef.current = symbologies; }, [symbologies]);
+
   useEffect(() => {
     let stopped = false;
     let cameraRef: Camera | null = null;
@@ -69,7 +80,12 @@ export default function ScanditScanner({ licenseKey, onScan, className, symbolog
         await ctx.setFrameSource(camera);
 
         const settings = new BarcodeCaptureSettings();
-        const enabled = symbologies ?? LICENSED_SYMBOLOGIES;
+        // symbologies is read at SDK-init time; the ref deref captures
+        // whatever the parent had on first mount. If the parent ever
+        // wants to change which symbologies are decoded, that requires
+        // a remount — keyed-by-symbologies would be the call-site fix,
+        // but no caller does that today.
+        const enabled = symbologiesRef.current ?? LICENSED_SYMBOLOGIES;
         for (const key of enabled) {
           if ((Symbology as any)[key] !== undefined) {
             settings.enableSymbology((Symbology as any)[key], true);
@@ -79,7 +95,7 @@ export default function ScanditScanner({ licenseKey, onScan, className, symbolog
         capture.addListener({
           didScan: (_m, session) => {
             const b = (session as any).newlyRecognizedBarcode;
-            if (b) onScan({ data: b.data ?? "", symbology: b.symbology ?? "?" });
+            if (b) onScanRef.current({ data: b.data ?? "", symbology: b.symbology ?? "?" });
           },
         });
 
@@ -101,7 +117,9 @@ export default function ScanditScanner({ licenseKey, onScan, className, symbolog
       cameraRef?.switchToDesiredState(FrameSourceState.Off).catch(() => {});
       contextRef?.dispose?.().catch?.(() => {});
     };
-  }, [licenseKey, onScan, symbologies]);
+    // Only license-key changes warrant a full SDK teardown / re-init.
+    // onScan and symbologies flow through refs above.
+  }, [licenseKey]);
 
   return (
     <div className={className ?? "flex flex-col h-[70vh]"}>

--- a/web/src/components/scanner/ZxingScanner.tsx
+++ b/web/src/components/scanner/ZxingScanner.tsx
@@ -117,6 +117,16 @@ export default function ZxingScanner({ onScan, className, symbologies }: Props) 
   // closure that was captured when the camera effect first ran.
   const zoomRef = useRef<number>(1);
   const zoomModeRef = useRef<ZoomMode>("digital");
+  // Refs for `onScan` and `symbologies` — same rationale as the Scandit
+  // scanner. Without these, the eslint-disable-deps comment further down
+  // was the only thing keeping the camera effect from tearing down on
+  // every parent re-render. Now the loop reads `onScanRef.current(...)`
+  // at hit time, so a fresh closure from the parent flows through
+  // without restarting the camera (FE CRIT-2 / MED-9).
+  const onScanRef = useRef(onScan);
+  useEffect(() => { onScanRef.current = onScan; }, [onScan]);
+  const symbologiesRef = useRef(symbologies);
+  useEffect(() => { symbologiesRef.current = symbologies; }, [symbologies]);
 
   const [status, setStatus] = useState<{
     text: string;
@@ -149,7 +159,12 @@ export default function ZxingScanner({ onScan, className, symbologies }: Props) 
     let timer: number | null = null;
     let stopped = false;
 
-    const enabled = (symbologies && symbologies.length ? symbologies : DEFAULT_SYMBOLOGIES)
+    // Read symbologies from the ref so the parent can pass an inline
+    // array literal (memoised at the call site is preferred, but this
+    // keeps us robust if a caller forgets). Captured at effect-init
+    // time; subsequent prop changes don't restart the camera.
+    const enabledSyms = symbologiesRef.current;
+    const enabled = (enabledSyms && enabledSyms.length ? enabledSyms : DEFAULT_SYMBOLOGIES)
       .map(s => ZXING_FORMAT_BY_PUBLIC[s])
       .filter(Boolean);
 
@@ -290,7 +305,7 @@ export default function ZxingScanner({ onScan, className, symbologies }: Props) 
                 lastHitRef.current = { data: hit.text, t: now };
                 const sym = PUBLIC_NAME_BY_ZXING[hit.format] ?? hit.format ?? "?";
                 scanFeedback();
-                onScan({ data: hit.text, symbology: sym });
+                onScanRef.current({ data: hit.text, symbology: sym });
               }
             }
           } catch {
@@ -347,9 +362,9 @@ export default function ZxingScanner({ onScan, className, symbologies }: Props) 
     // Restarting the camera is the whole point of a deviceId change — we want
     // the dep. retryToken is bumped by the "Try again" button after a
     // permission-denied error, so the user can re-prompt without a full
-    // reload. `symbologies` and `onScan` are intentionally excluded so the
-    // loop doesn't tear down when the parent re-renders with a new closure.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // reload. `symbologies` and `onScan` flow through refs (declared at
+    // the top of the component) so a parent re-render with fresh closures
+    // doesn't tear down the camera.
   }, [deviceId, retryToken]);
 
   // ---------------------------------------------------------------------

--- a/web/src/routes/parts/ScanImport.tsx
+++ b/web/src/routes/parts/ScanImport.tsx
@@ -30,6 +30,13 @@ const PROVIDER_LABEL: Record<string, string> = {
   none: "no provider",
 };
 
+// Module-level constant — referenced by `<Scanner symbologies={...}>` below.
+// Inline `["DataMatrix", "QR"]` would be a fresh array on every render, which
+// (combined with effect deps in ScanditScanner / ZxingScanner) would tear
+// down and rebuild the multi-MB scanner SDK on every parent state change.
+// FE CRIT-2 in the 2026-04-30 review.
+const SCAN_IMPORT_SYMBOLOGIES = ["DataMatrix", "QR"] as const;
+
 type LookupState =
   | { kind: "pending" }
   | { kind: "duplicate"; existing: Part }
@@ -345,7 +352,7 @@ export default function ScanImport() {
         <div className="card p-3">
           <Scanner
             onScan={handleScan}
-            symbologies={["DataMatrix", "QR"]}
+            symbologies={SCAN_IMPORT_SYMBOLOGIES}
             className="flex flex-col h-[55vh]"
           />
           <div className="mt-3 text-xs text-muted leading-relaxed">


### PR DESCRIPTION
## Summary

Tier E, PR #13 of the comprehensive remediation plan. Closes FE CRIT-2 (Scandit SDK reloading wasm on every parent render) and FE MED-9 (ZXing's `eslint-disable-next-line react-hooks/exhaustive-deps` stale-closure trap).

## Changes

### Caller (`web/src/routes/parts/ScanImport.tsx`)
Module-level `SCAN_IMPORT_SYMBOLOGIES = ["DataMatrix", "QR"] as const` replaces the inline array. `handleScan` was already `useCallback`'d. Both references now stable across renders.

### Scanners (`ScanditScanner.tsx`, `ZxingScanner.tsx`)
Belt-and-suspenders. Even if a caller forgets to memoize, the SDK shouldn't tear down. Both scanners now:
- Hold `onScan` and `symbologies` in refs (updated via small `useEffect`s).
- Drop both from the SDK-init effect's dep array — only `licenseKey` (Scandit) / `deviceId`, `retryToken` (ZXing) remain.
- Listener callbacks read `onScanRef.current(...)` at hit time so a fresh parent closure flows through live without re-init.

`ZxingScanner` also drops the `eslint-disable-next-line react-hooks/exhaustive-deps` comment — the dep array is honest now.

## Verified

- `tsc -b` clean
- `vitest run` 14/14 (bagCode regression suite)

## Test plan

- [x] Type-check + unit tests
- [ ] Post-deploy smoke matrix:
  - Open `/parts/scan-import`, scan a bag, then trigger a re-render in the parent (type in another input, dismiss a toast). Camera stays live across the re-render — pre-fix it visibly stuttered or went black.
  - Switch between Scandit and ZXing scanner backends in workspace settings; new scanner mounts cleanly.
  - Save the workspace settings page while the scanner is open in a separate tab; scanner does not reload (the `["ws", "current"]` invalidation cascade no longer cascades through Scanner's effect deps).
  - Toast/sonner notification fires while scanning; camera unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)