### PR TITLE
feat(security): encrypt workspace secrets at rest (Sec HIGH-9)

### DIFF
--- a/backend/alembic/versions/0015_encrypt_workspace_secrets.py
+++ b/backend/alembic/versions/0015_encrypt_workspace_secrets.py
@@ -1,0 +1,147 @@
+"""encrypt workspace-level secrets at rest
+
+Revision ID: 0015
+Revises: 0014
+Create Date: 2026-05-02
+
+The 2026-04-30 review's Sec HIGH-9: workspace.parts_provider_api_key /
+parts_provider_api_secret / scanner_license_key were stored as
+plaintext columns. A DB dump leaked every workspace's third-party
+credentials.
+
+Behaviour:
+  * Bump column lengths so a Fernet ciphertext (~30% larger than
+    plaintext after base64) fits with headroom.
+      - parts_provider_api_key   String(255)  -> String(1024)
+      - parts_provider_api_secret String(255)  -> String(1024)
+      - scanner_license_key      String(2048) -> String(4096)
+  * Encrypt every existing non-NULL row in place via Python (using
+    `app.core.secrets.encrypt`). Reading the plaintext directly into
+    Python keeps the values out of any SQL trace / log.
+  * The columns stay nullable; route layer encrypts on PATCH and
+    decrypts on read.
+
+Operational hazard:
+  Lose `WORKSPACE_SECRETS_KEY` and every credential becomes
+  unrecoverable. The dev fallback key in `app/core/secrets.py` keeps
+  local-first runs zero-config; prod must set the env var. Document
+  the key in escrow alongside SESSION_SECRET.
+
+Downgrade:
+  Schema reversal works (column lengths shrink back), but cannot
+  recover plaintext from a key that was lost. If a real rollback is
+  needed, restore from the pre-deploy `pg_dump` instead.
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0015"
+down_revision = "0014"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Lengthen columns first so post-encryption ciphertexts fit.
+    op.alter_column(
+        "workspaces", "parts_provider_api_key",
+        existing_type=sa.String(255),
+        type_=sa.String(1024),
+        existing_nullable=True,
+    )
+    op.alter_column(
+        "workspaces", "parts_provider_api_secret",
+        existing_type=sa.String(255),
+        type_=sa.String(1024),
+        existing_nullable=True,
+    )
+    op.alter_column(
+        "workspaces", "scanner_license_key",
+        existing_type=sa.String(2048),
+        type_=sa.String(4096),
+        existing_nullable=True,
+    )
+
+    # Backfill: encrypt every existing non-empty value. Done in Python
+    # so the plaintext never appears in a SQL log line.
+    from app.core.config import settings
+    from app.core.secrets import encrypt, safe_decrypt
+
+    bind = op.get_bind()
+
+    # Guardrail: if there are non-NULL credentials AND the operator
+    # forgot to set WORKSPACE_SECRETS_KEY in env, refuse to run rather
+    # than silently encrypt under the dev fallback key (which would
+    # then 500 every credential read at runtime when prod expects a
+    # real key). Empty DB / no credentials → nothing to encrypt → safe.
+    has_creds = bind.execute(
+        sa.text(
+            "SELECT COUNT(*) FROM workspaces WHERE "
+            " parts_provider_api_key IS NOT NULL OR"
+            " parts_provider_api_secret IS NOT NULL OR"
+            " scanner_license_key IS NOT NULL"
+        )
+    ).scalar()
+    if has_creds and not settings().WORKSPACE_SECRETS_KEY:
+        raise RuntimeError(
+            "0015: refusing to encrypt under the dev fallback key. "
+            "Set WORKSPACE_SECRETS_KEY in env (Fernet-generated) before "
+            "running this migration against non-empty data."
+        )
+
+    rows = bind.execute(
+        sa.text(
+            "SELECT id, parts_provider_api_key, parts_provider_api_secret, scanner_license_key "
+            "FROM workspaces"
+        )
+    ).fetchall()
+    # Idempotency: `safe_decrypt` round-trips an already-encrypted
+    # token through decrypt -> plaintext, then re-encrypts. On a fresh
+    # plaintext row, safe_decrypt returns the input unchanged so
+    # encrypt() produces the first ciphertext. On an already-encrypted
+    # row (from a prior partial-failure retry), safe_decrypt returns
+    # the plaintext and encrypt() produces a fresh ciphertext bound to
+    # the same plaintext. Either way the post-migration plaintext
+    # matches the pre-migration plaintext.
+    for row_id, key, secret, license_key in rows:
+        bind.execute(
+            sa.text(
+                "UPDATE workspaces SET "
+                " parts_provider_api_key = :k,"
+                " parts_provider_api_secret = :s,"
+                " scanner_license_key = :l "
+                "WHERE id = :i"
+            ),
+            {
+                "k": encrypt(safe_decrypt(key)),
+                "s": encrypt(safe_decrypt(secret)),
+                "l": encrypt(safe_decrypt(license_key)),
+                "i": row_id,
+            },
+        )
+
+
+def downgrade() -> None:
+    """Schema reversal only; plaintext cannot be recovered from a key
+    rotation. Restore from `pg_dump` for a real rollback."""
+    op.alter_column(
+        "workspaces", "scanner_license_key",
+        existing_type=sa.String(4096),
+        type_=sa.String(2048),
+        existing_nullable=True,
+    )
+    op.alter_column(
+        "workspaces", "parts_provider_api_secret",
+        existing_type=sa.String(1024),
+        type_=sa.String(255),
+        existing_nullable=True,
+    )
+    op.alter_column(
+        "workspaces", "parts_provider_api_key",
+        existing_type=sa.String(1024),
+        type_=sa.String(255),
+        existing_nullable=True,
+    )

--- a/backend/app/api/routes/parts.py
+++ b/backend/app/api/routes/parts.py
@@ -16,6 +16,7 @@ from app.api.routes._activity import build_activity
 from app.core.config import settings
 from app.core.deps import CurrentUser, CurrentWorkspace, DbSession
 from app.core.responses import ok
+from app.core.secrets import decrypt
 from app.domain.custom_fields.models import CustomField
 from app.domain.parts.models import Part, PartMetaMember, PartSubstitute
 from app.domain.parts.providers import make_provider
@@ -647,8 +648,8 @@ def refresh_from_provider(
 
     provider = make_provider(
         ws.parts_provider,
-        ws.parts_provider_api_key,
-        ws.parts_provider_api_secret,
+        decrypt(ws.parts_provider_api_key),
+        decrypt(ws.parts_provider_api_secret),
     )
     if provider is None:
         raise HTTPException(
@@ -838,8 +839,8 @@ def bulk_import_from_scan(
     """
     provider = make_provider(
         ws.parts_provider,
-        ws.parts_provider_api_key,
-        ws.parts_provider_api_secret,
+        decrypt(ws.parts_provider_api_key),
+        decrypt(ws.parts_provider_api_secret),
     )
     if provider is None:
         raise HTTPException(

--- a/backend/app/api/routes/parts_provider.py
+++ b/backend/app/api/routes/parts_provider.py
@@ -20,10 +20,14 @@ class LookupIn(BaseModel):
 
 @router.post("/lookup-mpn")
 def lookup_mpn(payload: LookupIn, ws: CurrentWorkspace):
+    # Decrypt credentials at the boundary (Sec HIGH-9). The columns
+    # store Fernet ciphertext post-0015; provider classes get the
+    # plaintext.
+    from app.core.secrets import decrypt
     provider = make_provider(
         ws.parts_provider,
-        ws.parts_provider_api_key,
-        ws.parts_provider_api_secret,
+        decrypt(ws.parts_provider_api_key),
+        decrypt(ws.parts_provider_api_secret),
     )
     if provider is None:
         return ok({

--- a/backend/app/api/routes/workspaces.py
+++ b/backend/app/api/routes/workspaces.py
@@ -11,6 +11,7 @@ from sqlalchemy import select
 from app.core.config import settings
 from app.core.deps import CurrentUser, CurrentWorkspace, DbSession, require_role
 from app.core.responses import ok
+from app.core.secrets import decrypt, encrypt
 from app.domain.users.models import User
 from app.domain.workspaces.models import Workspace, WorkspaceMember
 
@@ -87,7 +88,10 @@ def current_scanner_license_key(ws: CurrentWorkspace):
     serializer only emits has_scanner_license_key. Any authenticated
     workspace member already has access; this just keeps the value out of
     response bodies that are fetched on every page."""
-    return ok({"license_key": ws.scanner_license_key or ""})
+    # Decrypt at the boundary (Sec HIGH-9 fix). The column stores a
+    # Fernet ciphertext post-0015; decrypt yields the plaintext the
+    # Scandit SDK expects.
+    return ok({"license_key": decrypt(ws.scanner_license_key) or ""})
 
 
 class WorkspacePatch(BaseModel):
@@ -121,15 +125,17 @@ def patch_current(payload: WorkspacePatch, db: DbSession, ws: CurrentWorkspace):
 
     # parts_provider_api_key / _api_secret need special handling so ''
     # actually clears (rather than being stored as an empty string).
+    # All three credentials are encrypted at rest via app.core.secrets
+    # (Sec HIGH-9): Fernet token in, Fernet token out.
     if "parts_provider_api_key" in data:
         new_key = data.pop("parts_provider_api_key")
-        ws.parts_provider_api_key = new_key if new_key else None
+        ws.parts_provider_api_key = encrypt(new_key) if new_key else None
     if "parts_provider_api_secret" in data:
         new_secret = data.pop("parts_provider_api_secret")
-        ws.parts_provider_api_secret = new_secret if new_secret else None
+        ws.parts_provider_api_secret = encrypt(new_secret) if new_secret else None
     if "scanner_license_key" in data:
         new_license = data.pop("scanner_license_key")
-        ws.scanner_license_key = new_license if new_license else None
+        ws.scanner_license_key = encrypt(new_license) if new_license else None
 
     for k, v in data.items():
         setattr(ws, k, v)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -30,6 +30,13 @@ class Settings(BaseSettings):
     # the tunnel is an open ingress that anyone on the internet can
     # use to pump arbitrary bytes through this worker.
     SENTRY_TUNNEL_MAX_BYTES: int = 200 * 1024
+    # Fernet key (urlsafe-base64-encoded 32 bytes) for encrypting
+    # workspace-level secrets at rest: parts_provider_api_key,
+    # parts_provider_api_secret, scanner_license_key. Empty string →
+    # falls back to a dev-only default (see app/core/secrets.py).
+    # Generate a real key for prod with:
+    #   python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+    WORKSPACE_SECRETS_KEY: str = ""
     CORS_ORIGINS: str = "http://localhost:5173"
     # Sentry. Empty string → SDK is not initialised (no events sent, no
     # network egress, no performance overhead). Populate in .env.prod

--- a/backend/app/core/secrets.py
+++ b/backend/app/core/secrets.py
@@ -1,0 +1,85 @@
+"""Symmetric encryption for workspace-level secrets at rest.
+
+The 2026-04-30 review's Sec HIGH-9: workspace.parts_provider_api_key /
+parts_provider_api_secret / scanner_license_key were stored as
+plaintext columns. A DB dump (legitimate backup, replica, log) leaked
+every workspace's third-party credentials. Same shape as PR #18's
+invitation tokens, but two-way: we need to decrypt at request time
+to call Mouser/DigiKey/Scandit, so a hash-only approach won't work.
+
+Uses Fernet (AES-128-CBC + HMAC-SHA256, with timestamp + version) keyed
+off `WORKSPACE_SECRETS_KEY` (a base64-encoded 32-byte Fernet key from
+env). Generate one with:
+
+    python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+
+Storage format: the same base64 token Fernet emits, written into a
+String column. `decrypt()` returns the plaintext or `None` if the
+input is empty / None — letting routes ergonomically pass the column
+through without nullable-handling boilerplate.
+
+Operational hazard: losing `WORKSPACE_SECRETS_KEY` makes every encrypted
+column unrecoverable. The dev default below is intentionally weak to
+make local-first runs zero-config; prod must override via env.
+"""
+from __future__ import annotations
+
+from functools import lru_cache
+
+from cryptography.fernet import Fernet, InvalidToken
+
+
+# Dev-only default — weak by design so local runs work without a
+# `.env` step. Prod overrides via the `WORKSPACE_SECRETS_KEY` env var
+# (set in `.env.prod` and not committed). If you ever change THIS
+# default in dev, all dev-encrypted secrets become garbage; fine
+# locally, but a discovery-time gotcha for someone who skipped reading
+# the comment.
+_DEV_DEFAULT_KEY = b"OXmO1Y_-zTtTJ_NXxL5RQqGsbwI3wQAOJ-V_M5HH4_o="
+
+
+@lru_cache(maxsize=1)
+def _fernet() -> Fernet:
+    from app.core.config import settings
+
+    key = settings().WORKSPACE_SECRETS_KEY
+    if not key:
+        return Fernet(_DEV_DEFAULT_KEY)
+    return Fernet(key.encode("ascii"))
+
+
+def encrypt(plaintext: str | None) -> str | None:
+    """Encrypt a plaintext string for storage. None → None (lets
+    callers pass nullable columns straight through)."""
+    if plaintext is None:
+        return None
+    if plaintext == "":
+        # Treat empty-string the same as None — the route layer uses
+        # empty payloads as "clear this credential".
+        return None
+    return _fernet().encrypt(plaintext.encode("utf-8")).decode("ascii")
+
+
+def decrypt(token: str | None) -> str | None:
+    """Decrypt a stored token back to plaintext. None / empty → None.
+    A token encrypted with a different key (e.g. after rotation
+    without re-encryption) raises `cryptography.fernet.InvalidToken` —
+    callers should let that propagate so the API errors loudly rather
+    than silently treating the credential as unset."""
+    if not token:
+        return None
+    return _fernet().decrypt(token.encode("ascii")).decode("utf-8")
+
+
+def safe_decrypt(token: str | None) -> str | None:
+    """Lenient decrypt — used during the 0015 migration backfill where
+    rows that were not yet encrypted (any pre-migration row) need to
+    flow through unchanged. Outside the migration, prefer `decrypt()`
+    so a key rotation surfaces immediately rather than corrupting the
+    request silently."""
+    if not token:
+        return None
+    try:
+        return _fernet().decrypt(token.encode("ascii")).decode("utf-8")
+    except InvalidToken:
+        return token

--- a/backend/app/domain/workspaces/models.py
+++ b/backend/app/domain/workspaces/models.py
@@ -26,13 +26,15 @@ class Workspace(Base):
     catalog_token = Column(String(64), nullable=True)
     catalog_enabled = Column(Boolean, nullable=False, default=False)
     parts_provider = Column(String(40), nullable=False, default="none")  # none | mouser | digikey
-    parts_provider_api_key = Column(String(255), nullable=True)
+    # Encrypted at rest via app.core.secrets (Sec HIGH-9). Fernet
+    # tokens are ~140 chars for a 36-char API key, but we leave headroom.
+    parts_provider_api_key = Column(String(1024), nullable=True)
     # DigiKey needs a second credential (client_secret). Mouser leaves this NULL.
-    parts_provider_api_secret = Column(String(255), nullable=True)
+    parts_provider_api_secret = Column(String(1024), nullable=True)
     # Which client-side decoder the scanner pages mount. 'zxing' is the
     # royalty-free default; 'scandit' is opt-in and consumes scanner_license_key.
     scanner = Column(String(40), nullable=False, default="zxing")  # zxing | scandit
-    scanner_license_key = Column(String(2048), nullable=True)
+    scanner_license_key = Column(String(4096), nullable=True)
     created_at = Column(DateTime(timezone=True), nullable=False, default=_utcnow)
 
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -13,6 +13,9 @@ dependencies = [
     "pydantic-settings>=2.4",
     "python-multipart>=0.0.9",
     "argon2-cffi>=23.1",
+    # Symmetric encryption for workspace-level secrets (provider API keys,
+    # scanner license keys). See app/core/secrets.py + alembic 0015.
+    "cryptography>=42.0",
     "itsdangerous>=2.2",
     "email-validator>=2.2",
     "chardet>=5.2",

--- a/backend/tests/test_workspace_secrets.py
+++ b/backend/tests/test_workspace_secrets.py
@@ -1,0 +1,103 @@
+"""Tests for the workspace-secrets-at-rest encryption (Sec HIGH-9).
+
+Pins:
+  - encrypt(plaintext) -> decrypt round-trips.
+  - encrypt(None) and encrypt("") collapse to None (matches the route's
+    "empty payload clears the credential" semantics).
+  - The DB column carries ciphertext, not plaintext, after a PATCH.
+  - The /current/scanner-license-key endpoint returns the plaintext
+    (decrypted at the boundary) so the SDK can consume it.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.core.secrets import decrypt, encrypt
+from app.main import app
+
+
+def test_encrypt_decrypt_roundtrip():
+    plain = "RC0402JR-070R-fake-key-1234567890"
+    cipher = encrypt(plain)
+    assert cipher is not None
+    assert cipher != plain  # must not store as-is
+    assert decrypt(cipher) == plain
+
+
+def test_encrypt_none_and_empty_collapse_to_none():
+    assert encrypt(None) is None
+    assert encrypt("") is None
+
+
+def test_decrypt_none_and_empty_passthrough():
+    assert decrypt(None) is None
+    assert decrypt("") is None
+
+
+@pytest.fixture
+def admin():
+    c = TestClient(app)
+    c.post(
+        "/api/auth/signup",
+        json={"email": f"u-{uuid.uuid4().hex[:8]}@x.com", "name": "u", "password": "password123"},
+    )
+    return c
+
+
+def test_patch_workspace_stores_credentials_encrypted(admin):
+    """PATCH /api/workspaces/current with a Mouser API key. The DB
+    column must contain a Fernet token, NOT the plaintext."""
+    plaintext = "MOUSER-FAKE-KEY-DEADBEEF-1234567890"
+    r = admin.patch(
+        "/api/workspaces/current",
+        json={"parts_provider": "mouser", "parts_provider_api_key": plaintext},
+    )
+    assert r.status_code == 200, r.text
+    ws_id = admin.get("/api/workspaces/current").json()["data"]["id"]
+
+    # Reach into the DB and verify THIS workspace's stored value
+    # (other tests may have leftover workspaces in the same DB).
+    from app.domain.workspaces.models import Workspace
+    from app.infra.db import SessionLocal
+
+    with SessionLocal() as s:
+        ws = s.get(Workspace, uuid.UUID(ws_id))
+        assert ws is not None
+        stored = ws.parts_provider_api_key
+        assert stored is not None
+        assert stored != plaintext, "stored value must not be the plaintext"
+        # And we can decrypt it back to the original.
+        assert decrypt(stored) == plaintext
+
+
+def test_scanner_license_key_endpoint_returns_decrypted_plaintext(admin):
+    """The /current/scanner-license-key endpoint must decrypt at the
+    boundary so the SDK gets the plaintext it expects."""
+    plaintext = "SCANDIT-FAKE-LICENSE-" + ("X" * 100)
+    r = admin.patch(
+        "/api/workspaces/current",
+        json={"scanner": "scandit", "scanner_license_key": plaintext},
+    )
+    assert r.status_code == 200, r.text
+
+    r = admin.get("/api/workspaces/current/scanner-license-key")
+    assert r.status_code == 200
+    assert r.json()["data"]["license_key"] == plaintext
+
+
+def test_clearing_credential_with_empty_string(admin):
+    """Empty-string payload still clears the column (the existing
+    semantics — encrypt('') returns None)."""
+    admin.patch(
+        "/api/workspaces/current",
+        json={"parts_provider": "mouser", "parts_provider_api_key": "ABC"},
+    )
+    admin.patch(
+        "/api/workspaces/current",
+        json={"parts_provider_api_key": ""},
+    )
+    out = admin.get("/api/workspaces/current").json()["data"]
+    assert out["has_parts_provider_api_key"] is False


### PR DESCRIPTION
## Summary

Closes Sec HIGH-9. Workspace `parts_provider_api_key`, `parts_provider_api_secret`, and `scanner_license_key` were plaintext columns. DB dump = leaked credentials.

Same shape as PR #18's invitation tokens, but two-way (routes call provider/SDK with plaintext at request time).

## Foundation

`app/core/secrets.py`: Fernet (AES-128 + HMAC-SHA256) keyed off `WORKSPACE_SECRETS_KEY` env. `encrypt`/`decrypt`/`safe_decrypt` helpers.

## Migration 0015

- Bump column lengths (255→1024, 2048→4096) for Fernet headroom.
- Backfill via Python: `encrypt(safe_decrypt(value))` per row → idempotent under partial-failure retry.
- Guardrail: refuses to run if non-NULL credentials exist AND `WORKSPACE_SECRETS_KEY` is unset.

## Routes

PATCH encrypts; lookup-mpn / refresh-from-provider / bulk-import-from-scan / scanner-license-key endpoint all decrypt at the boundary.

## Tests

6 new in `test_workspace_secrets.py` — round-trip, edge cases, PATCH→ciphertext, scanner endpoint plaintext, clearing.

**Full backend suite: 237/237.**

## Review

`alembic-migration-reviewer`: ⚠️ minor → flagged idempotency + key-presence guard. **Both addressed before commit.**

## Pre-deploy

1. **`pg_dump`** of `workspaces` (or full DB).
2. **Generate + set `WORKSPACE_SECRETS_KEY`** in `.env.prod`:
   ```
   python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
   ```
   Escrow alongside `SESSION_SECRET`. Losing this key = unrecoverable credentials.
3. Verify env var reaches the backend container at deploy time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)