### PR TITLE
feat(infra): pre-deploy pg_dump + post-deploy health gate; /api/health checks DB + uploads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,5 +121,39 @@ jobs:
             # deploys.
             export SENTRY_RELEASE
             SENTRY_RELEASE=$(git rev-parse --short=12 HEAD)
+
+            # Pre-deploy DB snapshot (INFRA2-001 / Infra CRIT-1).
+            # Runs before `docker compose up` so the pre-migration state
+            # of the running Postgres is captured. Fails loud — if the
+            # dump can't be written, the deploy aborts here and the old
+            # containers keep serving the old code.
+            bash deploy/predeploy-dump.sh "${SENTRY_RELEASE}"
+
             docker compose -f docker-compose.prod.yml --env-file .env.prod up -d --build
             docker image prune -f
+
+            # Post-deploy health gate (INFRA2-002 / Infra HIGH-1/7/8).
+            # Polls the public health endpoint until 200 — covers the
+            # rebuild window plus alembic upgrade plus first-request
+            # warm-up. The 30 × 5s = 150s ceiling is generous for our
+            # one-worker stack; tighten if it routinely takes less.
+            # On failure the SSH script exits non-zero, which fails the
+            # deploy job and surfaces in GitHub Actions instead of
+            # leaving prod broken with a green CI badge.
+            echo "post-deploy health gate"
+            ok=0
+            for i in $(seq 1 30); do
+              if curl -fsS https://parts.matescb.cz/api/health > /dev/null 2>&1; then
+                echo "  /api/health OK after ${i} attempts ($((i*5))s)"
+                ok=1
+                break
+              fi
+              sleep 5
+            done
+            if [ "${ok}" -ne 1 ]; then
+              echo "post-deploy health gate FAILED — last response:"
+              curl -v https://parts.matescb.cz/api/health || true
+              echo "--- backend logs (tail) ---"
+              docker compose -f docker-compose.prod.yml --env-file .env.prod logs --tail=80 backend || true
+              exit 1
+            fi

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -171,4 +171,47 @@ app.include_router(catalog.router, prefix="/catalog", tags=["catalog"])
 
 @app.get("/api/health")
 def health():
