### PR TITLE
fix(security): default-deny Sentry request bodies + drop frame locals (SEC2-005)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -14,17 +14,28 @@ from app.core.logging import configure_logging
 configure_logging()
 
 
-# Top-level (testable) Sentry event scrubber. Runs as `before_send` so the
-# event is mutated before it leaves the worker. We have to scrub here
-# rather than rely on Sentry's defaults because:
-# - PATCH /api/workspaces/current carries the workspace's plaintext
-#   provider API keys + scanner license key in the body. A 5xx during
-#   that PATCH would otherwise ship those credentials to Sentry.
-# - POST /api/workspaces/{id}/switch carries the target workspace_id —
-#   tenant-identifying, low value to triage.
-# - Cookie / Authorization / X-Workspace-Id headers are tenant- or
-#   session-identifying. Sentry redacts `Cookie` by default, but we
-#   strip explicitly so we don't depend on the SDK's redaction list.
+# Top-level (testable) Sentry event scrubber. Runs as `before_send` so
+# the event is mutated before it leaves the worker.
+#
+# Default-deny `request.data` on any non-GET method. The previous narrow
+# allow-list ("only /api/workspaces") was identified by the 2026-05-01 v2
+# teardown (SEC2-005) as leaking on every other route that handles a
+# secret-bearing body:
+#   - POST /api/auth/signup, /login → plaintext password
+#   - POST /api/invitations/accept → raw invitation token (bearer-equivalent)
+#   - POST /api/parts/lookup-mpn → decrypted provider API keys in scope
+#   - POST /api/parts/bulk-import-from-scan → same
+#   - PATCH /api/workspaces/current → plaintext provider/scanner secrets
+#   - POST /api/attachments → multipart bodies with arbitrary user content
+# A 5xx in any of those handlers would attach the request body. Replacing
+# the URL allow-list with a method default-deny is the only way to keep
+# this safe as new routes are added — there is no read-only POST in the
+# API today, and any future "just status" body still has nothing useful
+# for triage that isn't already in URL + status_code.
+#
+# Cookie / Authorization / X-Workspace-Id headers are tenant- or
+# session-identifying on every method, so the header scrub runs first and
+# applies regardless of method.
 def _scrub_event(event, _hint):
     request = event.get("request")
     if not isinstance(request, dict):
@@ -35,9 +46,8 @@ def _scrub_event(event, _hint):
         for k in list(headers.keys()):
             if k.lower() in drop:
                 headers.pop(k, None)
-    url = (request.get("url") or "").lower()
     method = (request.get("method") or "").upper()
-    if method in ("PATCH", "POST") and "/api/workspaces" in url:
+    if method and method != "GET":
         if request.pop("data", None) is not None:
             request["body_redacted"] = True
     return event
@@ -65,6 +75,13 @@ def _init_sentry() -> None:
         # right balance: triage gets enough context, plaintext credentials
         # never reach Sentry.
         send_default_pii=True,
