### PR TITLE
feat(types): zod schemas at the API boundary, opt-in (FE HIGH-2)

### DIFF
--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Tests for the zod-validating `api.parsed` flavour.
+ *
+ * The parsed path goes through fetch → JSON-decode → schema.safeParse.
+ * We mock fetch so the test is purely about the parse layer's
+ * behaviour: success returns a typed object; failure throws a
+ * structured `ApiError` carrying field-level errors.
+ */
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { z } from "zod";
+import { api, ApiError } from "./api";
+
+const Schema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  count: z.number(),
+});
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+function mockFetch(status: number, body: unknown) {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: "ok",
+    headers: new Headers({ "content-type": "application/json" }),
+    json: async () => body,
+  } as Response);
+}
+
+describe("api.parsed.get", () => {
+  it("returns the parsed object on a matching response", async () => {
+    mockFetch(200, {
+      data: { id: "11111111-1111-1111-1111-111111111111", name: "Cap", count: 5 },
+      status: { category: "ok", message: "OK" },
+    });
+    const out = await api.parsed.get("/whatever", Schema);
+    expect(out).toEqual({
+      id: "11111111-1111-1111-1111-111111111111",
+      name: "Cap",
+      count: 5,
+    });
+  });
+
+  it("throws ApiError(0, schema-mismatch) when fields are missing", async () => {
+    mockFetch(200, {
+      data: { id: "11111111-1111-1111-1111-111111111111", name: "Cap" }, // missing count
+      status: { category: "ok", message: "OK" },
+    });
+    await expect(api.parsed.get("/whatever", Schema)).rejects.toMatchObject({
+      status: 0,
+      body: { status: { category: "client_schema_mismatch" } },
+    });
+  });
+
+  it("throws ApiError(0, schema-mismatch) on wrong type", async () => {
+    mockFetch(200, {
+      data: { id: "not-a-uuid", name: "Cap", count: "five" },
+      status: { category: "ok", message: "OK" },
+    });
+    await expect(api.parsed.get("/whatever", Schema)).rejects.toBeInstanceOf(ApiError);
+  });
+
+  it("strips unknown fields silently (forward-compat)", async () => {
+    mockFetch(200, {
+      data: {
+        id: "11111111-1111-1111-1111-111111111111",
+        name: "Cap",
+        count: 5,
+        future_field: "added by backend",
+      },
+      status: { category: "ok", message: "OK" },
+    });
+    const out = await api.parsed.get("/whatever", Schema);
+    expect(out).toEqual({
+      id: "11111111-1111-1111-1111-111111111111",
+      name: "Cap",
+      count: 5,
+    });
+    expect((out as Record<string, unknown>).future_field).toBeUndefined();
+  });
+
+  it("propagates HTTP errors as ApiError with the right status", async () => {
+    mockFetch(404, {
+      data: null,
+      status: { category: "not_found", message: "part not found" },
+    });
+    await expect(api.parsed.get("/whatever", Schema)).rejects.toMatchObject({
+      status: 404,
+    });
+  });
+});

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,3 +1,23 @@
+/**
+ * Thin fetch wrapper around the backend's `{data, status}` envelope.
+ *
+ * Two flavours of read methods:
+ *
+ * - `api.get<T>(path)` / `api.post<T>(...)` etc. — legacy untyped path.
+ *   Returns `body.data` cast to `T` with no runtime validation. Used
+ *   by call sites that haven't migrated to the parsed flavour yet.
+ *
+ * - `api.parsed.get(path, schema)` / `parsed.post(...)` etc. — new
+ *   zod-validating path. Parses `body.data` against the supplied
+ *   schema; throws `ApiError` on schema mismatch with field-level
+ *   detail. Adopt for security-sensitive paths and any endpoint where
+ *   silent shape drift would be a real bug. See `lib/schemas.ts`.
+ *
+ * Both flavours share the same `request()` core; only the post-body
+ * handling differs.
+ */
+import type { ZodType } from "zod";
+
 export type ApiOk<T> = { data: T; status: { category: string; message: string } };
 export type ApiErr = { data: null; status: { category: string; message: string }; errors?: { field: string; message: string }[] };
 
@@ -13,7 +33,7 @@ export class ApiError extends Error {
   }
 }
 
