### PR TITLE
fix(stock): add_stock/receive/release lock + service-trigger NULL bucket alignment

### DIFF
--- a/backend/app/domain/builds/service.py
+++ b/backend/app/domain/builds/service.py
@@ -23,7 +23,7 @@ from app.domain.lots.models import Lot
 from app.domain.parts.models import Part, PartMetaMember, PartSubstitute
 from app.domain.projects.models import Project, ProjectEntry
 from app.domain.stock.models import StockEntry
-from app.domain.stock.service import current_quantity
+from app.domain.stock.service import current_quantity, lock_parts_for_stock_write
 from app.domain.storage.models import StorageLocation
 
 
@@ -162,9 +162,20 @@ def apply_reservations(
     only by (build_id, part_id, project_id, entry quantity) — no storage
     location or lot is bound, since the consumer picks those at consume-time.
     """
+    # BE2-008: lock every distinct part_id we're about to touch, in
+    # deterministic order, before any read. Without this, concurrent
+    # apply_reservations / release_reservations / consume on overlapping
+    # BOMs race on the reserved ledger and can either double-write or
+    # under-write the counter rows.
+    consumable = _consumable_entries(db, workspace_id=workspace_id, project=project)
+    lock_parts_for_stock_write(
+        db,
+        workspace_id=workspace_id,
+        part_ids=[e.part_id for e in consumable if e.part_id is not None],
+    )
     now = _now()
     written = 0
-    for e in _consumable_entries(db, workspace_id=workspace_id, project=project):
+    for e in consumable:
         part = db.get(Part, e.part_id)
         if part is None:
             continue
@@ -210,6 +221,15 @@ def release_reservations(
     )
     if not reserve_rows:
         return 0
+    # BE2-008: aggregate distinct part_ids from the reserve set, sort,
+    # take the per-part lock before reading the release-counter set.
+    # This serialises archive-while-consuming and any release flow that
+    # races with another build releasing the same parts.
+    lock_parts_for_stock_write(
+        db,
+        workspace_id=workspace_id,
+        part_ids=[r.part_id for r in reserve_rows],
+    )
     released_ids = set(
         db.execute(
             select(StockEntry.related_entry_id)
@@ -257,6 +277,33 @@ def consume(
     if build.status not in ("planned", "in_progress"):
         raise BuildError(f"build is {build.status}")
 
+    # Take every lock this transaction needs up front, in deterministic
+    # UUID-string order, before any read or write. Bundles together the
+    # part_ids from: the project's BOM (touched by `release_reservations`),
+    # the consume lines themselves, and the optional sub-assembly output.
+    # Calling `lock_parts_for_stock_write` here means the inner
+    # `release_reservations` / per-line writes / `output_lot` insert all
+    # acquire their lock as a re-entrant no-op (Postgres advisory locks
+    # are transaction-scoped). Without bundling, two concurrent consumes
+    # touching overlapping BOM ∪ line sets could acquire locks in
+    # different orders → AB/BA deadlock.
+    bom_part_ids = [
+        e.part_id
+        for e in _consumable_entries(db, workspace_id=workspace_id, project=project)
+        if e.part_id is not None
+    ]
+    line_part_ids = [line.part_id for line in payload.lines]
+    output_part_ids: list[UUID] = (
+        [project.associated_subassembly_part_id]
+        if project.associated_subassembly_part_id is not None
+        else []
+    )
+    lock_parts_for_stock_write(
+        db,
+        workspace_id=workspace_id,
+        part_ids=[*bom_part_ids, *line_part_ids, *output_part_ids],
+    )
+
     # Release any outstanding reservations first so the consumption itself
     # doesn't get double-counted against on_hand+reserved.
     release_reservations(db, workspace_id=workspace_id, user_id=user_id, build=build)
@@ -286,6 +333,7 @@ def consume(
             part_id=part_id,
             lot_id=lot_id,
             storage_location_id=storage_location_id,
+            bucket_match=True,
         )
         if total_demand > avail:
             raise BuildError(
@@ -342,6 +390,7 @@ def consume(
             part_id=line.part_id,
             storage_location_id=line.storage_location_id,
             lot_id=line.lot_id,
+            bucket_match=True,
         )
         if line.quantity > avail:
             raise BuildError(

--- a/backend/app/domain/orders/service.py
+++ b/backend/app/domain/orders/service.py
@@ -16,6 +16,7 @@ log = get_logger(__name__)
 from app.domain.orders.schemas import ReceiveIn
 from app.domain.parts.models import Part
 from app.domain.stock.models import StockEntry
+from app.domain.stock.service import lock_parts_for_stock_write
 from app.domain.storage.models import StorageLocation
 from app.domain.workspaces.models import Workspace
 
@@ -59,6 +60,17 @@ def receive(
         .filter(OrderEntry.workspace_id == workspace_id, OrderEntry.order_id == order.id)
         .all()
     }
+
+    # BE2-001: receive is the order-side producer write. Lock every
+    # distinct part this receive touches (across all entries on this
+    # order, even if some lines target only a subset — keeps lock
+    # coverage symmetric with concurrent build_consume / remove paths
+    # on the same parts). Sorted-UUID order keeps it deadlock-safe.
+    lock_parts_for_stock_write(
+        db,
+        workspace_id=workspace_id,
+        part_ids=[e.part_id for e in entries_by_id.values() if e.part_id is not None],
+    )
 
     received_at = _now()
     created_lots: list[Lot] = []

--- a/backend/app/domain/stock/service.py
+++ b/backend/app/domain/stock/service.py
@@ -40,7 +40,7 @@ def _lock_for_stock_write(db: Session, *, workspace_id: UUID, part_id: UUID) -> 
     The append-only ledger has a TOCTOU race: two concurrent operators
     consuming from the same lot both read available=N from
     `current_quantity()`, both pass `qty <= available`, then both insert
-    a -qty row — the lot ends up at -qty (BE CRIT-1).
+    a -qty row — the lot ends up at -qty (BE CRIT-1 / BE2-001).
 
     `pg_advisory_xact_lock` takes a session-level lock keyed on a
     bigint hash of (workspace_id, part_id). The lock is released
@@ -49,6 +49,19 @@ def _lock_for_stock_write(db: Session, *, workspace_id: UUID, part_id: UUID) -> 
     finish, then re-reads `current_quantity` against the updated
     state. The 0013 trigger is the database-side fall-back if the
     lock is ever bypassed (e.g. raw SQL outside the service layer).
+
+    Acquired by every mutating ledger entry — producer (add / receive /
+    build_produce) and consumer (remove / move / adjust / build_consume
+    / reservation release). The original PR #11 omitted the producer
+    side on the reasoning that "positive deltas can't go negative", but
+    BE2-001 surfaced two real consequences:
+      - producer/consumer races observe inconsistent intermediate
+        balances when invariant checks (single_part_only, default-
+        storage-mandatory) read DB state without holding the lock.
+      - the 0013 trigger fires after every insert; a producer skipping
+        the lock can race with a consumer and turn a controllable 4xx
+        into an uncaught 500 from the trigger.
+    Defence in depth on the producer is cheap (~ms) and removes both.
     """
     # UUID's __str__ is stable RFC 4122 canonical form, so the same
     # (workspace_id, part_id) pair always hashes to the same int8 lock id.
@@ -56,6 +69,24 @@ def _lock_for_stock_write(db: Session, *, workspace_id: UUID, part_id: UUID) -> 
         text("SELECT pg_advisory_xact_lock(hashtextextended(:k, 0))"),
         {"k": f"{workspace_id}:{part_id}"},
     )