-    return {"data": {"status": "ok"}, "status": {"category": "ok", "message": "OK"}}
+    """Liveness + DB + uploads-volume check.
+
+    Used by three callers:
+    - the docker-compose backend healthcheck (controls when `web` starts,
+      and what `docker compose ps` reports for status),
+    - the post-deploy CI gate (`curl /api/health` retried after `docker
+      compose up` so a failed migration / missing env / DB outage fails
+      the deploy instead of returning a green CI result on a broken prod),
+    - manual smoke after operator-driven changes.
+
+    Returns 503 with structured detail when a check fails so the caller
+    can distinguish `app not started yet` (connection refused) from
+    `app up but DB unreachable`. INFRA2-002 / INFRA-001 / Infra HIGH-1.
+    """
+    from sqlalchemy import text
+
+    from app.infra.db import get_engine
+
+    db_ok = True
+    db_detail: str | None = None
+    try:
+        with get_engine().connect() as conn:
+            conn.execute(text("SELECT 1")).scalar_one()
+    except Exception as e:  # noqa: BLE001 — surface any DB-side error generically
+        db_ok = False
+        db_detail = type(e).__name__
+
+    upload_dir = settings().UPLOAD_DIR
+    uploads_ok = os.path.isdir(upload_dir) and os.access(upload_dir, os.W_OK)
+
+    if db_ok and uploads_ok:
+        return {
+            "data": {"status": "ok", "db": "ok", "uploads": "ok"},
+            "status": {"category": "ok", "message": "OK"},
+        }
+
+    raise HTTPException(
+        status_code=503,
+        detail={
+            "message": "service unhealthy",
+            "db": "ok" if db_ok else f"error: {db_detail}",
+            "uploads": "ok" if uploads_ok else f"not writable: {upload_dir}",
+        },
+    )

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,0 +1,84 @@
+"""Tests for the upgraded `/api/health` endpoint (INFRA2-002 / Infra HIGH-1).
+
+The route now executes a `SELECT 1` against the engine and checks
+write-access to `UPLOAD_DIR`. We pin both the happy path and the
+controlled failure modes — the post-deploy CI gate, the docker compose
+healthcheck, and any future external probe all rely on these contracts.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+def test_health_returns_200_when_db_and_uploads_ok(client):
+    """Conftest stands up the test Postgres + an UPLOAD_DIR; a healthy
+    suite-startup is the contract this test pins for the CI gate."""
+    r = client.get("/api/health")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["data"]["status"] == "ok"
+    assert body["data"]["db"] == "ok"
+    assert body["data"]["uploads"] == "ok"
+    assert body["status"]["category"] == "ok"
+
+
+def test_health_returns_503_when_uploads_dir_unwritable(client):
+    """If the uploads volume isn't writable (lost mount, perms drift),
+    the route reports 503 with structured detail so the operator sees
+    `uploads: not writable: <path>` in the failure log instead of a
+    bare 500."""
+    with patch("app.main.os.access", return_value=False):
+        r = client.get("/api/health")
+    assert r.status_code == 503, r.text
+    body = r.json()
+    assert body["data"] is None
+    assert body["status"]["category"] == "server_error"
+    assert "uploads" in body
+    assert "not writable" in body["uploads"]
+    assert body["db"] == "ok"
+
+
+def test_health_returns_503_when_db_query_raises(client):
+    """A DB outage during health probe shows up as 503 with the
+    exception type name — operator gets a concrete signal rather than
+    the route crashing silently or returning 200 on a dead DB."""
+    from app.infra.db import get_engine
+
+    real_engine = get_engine()
+
+    class _BrokenEngine:
+        def connect(self):
+            raise RuntimeError("simulated DB outage")
+
+    with patch("app.main.os.access", wraps=lambda *a, **kw: True):
+        with patch("app.infra.db.get_engine", return_value=_BrokenEngine()):
+            r = client.get("/api/health")
+
+    assert real_engine is not None  # sanity — we didn't actually break the suite
+    assert r.status_code == 503, r.text
+    body = r.json()
+    assert "error: RuntimeError" in body["db"]
+    assert body["uploads"] == "ok"
+
+
+def test_health_envelope_shape_on_failure(client):
+    """The `{data, status}` envelope contract from CLAUDE.md must hold
+    on the 503 path too. The operator's tooling (and the post-deploy
+    curl gate) parses the body the same way as any other endpoint."""
+    with patch("app.main.os.access", return_value=False):
+        r = client.get("/api/health")
+    body = r.json()
+    assert set(body.keys()) >= {"data", "status"}
+    assert body["data"] is None
+    assert "category" in body["status"]
+    assert "message" in body["status"]

--- a/deploy/predeploy-dump.sh
+++ b/deploy/predeploy-dump.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# Pre-deploy DB snapshot. Runs from the SSH deploy step in
+# .github/workflows/ci.yml AFTER `git reset --hard origin/main` and
+# BEFORE `docker compose up --build`. Captures the state of the
+# running Postgres container before any new alembic migration applies.
+#
+# Closes 2026-04-30 review's Infra CRIT-1 ("no rollback path for
+# destructive migrations") and the v2 teardown's INFRA2-001
+# ("automated DB backup before destructive deploys"). On dump failure,
+# this script exits non-zero so the SSH deploy aborts and the existing
+# container keeps serving the old code.
+#
+# Output: /srv/backups/stockmanager/pre-deploy-${TS}-${SHA}.sql.gz
+#
+# Retention: separate from the nightly cron-driven backups in
+# `backup.sh`. Keep the last 14 pre-deploy dumps. Rationale: nightlies
+# are the canonical retention; pre-deploy dumps are a short-window
+# safety net for the deploy itself.
+#
+# Args:
+#   $1 — short git SHA being deployed (used in the filename so an
+#         operator can tie a dump to the deploy that triggered it).
+#         Optional; defaults to "unknown" if missing.
+
+set -euo pipefail
+
+REPO_DIR="/srv/stockmanager"
+BACKUP_DIR="/srv/backups/stockmanager"
+RETAIN_PREDEPLOY=14
+COMPOSE_FILE="${REPO_DIR}/docker-compose.prod.yml"
+ENV_FILE="${REPO_DIR}/.env.prod"
+SHA="${1:-unknown}"
+TS="$(date +%FT%H%M)"
+
+mkdir -p "${BACKUP_DIR}"
+
+POSTGRES_USER="$(grep -E '^POSTGRES_USER=' "${ENV_FILE}" | cut -d= -f2-)"
+POSTGRES_DB="$(grep -E '^POSTGRES_DB=' "${ENV_FILE}" | cut -d= -f2-)"
+
+if [[ -z "${POSTGRES_USER}" || -z "${POSTGRES_DB}" ]]; then
+    echo "ERROR: POSTGRES_USER / POSTGRES_DB missing from ${ENV_FILE}" >&2
+    exit 1
+fi
+
+OUT="${BACKUP_DIR}/pre-deploy-${TS}-${SHA}.sql.gz"
+
+echo "$(date -Iseconds)  pre-deploy dump  ${SHA}  ->  ${OUT}"
+
+# Fail loudly if the running db container is missing — the dump is the
+# whole point; a deploy that skips it is exactly what this script
+# exists to prevent.
+if ! docker compose -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" ps --status running --services | grep -qx db; then
+    echo "ERROR: db container not running — refusing to deploy without a snapshot" >&2
+    exit 1
+fi
+
+docker compose -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" exec -T db \
+    pg_dump -U "${POSTGRES_USER}" "${POSTGRES_DB}" \
+    | gzip > "${OUT}.tmp"
+mv "${OUT}.tmp" "${OUT}"
+
+# pg_dump emits non-empty output even for an empty schema (header,
+# extensions, etc). A truly empty file means the pipe broke; treat
+# that as a dump failure.
+if [[ ! -s "${OUT}" ]]; then
+    echo "ERROR: dump file is empty — assuming pg_dump failed" >&2
+    rm -f "${OUT}"
+    exit 1
+fi
+
+echo "$(date -Iseconds)  pre-deploy dump OK  $(du -h "${OUT}" | cut -f1)"
+
+# Retention: keep the most recent N pre-deploy dumps. Sort by mtime
+# descending, skip the first N, delete the rest.
+ls -1t "${BACKUP_DIR}"/pre-deploy-*.sql.gz 2>/dev/null \
+    | tail -n +$((RETAIN_PREDEPLOY + 1)) \
+    | xargs -r rm -v

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -57,6 +57,18 @@ services:
         condition: service_healthy
     expose:
       - "8000"
+    # INFRA2-002 / INFRA-001: a healthy container in compose's eyes means
+    # "/api/health returns 200." Failures during start_period don't count
+    # against retries — alembic upgrade + DB connect on first boot can
+    # take >10s, so we give it 60s before any miss is fatal. `web` waits
+    # on this via depends_on.condition below, eliminating the post-deploy
+    # 502 window where nginx came up before the backend.
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:8000/api/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 6
+      start_period: 60s
     # --proxy-headers + --forwarded-allow-ips='*' make uvicorn rewrite
     # request.client.host from the X-Forwarded-For header that Apache
     # populates. Without it, every request looks like it came from the
@@ -109,8 +121,13 @@ services:
         SENTRY_ORG: ${SENTRY_ORG:-}
         SENTRY_PROJECT: ${SENTRY_PROJECT:-}
     restart: unless-stopped
+    # `service_healthy` (rather than the bare `- backend`) makes the web
+    # container hold off until the backend's healthcheck reports green.
+    # Closes the post-deploy 502 window where nginx was already serving
+    # but the backend hadn't finished alembic upgrade.
     depends_on:
-      - backend
+      backend:
+        condition: service_healthy
     # Loopback-only host port. Apache (on the host) reverse-proxies
     # parts.matescb.cz → 127.0.0.1:8091. See deploy/parts.matescb.cz.conf.
     ports:


### PR DESCRIPTION
## Summary

Closes the deploy-safety gap that v1 Infra CRIT-1 / HIGH-1/7/8 and v2 `INFRA2-001` + `INFRA2-002` (both Critical) surface from the same root cause: auto-deploy on `main` ships a destructive migration in seconds with no pre-migration snapshot and no post-deploy verification.

Three coupled changes:

1. **`/api/health`** (`backend/app/main.py`) executes `SELECT 1` against the engine and checks `UPLOAD_DIR` is a writable directory. Returns 200 with `{db, uploads}` detail on success, 503 with the same shape on failure. Preserves the `{data, status}` envelope.
2. **`docker-compose.prod.yml`** — new backend healthcheck (curl /api/health, 60s start_period for alembic upgrade) and `web.depends_on.backend.condition: service_healthy`. Closes the post-deploy 502 window where nginx served before the backend was ready.
3. **CI deploy script** (`.github/workflows/ci.yml`) — pre-deploy `pg_dump` via new `deploy/predeploy-dump.sh` (fails loud, dump must land at `/srv/backups/stockmanager/pre-deploy-${TS}-${SHA}.sql.gz`); post-deploy 30 × 5s curl loop against the public health endpoint, with backend log tail on failure.

## Test plan

- [ ] CI green — new `backend/tests/test_health.py` covers 200 happy path + 503 on unwritable uploads + 503 on DB exception + envelope shape.
- [ ] `bash -n deploy/predeploy-dump.sh` — syntax verified locally.
- [ ] Manual post-deploy: dump file appears at `/srv/backups/stockmanager/pre-deploy-*.sql.gz`; `docker compose ps` shows backend as `healthy`; CI run logs show the curl loop succeeding within ~10–30s.
- [ ] Manual rollback rehearsal: pick a recent pre-deploy dump and verify it loads cleanly into a throwaway local Postgres (`gunzip -c <dump> | psql ...`).

## Ops considerations

- The dump runs against the **running** db container, BEFORE `docker compose up --build`. If the dump fails, the deploy aborts and the existing containers keep serving the old code — exactly the rollback path that didn't exist before.
- The healthcheck's `start_period: 60s` covers cold-boot alembic upgrade; the curl loop's 30 × 5s covers the rebuild + warm-up window.
- Dumps are pruned to the last 14 (separate retention from the nightly cron at `deploy/backup.sh`).
- No env var changes. No schema change. No ops step before merge — this just adds checks.
- Independent of #26 / #27 / #28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)