-async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
+async function rawRequest(path: string, init: RequestInit = {}): Promise<unknown> {
   const headers = new Headers(init.headers || {});
   if (init.body && !(init.body instanceof FormData) && !headers.has("content-type")) {
     headers.set("content-type", "application/json");
@@ -28,10 +48,44 @@ async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
     const msg = body?.status?.message || res.statusText;
     throw new ApiError(res.status, body, msg);
   }
-  return body?.data as T;
+  return body?.data ?? null;
+}
+
+// Unsafe legacy cast — kept for back-compat while call sites migrate.
+async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
+  return (await rawRequest(path, init)) as T;
+}
+
+// Zod-validating path. Throws ApiError(0, null, ...) on schema mismatch.
+async function parsedRequest<S extends ZodType>(
+  path: string,
+  schema: S,
+  init: RequestInit = {},
+): Promise<S["_output"]> {
+  const data = await rawRequest(path, init);
+  const result = schema.safeParse(data);
+  if (!result.success) {
+    // Flatten zod errors into the same shape the backend produces for
+    // its 422 responses, so callers can inspect `body.errors`.
+    const errors = result.error.issues.map((i) => ({
+      field: i.path.join(".") || "<root>",
+      message: i.message,
+    }));
+    throw new ApiError(
+      0,
+      {
+        data: null,
+        status: { category: "client_schema_mismatch", message: "API response shape changed" },
+        errors,
+      },
+      `API response did not match schema: ${errors.slice(0, 3).map((e) => `${e.field} (${e.message})`).join("; ")}`,
+    );
+  }
+  return result.data;
 }
 
 export const api = {
+  // --- legacy untyped flavour ---
   get: <T>(p: string) => request<T>(p),
   post: <T>(p: string, body?: any) =>
     request<T>(p, { method: "POST", body: body !== undefined ? JSON.stringify(body) : undefined }),
@@ -39,4 +93,21 @@ export const api = {
     request<T>(p, { method: "PATCH", body: body !== undefined ? JSON.stringify(body) : undefined }),
   delete: <T>(p: string) => request<T>(p, { method: "DELETE" }),
   upload: <T>(p: string, form: FormData) => request<T>(p, { method: "POST", body: form }),
+
+  // --- zod-validating flavour ---
+  parsed: {
+    get: <S extends ZodType>(p: string, schema: S) => parsedRequest(p, schema),
+    post: <S extends ZodType>(p: string, schema: S, body?: any) =>
+      parsedRequest(p, schema, {
+        method: "POST",
+        body: body !== undefined ? JSON.stringify(body) : undefined,
+      }),
+    patch: <S extends ZodType>(p: string, schema: S, body?: any) =>
+      parsedRequest(p, schema, {
+        method: "PATCH",
+        body: body !== undefined ? JSON.stringify(body) : undefined,
+      }),
+    delete: <S extends ZodType>(p: string, schema: S) =>
+      parsedRequest(p, schema, { method: "DELETE" }),
+  },
 };

--- a/web/src/lib/auth.tsx
+++ b/web/src/lib/auth.tsx
@@ -1,10 +1,8 @@
 import { createContext, ReactNode, useContext, useEffect, useState } from "react";
 import { api, ApiError } from "./api";
+import { MeSchema, type Me } from "./schemas";
 
-export type Me = {
-  user: { id: string; email: string; name: string };
-  workspaces: { id: string; name: string; kind: string }[];
-};
+export type { Me };
 
 type Ctx = {
   me: Me | null;
@@ -27,7 +25,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   async function refresh() {
     setLoading(true);
     try {
-      const data = await api.get<Me>("/auth/me");
+      // Parsed boundary: schema mismatch on /auth/me would cascade into
+      // every authed page, so this is the highest-stakes path to validate.
+      const data = await api.parsed.get("/auth/me", MeSchema);
       setMe(data);
       if (!workspaceId && data.workspaces[0]) {
         setWorkspaceId(data.workspaces[0].id);

--- a/web/src/lib/schemas.ts
+++ b/web/src/lib/schemas.ts
@@ -1,0 +1,243 @@
+/**
+ * Zod schemas for API response shapes.
+ *
+ * The 2026-04-30 review's FE HIGH-2 flagged that `body?.data as T` in
+ * `lib/api.ts` returns whatever the server sent without runtime
+ * validation — server-side endpoint changes silently break the UI.
+ * This module is the foundation for fixing that: each schema mirrors
+ * its TypeScript counterpart in `types.ts`, and `api.parsed*` (in
+ * lib/api.ts) parses responses through these schemas at the boundary.
+ *
+ * Migration is opt-in: callers that haven't switched still get the
+ * legacy `as T` cast. New code and security-sensitive paths should
+ * adopt `api.parsed*`.
+ *
+ * Maintenance rule: when a backend Pydantic schema changes, update the
+ * matching schema here. Drift between the two surfaces as a parse
+ * error in the running app, not a silent UI break days later.
+ *
+ * Zod default behaviour:
+ *  - Unknown fields on the backend response are stripped (we don't use
+ *    .strict()). Forward-compatible — backend can add fields without
+ *    breaking the frontend.
+ *  - Missing required fields throw at parse time → ApiError surfaces
+ *    a clear "schema mismatch" error.
+ */
+import { z } from "zod";
+
+// ---------------------------------------------------------------------
+// Atom-shaped helpers reused across resources.
+// ---------------------------------------------------------------------
+
+const uuid = z.string().uuid();
+const isoDate = z.string();           // ISO 8601 string; not parsed to Date
+const nullableString = z.string().nullable();
+const nullableNumber = z.number().nullable();
+
+// ---------------------------------------------------------------------
+// Resource schemas. Mirror types.ts; export inferred types so consumers
+// have a single source of truth (types.ts re-exports these).
+// ---------------------------------------------------------------------
+
+export const PartSchema = z.object({
+  id: uuid,
+  part_type: z.enum(["linked", "local", "meta", "sub_assembly"]),
+  name: z.string(),
+  manufacturer: nullableString,
+  mpn: nullableString,
+  internal_part_number: nullableString,
+  description: nullableString,
+  footprint: nullableString,
+  notes_markdown: nullableString,
+  low_stock_report_quantity: nullableNumber,
+  attrition_percentage: z.number(),
+  attrition_min_quantity: z.number(),
+  default_storage_location_id: uuid.nullable(),
+  default_storage_mandatory: z.boolean(),
+  serialized: z.boolean(),
+  published: z.boolean().optional(),
+  linked_provider: z.enum(["mouser", "digikey"]).nullable(),
+  linked_external_id: nullableString,
+  last_refresh_at: nullableString,
+  description_locally_edited: z.boolean(),
+  archived_at: nullableString,
+  on_hand: nullableNumber,
+  reserved: z.number(),
+  available: z.number(),
+  image_url: nullableString,
+});
+export type Part = z.infer<typeof PartSchema>;
+
+export const PartsListSchema = z.array(PartSchema);
+
+export const StorageLocationSchema = z.object({
+  id: uuid,
+  name: z.string(),
+  description: nullableString,
+  single_part_only: z.boolean(),
+  existing_parts_only: z.boolean(),
+  is_full: z.boolean(),
+  archived_at: nullableString,
+});
+export type StorageLocation = z.infer<typeof StorageLocationSchema>;
+
+export const StorageLocationsListSchema = z.array(StorageLocationSchema);
+
+export const SpecSourceSchema = z.enum(["provider", "manual", "override"]);
+export type SpecSource = z.infer<typeof SpecSourceSchema>;
+
+export const CustomFieldRowSchema = z.object({
+  id: uuid,
+  key: z.string(),
+  value: nullableString,
+  source: SpecSourceSchema,
+  original_value: nullableString,
+});
+export type CustomFieldRow = z.infer<typeof CustomFieldRowSchema>;
+
+export const CustomFieldRowsListSchema = z.array(CustomFieldRowSchema);
+
+export const LotSchema = z.object({
+  id: uuid,
+  part_id: uuid,
+  name: nullableString,
+  serial_number: nullableString,
+  parent_lot_id: uuid.nullable(),
+  description: nullableString,
+  comments: nullableString,
+  expiration_date: nullableString,
+  source_type: z.string(),
+  purchase_quantity: nullableNumber,
+  purchase_unit_cost: nullableNumber,
+  purchase_currency: nullableString,
+  current_quantity: nullableNumber,
+  created_at: isoDate,
+});
+export type Lot = z.infer<typeof LotSchema>;
+
+export const LotsListSchema = z.array(LotSchema);
+
+export const StockEntrySchema = z.object({
+  id: uuid,
+  part_id: uuid,
+  lot_id: uuid.nullable(),
+  storage_location_id: uuid.nullable(),
+  quantity_delta: z.number(),
+  status: z.string(),
+  unit_price: nullableNumber,
+  currency: nullableString,
+  operation_type: z.string(),
+  comments: nullableString,
+  occurred_at: isoDate,
+});
+export type StockEntry = z.infer<typeof StockEntrySchema>;
+
+export const ProjectSchema = z.object({
+  id: uuid,
+  name: z.string(),
+  description: nullableString,
+  notes_markdown: nullableString,
+  associated_subassembly_part_id: uuid.nullable(),
+  archived_at: nullableString,
+  created_at: isoDate,
+  updated_at: isoDate,
+});
+export type Project = z.infer<typeof ProjectSchema>;
+
+export const ProjectsListSchema = z.array(ProjectSchema);
+
+export const OrderSchema = z.object({
+  id: uuid,
+  name: z.string(),
+  order_type: z.enum(["purchase", "sales"]),
+  supplier: nullableString,
+  status: z.enum(["draft", "open", "partial", "received", "cancelled"]),
+  ordered_on: nullableString,
+  expected_on: nullableString,
+  received_on: nullableString,
+  currency: nullableString,
+  comments: nullableString,
+  archived_at: nullableString,
+  totals: z.object({ ordered: z.number(), received: z.number() }),
+  created_at: isoDate,
+  updated_at: isoDate,
+});
+export type Order = z.infer<typeof OrderSchema>;
+
+export const OrdersListSchema = z.array(OrderSchema);
+
+export const OrderEntrySchema = z.object({
+  id: uuid,
+  order_id: uuid,
+  part_id: uuid.nullable(),
+  name: nullableString,
+  quantity_ordered: z.number(),
+  quantity_received: z.number(),
+  unit_price: nullableNumber,
+  currency: nullableString,
+  comments: nullableString,
+  order_index: z.number(),
+});
+export type OrderEntry = z.infer<typeof OrderEntrySchema>;
+
+export const BuildSchema = z.object({
+  id: uuid,
+  name: z.string(),
+  project_id: uuid,
+  quantity: z.number(),
+  status: z.enum(["planned", "in_progress", "complete", "cancelled"]),
+  started_at: nullableString,
+  completed_at: nullableString,
+  output_lot_id: uuid.nullable(),
+  comments: nullableString,
+  archived_at: nullableString,
+  created_at: isoDate,
+  updated_at: isoDate,
+});
+export type Build = z.infer<typeof BuildSchema>;
+
+export const BuildsListSchema = z.array(BuildSchema);
+
+export const ProjectEntrySchema = z.object({
+  id: uuid,
+  project_id: uuid,
+  entry_type: z.enum(["part", "meta_part", "non_part", "unmatched"]),
+  part_id: uuid.nullable(),
+  meta_part_id: uuid.nullable(),
+  name: nullableString,
+  quantity: z.number(),
+  comments: nullableString,
+  designators: z.array(z.string()),
+  cad_footprint: nullableString,
+  cad_key: nullableString,
+  dnp: z.boolean(),
+  order_index: z.number(),
+});
+export type ProjectEntry = z.infer<typeof ProjectEntrySchema>;
+
+// ---------------------------------------------------------------------
+// Auth surface — load-bearing for the gate. Schema mismatch here
+// breaks the login → workspace bootstrap, so it's the highest-value
+// migration target.
+// ---------------------------------------------------------------------
+
+// `/api/auth/me` shape: matches the backend's response in
+// app/api/routes/auth.py::me. The membership-status filter is applied
+// server-side, so workspaces in the response are always active for
+// this user.
+export const MeWorkspaceSchema = z.object({
+  id: uuid,
+  name: z.string(),
+  kind: z.string(),
+});
+export type MeWorkspace = z.infer<typeof MeWorkspaceSchema>;
+
+export const MeSchema = z.object({
+  user: z.object({
+    id: uuid,
+    email: z.string(),
+    name: z.string(),
+  }),
+  workspaces: z.array(MeWorkspaceSchema),
+});
+export type Me = z.infer<typeof MeSchema>;

--- a/web/src/routes/parts/PartsList.tsx
+++ b/web/src/routes/parts/PartsList.tsx
@@ -4,6 +4,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { Boxes, ImageOff, Trash2 } from "lucide-react";
 import { api, ApiError } from "@/lib/api";
+import { PartsListSchema } from "@/lib/schemas";
 import { DataTable } from "@/components/DataTable";
 import EmptyState from "@/components/EmptyState";
 import PartsTopNav from "@/components/PartsTopNav";
@@ -16,7 +17,8 @@ export default function PartsList({ archived = false }: { archived?: boolean }) 
   const [busy, setBusy] = useState(false);
   const { data, isLoading } = useQuery({
     queryKey: ["parts", { archived }],
-    queryFn: () => api.get<Part[]>(`/parts${archived ? "?archived=true" : ""}`),
+    queryFn: () =>
+      api.parsed.get(`/parts${archived ? "?archived=true" : ""}`, PartsListSchema),
   });
 
   const partsById = new Map((data ?? []).map(p => [p.id, p]));

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -1,140 +1,35 @@
-export type Part = {
-  id: string;
-  part_type: "linked" | "local" | "meta" | "sub_assembly";
-  name: string;
-  manufacturer: string | null;
-  mpn: string | null;
-  internal_part_number: string | null;
-  description: string | null;
-  footprint: string | null;
-  notes_markdown: string | null;
-  low_stock_report_quantity: number | null;
-  attrition_percentage: number;
-  attrition_min_quantity: number;
-  default_storage_location_id: string | null;
-  default_storage_mandatory: boolean;
-  serialized: boolean;
-  published?: boolean;
-  linked_provider: "mouser" | "digikey" | null;
-  linked_external_id: string | null;
-  last_refresh_at: string | null;
-  description_locally_edited: boolean;
-  archived_at: string | null;
-  on_hand: number | null;
-  reserved: number;
-  available: number;
-  // Local path under /api/parts/assets/... after a download succeeds, or
-  // the upstream URL when it didn't, or null when no image was attached.
-  // Sourced from the `image_url` custom_field row at list-fetch time.
-  image_url: string | null;
-};
+/**
+ * Public type re-exports.
+ *
+ * Resource types are inferred from zod schemas in `lib/schemas.ts`,
+ * so this module is the single TypeScript-facing facade. Keep new
+ * resource types in `schemas.ts` and re-export here.
+ *
+ * Pre-PR-#15 these were standalone TypeScript declarations. Migrating
+ * them to `z.infer` outputs gives us:
+ *  - One source of truth for the response shape (the zod schema).
+ *  - Runtime validation via `api.parsed.*` for callers that opt in.
+ *  - Compile-time identity for callers still using `api.get<T>` —
+ *    no breakage during incremental migration.
+ */
 
-export type SpecSource = "provider" | "manual" | "override";
+// Resources currently covered by zod schemas.
+export type {
+  Part,
+  StorageLocation,
+  SpecSource,
+  CustomFieldRow,
+  Lot,
+  StockEntry,
+  Project,
+  Order,
+  OrderEntry,
+  Build,
+  ProjectEntry,
+} from "./lib/schemas";
 
-export type CustomFieldRow = {
-  id: string;
-  key: string;
-  value: string | null;
-  source: SpecSource;
-  original_value: string | null;
-};
-
-export type StorageLocation = {
-  id: string;
-  name: string;
-  description: string | null;
-  single_part_only: boolean;
-  existing_parts_only: boolean;
-  is_full: boolean;
-  archived_at: string | null;
-};
-
-export type Lot = {
-  id: string;
-  part_id: string;
-  name: string | null;
-  serial_number: string | null;
-  parent_lot_id: string | null;
-  description: string | null;
-  comments: string | null;
-  expiration_date: string | null;
-  source_type: string;
-  purchase_quantity: number | null;
-  purchase_unit_cost: number | null;
-  purchase_currency: string | null;
-  current_quantity: number | null;
-  created_at: string;
-};
-
-export type StockEntry = {
-  id: string;
-  part_id: string;
-  lot_id: string | null;
-  storage_location_id: string | null;
-  quantity_delta: number;
-  status: string;
-  unit_price: number | null;
-  currency: string | null;
-  operation_type: string;
-  comments: string | null;
-  occurred_at: string;
-};
-
-export type Project = {
-  id: string;
-  name: string;
-  description: string | null;
-  notes_markdown: string | null;
-  associated_subassembly_part_id: string | null;
-  archived_at: string | null;
-  created_at: string;
-  updated_at: string;
-};
-
-export type Order = {
-  id: string;
-  name: string;
-  order_type: "purchase" | "sales";
-  supplier: string | null;
-  status: "draft" | "open" | "partial" | "received" | "cancelled";
-  ordered_on: string | null;
-  expected_on: string | null;
-  received_on: string | null;
-  currency: string | null;
-  comments: string | null;
-  archived_at: string | null;
-  totals: { ordered: number; received: number };
-  created_at: string;
-  updated_at: string;
-};
-
-export type OrderEntry = {
-  id: string;
-  order_id: string;
-  part_id: string | null;
-  name: string | null;
-  quantity_ordered: number;
-  quantity_received: number;
-  unit_price: number | null;
-  currency: string | null;
-  comments: string | null;
-  order_index: number;
-};
-
-export type Build = {
-  id: string;
-  name: string;
-  project_id: string;
-  quantity: number;
-  status: "planned" | "in_progress" | "complete" | "cancelled";
-  started_at: string | null;
-  completed_at: string | null;
-  output_lot_id: string | null;
-  comments: string | null;
-  archived_at: string | null;
-  created_at: string;
-  updated_at: string;
-};
+// Types not yet covered by zod schemas (kept inline for now).
+// Migrate to `lib/schemas.ts` when their endpoints are touched.
 
 export type BuildShortageRow = {
   project_entry_id: string;
@@ -167,20 +62,4 @@ export type MpnLookupResult = {
   message: string | null;
   /** Which provider produced this response (or "none" when unconfigured). */
   provider: PartsProviderName;
-};
-
-export type ProjectEntry = {
-  id: string;
-  project_id: string;
-  entry_type: "part" | "meta_part" | "non_part" | "unmatched";
-  part_id: string | null;
-  meta_part_id: string | null;
-  name: string | null;
-  quantity: number;
-  comments: string | null;
-  designators: string[];
-  cad_footprint: string | null;
-  cad_key: string | null;
-  dnp: boolean;
-  order_index: number;
 };


### PR DESCRIPTION
## Summary

Tier E, PR #15. Closes FE HIGH-2 — `body?.data as T` returned whatever the server sent without runtime validation.

This PR lands the zod boundary as **opt-in**: existing `api.get<T>` callers continue to work, and a new `api.parsed.*` family parses through a zod schema and throws structured errors on mismatch. Migration is per-call-site; no big-bang rewrite.

## What's in this PR

### Infrastructure
- `web/src/lib/schemas.ts` — zod schemas for 11 resources: `Part`, `StorageLocation`, `CustomFieldRow`, `Lot`, `StockEntry`, `Project`, `ProjectEntry`, `Order`, `OrderEntry`, `Build`, `Me`. Each exports an inferred TypeScript type.
- `web/src/types.ts` re-exports the zod-inferred types so types and schemas can no longer drift.
- `web/src/lib/api.ts` — `api.parsed.{get,post,patch,delete}(path, schema, ...)` family. `safeParse` failure → `ApiError(0, {category: "client_schema_mismatch", errors})`. Error shape matches the backend's 422 envelope.

### Demonstration migrations
- `lib/auth.tsx::refresh` — `/auth/me` is the most-load-bearing path; schema mismatch cascades into every authed page.
- `routes/parts/PartsList.tsx` — most-frequent fetch.

### Tests
5 new cases in `lib/api.test.ts` (mocks `fetch`, exercises the parsing layer):
- matching response → typed object
- missing field → `ApiError(0, schema_mismatch)`
- wrong type → `ApiError`
- unknown fields stripped (forward-compat)
- HTTP error → `ApiError` with right status

**vitest: 19/19** (was 14, +5 new). `tsc -b` clean.

## Behaviour

- **Forward-compat**: backend can add fields; zod strips them by default. Missing required fields throw at parse time.
- **Failure mode**: `ApiError` with `body.errors[]` carrying `field` + `message` per zod issue, parallel to backend 422 errors. UI's existing `ApiError` handlers automatically display the message.

## Out of scope (deliberate)

- Per-route migration of every `api.get<T>` site → mechanical follow-up sweep.
- Request-body schemas → Pydantic on the backend already validates inputs; this PR closes the *response* gap.

## Test plan

- [x] `tsc -b` clean
- [x] vitest 19/19
- [ ] Post-deploy: log in, verify auth/me parses cleanly; navigate to `/parts`, list parses cleanly. Both legacy + new paths still work for unmigrated routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)