### PR TITLE
fix(ui): replace native confirm/prompt with styled dialog primitives (FE HIGH-5)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,6 +2,7 @@ import { lazy, Suspense } from "react";
 import { Navigate, Outlet, Route, Routes } from "react-router-dom";
 import { AuthProvider, useAuth } from "@/lib/auth";
 import AppShell from "@/components/layout/AppShell";
+import { ConfirmDialogProvider } from "@/components/ConfirmDialog";
 
 // Auth pages — small, eager-loaded so the login form renders without
 // a fallback flash on first paint.
@@ -125,7 +126,8 @@ const lazyFallback = <div className="p-6 text-muted">Loading…</div>;
 export default function App() {
   return (
     <AuthProvider>
-      <Suspense fallback={lazyFallback}>
+      <ConfirmDialogProvider>
+        <Suspense fallback={lazyFallback}>
         <Routes>
           <Route path="/login" element={<Login />} />
           <Route path="/signup" element={<Signup />} />
@@ -220,7 +222,8 @@ export default function App() {
             <Route path="*" element={<div className="text-muted">Not found.</div>} />
           </Route>
         </Routes>
-      </Suspense>
+        </Suspense>
+      </ConfirmDialogProvider>
     </AuthProvider>
   );
 }

--- a/web/src/components/AttachmentsPanel.tsx
+++ b/web/src/components/AttachmentsPanel.tsx
@@ -3,6 +3,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { Trash2, Download, UploadCloud, Paperclip } from "lucide-react";
 import { api, ApiError } from "@/lib/api";
+import { useConfirm } from "@/components/ConfirmDialog";
 
 type Attachment = {
   id: string;
@@ -29,6 +30,7 @@ function humanSize(bytes: number): string {
 }
 
 export default function AttachmentsPanel({ objectType, objectId, canWrite }: Props) {
+  const confirm = useConfirm();
   const qc = useQueryClient();
   const queryKey = ["attachments", objectType, objectId];
   const { data, isLoading } = useQuery({
@@ -68,7 +70,7 @@ export default function AttachmentsPanel({ objectType, objectId, canWrite }: Pro
   }
 
   async function doDelete(a: Attachment) {
-    if (!confirm(`Delete ${a.file_name}?`)) return;
+    if (!(await confirm({ message: `Delete ${a.file_name}?`, severity: "danger" }))) return;
     try {
       await api.delete(`/attachments/${a.id}`);
       toast.success("Attachment deleted.");

--- a/web/src/components/ConfirmDialog.tsx
+++ b/web/src/components/ConfirmDialog.tsx
@@ -1,0 +1,253 @@
+/**
+ * Imperative confirm + prompt primitives.
+ *
+ * Replaces every `window.confirm(...)` / `window.prompt(...)` call site
+ * in the app (FE HIGH-5 in the 2026-04-30 review). Native browser dialogs
+ * are not styled, look like phishing prompts on most platforms, are not
+ * keyboard-accessible on mobile Safari, and block the event loop. This
+ * file provides:
+ *
+ *   const confirm = useConfirm();
+ *   if (!await confirm({ message: "Delete this entry?", severity: "danger" })) return;
+ *
+ *   const prompt = usePrompt();
+ *   const name = await prompt({ message: "Preset name?", defaultValue: "" });
+ *   if (name === null) return;
+ *
+ * Identical call shape to the natives, just async. The provider mounts
+ * once at the top of `<App>`; the hooks read its imperative methods
+ * out of context.
+ */
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { createPortal } from "react-dom";
+
+type Severity = "default" | "danger" | "warning";
+
+type ConfirmOptions = {
+  message: string;
+  /** Title above the message. Optional — defaults to "Confirm" / "Delete". */
+  title?: string;
+  /** Label on the OK button. Optional — defaults vary by severity. */
+  confirmLabel?: string;
+  /** Label on the Cancel button. Defaults to "Cancel". */
+  cancelLabel?: string;
+  /** Tints the OK button. `danger` = red, `warning` = amber. */
+  severity?: Severity;
+};
+
+type PromptOptions = {
+  message: string;
+  title?: string;
+  defaultValue?: string;
+  /** Label on the OK button. Defaults to "OK". */
+  confirmLabel?: string;
+  /** Label on the Cancel button. Defaults to "Cancel". */
+  cancelLabel?: string;
+  /** Optional placeholder for the input. */
+  placeholder?: string;
+};
+
+type ConfirmCtx = {
+  confirm: (opts: ConfirmOptions) => Promise<boolean>;
+  prompt: (opts: PromptOptions) => Promise<string | null>;
+};
+
+const Ctx = createContext<ConfirmCtx | null>(null);
+
+type DialogState =
+  | { kind: "none" }
+  | { kind: "confirm"; opts: ConfirmOptions; resolve: (v: boolean) => void }
+  | { kind: "prompt"; opts: PromptOptions; resolve: (v: string | null) => void };
+
+export function ConfirmDialogProvider({ children }: { children: ReactNode }) {
+  const [state, setState] = useState<DialogState>({ kind: "none" });
+  const [inputValue, setInputValue] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Reset prompt input whenever a new prompt opens.
+  useEffect(() => {
+    if (state.kind === "prompt") {
+      setInputValue(state.opts.defaultValue ?? "");
+      // Focus + select-all on next paint so the user can just type.
+      queueMicrotask(() => {
+        inputRef.current?.focus();
+        inputRef.current?.select();
+      });
+    }
+  }, [state]);
+
+  // Esc closes (cancels) the dialog. Capture-phase so app-wide handlers
+  // don't swallow it first.
+  useEffect(() => {
+    if (state.kind === "none") return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        if (state.kind === "confirm") state.resolve(false);
+        if (state.kind === "prompt") state.resolve(null);
+        setState({ kind: "none" });
+      }
+    };
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
+  }, [state]);
+
+  const confirm = useCallback((opts: ConfirmOptions) => {
+    return new Promise<boolean>((resolve) => {
+      // If something else is already open, drop it (resolve false) and
+      // replace. Avoids nesting prompts; in practice this doesn't fire.
+      setState((prev) => {
+        if (prev.kind === "confirm") prev.resolve(false);
+        if (prev.kind === "prompt") prev.resolve(null);
+        return { kind: "confirm", opts, resolve };
+      });
+    });
+  }, []);
+
+  const prompt = useCallback((opts: PromptOptions) => {
+    return new Promise<string | null>((resolve) => {
+      setState((prev) => {
+        if (prev.kind === "confirm") prev.resolve(false);
+        if (prev.kind === "prompt") prev.resolve(null);
+        return { kind: "prompt", opts, resolve };
+      });
+    });
+  }, []);
+
+  const closeWith = useCallback(
+    (value: boolean | string | null) => {
+      setState((prev) => {
+        if (prev.kind === "confirm" && typeof value === "boolean") prev.resolve(value);
+        if (prev.kind === "prompt") prev.resolve(value as string | null);
+        return { kind: "none" };
+      });
+    },
+    [],
+  );
+
+  return (
+    <Ctx.Provider value={{ confirm, prompt }}>
+      {children}
+      {state.kind !== "none" &&
+        createPortal(
+          <DialogShell
+            state={state}
+            inputRef={inputRef}
+            inputValue={inputValue}
+            setInputValue={setInputValue}
+            onConfirm={() => {
+              if (state.kind === "confirm") closeWith(true);
+              if (state.kind === "prompt") closeWith(inputValue);
+            }}
+            onCancel={() => {
+              if (state.kind === "confirm") closeWith(false);
+              if (state.kind === "prompt") closeWith(null);
+            }}
+          />,
+          document.body,
+        )}
+    </Ctx.Provider>
+  );
+}
+
+function DialogShell({
+  state,
+  inputRef,
+  inputValue,
+  setInputValue,
+  onConfirm,
+  onCancel,
+}: {
+  state: Exclude<DialogState, { kind: "none" }>;
+  inputRef: React.RefObject<HTMLInputElement>;
+  inputValue: string;
+  setInputValue: (s: string) => void;
+  onConfirm: () => void;
+  onCancel: () => void;
+}) {
+  const opts = state.opts;
+  const isPrompt = state.kind === "prompt";
+  const severity: Severity = isPrompt ? "default" : ((opts as ConfirmOptions).severity ?? "default");
+  const defaultTitle =
+    state.kind === "prompt" ? "Enter a value" : severity === "danger" ? "Confirm delete" : "Confirm";
+  const defaultConfirmLabel =
+    isPrompt ? "OK" : severity === "danger" ? "Delete" : severity === "warning" ? "Continue" : "OK";
+
+  const confirmClass =
+    severity === "danger"
+      ? "btn-danger"
+      : severity === "warning"
+        ? "btn border-warning/50 bg-warning/10 text-warning hover:bg-warning/20"
+        : "btn-primary";
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      role="dialog"
+      aria-modal="true"
+      onMouseDown={(e) => {
+        // Click outside the panel cancels.
+        if (e.target === e.currentTarget) onCancel();
+      }}
+    >
+      <div className="card max-w-md w-full p-4 space-y-3 shadow-lg">
+        <h2 className="text-base font-semibold text-text">
+          {opts.title ?? defaultTitle}
+        </h2>
+        <p className="text-sm text-text whitespace-pre-wrap">{opts.message}</p>
+        {state.kind === "prompt" && (
+          <input
+            ref={inputRef}
+            className="input"
+            value={inputValue}
+            onChange={(e) => setInputValue(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                onConfirm();
+              }
+            }}
+            placeholder={(state.opts as PromptOptions).placeholder}
+          />
+        )}
+        <div className="flex justify-end gap-2 pt-2">
+          <button type="button" className="btn-ghost" onClick={onCancel}>
+            {opts.cancelLabel ?? "Cancel"}
+          </button>
+          <button
+            type="button"
+            className={confirmClass}
+            onClick={onConfirm}
+            autoFocus={!isPrompt}
+          >
+            {opts.confirmLabel ?? defaultConfirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function useConfirm(): (opts: ConfirmOptions) => Promise<boolean> {
+  const ctx = useContext(Ctx);
+  if (!ctx) {
+    throw new Error("useConfirm must be used inside <ConfirmDialogProvider>");
+  }
+  return ctx.confirm;
+}
+
+export function usePrompt(): (opts: PromptOptions) => Promise<string | null> {
+  const ctx = useContext(Ctx);
+  if (!ctx) {
+    throw new Error("usePrompt must be used inside <ConfirmDialogProvider>");
+  }
+  return ctx.prompt;
+}

--- a/web/src/routes/orders/OrderDetail.tsx
+++ b/web/src/routes/orders/OrderDetail.tsx
@@ -7,6 +7,7 @@ import EntityHeader from "@/components/EntityHeader";
 import { DataTable } from "@/components/DataTable";
 import AttachmentsPanel from "@/components/AttachmentsPanel";
 import ActivityTimeline from "@/components/ActivityTimeline";
+import { useConfirm } from "@/components/ConfirmDialog";
 import type { Order, OrderEntry, Part, StorageLocation } from "@/types";
 
 type DetailOut = { order: Order; entries: OrderEntry[] };
@@ -15,6 +16,7 @@ export default function OrderDetail() {
   const { orderId } = useParams<{ orderId: string }>();
   const qc = useQueryClient();
   const nav = useNavigate();
+  const confirm = useConfirm();
 
   const { data } = useQuery({
     queryKey: ["order", orderId],
@@ -65,7 +67,7 @@ export default function OrderDetail() {
   }
 
   async function removeEntry(entryId: string) {
-    if (!confirm("Delete this entry?")) return;
+    if (!(await confirm({ message: "Delete this entry?", severity: "danger" }))) return;
     try {
       await api.delete(`/orders/${orderId}/entries/${entryId}`);
       qc.invalidateQueries({ queryKey: ["order", orderId] });

--- a/web/src/routes/parts/detail/PartSpecs.tsx
+++ b/web/src/routes/parts/detail/PartSpecs.tsx
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 import { Plus, RotateCcw, Trash2 } from "lucide-react";
 import { api, ApiError } from "@/lib/api";
 import { isSpecKey } from "@/lib/providerCatalog";
+import { useConfirm } from "@/components/ConfirmDialog";
 import type { CustomFieldRow, Part, SpecSource } from "@/types";
 
 const SOURCE_BADGE: Record<SpecSource, string> = {
@@ -39,6 +40,7 @@ const PROVIDER_SEARCH_URL: Record<string, (mpn: string) => string> = {
  * original_value, so a single click on Restore reverts cleanly.
  */
 export default function PartSpecs() {
+  const confirm = useConfirm();
   const { part } = useOutletContext<{ part: Part }>();
   const qc = useQueryClient();
   const queryKey = ["part", part.id, "custom-fields"];
@@ -95,7 +97,7 @@ export default function PartSpecs() {
   }
 
   async function remove(row: CustomFieldRow) {
-    if (!confirm(`Delete spec "${row.key}"?`)) return;
+    if (!(await confirm({ message: `Delete spec "${row.key}"?`, severity: "danger" }))) return;
     try {
       await api.delete(`/custom-fields/${row.id}`);
       qc.invalidateQueries({ queryKey });

--- a/web/src/routes/projects/detail/ProjectImport.tsx
+++ b/web/src/routes/projects/detail/ProjectImport.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { api, ApiError } from "@/lib/api";
+import { useConfirm, usePrompt } from "@/components/ConfirmDialog";
 
 type Preset = {
   id: string;
@@ -71,6 +72,8 @@ async function fileToBase64(file: File): Promise<string> {
 }
 
 export default function ProjectImport() {
+  const confirm = useConfirm();
+  const prompt = usePrompt();
   const { projectId } = useParams<{ projectId: string }>();
   const nav = useNavigate();
   const qc = useQueryClient();
@@ -99,7 +102,11 @@ export default function ProjectImport() {
   }
 
   async function savePreset() {
-    const name = prompt("Save current mapping as preset — name?");
+    const name = await prompt({
+      message: "Save current mapping as preset — name?",
+      title: "Save preset",
+      placeholder: "e.g. Mouser PCB BOM",
+    });
     if (!name) return;
     try {
       await api.post("/bom-presets", {
@@ -120,7 +127,7 @@ export default function ProjectImport() {
   }
 
   async function deletePreset(id: string) {
-    if (!confirm("Delete this preset?")) return;
+    if (!(await confirm({ message: "Delete this preset?", severity: "danger" }))) return;
     await api.delete(`/bom-presets/${id}`);
     refetchPresets();
     toast.success("Preset deleted.");

--- a/web/src/routes/settings/Workspace.tsx
+++ b/web/src/routes/settings/Workspace.tsx
@@ -3,6 +3,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { api, ApiError } from "@/lib/api";
 import { useAuth } from "@/lib/auth";
+import { useConfirm } from "@/components/ConfirmDialog";
 
 type Ws = {
   id: string;
@@ -39,6 +40,7 @@ type Invitation = {
 };
 
 export default function WorkspaceSettings() {
+  const confirm = useConfirm();
   const { me } = useAuth();
   const qc = useQueryClient();
   const { data: cur } = useQuery({ queryKey: ["ws", "current"], queryFn: () => api.get<Ws>("/workspaces/current") });
@@ -121,7 +123,11 @@ export default function WorkspaceSettings() {
   }
 
   async function removeMember(id: string) {
-    if (!confirm("Remove this member from the workspace?")) return;
+    if (!(await confirm({
+      message: "Remove this member from the workspace?",
+      severity: "danger",
+      confirmLabel: "Remove",
+    }))) return;
     setErr(null);
     try {
       await api.delete(`/workspaces/members/${id}`);
@@ -135,7 +141,11 @@ export default function WorkspaceSettings() {
   }
 
   async function revokeInvite(id: string) {
-    if (!confirm("Revoke this invitation?")) return;
+    if (!(await confirm({
+      message: "Revoke this invitation?",
+      severity: "danger",
+      confirmLabel: "Revoke",
+    }))) return;
     await api.delete(`/invitations/${id}`);
     refetchInvites();
     toast.success("Invitation revoked.");
@@ -231,8 +241,12 @@ export default function WorkspaceSettings() {
                 </button>
                 <button
                   className="btn-ghost"
-                  onClick={() => {
-                    if (!confirm("Regenerate the catalog token? The current URL will stop working immediately.")) return;
+                  onClick={async () => {
+                    if (!(await confirm({
+                      message: "Regenerate the catalog token? The current URL will stop working immediately.",
+                      severity: "warning",
+                      confirmLabel: "Regenerate",
+                    }))) return;
                     patch({ regenerate_catalog_token: true, catalog_enabled: true });
                   }}
                   type="button"
@@ -322,7 +336,11 @@ export default function WorkspaceSettings() {
                     className="btn"
                     disabled={providerKeyBusy}
                     onClick={async () => {
-                      if (!confirm("Clear both DigiKey credentials?")) return;
+                      if (!(await confirm({
+                        message: "Clear both DigiKey credentials?",
+                        severity: "danger",
+                        confirmLabel: "Clear",
+                      }))) return;
                       setProviderKeyBusy(true);
                       try {
                         await api.patch("/workspaces/current", {


### PR DESCRIPTION
## Summary

Tier E, PR #14. Closes FE HIGH-5 — every destructive action routed through `window.confirm()` / `window.prompt()`. Native dialogs look like phishing prompts on most platforms.

## Changes

- New `ConfirmDialogProvider` mounted once at `<App>` top.
- New `useConfirm()` and `usePrompt()` hooks. Same call shape as the natives, just async.
- Modal renders portal-mounted with severity-tinted buttons (default/warning/danger), Esc-to-cancel, click-outside-to-cancel, autoFocus on confirm.
- All 9 sites replaced (8 confirms + 1 prompt). Zero remaining native calls in `web/src`.

## Verified

- `tsc -b` clean
- `vitest run` 14/14
- `grep "confirm(\|prompt(" web/src` → no remaining native calls

## Test plan

- [ ] Post-deploy smoke: trigger each of the 9 sites; modal renders with existing Tailwind component classes; Esc cancels; click-outside cancels; Enter on prompt confirms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)