+
+
+def lock_parts_for_stock_write(
+    db: Session, *, workspace_id: UUID, part_ids: Iterable[UUID]
+) -> None:
+    """Take the per-(workspace, part) advisory lock for a set of parts
+    in deterministic UUID-string order. Used by routes that mutate
+    several parts in one transaction — `builds.consume`,
+    `builds.apply_reservations` / `release_reservations`, `orders.receive`.
+
+    Deterministic ordering is what prevents AB/BA deadlocks: two
+    concurrent transactions touching the same set of parts acquire
+    locks in the same sequence, so the second waits cleanly rather
+    than circular-waiting. UUID string sort works because two
+    transactions seeing the same set of UUIDs always produce the same
+    sorted list."""
+    for pid in sorted(set(part_ids), key=str):
+        _lock_for_stock_write(db, workspace_id=workspace_id, part_id=pid)
 
 
 def current_quantity(
@@ -66,17 +97,48 @@ def current_quantity(
     storage_location_id: UUID | None = None,
     lot_id: UUID | None = None,
     status: str = "on_hand",
+    bucket_match: bool = False,
 ) -> int:
+    """On-hand sum of quantity_delta. Two interpretations of `None`:
+
+    - `bucket_match=False` (default, used by global / report queries):
+      `None` means "don't filter on this dimension" — aggregates across
+      every value of `storage_location_id` / `lot_id` for the part.
+
+    - `bucket_match=True` (used by mutate validators): `None` means
+      "match the SQL NULL bucket specifically", using `IS NULL`. Aligns
+      with the 0013 `check_stock_nonneg` trigger which groups by
+      `IS NOT DISTINCT FROM NEW.lot_id` / `IS NOT DISTINCT FROM
+      NEW.storage_location_id` (NULL is a distinct bucket, not a
+      wildcard).
+
+    Without the explicit `bucket_match`, the validator and the trigger
+    diverge whenever a caller omits `lot_id` or `storage_location_id`
+    against a part whose stock lives in a non-NULL bucket: the
+    validator says "you have N globally" → request passes → trigger
+    fires on the NULL-bucket sum (= 0) → `check_violation` → API
+    surfaces 500. This is BE-002 / DB-002 in the v2 teardown.
+    """
     q = (
         select(func.coalesce(func.sum(StockEntry.quantity_delta), 0))
         .where(StockEntry.workspace_id == workspace_id)
         .where(StockEntry.part_id == part_id)
         .where(StockEntry.status == status)
     )
-    if storage_location_id is not None:
-        q = q.where(StockEntry.storage_location_id == storage_location_id)
-    if lot_id is not None:
-        q = q.where(StockEntry.lot_id == lot_id)
+    if bucket_match:
+        if storage_location_id is None:
+            q = q.where(StockEntry.storage_location_id.is_(None))
+        else:
+            q = q.where(StockEntry.storage_location_id == storage_location_id)
+        if lot_id is None:
+            q = q.where(StockEntry.lot_id.is_(None))
+        else:
+            q = q.where(StockEntry.lot_id == lot_id)
+    else:
+        if storage_location_id is not None:
+            q = q.where(StockEntry.storage_location_id == storage_location_id)
+        if lot_id is not None:
+            q = q.where(StockEntry.lot_id == lot_id)
     return int(db.execute(q).scalar_one() or 0)
 
 
@@ -155,6 +217,12 @@ def add_stock(
     user_id: UUID | None,
     payload: AddStockIn,
 ) -> StockEntry:
+    # Producer-side advisory lock (BE2-001). Held for the rest of the
+    # transaction; serialises concurrent producer/consumer writes on
+    # the same (workspace, part) so invariant reads (default-storage,
+    # serial-tracking, single_part_only) and the StockEntry insert are
+    # not interleaved with a remove/move/adjust on another connection.
+    _lock_for_stock_write(db, workspace_id=workspace_id, part_id=payload.part_id)
     part = db.get(Part, payload.part_id)
     if not _belongs(part, workspace_id):
         raise StockError("part not found")
@@ -272,6 +340,7 @@ def remove_stock(
         part_id=part.id,
         storage_location_id=payload.storage_location_id,
         lot_id=payload.lot_id,
+        bucket_match=True,
     )
     if payload.quantity > available:
         raise StockError(f"insufficient stock (have {available}, want {payload.quantity})")
@@ -333,6 +402,7 @@ def move_stock(
         part_id=part.id,
         storage_location_id=payload.source_storage_location_id,
         lot_id=payload.source_lot_id,
+        bucket_match=True,
     )
     if payload.quantity > available:
         raise StockError(f"insufficient stock at source (have {available}, want {payload.quantity})")
@@ -441,6 +511,7 @@ def adjust_stock(
         part_id=part.id,
         storage_location_id=payload.storage_location_id,
         lot_id=payload.lot_id,
+        bucket_match=True,
     )
     delta = payload.actual_quantity - current
     if delta == 0:

--- a/backend/tests/test_stock_null_bucket.py
+++ b/backend/tests/test_stock_null_bucket.py
@@ -1,0 +1,249 @@
+"""Tests for the BE-002 / DB-002 fix: align service-side validation with
+the 0013 `check_stock_nonneg` trigger's NULL-bucket grouping.
+
+The trigger groups by `IS NOT DISTINCT FROM NEW.lot_id` and `IS NOT
+DISTINCT FROM NEW.storage_location_id` — i.e. NULL is a distinct
+bucket, not a wildcard. Before this PR, the service's `current_quantity`
+treated `lot_id=None` / `storage_location_id=None` as "don't filter,
+aggregate globally", so a remove with NULL coordinates against a part
+whose stock lived in non-NULL buckets passed validation, fell through
+the trigger, and surfaced as a 500.
+
+After: passing `bucket_match=True` (which `remove_stock` /
+`move_stock` / `adjust_stock` and `consume`'s pre-pass + per-line
+checks now do) makes `None` mean "the SQL NULL bucket specifically".
+The validator returns the trigger's view of the world; mismatches
+surface as a clean 4xx StockError instead of a check_violation 500.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.domain.parts.models import Part
+from app.domain.stock.schemas import AddStockIn, LotInput, RemoveStockIn
+from app.domain.stock.service import (
+    StockError,
+    add_stock,
+    current_quantity,
+    remove_stock,
+    total_for_part,
+)
+from app.domain.storage.models import StorageLocation
+from app.domain.users.models import User
+from app.domain.workspaces.models import Workspace, WorkspaceMember
+
+
+@pytest.fixture
+def ws_user(db: Session):
+    user = User(email=f"u-{uuid.uuid4().hex[:6]}@x.com", name="t", password_hash="x")
+    db.add(user)
+    db.flush()
+    ws = Workspace(name="W", kind="organization", owner_user_id=user.id, currency_default="USD")
+    db.add(ws)
+    db.flush()
+    db.add(WorkspaceMember(workspace_id=ws.id, user_id=user.id, status="active"))
+    db.commit()
+    return ws, user
+
+
+@pytest.fixture
+def part_and_storage(db, ws_user):
+    ws, user = ws_user
+    part = Part(
+        workspace_id=ws.id,
+        name="R 10k",
+        part_type="local",
+        created_by=user.id,
+        updated_by=user.id,
+    )
+    db.add(part)
+    storage = StorageLocation(
+        workspace_id=ws.id, name="Bin", created_by=user.id, updated_by=user.id
+    )
+    db.add(storage)
+    db.commit()
+    return ws, user, part, storage
+
+
+def test_remove_with_null_lot_against_non_null_lot_raises_clean_4xx(db, part_and_storage):
+    """Stock lives at (storage=Bin, lot=L1, qty=100). A remove with
+    `lot_id=None` would previously aggregate to 100, pass the service
+    check, then fail at the trigger with check_violation → 500. After
+    bucket_match=True, the validator looks at the NULL-lot bucket
+    (which has 0 stock) and raises StockError before any insert."""
+    ws, user, part, storage = part_and_storage
+    add_stock(
+        db,
+        workspace_id=ws.id,
+        user_id=user.id,
+        payload=AddStockIn(
+            part_id=part.id,
+            quantity=100,
+            storage_location_id=storage.id,
+            lot=LotInput(name="L1"),
+        ),
+    )
+    db.commit()
+
+    # Sanity: the stock is in a non-NULL lot bucket.
+    assert total_for_part(db, workspace_id=ws.id, part_id=part.id) == 100
+
+    # Remove with lot_id=None (NULL bucket) against a part whose stock
+    # is in lot=L1 → service-layer 4xx, NOT a 500 from the trigger.
+    with pytest.raises(StockError, match="insufficient stock"):
+        remove_stock(
+            db,
+            workspace_id=ws.id,
+            user_id=user.id,
+            payload=RemoveStockIn(
+                part_id=part.id,
+                quantity=10,
+                storage_location_id=storage.id,
+                lot_id=None,
+            ),
+        )
+
+
+def test_remove_with_null_storage_against_non_null_storage_raises_clean_4xx(
+    db, part_and_storage
+):
+    """Same shape as above but for storage_location_id."""
+    ws, user, part, storage = part_and_storage
+    add_stock(
+        db,
+        workspace_id=ws.id,
+        user_id=user.id,
+        payload=AddStockIn(
+            part_id=part.id,
+            quantity=50,
+            storage_location_id=storage.id,
+        ),
+    )
+    db.commit()
+
+    with pytest.raises(StockError, match="insufficient stock"):
+        remove_stock(
+            db,
+            workspace_id=ws.id,
+            user_id=user.id,
+            payload=RemoveStockIn(
+                part_id=part.id,
+                quantity=5,
+                storage_location_id=None,  # mismatch — stock is at storage.id
+            ),
+        )
+
+
+def test_remove_with_explicit_bucket_still_works(db, part_and_storage):
+    """Happy path regression — passing the same bucket the add wrote to
+    aligns with the trigger and the remove succeeds cleanly."""
+    ws, user, part, storage = part_and_storage
+    e = add_stock(
+        db,
+        workspace_id=ws.id,
+        user_id=user.id,
+        payload=AddStockIn(
+            part_id=part.id,
+            quantity=20,
+            storage_location_id=storage.id,
+            lot=LotInput(name="L1"),
+        ),
+    )
+    db.commit()
+    assert e.lot_id is not None
+
+    remove_stock(
+        db,
+        workspace_id=ws.id,
+        user_id=user.id,
+        payload=RemoveStockIn(
+            part_id=part.id,
+            quantity=5,
+            storage_location_id=storage.id,
+            lot_id=e.lot_id,
+        ),
+    )
+    db.commit()
+
+    # bucket_match=True query confirms 15 at (storage, lot=L1, status=on_hand).
+    assert (
+        current_quantity(
+            db,
+            workspace_id=ws.id,
+            part_id=part.id,
+            storage_location_id=storage.id,
+            lot_id=e.lot_id,
+            bucket_match=True,
+        )
+        == 15
+    )
+
+
+def test_total_for_part_still_aggregates_globally(db, part_and_storage):
+    """`total_for_part` and the default `current_quantity` calls (used
+    by reports / list endpoints) keep `bucket_match=False` so they sum
+    across all (storage, lot) buckets. Pin that we didn't break that."""
+    ws, user, part, storage = part_and_storage
+    # Two adds: one with a lot, one without. Total should be 30.
+    add_stock(
+        db,
+        workspace_id=ws.id,
+        user_id=user.id,
+        payload=AddStockIn(
+            part_id=part.id,
+            quantity=10,
+            storage_location_id=storage.id,
+            lot=LotInput(name="L1"),
+        ),
+    )
+    add_stock(
+        db,
+        workspace_id=ws.id,
+        user_id=user.id,
+        payload=AddStockIn(
+            part_id=part.id,
+            quantity=20,
+            storage_location_id=storage.id,
+        ),
+    )
+    db.commit()
+
+    assert total_for_part(db, workspace_id=ws.id, part_id=part.id) == 30
+
+    # Per-bucket views with bucket_match=True see only their own bucket.
+    null_lot = current_quantity(
+        db,
+        workspace_id=ws.id,
+        part_id=part.id,
+        storage_location_id=storage.id,
+        lot_id=None,
+        bucket_match=True,
+    )
+    assert null_lot == 20  # only the second add (no lot)
+
+
+def test_add_stock_takes_advisory_lock(db, part_and_storage):
+    """Smoke check that `add_stock` issues `pg_advisory_xact_lock` —
+    same posture as the existing remove/move/adjust tests. The lock is
+    a `SELECT pg_advisory_xact_lock(...)` so we observe it via a
+    successful add (the lock SQL would raise if mis-shaped) and the
+    resulting row landing as expected. The contended-write coverage
+    lives in the threaded test in test_stock_concurrency.py — what we
+    pin here is just "add_stock doesn't bypass the lock helper."""
+    ws, user, part, storage = part_and_storage
+    e = add_stock(
+        db,
+        workspace_id=ws.id,
+        user_id=user.id,
+        payload=AddStockIn(
+            part_id=part.id,
+            quantity=7,
+            storage_location_id=storage.id,
+        ),
+    )
+    db.commit()
+    assert e.quantity_delta == 7
+    assert total_for_part(db, workspace_id=ws.id, part_id=part.id) == 7


### PR DESCRIPTION
## Summary

Closes the three gaps that PR #11 (the stock TOCTOU fix from 2026-05-01) left open, all flagged by the v2 teardown:

- **BE2-001** (Critical) — `add_stock`, `receive`, and the `output_lot` path inside `consume` now take the per-(workspace, part) advisory lock. The original PR's "positive deltas can't go negative" reasoning ignored that producer-side invariant reads (default-storage-mandatory, single_part_only, storage-archived) executed without the lock, surfacing as 500s from the 0013 trigger instead of clean 4xx.
- **BE2-008** (High) — `apply_reservations` and `release_reservations` mutate the reserved ledger; both now aggregate the part_ids they touch, sort by UUID string, and acquire the lock in deterministic order before any read. `consume` bundles all required locks (BOM ∪ lines ∪ output) up front so subsequent inner calls re-acquire as a no-op — eliminates AB/BA deadlocks between concurrent consumes on overlapping BOMs.
- **DB-002 / BE-002** (High) — `current_quantity` gains a `bucket_match: bool` parameter. When True, `None` means "the SQL NULL bucket specifically" (matches the 0013 trigger's `IS NOT DISTINCT FROM` grouping); when False (default), `None` means "don't filter" (preserves global aggregates for reports). The mutate paths (`remove`, `move`, `adjust`, `consume`) pass True so a remove with NULL coordinates against stock in a non-NULL bucket now raises a clean `StockError` instead of falling through to a check_violation 500.

New helper `lock_parts_for_stock_write(part_ids=...)` is exported from `domain/stock/service.py` and used by the multi-part call sites.

## Test plan

- [ ] CI green (244+ existing tests + new `test_stock_null_bucket.py`).
- [ ] New regression tests cover: NULL-lot remove against non-NULL stock raises 4xx; NULL-storage same; explicit-bucket happy path still works; `total_for_part` still aggregates globally.
- [ ] Existing tests using `_add_stock(... no lot)` + consume `(... no lot_id)` pattern still pass — the stock lands at lot=NULL and the consumer targets the same NULL bucket. Verified by code inspection of `test_builds.py`, `test_reservations.py`, `test_meta_parts.py`.
- [ ] Manual post-deploy smoke: receive an order, add stock, build consume on a project — common ledger flows still work.

No migration. No ops step. Independent of PRs #26 and #27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)