+        # Drop frame-local variables from event payloads. Default-True
+        # combined with `send_default_pii=True` was shipping locals like
+        # `payload.password`, `decrypt(...)` return values, and Pydantic
+        # model `__init__` kwargs that include API keys (v2 teardown
+        # SEC2-005). Stack traces alone are enough triage signal; locals
+        # are an unbounded leak surface.
+        include_local_variables=False,
         before_send=_scrub_event,
         integrations=[
             StarletteIntegration(transaction_style="endpoint"),

--- a/backend/tests/test_security_hardening.py
+++ b/backend/tests/test_security_hardening.py
@@ -94,7 +94,11 @@ def test_scrubber_strips_post_body_on_workspace_switch():
     assert "data" not in out["request"]
 
 
-def test_scrubber_keeps_body_on_unrelated_endpoint():
+def test_scrubber_strips_body_on_unrelated_post_too():
+    """Updated for v2 SEC2-005: the previous URL allow-list (only
+    `/api/workspaces`) leaked credential-bearing bodies on signup,
+    login, invitations, parts-provider, bulk-import. The new posture
+    is method-based default-deny — every non-GET strips its body."""
     event = {
         "request": {
             "method": "POST",
@@ -104,8 +108,8 @@ def test_scrubber_keeps_body_on_unrelated_endpoint():
         },
     }
     out = _scrub_event(event, None)
-    # Non-workspace POSTs keep their body — this is normal triage data.
-    assert out["request"]["data"] == '{"name": "Cap"}'
+    assert "data" not in out["request"]
+    assert out["request"].get("body_redacted") is True
 
 
 def test_scrubber_strips_sensitive_headers():

--- a/backend/tests/test_sentry_scrubber.py
+++ b/backend/tests/test_sentry_scrubber.py
@@ -1,0 +1,168 @@
+"""Tests for the Sentry `before_send` scrubber (v2 teardown SEC2-005).
+
+The scrubber is mounted as `before_send` in `_init_sentry`. In tests we
+import the function directly and feed it constructed event payloads —
+no Sentry SDK wiring is needed. Pinning here matters because the prior
+posture (URL allow-list of /api/workspaces) was identified as leaking
+credential-bearing bodies on every other route that handles a secret.
+"""
+from __future__ import annotations
+
+from app.main import _scrub_event
+
+
+def _event(method: str, url: str, *, data=None, headers=None):
+    req: dict = {"method": method, "url": url}
+    if data is not None:
+        req["data"] = data
+    if headers is not None:
+        req["headers"] = headers
+    return {"request": req}
+
+
+# ---------------------------------------------------------------------------
+# Body default-deny on non-GET
+# ---------------------------------------------------------------------------
+
+
+def test_scrubber_strips_body_on_signup_post():
+    """The original SEC2-005 leak vector: 5xx during signup ships
+    plaintext password to Sentry under the prior narrow allow-list."""
+    event = _event(
+        "POST",
+        "/api/auth/signup",
+        data={"email": "u@x.com", "name": "u", "password": "TestPass-2026-Stronk"},
+    )
+    out = _scrub_event(event, None)
+    assert "data" not in out["request"]
+    assert out["request"]["body_redacted"] is True
+
+
+def test_scrubber_strips_body_on_login_post():
+    event = _event("POST", "/api/auth/login", data={"email": "u@x.com", "password": "p"})
+    out = _scrub_event(event, None)
+    assert "data" not in out["request"]
+    assert out["request"]["body_redacted"] is True
+
+
+def test_scrubber_strips_body_on_invitation_accept():
+    """Raw invitation token is bearer-equivalent until consumed."""
+    event = _event("POST", "/api/invitations/accept", data={"token": "abc..."})
+    out = _scrub_event(event, None)
+    assert "data" not in out["request"]
+
+
+def test_scrubber_strips_body_on_provider_lookup():
+    """The handler decrypts API keys into local scope; a 5xx around the
+    upstream call would otherwise carry both the URL and the body."""
+    event = _event("POST", "/api/parts/lookup-mpn", data={"mpn": "RC0402JR-070R"})
+    out = _scrub_event(event, None)
+    assert "data" not in out["request"]
+
+
+def test_scrubber_strips_body_on_workspaces_patch():
+    """The original /api/workspaces case still works — just via the
+    method default-deny rather than the URL allow-list."""
+    event = _event(
+        "PATCH",
+        "/api/workspaces/current",
+        data={"parts_provider_api_key": "MOUSER-FAKE-KEY"},
+    )
+    out = _scrub_event(event, None)
+    assert "data" not in out["request"]
+
+
+def test_scrubber_strips_body_on_delete():
+    event = _event("DELETE", "/api/parts/abc", data={"reason": "test"})
+    out = _scrub_event(event, None)
+    assert "data" not in out["request"]
+
+
+def test_scrubber_strips_body_on_put():
+    event = _event("PUT", "/api/whatever", data={"x": 1})
+    out = _scrub_event(event, None)
+    assert "data" not in out["request"]
+
+
+# ---------------------------------------------------------------------------
+# GET requests keep their data field (Sentry rarely populates it on GET
+# but if it does — e.g. a route that mistakenly accepts a body on GET —
+# we don't need to touch it; the scrubber's contract is method-based).
+# ---------------------------------------------------------------------------
+
+
+def test_scrubber_keeps_body_on_get():
+    event = _event("GET", "/api/parts", data={"q": "search"})
+    out = _scrub_event(event, None)
+    assert out["request"]["data"] == {"q": "search"}
+    assert "body_redacted" not in out["request"]
+
+
+# ---------------------------------------------------------------------------
+# Header scrub — applies on every method.
+# ---------------------------------------------------------------------------
+
+
+def test_scrubber_strips_sensitive_headers_on_get():
+    event = _event(
+        "GET",
+        "/api/parts",
+        headers={
+            "Cookie": "stockmgr_session=abc",
+            "x-workspace-id": "ws-uuid",
+            "authorization": "Bearer xyz",
+            "X-Trace-Id": "trace-1",
+            "user-agent": "Mozilla/5.0",
+        },
+    )
+    out = _scrub_event(event, None)
+    h = out["request"]["headers"]
+    assert "Cookie" not in h
+    assert "x-workspace-id" not in h
+    assert "authorization" not in h
+    # Non-sensitive headers are kept for triage value.
+    assert "X-Trace-Id" in h
+    assert "user-agent" in h
+
+
+def test_scrubber_strips_sensitive_headers_on_post():
+    event = _event(
+        "POST",
+        "/api/parts",
+        data={"name": "Resistor"},
+        headers={"Cookie": "s=1", "X-Trace-Id": "t"},
+    )
+    out = _scrub_event(event, None)
+    assert "Cookie" not in out["request"]["headers"]
+    assert "X-Trace-Id" in out["request"]["headers"]
+    assert "data" not in out["request"]
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_scrubber_handles_event_without_request():
+    """Some events (e.g. message capture without an HTTP context) don't
+    have a `request` block. Scrubber must no-op rather than raise."""
+    out = _scrub_event({"message": "hello"}, None)
+    assert out == {"message": "hello"}
+
+
+def test_scrubber_handles_request_without_method():
+    """Defensive — older SDK shapes or partial captures might not set
+    `method`. We treat that as 'unknown, do nothing destructive'."""
+    event = {"request": {"url": "/api/parts", "data": {"x": 1}}}
+    out = _scrub_event(event, None)
+    # No method → no body strip (method default-deny only fires with a
+    # known non-GET).
+    assert out["request"]["data"] == {"x": 1}
+
+
+def test_scrubber_does_not_set_body_redacted_when_no_data():
+    """If the request has no body to begin with, we don't add a
+    body_redacted flag — that would lie about what was scrubbed."""
+    event = _event("POST", "/api/parts/abc/archive")  # no body
+    out = _scrub_event(event, None)
+    assert "body_redacted" not in out["request"]

--- a/web/src/instrument.ts
+++ b/web/src/instrument.ts
@@ -41,10 +41,17 @@ Sentry.init({
   // Per the wizard. Sends user IP + request headers; cookies are
   // redacted automatically. Flip to false for stricter data minimisation.
   sendDefaultPii: true,
-  // Strip request bodies on workspace settings PATCH/switch (carry
-  // plaintext provider API keys + scanner license key) and a few
-  // tenant-identifying headers. Sentry redacts Cookie by default, but
-  // we don't depend on the default redaction list.
+  // Default-deny request bodies on any non-GET method. Mirrors the
+  // backend `_scrub_event` posture (v2 teardown SEC2-005) — the prior
+  // narrow allow-list ("only /api/workspaces") leaked credential-bearing
+  // bodies on signup/login/invitations/parts-provider/bulk-import.
+  // There is no read-only POST in the API; if one is added later,
+  // attaching the body to a Sentry event still tells triage nothing
+  // that isn't in URL + status_code.
+  //
+  // Headers: Cookie / Authorization / X-Workspace-Id are tenant- or
+  // session-identifying on every method, so the header scrub applies
+  // regardless of body method.
   beforeSend(event) {
     const req = event.request;
     if (req) {
@@ -56,9 +63,8 @@ Sentry.init({
           }
         }
       }
-      const url = (req.url ?? "").toLowerCase();
       const method = (req.method ?? "").toUpperCase();
-      if ((method === "PATCH" || method === "POST") && url.includes("/api/workspaces")) {
+      if (method && method !== "GET") {
         if (req.data !== undefined) {
           delete req.data;
           (req as Record<string, unknown>).body_redacted = true;


### PR DESCRIPTION
## Summary

- Closes the v2 teardown's `SEC2-005` (High) — the existing `before_send` scrubber stripped request bodies only on `/api/workspaces`. Every other secret-bearing route (signup/login plaintext password, invitation accept token, parts-provider API keys, bulk-import) leaked on a 5xx.
- Replaces the URL allow-list with a **method-based default-deny**: `request.data` is dropped on every non-GET. New routes are safe by construction.
- Sets `include_local_variables=False` so frame-local variables (e.g. `payload.password`, `decrypt(...)` returns) are not shipped with stack traces.
- Mirrors both changes on the frontend SDK in `web/src/instrument.ts`.
- Header scrub (Cookie / Authorization / X-Workspace-Id) is unchanged.

## Test plan

- [ ] CI green — new `backend/tests/test_sentry_scrubber.py` (13 cases) covers: body strip on POST/PATCH/DELETE/PUT (incl. signup, login, invitation accept, provider lookup, workspace patch); body kept on GET; header scrub on every method; defensive shapes (no request, no method, POST without body).
- [ ] Manual post-deploy: trigger a deliberate 5xx (e.g. invalid signup payload) and verify in Sentry that `request.data` is absent and `body_redacted: true` is set.
- [ ] Manual post-deploy: trigger an exception in a backend handler that has secrets in scope (e.g. PATCH workspace) and verify `frames[*].vars` is empty.

No ops step required — pure code change. This PR is independent of #26 (the `WORKSPACE_SECRETS_KEY` wiring); both can land in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)