### PR TITLE
fix(api): add limit query param to all list endpoints

### DIFF
--- a/backend/app/api/routes/bom_presets.py
+++ b/backend/app/api/routes/bom_presets.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, HTTPException, Query, status
 from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import select
 
@@ -39,13 +39,18 @@ def _serialize(p: BomImportPreset) -> dict:
 
 
 @router.get("")
-def list_presets(db: DbSession, ws: CurrentWorkspace):
+def list_presets(
+    db: DbSession,
+    ws: CurrentWorkspace,
+    limit: int = Query(default=200, le=1000),
+):
     rows = list(
         db.execute(
             select(BomImportPreset)
             .where(BomImportPreset.workspace_id == ws.id)
             .where(BomImportPreset.archived_at.is_(None))
             .order_by(BomImportPreset.name)
+            .limit(limit)
         ).scalars()
     )
     return ok([_serialize(p) for p in rows])

--- a/backend/app/api/routes/builds.py
+++ b/backend/app/api/routes/builds.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, HTTPException, Query, status
 from sqlalchemy import select
 
 from app.api.routes._activity import build_activity
@@ -56,12 +56,18 @@ def _get_project(db, ws_id, pid) -> Project:
 
 
 @router.get("")
-def list_builds(db: DbSession, ws: CurrentWorkspace, archived: bool = False, project_id: UUID | None = None):
+def list_builds(
+    db: DbSession,
+    ws: CurrentWorkspace,
+    archived: bool = False,
+    project_id: UUID | None = None,
+    limit: int = Query(default=200, le=1000),
+):
     stmt = select(Build).where(Build.workspace_id == ws.id)
     stmt = stmt.where(Build.archived_at.is_(None) if not archived else Build.archived_at.is_not(None))
     if project_id:
         stmt = stmt.where(Build.project_id == project_id)
-    stmt = stmt.order_by(Build.created_at.desc())
+    stmt = stmt.order_by(Build.created_at.desc()).limit(limit)
     return ok([_serialize(b) for b in db.execute(stmt).scalars()])
 
 

--- a/backend/app/api/routes/invitations.py
+++ b/backend/app/api/routes/invitations.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 from typing import Literal
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from pydantic import BaseModel, ConfigDict, EmailStr
 from sqlalchemy import select
 
