### PR TITLE
fix(rbac): gate archive/restore/bulk-delete on admin+ (Arch HIGH-3)

### DIFF
--- a/backend/app/api/routes/builds.py
+++ b/backend/app/api/routes/builds.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import select
 
 from app.api.routes._activity import build_activity
-from app.core.deps import CurrentUser, CurrentWorkspace, DbSession
+from app.core.deps import CurrentUser, CurrentWorkspace, DbSession, require_role
 from app.core.responses import ok
 from app.domain.builds.models import Build
 from app.domain.builds.schemas import BuildCreateIn, BuildPatchIn, ConsumeIn
@@ -137,7 +137,7 @@ def patch_build(build_id: UUID, payload: BuildPatchIn, db: DbSession, ws: Curren
     return ok(_serialize(b))
 
 
-@router.post("/{build_id}/archive")
+@router.post("/{build_id}/archive", dependencies=[Depends(require_role("admin"))])
 def archive_build(build_id: UUID, db: DbSession, ws: CurrentWorkspace, user: CurrentUser):
     b = _get_build(db, ws.id, build_id)
     release_reservations(db, workspace_id=ws.id, user_id=user.id, build=b)
@@ -146,7 +146,7 @@ def archive_build(build_id: UUID, db: DbSession, ws: CurrentWorkspace, user: Cur
     return ok(None, "archived")
 
 
-@router.post("/{build_id}/restore")
+@router.post("/{build_id}/restore", dependencies=[Depends(require_role("admin"))])
 def restore_build(build_id: UUID, db: DbSession, ws: CurrentWorkspace):
     b = _get_build(db, ws.id, build_id)
     b.archived_at = None

--- a/backend/app/api/routes/orders.py
+++ b/backend/app/api/routes/orders.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import or_, select
 
 from app.api.routes._activity import build_activity
-from app.core.deps import CurrentUser, CurrentWorkspace, DbSession
+from app.core.deps import CurrentUser, CurrentWorkspace, DbSession, require_role
 from app.core.responses import ok
 from app.domain.orders.models import Order, OrderEntry
 from app.domain.stock.models import StockEntry
@@ -166,7 +166,7 @@ def patch_order(order_id: UUID, payload: OrderPatchIn, db: DbSession, ws: Curren
     return ok(_serialize(o, totals=_totals(entries)))
 
 
-@router.post("/{order_id}/archive")
+@router.post("/{order_id}/archive", dependencies=[Depends(require_role("admin"))])
 def archive_order(order_id: UUID, db: DbSession, ws: CurrentWorkspace):
     o = _get_order(db, ws.id, order_id)
     o.archived_at = datetime.now(timezone.utc)
@@ -174,7 +174,7 @@ def archive_order(order_id: UUID, db: DbSession, ws: CurrentWorkspace):
     return ok(None, "archived")
 
 
-@router.post("/{order_id}/restore")
+@router.post("/{order_id}/restore", dependencies=[Depends(require_role("admin"))])
 def restore_order(order_id: UUID, db: DbSession, ws: CurrentWorkspace):
     o = _get_order(db, ws.id, order_id)
     o.archived_at = None

--- a/backend/app/api/routes/parts.py
+++ b/backend/app/api/routes/parts.py
@@ -6,7 +6,7 @@ from uuid import UUID
 
 import os
 
-from fastapi import APIRouter, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import FileResponse
 from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import or_, select
@@ -14,7 +14,7 @@ from sqlalchemy import or_, select
 from app.api._helpers import assert_in_workspace
 from app.api.routes._activity import build_activity
 from app.core.config import settings
-from app.core.deps import CurrentUser, CurrentWorkspace, DbSession
+from app.core.deps import CurrentUser, CurrentWorkspace, DbSession, require_role
 from app.core.responses import ok
 from app.core.secrets import decrypt
 from app.domain.custom_fields.models import CustomField
@@ -379,7 +379,9 @@ def patch_part(part_id: UUID, payload: PartPatch, db: DbSession, ws: CurrentWork
     )
 
 
-@router.post("/{part_id}/archive")
+# Archive/restore are admin+ — they're workspace-management ops, not
+# regular operational tasks. Members get a 403 if they try (Arch HIGH-3).
+@router.post("/{part_id}/archive", dependencies=[Depends(require_role("admin"))])
 def archive_part(part_id: UUID, db: DbSession, ws: CurrentWorkspace):
     p = _get_part(db, ws.id, part_id)
     p.archived_at = datetime.now(timezone.utc)
@@ -387,7 +389,7 @@ def archive_part(part_id: UUID, db: DbSession, ws: CurrentWorkspace):
     return ok(None, "archived")
 
 
-@router.post("/{part_id}/restore")
+@router.post("/{part_id}/restore", dependencies=[Depends(require_role("admin"))])
 def restore_part(part_id: UUID, db: DbSession, ws: CurrentWorkspace):
     p = _get_part(db, ws.id, part_id)
     p.archived_at = None
@@ -403,7 +405,7 @@ class BulkDeleteIn(BaseModel):
     part_ids: list[UUID] = Field(min_length=1, max_length=100)
 
 
-@router.post("/bulk-delete")
+@router.post("/bulk-delete", dependencies=[Depends(require_role("admin"))])
 def bulk_delete_parts(payload: BulkDeleteIn, db: DbSession, ws: CurrentWorkspace):
     """Soft-delete (archive) the listed parts in one shot. Hard-deleting
     would foreign-key-cascade into stock_entries / lots / order_entries

--- a/backend/app/api/routes/projects.py
+++ b/backend/app/api/routes/projects.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy import or_, select
 
 from app.api._helpers import assert_in_workspace
-from app.core.deps import CurrentUser, CurrentWorkspace, DbSession
+from app.core.deps import CurrentUser, CurrentWorkspace, DbSession, require_role
 from app.core.responses import ok
 from app.domain.parts.models import Part
 from app.domain.projects import bom_import as bom
@@ -110,7 +110,7 @@ def patch_project(project_id: UUID, payload: ProjectPatchIn, db: DbSession, ws: 
     return ok(_serialize(p))
 
 
-@router.post("/{project_id}/archive")
+@router.post("/{project_id}/archive", dependencies=[Depends(require_role("admin"))])
 def archive_project(project_id: UUID, db: DbSession, ws: CurrentWorkspace):
     p = _get(db, ws.id, project_id)
     p.archived_at = datetime.now(timezone.utc)
@@ -118,7 +118,7 @@ def archive_project(project_id: UUID, db: DbSession, ws: CurrentWorkspace):
     return ok(None, "archived")
 
 
-@router.post("/{project_id}/restore")
+@router.post("/{project_id}/restore", dependencies=[Depends(require_role("admin"))])
 def restore_project(project_id: UUID, db: DbSession, ws: CurrentWorkspace):
     p = _get(db, ws.id, project_id)
     p.archived_at = None

--- a/backend/app/api/routes/storage.py
+++ b/backend/app/api/routes/storage.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import or_, select
 
-from app.core.deps import CurrentUser, CurrentWorkspace, DbSession
+from app.core.deps import CurrentUser, CurrentWorkspace, DbSession, require_role
 from app.core.responses import ok
 from app.domain.storage.models import StorageLocation
 from app.domain.stock.service import (
@@ -108,7 +108,7 @@ def patch_storage(storage_id: UUID, payload: StoragePatch, db: DbSession, ws: Cu
     return ok(_serialize(s))
 
 
-@router.post("/{storage_id}/archive")
+@router.post("/{storage_id}/archive", dependencies=[Depends(require_role("admin"))])
 def archive_storage(storage_id: UUID, db: DbSession, ws: CurrentWorkspace):
     s = _get(db, ws.id, storage_id)
     s.archived_at = datetime.now(timezone.utc)
@@ -116,7 +116,7 @@ def archive_storage(storage_id: UUID, db: DbSession, ws: CurrentWorkspace):
     return ok(None, "archived")
 
 
-@router.post("/{storage_id}/restore")
+@router.post("/{storage_id}/restore", dependencies=[Depends(require_role("admin"))])
 def restore_storage(storage_id: UUID, db: DbSession, ws: CurrentWorkspace):
     s = _get(db, ws.id, storage_id)
     s.archived_at = None


### PR DESCRIPTION
## Summary

Closes Arch HIGH-3. Previously every member could archive workspace-level resources. Archive/unarchive are workspace-management ops, not regular work.

## Gates applied (admin+ via `Depends(require_role("admin"))`)

- `/api/parts/{id}/archive`, `/restore`
- `/api/parts/bulk-delete`
- `/api/storage/{id}/archive`, `/restore`
- `/api/orders/{id}/archive`, `/restore`
- `/api/builds/{id}/archive`, `/restore`
- `/api/projects/{id}/archive`, `/restore`

## Operational ops stay at member+

Stock add/remove/move/adjust, build consume, order receive, BOM CRUD, lot ops, custom fields, tags, attachments, refresh-from-provider.

**Backend tests: 237/237** (existing tests run as owner = satisfies admin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)