### PR TITLE
fix(ui): Sentry user identity + 404 page + console.* removal

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -15,6 +15,7 @@ import Signup from "@/routes/auth/Signup";
 // small, and code-splitting them would just trade one set of network
 // round-trips for another.
 import PartsList from "@/routes/parts/PartsList";
+import NotFound from "@/routes/NotFound";
 import PartCreate from "@/routes/parts/PartCreate";
 import ScanImport from "@/routes/parts/ScanImport";
 import StockHistory from "@/routes/parts/StockHistory";
@@ -219,7 +220,7 @@ export default function App() {
             <Route path="/settings/account" element={<Account />} />
             <Route path="/settings/workspace" element={<WorkspaceSettings />} />
 
-            <Route path="*" element={<div className="text-muted">Not found.</div>} />
+            <Route path="*" element={<NotFound />} />
           </Route>
         </Routes>
         </Suspense>

--- a/web/src/components/scanner/ScanditScanner.tsx
+++ b/web/src/components/scanner/ScanditScanner.tsx
@@ -107,7 +107,13 @@ export default function ScanditScanner({ licenseKey, onScan, className, symbolog
         await camera.switchToDesiredState(FrameSourceState.On);
         setStatus({ text: "Ready — point camera at a barcode", kind: "ready" });
       } catch (err: any) {
-        console.error(err);
+        // Surface to Sentry so ops sees recurring init failures (license
+        // expiry, libraryLocation misconfig, etc.) without depending on
+        // someone watching the browser console.
+        try {
+          const Sentry = await import("@sentry/react");
+          Sentry.captureException(err);
+        } catch { /* Sentry import failed — non-fatal */ }
         setStatus({ text: `Error: ${err?.message ?? err}`, kind: "err" });
       }
     })();

--- a/web/src/lib/auth.tsx
+++ b/web/src/lib/auth.tsx
@@ -1,4 +1,5 @@
 import { createContext, ReactNode, useContext, useEffect, useState } from "react";
+import * as Sentry from "@sentry/react";
 import { api, ApiError } from "./api";
 import { MeSchema, type Me } from "./schemas";
 
@@ -29,13 +30,25 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       // every authed page, so this is the highest-stakes path to validate.
       const data = await api.parsed.get("/auth/me", MeSchema);
       setMe(data);
+      // Pipe the user's identity into Sentry so events can be deduped
+      // by user (FE MED-10). We send the id + email; the backend's
+      // before_send scrubber strips request bodies and tenant headers,
+      // and Sentry's "send default PII" already handles IP, so this is
+      // additive identification, not new exfiltration.
+      Sentry.setUser({ id: data.user.id, email: data.user.email });
       if (!workspaceId && data.workspaces[0]) {
         setWorkspaceId(data.workspaces[0].id);
         localStorage.setItem("workspaceId", data.workspaces[0].id);
       }
     } catch (e) {
-      if (!(e instanceof ApiError && e.status === 401)) console.error(e);
+      // 401 is the unauthenticated path (no log noise). Anything else
+      // — including ApiError(0, schema_mismatch) — goes to Sentry so
+      // ops sees real shape drift rather than silent UI degradation.
+      if (!(e instanceof ApiError && e.status === 401)) {
+        Sentry.captureException(e);
+      }
       setMe(null);
+      Sentry.setUser(null);
     } finally {
       setLoading(false);
     }
@@ -48,6 +61,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     localStorage.removeItem("workspaceId");
     setMe(null);
     setWorkspaceId(null);
+    Sentry.setUser(null);
   }
 
   async function switchWorkspace(id: string) {

--- a/web/src/routes/NotFound.tsx
+++ b/web/src/routes/NotFound.tsx
@@ -1,0 +1,56 @@
+import { Link } from "react-router-dom";
+
+/**
+ * 404 page. Replaces the previous one-line catch-all (FE MED-4).
+ * Renders inside the AppShell layout so the sidebar / nav stay
+ * visible — the user can recover by clicking somewhere familiar
+ * rather than having to retype the URL.
+ */
+export default function NotFound() {
+  return (
+    <div className="card p-6 max-w-xl space-y-3">
+      <h1 className="text-xl font-semibold">Not found</h1>
+      <p className="text-sm text-muted">
+        The page you're looking for doesn't exist, or you don't have
+        access to it. Common destinations:
+      </p>
+      <ul className="text-sm space-y-1">
+        <li>
+          <Link to="/parts" className="text-accent hover:underline">
+            Parts
+          </Link>
+        </li>
+        <li>
+          <Link to="/orders" className="text-accent hover:underline">
+            Orders
+          </Link>
+        </li>
+        <li>
+          <Link to="/builds" className="text-accent hover:underline">
+            Builds
+          </Link>
+        </li>
+        <li>
+          <Link to="/projects" className="text-accent hover:underline">
+            Projects
+          </Link>
+        </li>
+        <li>
+          <Link to="/reports" className="text-accent hover:underline">
+            Reports
+          </Link>
+        </li>
+        <li>
+          <Link to="/storage" className="text-accent hover:underline">
+            Storage
+          </Link>
+        </li>
+        <li>
+          <Link to="/settings/workspace" className="text-accent hover:underline">
+            Workspace settings
+          </Link>
+        </li>
+      </ul>
+    </div>
+  );
+}

--- a/web/src/routes/parts/ScanImport.tsx
+++ b/web/src/routes/parts/ScanImport.tsx
@@ -184,16 +184,6 @@ export default function ScanImport() {
   const handleScan = useCallback(async (s: ScanResult) => {
     const parsed = parseBagCode(s.data);
     const sig = await bagSignature(s.data);
-    // eslint-disable-next-line no-console
-    console.log("[bag scan]", {
-      symbology: s.symbology,
-      raw: s.data,
-      escaped: JSON.stringify(s.data),
-      length: s.data.length,
-      codepoints: Array.from(s.data, c => c.charCodeAt(0)),
-      parsed,
-      signature: sig,
-    });
     const mpn = parsed.mpn.trim();
     if (!mpn) return;
     // Dedup by signature first (the same physical bag re-fires the scan


### PR DESCRIPTION
## Summary

Bundle of small frontend fixes from the audit: FE MED-4 (no 404 page), MED-10 (Sentry user identity not set), LOW-1 (3 console.* calls in production).

## Changes

- **Sentry user identity**: `auth.tsx::refresh` calls `Sentry.setUser({id, email})` after `/auth/me` resolves; logout clears it. Non-401 refresh errors now `Sentry.captureException` instead of `console.error`.
- **404 page**: new `routes/NotFound.tsx` with quick-link list. Replaces the one-line catchall.
- **console.* cleanup**: dropped the `[bag scan]` DevTools log; `ScanditScanner` init errors now go to Sentry via a lazy import; `auth.tsx` covered by `captureException` above. Grep for `console.*` outside test files in `web/src` is empty.

## Verified

- `tsc -b` clean
- `vitest run` 19/19

## Out of scope

Comprehensive a11y sweep (htmlFor/id, color-only status, keyboard focus traps) and `<details>`→menu primitive — each deserves its own pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)