@@ -120,12 +120,17 @@ def create_invitation(
 
 
 @router.get("", dependencies=[Depends(require_role("admin"))])
-def list_invitations(db: DbSession, ws: CurrentWorkspace):
+def list_invitations(
+    db: DbSession,
+    ws: CurrentWorkspace,
+    limit: int = Query(default=200, le=1000),
+):
     rows = list(
         db.execute(
             select(WorkspaceInvitation)
             .where(WorkspaceInvitation.workspace_id == ws.id)
             .order_by(WorkspaceInvitation.created_at.desc())
+            .limit(limit)
         ).scalars()
     )
     return ok([_serialize(r) for r in rows])

--- a/backend/app/api/routes/lots.py
+++ b/backend/app/api/routes/lots.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, HTTPException, Query, status
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy import select
 
@@ -42,10 +42,17 @@ def _serialize(l: Lot, quantity: int | None = None) -> dict:
 
 
 @router.get("")
-def list_lots(db: DbSession, ws: CurrentWorkspace):
+def list_lots(
+    db: DbSession,
+    ws: CurrentWorkspace,
+    limit: int = Query(default=200, le=1000),
+):
     lots = list(
         db.execute(
-            select(Lot).where(Lot.workspace_id == ws.id).order_by(Lot.created_at.desc())
+            select(Lot)
+            .where(Lot.workspace_id == ws.id)
+            .order_by(Lot.created_at.desc())
+            .limit(limit)
         ).scalars()
     )
     out = []

--- a/backend/app/api/routes/orders.py
+++ b/backend/app/api/routes/orders.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, HTTPException, Query, status
 from sqlalchemy import or_, select
 
 from app.api.routes._activity import build_activity
@@ -90,6 +90,7 @@ def list_orders(
     archived: bool = False,
     q: str | None = None,
     order_status: str | None = None,
+    limit: int = Query(default=200, le=1000),
 ):
     stmt = select(Order).where(Order.workspace_id == ws.id)
     stmt = stmt.where(Order.archived_at.is_(None) if not archived else Order.archived_at.is_not(None))
@@ -98,7 +99,7 @@ def list_orders(
         stmt = stmt.where(or_(Order.name.ilike(like), Order.supplier.ilike(like), Order.comments.ilike(like)))
     if order_status:
         stmt = stmt.where(Order.status == order_status)
-    stmt = stmt.order_by(Order.updated_at.desc())
+    stmt = stmt.order_by(Order.updated_at.desc()).limit(limit)
     out = []
     for o in db.execute(stmt).scalars():
         entries = _entries_for(db, ws.id, o.id)

--- a/backend/app/api/routes/projects.py
+++ b/backend/app/api/routes/projects.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, HTTPException, Query, status
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy import or_, select
 
@@ -57,13 +57,19 @@ def _serialize_entry(e: ProjectEntry) -> dict:
 
 
 @router.get("")
-def list_projects(db: DbSession, ws: CurrentWorkspace, archived: bool = False, q: str | None = None):
+def list_projects(
+    db: DbSession,
+    ws: CurrentWorkspace,
+    archived: bool = False,
+    q: str | None = None,
+    limit: int = Query(default=200, le=1000),
+):
     stmt = select(Project).where(Project.workspace_id == ws.id)
     stmt = stmt.where(Project.archived_at.is_(None) if not archived else Project.archived_at.is_not(None))
     if q:
         like = f"%{q}%"
         stmt = stmt.where(or_(Project.name.ilike(like), Project.description.ilike(like)))
-    stmt = stmt.order_by(Project.updated_at.desc())
+    stmt = stmt.order_by(Project.updated_at.desc()).limit(limit)
     return ok([_serialize(p) for p in db.execute(stmt).scalars()])
 
 

--- a/backend/app/api/routes/storage.py
+++ b/backend/app/api/routes/storage.py
@@ -56,6 +56,7 @@ def list_storage(
     ws: CurrentWorkspace,
     archived: bool = Query(default=False),
     q: str | None = Query(default=None),
+    limit: int = Query(default=200, le=1000),
 ):
     stmt = select(StorageLocation).where(StorageLocation.workspace_id == ws.id)
     stmt = stmt.where(
@@ -64,7 +65,7 @@ def list_storage(
     if q:
         like = f"%{q}%"
         stmt = stmt.where(or_(StorageLocation.name.ilike(like), StorageLocation.description.ilike(like)))
-    stmt = stmt.order_by(StorageLocation.name)
+    stmt = stmt.order_by(StorageLocation.name).limit(limit)
     return ok([_serialize(s) for s in db.execute(stmt).scalars()])
 
 

--- a/backend/app/api/routes/tags.py
+++ b/backend/app/api/routes/tags.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from uuid import UUID
 
-from fastapi import APIRouter, status
+from fastapi import APIRouter, Query, status
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy import select
 
@@ -22,8 +22,19 @@ class TagIn(BaseModel):
 
 
 @router.get("")
-def list_tags(db: DbSession, ws: CurrentWorkspace):
-    rows = list(db.execute(select(Tag).where(Tag.workspace_id == ws.id).order_by(Tag.name)).scalars())
+def list_tags(
+    db: DbSession,
+    ws: CurrentWorkspace,
+    limit: int = Query(default=200, le=1000),
+):
+    rows = list(
+        db.execute(
+            select(Tag)
+            .where(Tag.workspace_id == ws.id)
+            .order_by(Tag.name)
+            .limit(limit)
+        ).scalars()
+    )
     return ok([{"id": str(r.id), "name": r.name, "color": r.color} for r in rows])
 
 


### PR DESCRIPTION
## Summary

Most list endpoints returned the full set with no cap. A workspace with 50k lots hangs the lots page. This PR applies the same `Query(default=200, le=1000)` cap that already lived on `/api/parts` and `/api/stock` to every other list endpoint:

- `/api/lots`, `/api/orders`, `/api/builds`, `/api/projects`, `/api/storage`, `/api/tags`, `/api/bom-presets`, `/api/invitations`

## Behaviour

- Default 200 is enough for any normal workspace.
- LE cap of 1000 is the upper bound a power user can opt into via `?limit=N`.
- Existing callers that don't pass `?limit` are unchanged in the common case (under 200 rows) and safely truncated above that.

True cursor-based pagination (offset / total / next-page) remains future work; this PR closes the operational risk (hung pages) without the larger refactor.

**Backend tests: 231/231.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)