### PR TITLE
fix(invitations): hash tokens at rest + rate-limit /accept

### DIFF
--- a/backend/alembic/versions/0014_invitation_token_hash.py
+++ b/backend/alembic/versions/0014_invitation_token_hash.py
@@ -1,0 +1,92 @@
+"""invitation tokens stored hashed at rest
+
+Revision ID: 0014
+Revises: 0013
+Create Date: 2026-05-02
+
+The plaintext invitation token used to sit on every WorkspaceInvitation
+row. A DB dump (legitimate backup, replica leak, ransomware, log line)
+exposed every pending invitation as a replayable credential. This
+migration switches to storing only `sha256(token)` — the plaintext is
+returned to the caller exactly once at creation time and never lands
+in any persisted artifact again.
+
+Behaviour:
+- Add `token_hash CHAR(64)` (SHA-256 hex digest) column.
+- Backfill from existing `token` values via Python (no plaintext
+  ever lands in the migration's stdout, so a logged ALTER trace
+  doesn't leak them).
+- Drop the unique constraint + plaintext `token` column.
+- Add unique constraint on `token_hash`.
+
+Downgrade is structurally reversible (re-add `token` column) but
+cannot recover the plaintext — legacy rows would have NULL tokens
+and nobody could accept those invitations. Documented in the
+downgrade docstring; in practice if we need to roll back we'd
+restore from the pre-deploy `pg_dump` instead.
+"""
+from __future__ import annotations
+
+import hashlib
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0014"
+down_revision = "0013"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # 1. Add the new column nullable so we can backfill before tightening.
+    op.add_column(
+        "workspace_invitations",
+        sa.Column("token_hash", sa.String(length=64), nullable=True),
+    )
+
+    # 2. Backfill each row's hash. Done in Python to keep raw plaintext
+    #    out of any SQL log / replay artifact.
+    bind = op.get_bind()
+    rows = bind.execute(
+        sa.text("SELECT id, token FROM workspace_invitations")
+    ).fetchall()
+    for row_id, plaintext in rows:
+        if plaintext is None:
+            continue
+        digest = hashlib.sha256(plaintext.encode("utf-8")).hexdigest()
+        bind.execute(
+            sa.text(
+                "UPDATE workspace_invitations SET token_hash = :h WHERE id = :i"
+            ),
+            {"h": digest, "i": row_id},
+        )
+
+    # 3. Tighten + swap constraints.
+    op.alter_column("workspace_invitations", "token_hash", nullable=False)
+    op.drop_constraint("uq_workspace_invitation_token", "workspace_invitations", type_="unique")
+    op.drop_column("workspace_invitations", "token")
+    op.create_unique_constraint(
+        "uq_workspace_invitation_token_hash",
+        "workspace_invitations",
+        ["token_hash"],
+    )
+
+
+def downgrade() -> None:
+    """Structurally reversible only. Hashes are one-way; the plaintext
+    cannot be recovered from `token_hash`. After downgrade, legacy rows
+    have `token = NULL` and cannot be accepted. If a real rollback is
+    needed, restore from the pre-deploy `pg_dump` instead."""
+    op.drop_constraint(
+        "uq_workspace_invitation_token_hash", "workspace_invitations", type_="unique"
+    )
+    op.add_column(
+        "workspace_invitations",
+        sa.Column("token", sa.String(length=120), nullable=True),
+    )
+    op.create_unique_constraint(
+        "uq_workspace_invitation_token", "workspace_invitations", ["token"]
+    )
+    op.drop_column("workspace_invitations", "token_hash")

--- a/backend/app/api/routes/invitations.py
+++ b/backend/app/api/routes/invitations.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+import hashlib
 import secrets
 from datetime import datetime, timezone
 from typing import Literal
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel, ConfigDict, EmailStr
 from sqlalchemy import select
 
@@ -15,11 +16,19 @@ from app.core.deps import (
     DbSession,
     require_role,
 )
+from app.core.ratelimit import limiter
 from app.core.responses import ok
 from app.domain.users.models import User
 from app.domain.workspaces.models import Workspace, WorkspaceInvitation, WorkspaceMember
 
 router = APIRouter()
+
+
+def _hash_token(plaintext: str) -> str:
+    """SHA-256 hex digest. Used both at create time (to compute what to
+    store) and at accept time (to look up by what the caller supplied).
+    """
+    return hashlib.sha256(plaintext.encode("utf-8")).hexdigest()
 
 
 class InviteIn(BaseModel):
@@ -29,14 +38,24 @@ class InviteIn(BaseModel):
     role: Literal["admin", "member", "viewer"] = "member"
 
 
