### PR TITLE
feat(logging): structured logging foundation + state-change log lines (BE MED-5)

### DIFF
--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -13,12 +13,14 @@ from app.core.auth import (
 )
 from app.core.config import settings
 from app.core.deps import CurrentUser, DbSession
+from app.core.logging import get_logger
 from app.core.ratelimit import limiter
 from app.core.responses import ok
 from app.domain.users.models import User
 from app.domain.workspaces.models import Workspace, WorkspaceMember
 
 router = APIRouter()
+log = get_logger(__name__)
 
 
 class SignupIn(BaseModel):
@@ -60,6 +62,7 @@ def _set_session_cookie(response: Response, token: str) -> None:
 def signup(request: Request, payload: SignupIn, response: Response, db: DbSession):
     existing = db.query(User).filter(User.email == payload.email).first()
     if existing:
+        log.warning("signup conflict", extra={"email": payload.email})
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="email already registered")
     user = User(email=payload.email, name=payload.name, password_hash=hash_password(payload.password))
     db.add(user)
@@ -76,6 +79,7 @@ def signup(request: Request, payload: SignupIn, response: Response, db: DbSessio
     db.commit()
 
     _set_session_cookie(response, sess.token)
+    log.info("signup", extra={"user_id": str(user.id), "workspace_id": str(ws.id)})
     return ok({"user": {"id": str(user.id), "email": user.email, "name": user.name}, "workspace_id": str(ws.id)})
 
 
@@ -86,11 +90,15 @@ def signup(request: Request, payload: SignupIn, response: Response, db: DbSessio
 def login(request: Request, payload: LoginIn, response: Response, db: DbSession):
     user = db.query(User).filter(User.email == payload.email).first()
     if not user or not verify_password(user.password_hash, payload.password):
+        # Log failures (without the password). Useful for spotting
+        # brute-force patterns alongside the slowapi rate-limit.
+        log.warning("login failed", extra={"email": payload.email})
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="invalid credentials")
     sess = create_session_row(db, user.id)
     user.last_login_at = datetime.now(timezone.utc)
     db.commit()
     _set_session_cookie(response, sess.token)
+    log.info("login", extra={"user_id": str(user.id)})
     return ok({"user": {"id": str(user.id), "email": user.email, "name": user.name}})
 
 
@@ -102,6 +110,7 @@ def logout(request: Request, response: Response, db: DbSession):
         revoke_session(db, token)
         db.commit()
     response.delete_cookie(cookie_name, path="/")
+    log.info("logout")
     return ok(None, "logged out")
 
 

--- a/backend/app/core/logging.py
+++ b/backend/app/core/logging.py
@@ -1,0 +1,109 @@
+"""Structured logging foundation.
+
+The 2026-04-30 review's BE MED-5: zero `logging.getLogger` calls
+anywhere in the codebase. Sentry catches errors but the running app
+had no log line for login/logout/provider failure/build consume/order
+receive, which made every "what happened five minutes ago" question
+require reading the database.
+
+This module configures the stdlib `logging` package once at FastAPI
+startup so the rest of the codebase can `logging.getLogger(__name__)`
+and call `.info(...)` / `.warning(...)` / `.error(...)` without
+worrying about handler setup. Logs go to stdout (Docker captures
+them as the container's stream); format depends on `APP_ENV`:
+
+- `prod`  → JSON-per-line, easy to grep / ship to a log aggregator.
+- `dev`/anything else → human-readable single line with timestamp.
+
+This is a minimum-viable foundation, NOT a complete observability
+solution. The follow-up is to add `logger.info(...)` lines at every
+state-change boundary (login, logout, build consume, order receive,
+attachment upload, etc.). This module makes that follow-up zero-config.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from typing import Any
+
+
+_CONFIGURED = False
+
+
+class _JsonFormatter(logging.Formatter):
+    """Compact JSON-per-line formatter. No multi-line stack traces in
+    the body; tracebacks land in `traceback` as a single string."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        out: dict[str, Any] = {
+            "ts": self.formatTime(record, "%Y-%m-%dT%H:%M:%S%z"),
+            "level": record.levelname,
+            "logger": record.name,
+            "msg": record.getMessage(),
+        }
+        # Custom fields attached via `logger.info("...", extra={...})`.
+        for k, v in record.__dict__.items():
+            if k in (
+                "name", "msg", "args", "levelname", "levelno", "pathname",
+                "filename", "module", "exc_info", "exc_text", "stack_info",
+                "lineno", "funcName", "created", "msecs", "relativeCreated",
+                "thread", "threadName", "processName", "process", "message",
+                "asctime", "taskName",
+            ):
+                continue
+            try:
+                json.dumps(v)
+                out[k] = v
+            except (TypeError, ValueError):
+                out[k] = repr(v)
+        if record.exc_info:
+            out["traceback"] = self.formatException(record.exc_info)
+        return json.dumps(out, separators=(",", ":"))
+
+
+def configure_logging() -> None:
+    """Idempotent. Called once from main.py at app construction."""
+    global _CONFIGURED
+    if _CONFIGURED:
+        return
+
+    from app.core.config import settings
+
+    cfg = settings()
+    is_prod = cfg.APP_ENV == "prod"
+
+    handler = logging.StreamHandler(sys.stdout)
+    if is_prod:
+        handler.setFormatter(_JsonFormatter())
+    else:
+        handler.setFormatter(
+            logging.Formatter(
+                fmt="%(asctime)s %(levelname)-5s %(name)s — %(message)s",
+                datefmt="%H:%M:%S",
+            )
+        )
+
+    root = logging.getLogger()
+    root.setLevel(logging.INFO)
+    # Don't double-up if uvicorn / pytest has already attached handlers
+    # — rip them out and replace with ours so format is consistent.
+    for h in list(root.handlers):
+        root.removeHandler(h)
+    root.addHandler(handler)
+
+    # Quiet down noisy stdlib / lib loggers — these are too chatty at
+    # INFO and we don't normally need their per-request lines.
+    logging.getLogger("sqlalchemy.engine").setLevel(logging.WARNING)
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+    logging.getLogger("urllib3").setLevel(logging.WARNING)
+    logging.getLogger("watchfiles").setLevel(logging.WARNING)
+
+    _CONFIGURED = True
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Convenience wrapper. Equivalent to `logging.getLogger(name)`,
+    but keeps the import surface stable if we ever swap out the
+    foundation (e.g., to structlog)."""
+    return logging.getLogger(name)

--- a/backend/app/core/responses.py
+++ b/backend/app/core/responses.py
@@ -5,6 +5,10 @@ from typing import Any
 from fastapi import HTTPException, Request, status
 from fastapi.responses import JSONResponse
 
+from app.core.logging import get_logger
+
+_log = get_logger(__name__)
+
 
 def ok(data: Any = None, message: str = "OK") -> dict[str, Any]:
     return {"data": data, "status": {"category": "ok", "message": message}}
@@ -17,7 +21,7 @@ def err(category: str, message: str, errors: list[dict] | None = None) -> dict[s
     return body
 
 
-async def http_exception_handler(_: Request, exc: HTTPException):
+async def http_exception_handler(request: Request, exc: HTTPException):
     # Routes can raise HTTPException(detail={"message": "...", ...extras})
     # to surface structured context alongside the human-readable message.
     # The "message" key (or stringified detail) goes into status.message;
@@ -31,6 +35,20 @@ async def http_exception_handler(_: Request, exc: HTTPException):
                 body[k] = v
     else:
         body = err(_category_for_status(exc.status_code), str(exc.detail))
+    # Log every 5xx as an error so the local journal has a full record
+    # of server-side failures (matched by Sentry but not contingent on
+    # it). 4xx is too noisy at INFO; route-level logging fires when a
+    # 4xx is actionable (login failures, etc.).
+    if exc.status_code >= 500:
+        _log.error(
+            "http error",
+            extra={
+                "status": exc.status_code,
+                "path": request.url.path,
+                "method": request.method,
+                "message": str(exc.detail)[:500],
+            },
+        )
     return JSONResponse(status_code=exc.status_code, content=body)
 
 

--- a/backend/app/domain/builds/service.py
+++ b/backend/app/domain/builds/service.py
@@ -14,8 +14,11 @@ from uuid import UUID
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from app.core.logging import get_logger
 from app.domain.builds.models import Build
 from app.domain.builds.schemas import ConsumeIn
+
+log = get_logger(__name__)
 from app.domain.lots.models import Lot
 from app.domain.parts.models import Part, PartMetaMember, PartSubstitute
 from app.domain.projects.models import Project, ProjectEntry
@@ -429,6 +432,16 @@ def consume(
     build.output_lot_id = output_lot.id if output_lot else None
     build.updated_by = user_id
 
+    log.info(
+        "build consumed",
+        extra={
+            "workspace_id": str(workspace_id),
+            "build_id": str(build.id),
+            "project_id": str(project.id),
+            "consumed_lines": len(consumed_entries),
+            "output_lot_id": str(output_lot.id) if output_lot else None,
+        },
+    )
     return {
         "build_id": str(build.id),
         "status": build.status,

--- a/backend/app/domain/orders/service.py
+++ b/backend/app/domain/orders/service.py
@@ -8,8 +8,11 @@ from uuid import UUID
 
 from sqlalchemy.orm import Session
 
+from app.core.logging import get_logger
 from app.domain.lots.models import Lot
 from app.domain.orders.models import Order, OrderEntry
+
+log = get_logger(__name__)
 from app.domain.orders.schemas import ReceiveIn
 from app.domain.parts.models import Part
 from app.domain.stock.models import StockEntry
@@ -151,6 +154,16 @@ def receive(
         order.received_on = received_at.date()
     order.updated_by = user_id
 
+    log.info(
+        "order received",
+        extra={
+            "workspace_id": str(workspace_id),
+            "order_id": str(order.id),
+            "status": order.status,
+            "lots_created": len(created_lots),
+            "entries_created": len(created_entries),
+        },
+    )
     return {
         "order_id": str(order.id),
         "status": order.status,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,6 +6,13 @@ from fastapi import Depends, FastAPI, HTTPException
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 
+from app.core.logging import configure_logging
+
+# Configure structured logging once at import time, before anything else
+# tries to log. uvicorn replays logs through the root logger so this
+# captures its lifecycle messages too.
+configure_logging()
+
 
 # Top-level (testable) Sentry event scrubber. Runs as `before_send` so the
 # event is mutated before it leaves the worker. We have to scrub here


### PR DESCRIPTION
## Summary

Closes BE MED-5 — zero `logging.getLogger` calls anywhere in the codebase.

## Foundation

`app/core/logging.py::configure_logging()` runs once at FastAPI import. Format depends on `APP_ENV`:
- **prod** → JSON-per-line (greppable, ship-to-aggregator-ready)
- **dev** → human-readable single line

Output to stdout (Docker captures it). Quiets noisy stdlib loggers (`sqlalchemy.engine`, `httpx`, etc.) to WARNING.

## State-change log lines (initial set)

- `auth.signup` INFO / WARNING
- `auth.login` INFO / WARNING (failure case useful for brute-force visibility alongside slowapi)
- `auth.logout` INFO
- `builds.consume` INFO with workspace + build + line count
- `orders.receive` INFO with workspace + order + status + lots/entries created
- 5xx responses ERROR with status + path + method + message (truncated)

## Out of scope

- Per-request access log middleware
- Attachment upload / download / build reservation lines

Each is a one-line addition once the foundation is in place.

**Backend tests: 231/231.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)