-def _serialize(inv: WorkspaceInvitation) -> dict:
+def _serialize(inv: WorkspaceInvitation, *, plaintext_token: str | None = None) -> dict:
+    """Serialise an invitation row.
+
+    `plaintext_token` is set ONLY in the create response — the only
+    moment the plaintext exists. Subsequent reads (list, revoke) never
+    have it, because the DB stores only the hash. The caller is
+    responsible for delivering the plaintext to the invitee out-of-band
+    immediately (typically via the link embedded in the response).
+    """
     return {
         "id": str(inv.id),
         "workspace_id": str(inv.workspace_id),
         "email": inv.email,
         "role": inv.role,
         "status": inv.status,
-        "token": inv.token if inv.status == "pending" else None,
+        # Only the create response carries the plaintext; all other
+        # serialisations return None here.
+        "token": plaintext_token if inv.status == "pending" else None,
         "created_at": inv.created_at.isoformat(),
         "accepted_at": inv.accepted_at.isoformat() if inv.accepted_at else None,
     }
@@ -67,6 +86,10 @@ def create_invitation(
         raise HTTPException(status_code=409, detail="user is already a member")
 
     # Existing pending invite for this email — reuse rather than duplicate.
+    # Note: we cannot return the existing plaintext token (we don't have
+    # it). The frontend interprets a pending row with token=None as
+    # "already invited; ask the operator to revoke + re-invite if the
+    # invitee never received the original email".
     existing = (
         db.execute(
             select(WorkspaceInvitation)
@@ -80,16 +103,20 @@ def create_invitation(
     if existing:
         return ok(_serialize(existing))
 
+    # Mint a new token. 32 bytes urlsafe ≈ 256 bits of entropy — well
+    # past brute-force feasibility. The hash goes to the DB; the
+    # plaintext goes back to the caller exactly once via the response.
+    plaintext = secrets.token_urlsafe(32)
     inv = WorkspaceInvitation(
         workspace_id=ws.id,
         email=payload.email,
         role=payload.role,
-        token=secrets.token_urlsafe(32),
+        token_hash=_hash_token(plaintext),
         invited_by=user.id,
     )
     db.add(inv)
     db.commit()
-    return ok(_serialize(inv))
+    return ok(_serialize(inv, plaintext_token=plaintext))
 
 
 @router.get("", dependencies=[Depends(require_role("admin"))])
@@ -125,11 +152,21 @@ class AcceptIn(BaseModel):
     token: str
 
 
+# Token is 256-bit so brute-force is infeasible, but the endpoint is
+# unauthenticated-by-workspace and could otherwise be hammered.
+# 10/min/IP is well above any legitimate user's behaviour and well
+# below useful enumeration speed.
 @router.post("/accept")
-def accept_invitation(payload: AcceptIn, db: DbSession, user: CurrentUser):
+@limiter.limit("10/minute")
+def accept_invitation(request: Request, payload: AcceptIn, db: DbSession, user: CurrentUser):
+    # Look up by hash — the plaintext is never stored, so an attacker
+    # with a DB dump cannot mint a valid lookup query without first
+    # cracking the hash (infeasible at 256 bits).
     inv = (
         db.execute(
-            select(WorkspaceInvitation).where(WorkspaceInvitation.token == payload.token)
+            select(WorkspaceInvitation).where(
+                WorkspaceInvitation.token_hash == _hash_token(payload.token)
+            )
         )
         .scalars()
         .first()

--- a/backend/app/domain/workspaces/models.py
+++ b/backend/app/domain/workspaces/models.py
@@ -53,14 +53,18 @@ class WorkspaceMember(Base):
 class WorkspaceInvitation(Base):
     __tablename__ = "workspace_invitations"
     __table_args__ = (
-        UniqueConstraint("token", name="uq_workspace_invitation_token"),
+        UniqueConstraint("token_hash", name="uq_workspace_invitation_token_hash"),
     )
 
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     workspace_id = Column(UUID(as_uuid=True), ForeignKey("workspaces.id", ondelete="CASCADE"), nullable=False, index=True)
     email = Column(String(320), nullable=False, index=True)
     role = Column(String(40), nullable=False, default="member")
-    token = Column(String(120), nullable=False)
+    # SHA-256 hex digest of the plaintext token. The plaintext is
+    # returned to the caller exactly once at creation time and is never
+    # persisted; without this, a DB dump leaks every pending invitation
+    # as a replayable credential.
+    token_hash = Column(String(64), nullable=False)
     status = Column(String(20), nullable=False, default="pending")  # pending | accepted | revoked
     invited_by = Column(UUID(as_uuid=True), ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
     created_at = Column(DateTime(timezone=True), nullable=False, default=_utcnow)

--- a/backend/tests/test_invitations.py
+++ b/backend/tests/test_invitations.py
@@ -138,3 +138,77 @@ def test_cannot_already_member(admin):
     # Now try to invite the same email again — should 409
     r = admin.post("/api/invitations", json={"email": invitee_email, "role": "member"})
     assert r.status_code == 409
+
+
+# ---------------------------------------------------------------------------
+# Token-hashing-at-rest (PR #18 / Sec MED-7-style hardening)
+# ---------------------------------------------------------------------------
+
+
+def test_token_is_stored_as_hash_not_plaintext(admin):
+    """The plaintext returned to the caller must NOT match what's
+    persisted. The DB has only the SHA-256 digest."""
+    import hashlib
+
+    invitee_email = f"hash-{uuid.uuid4().hex[:6]}@x.com"
+    inv = admin.post(
+        "/api/invitations", json={"email": invitee_email, "role": "member"}
+    ).json()["data"]
+    plaintext = inv["token"]
+    assert plaintext, "create response must carry the plaintext token"
+
+    # Reach into the DB and verify what landed.
+    from app.domain.workspaces.models import WorkspaceInvitation
+    from app.infra.db import SessionLocal
+
+    with SessionLocal() as s:
+        row = s.get(WorkspaceInvitation, uuid.UUID(inv["id"]))
+        assert row is not None
+        # The plaintext is gone — the model only has token_hash now.
+        assert not hasattr(row, "token") or getattr(row, "token", None) is None
+        assert row.token_hash == hashlib.sha256(plaintext.encode("utf-8")).hexdigest()
+        # Stored value is NOT the plaintext.
+        assert row.token_hash != plaintext
+
+
+def test_list_invitations_does_not_leak_token(admin):
+    """List endpoint returns token=None for every row — the plaintext
+    only ever exists in the create response. A re-fetch can't recover it."""
+    invitee_email = f"list-{uuid.uuid4().hex[:6]}@x.com"
+    admin.post("/api/invitations", json={"email": invitee_email, "role": "member"})
+
+    rows = admin.get("/api/invitations").json()["data"]
+    assert len(rows) >= 1
+    for r in rows:
+        if r["email"] == invitee_email:
+            assert r["token"] is None, "list must not echo any token, plaintext or hash"
+
+
+def test_accept_with_wrong_token_returns_404(admin):
+    """A token that doesn't hash to any stored token_hash → 404
+    (same path as a non-existent invitation)."""
+    invitee_email = f"wrong-{uuid.uuid4().hex[:6]}@x.com"
+    admin.post("/api/invitations", json={"email": invitee_email, "role": "member"})
+
+    invitee = TestClient(app)
+    invitee.post(
+        "/api/auth/signup",
+        json={"email": invitee_email, "name": "x", "password": "password123"},
+    )
+
+    # Submit a wrong token — must not match by hash, must 404.
+    r = invitee.post("/api/invitations/accept", json={"token": "WRONG-TOKEN-VALUE"})
+    assert r.status_code == 404, r.text
+
+
+def test_accept_endpoint_has_rate_limit_decorator():
+    """slowapi is disabled outside prod so we can't trip the limit at
+    runtime in tests. Pin the decorator's presence — if a future
+    refactor drops the @limiter.limit, this test fails."""
+    from app.api.routes.invitations import accept_invitation
+
+    markers = ("limiter_kwargs", "_limiter", "limit", "__wrapped__")
+    has_marker = any(hasattr(accept_invitation, m) for m in markers)
+    assert has_marker, (
+        f"expected @limiter.limit on accept_invitation; markers checked: {markers}"
+    )


### PR DESCRIPTION
## Summary

Tier F, PR #18 of the comprehensive remediation plan. Closes the audit's invitation-hardening notes.

**Before**: plaintext invitation tokens lived on every `WorkspaceInvitation` row. A DB dump exposed every pending invitation as a replayable credential.

**After**: only `sha256(token)` is persisted. Plaintext is returned to the caller exactly once at create time and never lands anywhere durable. Accept-time lookup hashes the supplied token and matches against the digest.

Plus `@limiter.limit("10/minute")` on `/api/invitations/accept`.

## Migration `0014`

3-step pattern: add nullable column → Python sha256 backfill → `SET NOT NULL` + drop plaintext + swap unique constraint. Downgrade structurally reversible but cannot recover plaintext.

## Tests

4 new in `tests/test_invitations.py`. Existing 7 preserved. **Full backend suite: 231/231**.

## Review

`alembic-migration-reviewer` subagent: **✅ ready to merge**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)