### PR TITLE
fix(security): provider asset hardening + security headers + BOM caps + route gaps

### DIFF
--- a/backend/app/api/routes/catalog.py
+++ b/backend/app/api/routes/catalog.py
@@ -7,16 +7,35 @@ from __future__ import annotations
 
 from html import escape
 
-from fastapi import APIRouter, HTTPException, status
-from fastapi.responses import HTMLResponse
+from fastapi import APIRouter, HTTPException, Request, status
+from fastapi.responses import HTMLResponse, JSONResponse
 from sqlalchemy import select
 
 from app.core.deps import DbSession
+from app.core.ratelimit import limiter
 from app.core.responses import ok
 from app.domain.parts.models import Part
 from app.domain.workspaces.models import Workspace
 
 router = APIRouter()
+
+
+# Same-origin headers for the public catalog responses (SEC2-009). The
+# nginx layer already attaches these for the SPA bundle, but the catalog
+# is fetched directly from FastAPI in some flows (e.g. the JSON endpoint
+# proxied through Apache without going through nginx) so we attach them
+# here too. Cheap and idempotent; nginx duplicates collapse.
+_CATALOG_HEADERS: dict[str, str] = {
+    "X-Content-Type-Options": "nosniff",
+    "X-Frame-Options": "DENY",
+    "Referrer-Policy": "same-origin",
+    "Content-Security-Policy": (
+        "default-src 'self'; img-src 'self' data:; "
+        "style-src 'self' 'unsafe-inline'; script-src 'none'; "
+        "frame-ancestors 'none'"
+    ),
+    "Permissions-Policy": "()",
+}
 
 
 def _resolve_workspace(db, token: str) -> Workspace:
@@ -134,19 +153,26 @@ def _render_html(ws: Workspace, parts: list[Part]) -> str:
 
 
 @router.get("/{token}", response_class=HTMLResponse)
-def catalog_html(token: str, db: DbSession):
+@limiter.limit("60/minute")
+def catalog_html(request: Request, token: str, db: DbSession):
     ws = _resolve_workspace(db, token)
     parts = _published_parts(db, ws.id)
-    return HTMLResponse(content=_render_html(ws, parts), status_code=200)
+    return HTMLResponse(
+        content=_render_html(ws, parts),
+        status_code=200,
+        headers=_CATALOG_HEADERS,
+    )
 
 
 @router.get("/{token}/parts.json")
-def catalog_json(token: str, db: DbSession):
+@limiter.limit("60/minute")
+def catalog_json(request: Request, token: str, db: DbSession):
     ws = _resolve_workspace(db, token)
     parts = _published_parts(db, ws.id)
-    return ok(
+    body = ok(
         {
             "workspace": {"id": str(ws.id), "name": ws.name},
             "parts": [_part_dict(p) for p in parts],
         }
     )
+    return JSONResponse(content=body, headers=_CATALOG_HEADERS)

--- a/backend/app/api/routes/parts.py
+++ b/backend/app/api/routes/parts.py
@@ -153,6 +153,22 @@ def _serialize(
 # ---------------------------------------------------------------------------
 
 
+# MIME-by-extension map for the serve route. Anything not in this set
+# is treated as an opaque binary and forced to download as an attachment
+# — which keeps a future provider-asset-MIME drift (e.g. an HTML page
+# erroneously saved with a .bin extension) from rendering inline. SVG is
+# intentionally absent; SEC2-006 / SEC2-011.
+_ASSET_MIME_BY_EXT: dict[str, str] = {
+    "jpg": "image/jpeg",
+    "jpeg": "image/jpeg",
+    "png": "image/png",
+    "gif": "image/gif",
+    "webp": "image/webp",
+    "pdf": "application/pdf",
+}
+_INLINE_EXTS: frozenset[str] = frozenset({"jpg", "jpeg", "png", "gif", "webp"})
+
+
 @router.get("/assets/{ws_id}/{filename}")
 def get_provider_asset(
     ws_id: UUID,
@@ -173,20 +189,40 @@ def get_provider_asset(
     if not os.path.isfile(abs_path):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="asset not found")
 
+    ext = filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
+    served_mime = _ASSET_MIME_BY_EXT.get(ext, "application/octet-stream")
+    # Image MIMEs may stay inline so <img> tags work; everything else
+    # (PDFs, opaque binaries) is forced to download to neuter any
+    # MIME-confusion path. Mirrors the attachments.py pattern.
+    inline = ext in _INLINE_EXTS
     headers = {
         # Content-addressed → safe to cache for a year, never re-revalidate.
         "Cache-Control": "public, max-age=31536000, immutable",
+        # Belt-and-braces against a future bug that lets a MIME differ
+        # from the served extension.
+        "X-Content-Type-Options": "nosniff",
     }
     if name:
-        # `inline` keeps PDF / image preview working; the filename only
-        # comes into play when the user does Save As. Restrict to a safe
+        # `inline` keeps image preview working; the filename only comes
+        # into play when the user does Save As. Restrict to a safe
         # subset and append the original extension so the saved file
         # opens in the right viewer.
         safe = "".join(c for c in name if c.isalnum() or c in "._-")[:80] or "datasheet"
-        ext = filename.rsplit(".", 1)[-1] if "." in filename else ""
         ext_suffix = f".{ext}" if ext and not safe.lower().endswith(f".{ext.lower()}") else ""
-        headers["Content-Disposition"] = f'inline; filename="{safe}{ext_suffix}"'
-    return FileResponse(abs_path, headers=headers)
+        disposition_type = "inline" if inline else "attachment"
+        headers["Content-Disposition"] = f'{disposition_type}; filename="{safe}{ext_suffix}"'
+        return FileResponse(abs_path, media_type=served_mime, headers=headers)
+
+    if inline:
+        return FileResponse(abs_path, media_type=served_mime, headers=headers)
+    # Non-image, no caller-supplied filename — still force attachment so
+    # an `evil.bin` lands as a download rather than a rendered page.
+    return FileResponse(
+        abs_path,
+        media_type=served_mime,
+        headers=headers,
+        content_disposition_type="attachment",
+    )
 
 
 @router.get("")

--- a/backend/app/api/routes/parts.py
+++ b/backend/app/api/routes/parts.py
@@ -217,12 +217,12 @@ def get_provider_asset(
         return FileResponse(abs_path, media_type=served_mime, headers=headers)
     # Non-image, no caller-supplied filename — still force attachment so
     # an `evil.bin` lands as a download rather than a rendered page.
-    return FileResponse(
-        abs_path,
-        media_type=served_mime,
-        headers=headers,
-        content_disposition_type="attachment",
-    )
+    # Set the header explicitly rather than relying on Starlette's
+    # `content_disposition_type` kwarg — that param was added in
+    # 0.36+ and silently no-ops on older versions, leaving the response
+    # without a Content-Disposition at all.
+    headers["Content-Disposition"] = "attachment"
+    return FileResponse(abs_path, media_type=served_mime, headers=headers)
 
 
 @router.get("")

--- a/backend/app/api/routes/storage.py
+++ b/backend/app/api/routes/storage.py
@@ -116,6 +116,29 @@ def archive_storage(storage_id: UUID, db: DbSession, ws: CurrentWorkspace, user:
     s = require_resource_access(
         db, StorageLocation, storage_id, ws=ws, user=user, role="admin", label="storage",
     )
+    # BE2-014 — archiving a storage that still holds stock would orphan
+    # those rows in a location the UI hides. Refuse with a structured
+    # 409 listing what's still inside so the operator can move it first.
+    # Runs after the auth gate so an attacker probing for ws-membership
+    # doesn't learn whether a foreign storage has stock.
+    on_hand = stock_for_storage(db, workspace_id=ws.id, storage_location_id=s.id)
+    blocking = [
+        {
+            "part_id": str(r["part_id"]),
+            "lot_id": str(r["lot_id"]) if r["lot_id"] else None,
+            "quantity": int(r["quantity"]),
+        }
+        for r in on_hand
+        if int(r["quantity"]) > 0
+    ]
+    if blocking:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "message": "storage still holds on-hand stock; move or remove it first",
+                "blocking": blocking,
+            },
+        )
     s.archived_at = datetime.now(timezone.utc)
     return ok(None, "archived")
 

--- a/backend/app/domain/orders/schemas.py
+++ b/backend/app/domain/orders/schemas.py
@@ -13,7 +13,9 @@ class OrderEntryIn(BaseModel):
 
     part_id: UUID | None = None
     name: str | None = None
-    quantity_ordered: int = Field(ge=0)
+    # BE2-013 — ordering zero of something is always a mistake; reject
+    # at the schema layer rather than letting it land as a phantom row.
+    quantity_ordered: int = Field(..., ge=1)
     unit_price: Decimal | None = None
     currency: str | None = None
     comments: str | None = None
@@ -24,7 +26,7 @@ class OrderEntryPatch(BaseModel):
 
     part_id: UUID | None = None
     name: str | None = None
-    quantity_ordered: int | None = None
+    quantity_ordered: int | None = Field(default=None, ge=1)
     unit_price: Decimal | None = None
     currency: str | None = None
     comments: str | None = None

--- a/backend/app/domain/parts/services/assets.py
+++ b/backend/app/domain/parts/services/assets.py
@@ -5,9 +5,27 @@ The helper is content-addressed (sha256 of body), idempotent, and
 fail-tolerant: a network timeout or oversize body returns `None` and
 the caller falls back to the original remote URL — i.e. the worst case
 is the same as today's behaviour, never worse.
+
+Hardening notes (SEC2-006):
+- Host allow-list. We only follow URLs whose hostname is on the
+  shipped-provider allow-list AND whose DNS resolves to a
+  globally-routable IP. This blocks SSRF into RFC1918 / loopback /
+  link-local / metadata-service ranges.
+- No redirects. `httpx.Client(..., follow_redirects=False)`. A 30x
+  upstream is a refusal — we don't want a future Mouser CDN swap to
+  silently broaden the egress surface, and the allow-list check would
+  be useless if we then chased a Location: header to anywhere.
+- No SVG. SVG is XML and can carry `<script>` / `xlink:href` payloads
+  that the browser will execute when it renders the file inline. We
+  drop `image/svg+xml` from the MIME map entirely; an upstream that
+  serves SVG ends up written with `.bin` (and our serve route forces
+  `Content-Disposition: attachment` for non-image MIMEs anyway).
 """
 from __future__ import annotations
 
+import ipaddress
+import logging
+import socket
 import hashlib
 import os
 from urllib.parse import urlparse
@@ -17,20 +35,41 @@ import httpx
 from app.core.config import settings
 
 
+log = logging.getLogger(__name__)
+
+
 _TIMEOUT_SEC = 10.0
 _MAX_BYTES = 10 * 1024 * 1024  # 10 MB ceiling — datasheet PDFs are usually 1-3 MB
 
 # Content-Type → file extension. Falls through to URL-suffix inference
-# for anything that doesn't match.
+# for anything that doesn't match. SVG is intentionally absent — see
+# the module docstring.
 _EXT_BY_MIME: dict[str, str] = {
     "image/jpeg": "jpg",
     "image/jpg": "jpg",
     "image/png": "png",
     "image/gif": "gif",
     "image/webp": "webp",
-    "image/svg+xml": "svg",
     "application/pdf": "pdf",
 }
+
+# Hostnames the helper is permitted to fetch from. Keep this narrow:
+# every entry here is part of the SSRF surface. New providers must be
+# added explicitly, never via wildcards.
+_ALLOWED_HOSTS: frozenset[str] = frozenset(
+    {
+        # Mouser
+        "www.mouser.com",
+        "mouser.com",
+        "media.mouser.com",
+        "eu.mouser.com",
+        # DigiKey
+        "www.digikey.com",
+        "digikey.com",
+        "media.digikey.com",
+        "mediacdn.digikey.com",
+    }
+)
 
 
 def _ext_from_url(url: str) -> str | None:
@@ -45,9 +84,17 @@ def _ext_from_url(url: str) -> str | None:
 
 def _ext_from_response(resp: httpx.Response, url: str) -> str:
     ct = (resp.headers.get("content-type") or "").split(";", 1)[0].strip().lower()
+    if ct == "image/svg+xml":
+        # Explicit refusal — the file lands as `.bin` and the serve
+        # route forces an `attachment` disposition for non-images.
+        log.warning("provider asset rejected: SVG content-type from %s", url)
+        return "bin"
     if ct in _EXT_BY_MIME:
         return _EXT_BY_MIME[ct]
     by_url = _ext_from_url(url)
+    if by_url == "svg":
+        log.warning("provider asset rejected: .svg URL suffix from %s", url)
+        return "bin"
     if by_url:
         return by_url
     # Fallback — write something rather than refuse. Browsers infer from
@@ -55,9 +102,35 @@ def _ext_from_response(resp: httpx.Response, url: str) -> str:
     return "bin"
 
 
+def _host_is_allowed(host: str) -> bool:
+    """True if `host` is on the explicit provider allow-list AND its
+    A-record resolves to a globally routable IP."""
+    if not host:
+        return False
+    if host.lower() not in _ALLOWED_HOSTS:
+        return False
+    try:
+        ip_str = socket.gethostbyname(host)
+    except OSError:
+        return False
+    try:
+        ip = ipaddress.ip_address(ip_str)
+    except ValueError:
+        return False
+    # `is_global` excludes private (RFC1918), loopback, link-local,
+    # multicast, reserved, and the AWS metadata range (169.254/16).
+    return ip.is_global
+
+
 def _http_get(url: str) -> httpx.Response:
-    """Network seam — patched by tests."""
-    with httpx.Client(timeout=_TIMEOUT_SEC, follow_redirects=True) as client:
+    """Network seam — patched by tests.
+
+    `follow_redirects=False` is load-bearing: a 30x upstream is treated
+    as a refusal (returns the redirect itself, which the caller rejects
+    because `status_code != 200`). Auto-following would void the host
+    allow-list since the Location: header could point anywhere.
+    """
+    with httpx.Client(timeout=_TIMEOUT_SEC, follow_redirects=False) as client:
         return client.get(url)
 
 
@@ -71,17 +144,26 @@ def fetch_provider_asset(url: str, workspace_id: str, kind: str) -> str | None:
 
     Returns None on:
       - empty / non-http URL
-      - HTTP error (4xx/5xx)
+      - host not on the provider allow-list
+      - host resolves to a non-public IP (SSRF guard)
+      - HTTP error (4xx/5xx) or 30x redirect
       - body > _MAX_BYTES
       - any network exception
     Caller should fall back to the original URL in those cases.
     """
     if not url or not url.lower().startswith(("http://", "https://")):
         return None
+    parsed = urlparse(url)
+    host = (parsed.hostname or "").lower()
+    if not _host_is_allowed(host):
+        log.warning("provider asset rejected: host not allow-listed (%s)", host)
+        return None
     try:
         resp = _http_get(url)
     except Exception:
         return None
+    # 30x is treated as a refusal — we don't follow redirects (see
+    # `_http_get` docstring).
     if resp.status_code != 200:
         return None
     body = resp.content

--- a/backend/app/domain/projects/bom_import.py
+++ b/backend/app/domain/projects/bom_import.py
@@ -9,6 +9,7 @@ from typing import Iterable
 from uuid import UUID
 
 import chardet
+from fastapi import HTTPException, status
 from sqlalchemy import and_, func, select
 from sqlalchemy.orm import Session
 
@@ -24,8 +25,31 @@ from app.domain.projects.schemas import (
 )
 
 
+# SEC2-007 / BE2-006 — second line of defence. The schema caps the
+# base64 input at 5 MB; this caps the decoded body at 4 MB and the row
+# count at 10 000 so a malicious payload that squeaks past the schema
+# (e.g. a wildly compressible CSV that base64-decodes oddly) still
+# can't OOM the worker.
+_MAX_DECODED_BYTES = 4_000_000
+_MAX_ROW_COUNT = 10_000
+
+
 def _decode_b64(b64: str) -> bytes:
-    return base64.b64decode(b64)
+    raw = base64.b64decode(b64)
+    if len(raw) > _MAX_DECODED_BYTES:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=f"BOM payload exceeds {_MAX_DECODED_BYTES} bytes after decode",
+        )
+    return raw
+
+
+def _enforce_row_cap(rows: list) -> None:
+    if len(rows) > _MAX_ROW_COUNT:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"BOM exceeds {_MAX_ROW_COUNT} rows; split the import",
+        )
 
 
 def _detect_encoding(raw: bytes, hint: str | None) -> str:
@@ -73,6 +97,7 @@ def preview(payload: BomImportPreviewIn) -> BomImportPreviewOut:
     sep = _detect_separator(text, payload.separator)
     rows_iter = csv.reader(io.StringIO(text), delimiter=sep)
     all_rows: list[list[str]] = [list(r) for r in rows_iter if any(c.strip() for c in r)]
+    _enforce_row_cap(all_rows)
     if not all_rows:
         return BomImportPreviewOut(
             detected_separator=sep,
@@ -228,6 +253,7 @@ def commit(
     text = raw.decode(payload.encoding or "utf-8", errors="replace")
     rows_iter = csv.reader(io.StringIO(text), delimiter=payload.separator or ",")
     all_rows: list[list[str]] = [list(r) for r in rows_iter if any(c.strip() for c in r)]
+    _enforce_row_cap(all_rows)
     if payload.has_header and all_rows:
         all_rows = all_rows[1:]
 

--- a/backend/app/domain/projects/schemas.py
+++ b/backend/app/domain/projects/schemas.py
@@ -67,7 +67,11 @@ class BomImportPreviewIn(BaseModel):
     """Step 1: parse the upload, return preview rows + suggested separator."""
     model_config = ConfigDict(extra="forbid")
 
-    text_b64: str
+    # Cap base64 input at 5 MB (≈3.75 MB of raw bytes after decode); the
+    # importer asserts the decoded size separately so a payload that
+    # squeaks under this limit but expands oddly still trips the
+    # post-decode guard. SEC2-007 / BE2-006.
+    text_b64: str = Field(..., max_length=5_000_000)
     separator: str | None = None  # auto-detect if None
     encoding: str | None = None
     has_header: bool | None = None
@@ -96,7 +100,8 @@ class BomMappingField(BaseModel):
 class BomImportCommitIn(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    text_b64: str
+    # See BomImportPreviewIn.text_b64 — same cap; SEC2-007 / BE2-006.
+    text_b64: str = Field(..., max_length=5_000_000)
     separator: str
     encoding: str
     has_header: bool

--- a/backend/app/domain/projects/schemas.py
+++ b/backend/app/domain/projects/schemas.py
@@ -67,11 +67,14 @@ class BomImportPreviewIn(BaseModel):
     """Step 1: parse the upload, return preview rows + suggested separator."""
     model_config = ConfigDict(extra="forbid")
 
-    # Cap base64 input at 5 MB (≈3.75 MB of raw bytes after decode); the
-    # importer asserts the decoded size separately so a payload that
-    # squeaks under this limit but expands oddly still trips the
-    # post-decode guard. SEC2-007 / BE2-006.
-    text_b64: str = Field(..., max_length=5_000_000)
+    # Cap base64 input at 6 MB (≈4.5 MB raw after decode). The importer
+    # asserts the decoded size separately at 4 MB so a payload that
+    # squeaks under this Field limit but decodes past the runtime cap
+    # still trips the post-decode 413 guard. The 6 MB / 4 MB pairing
+    # is deliberate: Field validation must allow a payload large enough
+    # for the runtime check to fire, otherwise the layered defence
+    # collapses to just the Pydantic 422. SEC2-007 / BE2-006.
+    text_b64: str = Field(..., max_length=6_000_000)
     separator: str | None = None  # auto-detect if None
     encoding: str | None = None
     has_header: bool | None = None
@@ -101,7 +104,7 @@ class BomImportCommitIn(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     # See BomImportPreviewIn.text_b64 — same cap; SEC2-007 / BE2-006.
-    text_b64: str = Field(..., max_length=5_000_000)
+    text_b64: str = Field(..., max_length=6_000_000)
     separator: str
     encoding: str
     has_header: bool

--- a/backend/tests/test_archive_storage.py
+++ b/backend/tests/test_archive_storage.py
@@ -1,0 +1,101 @@
+"""Regression tests for BE2-014 — archive_storage refuses when on-hand
+stock is still in residence.
+
+The previous shape would happily set `archived_at`, hiding the storage
+from the UI while leaving stock_entries pinned to that storage_id.
+Re-listing the storage parts then required showing archived rows or
+running a manual SQL fix-up. The fix returns a structured 409 with
+`blocking: [{part_id, lot_id, quantity}]` so the UI can show the
+operator what they need to move first.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+def _signup(c: TestClient) -> None:
+    email = f"arch-{uuid.uuid4().hex[:6]}@x.com"
+    r = c.post(
+        "/api/auth/signup",
+        json={"email": email, "name": "u", "password": "TestPass-2026-Stronk"},
+    )
+    assert r.status_code == 200, r.text
+
+
+@pytest.fixture
+def authed():
+    c = TestClient(app)
+    _signup(c)
+    return c
+
+
+def _create_part(c: TestClient, name: str) -> str:
+    r = c.post("/api/parts", json={"name": name, "part_type": "local"})
+    assert r.status_code == 201, r.text
+    return r.json()["data"]["id"]
+
+
+def _create_storage(c: TestClient, name: str) -> str:
+    r = c.post("/api/storage", json={"name": name})
+    assert r.status_code in (200, 201), r.text
+    return r.json()["data"]["id"]
+
+
+def test_archive_empty_storage_succeeds(authed):
+    sid = _create_storage(authed, "Empty Shelf")
+    r = authed.post(f"/api/storage/{sid}/archive")
+    assert r.status_code == 200, r.text
+
+
+def test_archive_with_on_hand_stock_409s_with_blocking_detail(authed):
+    pid = _create_part(authed, "Cap 0.1uF")
+    sid = _create_storage(authed, "Shelf-with-stock")
+
+    add = authed.post(
+        "/api/stock/add",
+        json={"part_id": pid, "quantity": 10, "storage_location_id": sid},
+    )
+    assert add.status_code in (200, 201), add.text
+
+    r = authed.post(f"/api/storage/{sid}/archive")
+    assert r.status_code == 409, r.text
+    body = r.json()
+    # http_exception_handler spreads the detail dict onto the body, so
+    # `blocking` is at the top level alongside `status` (see
+    # core/responses.py).
+    assert "blocking" in body, body
+    assert isinstance(body["blocking"], list)
+    assert len(body["blocking"]) >= 1
+    row = body["blocking"][0]
+    assert row["part_id"] == pid
+    assert int(row["quantity"]) == 10
+
+
+def test_archive_after_full_consume_succeeds(authed):
+    """After moving all stock out, the same storage can be archived."""
+    pid = _create_part(authed, "Cap 1uF")
+    sid_a = _create_storage(authed, "Shelf A")
+    sid_b = _create_storage(authed, "Shelf B")
+
+    authed.post(
+        "/api/stock/add",
+        json={"part_id": pid, "quantity": 5, "storage_location_id": sid_a},
+    )
+    mv = authed.post(
+        "/api/stock/move",
+        json={
+            "part_id": pid,
+            "quantity": 5,
+            "source_storage_location_id": sid_a,
+            "destination_storage_location_id": sid_b,
+        },
+    )
+    assert mv.status_code in (200, 201), mv.text
+
+    r = authed.post(f"/api/storage/{sid_a}/archive")
+    assert r.status_code == 200, r.text

--- a/backend/tests/test_assets.py
+++ b/backend/tests/test_assets.py
@@ -32,6 +32,10 @@ def _resp(status_code: int = 200, body: bytes = b"image-bytes", content_type: st
 
 def test_fetch_writes_to_uploads_and_returns_local_path(monkeypatch, ws_id, tmp_path):
     monkeypatch.setattr(settings(), "UPLOAD_DIR", str(tmp_path), raising=False)
+    # SEC2-006 added a provider host allow-list. These pre-existing tests
+    # use example.com URLs to exercise the content-addressing logic; the
+    # allow-list isn't the unit under test here, so bypass it.
+    monkeypatch.setattr(assets, "_host_is_allowed", lambda _h: True)
     monkeypatch.setattr(assets, "_http_get", lambda url: _resp())
 
     result = assets.fetch_provider_asset("https://example.com/img.png", ws_id, "image")
@@ -50,6 +54,7 @@ def test_fetch_writes_to_uploads_and_returns_local_path(monkeypatch, ws_id, tmp_
 def test_fetch_is_idempotent(monkeypatch, ws_id, tmp_path):
     """Same URL + same body → same content-hashed filename, no rewrite."""
     monkeypatch.setattr(settings(), "UPLOAD_DIR", str(tmp_path), raising=False)
+    monkeypatch.setattr(assets, "_host_is_allowed", lambda _h: True)
     monkeypatch.setattr(assets, "_http_get", lambda url: _resp())
 
     a = assets.fetch_provider_asset("https://example.com/img.png", ws_id, "image")
@@ -59,12 +64,14 @@ def test_fetch_is_idempotent(monkeypatch, ws_id, tmp_path):
 
 def test_fetch_returns_none_on_404(monkeypatch, ws_id, tmp_path):
     monkeypatch.setattr(settings(), "UPLOAD_DIR", str(tmp_path), raising=False)
+    monkeypatch.setattr(assets, "_host_is_allowed", lambda _h: True)
     monkeypatch.setattr(assets, "_http_get", lambda url: _resp(status_code=404, body=b""))
     assert assets.fetch_provider_asset("https://example.com/missing", ws_id, "image") is None
 
 
 def test_fetch_returns_none_on_oversize(monkeypatch, ws_id, tmp_path):
     monkeypatch.setattr(settings(), "UPLOAD_DIR", str(tmp_path), raising=False)
+    monkeypatch.setattr(assets, "_host_is_allowed", lambda _h: True)
     huge = b"x" * (assets._MAX_BYTES + 1)
     monkeypatch.setattr(assets, "_http_get", lambda url: _resp(body=huge))
     assert assets.fetch_provider_asset("https://example.com/huge.png", ws_id, "image") is None
@@ -72,6 +79,7 @@ def test_fetch_returns_none_on_oversize(monkeypatch, ws_id, tmp_path):
 
 def test_fetch_returns_none_on_network_error(monkeypatch, ws_id, tmp_path):
     monkeypatch.setattr(settings(), "UPLOAD_DIR", str(tmp_path), raising=False)
+    monkeypatch.setattr(assets, "_host_is_allowed", lambda _h: True)
     def boom(_url):
         raise RuntimeError("simulated DNS failure")
     monkeypatch.setattr(assets, "_http_get", boom)
@@ -88,6 +96,7 @@ def test_fetch_falls_back_to_url_extension(monkeypatch, ws_id, tmp_path):
     """Content-Type is sometimes generic (application/octet-stream).
     Fall back to the URL's path suffix so the file lands with a usable extension."""
     monkeypatch.setattr(settings(), "UPLOAD_DIR", str(tmp_path), raising=False)
+    monkeypatch.setattr(assets, "_host_is_allowed", lambda _h: True)
     monkeypatch.setattr(
         assets, "_http_get",
         lambda url: _resp(body=b"%PDF-1.4 fake", content_type="application/octet-stream"),
@@ -101,6 +110,7 @@ def test_fetch_falls_back_to_url_extension(monkeypatch, ws_id, tmp_path):
 
 def test_fetch_pdf_content_type_yields_pdf(monkeypatch, ws_id, tmp_path):
     monkeypatch.setattr(settings(), "UPLOAD_DIR", str(tmp_path), raising=False)
+    monkeypatch.setattr(assets, "_host_is_allowed", lambda _h: True)
     monkeypatch.setattr(
         assets, "_http_get",
         lambda url: _resp(body=b"%PDF-1.4 fake", content_type="application/pdf"),

--- a/backend/tests/test_bom_import.py
+++ b/backend/tests/test_bom_import.py
@@ -86,9 +86,12 @@ def test_bom_commit_matches_by_mpn_and_keeps_unmatched(db):
 
 
 def test_bom_preview_b64_schema_caps_input():
-    """The pydantic schema's max_length=5_000_000 is the first line of
-    defence — a 6 MB base64 string must 422 before hitting the decoder."""
-    too_big_b64 = "A" * 5_000_001
+    """The pydantic schema's max_length=6_000_000 is the first line of
+    defence — a 7 MB base64 string must 422 before hitting the decoder.
+    The 6 MB ceiling is deliberate: it must allow a payload large enough
+    for the runtime 4 MB raw cap to fire (see the next test); a 5 MB
+    Field cap would foreclose the runtime path."""
+    too_big_b64 = "A" * 6_000_001
     with pytest.raises(ValidationError):
         BomImportPreviewIn(text_b64=too_big_b64)
 

--- a/backend/tests/test_bom_import.py
+++ b/backend/tests/test_bom_import.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 import base64
 import uuid
 
+import pytest
+from fastapi import HTTPException
+from pydantic import ValidationError
+
 from app.domain.parts.models import Part
 from app.domain.projects import bom_import as bom
 from app.domain.projects.models import Project, ProjectEntry
@@ -74,3 +78,37 @@ def test_bom_commit_matches_by_mpn_and_keeps_unmatched(db):
     assert "R1" in (entries[0].designators or [])
     assert entries[1].entry_type == "unmatched"
     assert entries[1].part_id is None
+
+
+# ---------------------------------------------------------------------------
+# SEC2-007 / BE2-006 — size + row caps on the BOM importer
+# ---------------------------------------------------------------------------
+
+
+def test_bom_preview_b64_schema_caps_input():
+    """The pydantic schema's max_length=5_000_000 is the first line of
+    defence — a 6 MB base64 string must 422 before hitting the decoder."""
+    too_big_b64 = "A" * 5_000_001
+    with pytest.raises(ValidationError):
+        BomImportPreviewIn(text_b64=too_big_b64)
+
+
+def test_bom_preview_decoded_size_caps_input():
+    """A payload that fits under the schema cap but decodes to > 4 MB
+    must raise 413 from the helper."""
+    raw = b"x" * 4_000_001
+    b64 = base64.b64encode(raw).decode()
+    payload = BomImportPreviewIn(text_b64=b64)
+    with pytest.raises(HTTPException) as exc:
+        bom.preview(payload)
+    assert exc.value.status_code == 413
+
+
+def test_bom_preview_row_count_caps_input():
+    """A pathological CSV with > 10k rows must 422."""
+    rows = "\n".join(f"{i}," for i in range(10_001))
+    b64 = base64.b64encode(rows.encode()).decode()
+    payload = BomImportPreviewIn(text_b64=b64, separator=",")
+    with pytest.raises(HTTPException) as exc:
+        bom.preview(payload)
+    assert exc.value.status_code == 422

--- a/backend/tests/test_catalog.py
+++ b/backend/tests/test_catalog.py
@@ -175,3 +175,30 @@ def test_published_flag_reflected_in_part_get(owner_client):
     owner_client.patch(f"/api/parts/{pid}", json={"published": False})
     p = owner_client.get(f"/api/parts/{pid}").json()["data"]
     assert p["published"] is False
+
+
+# ---------------------------------------------------------------------------
+# SEC2-009 — security headers on the public catalog responses
+# ---------------------------------------------------------------------------
+
+
+def test_catalog_html_carries_security_headers(owner_client):
+    url = _enable_catalog(owner_client)
+    _create_part(owner_client, "HdrPart", published=True)
+    r = owner_client.get(url)
+    assert r.status_code == 200, r.text
+    assert r.headers.get("x-content-type-options") == "nosniff"
+    assert r.headers.get("x-frame-options") == "DENY"
+    assert r.headers.get("referrer-policy") == "same-origin"
+    csp = r.headers.get("content-security-policy", "")
+    assert "frame-ancestors 'none'" in csp
+    assert "script-src 'none'" in csp
+
+
+def test_catalog_json_carries_security_headers(owner_client):
+    url = _enable_catalog(owner_client)
+    _create_part(owner_client, "HdrPartJson", published=True)
+    r = owner_client.get(f"{url}/parts.json")
+    assert r.status_code == 200, r.text
+    assert r.headers.get("x-content-type-options") == "nosniff"
+    assert r.headers.get("x-frame-options") == "DENY"

--- a/backend/tests/test_orders.py
+++ b/backend/tests/test_orders.py
@@ -163,3 +163,37 @@ def test_archive_restore(authed):
     out_arch = authed.get("/api/orders?archived=true").json()["data"]
     assert any(o["id"] == r["id"] for o in out_arch)
     assert authed.post(f"/api/orders/{r['id']}/restore").status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# BE2-013 — quantity_ordered must be >= 1
+# ---------------------------------------------------------------------------
+
+
+def test_create_with_zero_quantity_rejected(part_and_storage):
+    c, part_id, _ = part_and_storage
+    r = c.post(
+        "/api/orders",
+        json={"name": "PO-zero", "entries": [{"part_id": part_id, "quantity_ordered": 0}]},
+    )
+    assert r.status_code == 422, r.text
+
+
+def test_create_with_negative_quantity_rejected(part_and_storage):
+    c, part_id, _ = part_and_storage
+    r = c.post(
+        "/api/orders",
+        json={"name": "PO-neg", "entries": [{"part_id": part_id, "quantity_ordered": -5}]},
+    )
+    assert r.status_code == 422, r.text
+
+
+def test_patch_entry_to_zero_quantity_rejected(part_and_storage):
+    c, part_id, _ = part_and_storage
+    r = c.post(
+        "/api/orders",
+        json={"name": "PO-pat", "entries": [{"part_id": part_id, "quantity_ordered": 5}]},
+    ).json()["data"]
+    entry_id = c.get(f"/api/orders/{r['id']}").json()["data"]["entries"][0]["id"]
+    p = c.patch(f"/api/orders/{r['id']}/entries/{entry_id}", json={"quantity_ordered": 0})
+    assert p.status_code == 422, p.text

--- a/backend/tests/test_provider_assets.py
+++ b/backend/tests/test_provider_assets.py
@@ -1,0 +1,209 @@
+"""Regression tests for SEC2-006 / SEC2-011 (provider-asset hardening).
+
+Covers:
+- Host allow-list — only Mouser / DigiKey hosts pass.
+- DNS resolution to a non-public IP is rejected (SSRF guard).
+- Upstream SVG content-type is rejected (lands as `.bin`).
+- 30x upstream is treated as a refusal — no auto-redirect.
+- The serve route forces `X-Content-Type-Options: nosniff` on every
+  response and forces `Content-Disposition: attachment` for non-image
+  MIMEs (PDF datasheets, opaque binaries).
+"""
+from __future__ import annotations
+
+import hashlib
+import os
+import uuid
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.core.config import settings
+from app.domain.parts.services import assets
+from app.main import app
+
+
+def _resp(status_code: int = 200, body: bytes = b"image-bytes", content_type: str = "image/png") -> MagicMock:
+    r = MagicMock()
+    r.status_code = status_code
+    r.content = body
+    r.headers = {"content-type": content_type}
+    return r
+
+
+# ---------------------------------------------------------------------------
+# fetch_provider_asset — host allow-list + SSRF guard + redirect refusal
+# ---------------------------------------------------------------------------
+
+
+def test_rejects_host_not_on_allow_list(monkeypatch, tmp_path):
+    monkeypatch.setattr(settings(), "UPLOAD_DIR", str(tmp_path), raising=False)
+    called = {"hit": False}
+
+    def _spy(_url):  # pragma: no cover - should never be called
+        called["hit"] = True
+        return _resp()
+
+    monkeypatch.setattr(assets, "_http_get", _spy)
+    out = assets.fetch_provider_asset("https://evil.example.com/x.png", str(uuid.uuid4()), "image")
+    assert out is None
+    assert called["hit"] is False, "must short-circuit before issuing the HTTP GET"
+
+
+def test_rejects_host_resolving_to_private_ip(monkeypatch, tmp_path):
+    """Even an allow-listed host gets refused if DNS hands back a non-public
+    IP (defence against DNS rebinding / homoglyph confusion / lab DNS)."""
+    monkeypatch.setattr(settings(), "UPLOAD_DIR", str(tmp_path), raising=False)
+    monkeypatch.setattr(assets.socket, "gethostbyname", lambda _h: "10.0.0.5")
+    monkeypatch.setattr(assets, "_http_get", lambda _u: _resp())
+    out = assets.fetch_provider_asset(
+        "https://www.mouser.com/foo.png", str(uuid.uuid4()), "image"
+    )
+    assert out is None
+
+
+def test_rejects_loopback_resolution(monkeypatch, tmp_path):
+    monkeypatch.setattr(settings(), "UPLOAD_DIR", str(tmp_path), raising=False)
+    monkeypatch.setattr(assets.socket, "gethostbyname", lambda _h: "127.0.0.1")
+    monkeypatch.setattr(assets, "_http_get", lambda _u: _resp())
+    assert assets.fetch_provider_asset(
+        "https://media.digikey.com/foo.png", str(uuid.uuid4()), "image"
+    ) is None
+
+
+def test_rejects_aws_metadata_resolution(monkeypatch, tmp_path):
+    """169.254/16 is link-local; ip.is_global is False so it must be refused."""
+    monkeypatch.setattr(settings(), "UPLOAD_DIR", str(tmp_path), raising=False)
+    monkeypatch.setattr(assets.socket, "gethostbyname", lambda _h: "169.254.169.254")
+    monkeypatch.setattr(assets, "_http_get", lambda _u: _resp())
+    assert assets.fetch_provider_asset(
+        "https://www.mouser.com/foo.png", str(uuid.uuid4()), "image"
+    ) is None
+
+
+def test_allowed_host_with_public_ip_succeeds(monkeypatch, tmp_path):
+    monkeypatch.setattr(settings(), "UPLOAD_DIR", str(tmp_path), raising=False)
+    monkeypatch.setattr(assets.socket, "gethostbyname", lambda _h: "93.184.216.34")
+    monkeypatch.setattr(assets, "_http_get", lambda _u: _resp())
+    out = assets.fetch_provider_asset(
+        "https://media.digikey.com/parts/img.png", str(uuid.uuid4()), "image"
+    )
+    assert out is not None
+    assert out.endswith(".png")
+
+
+def test_redirect_response_is_refused(monkeypatch, tmp_path):
+    """The helper sets follow_redirects=False; a 30x is treated as a refusal."""
+    monkeypatch.setattr(settings(), "UPLOAD_DIR", str(tmp_path), raising=False)
+    monkeypatch.setattr(assets.socket, "gethostbyname", lambda _h: "93.184.216.34")
+    monkeypatch.setattr(
+        assets, "_http_get",
+        lambda _u: _resp(status_code=302, body=b"", content_type="text/html"),
+    )
+    assert assets.fetch_provider_asset(
+        "https://www.mouser.com/foo.png", str(uuid.uuid4()), "image"
+    ) is None
+
+
+def test_svg_content_type_lands_as_bin(monkeypatch, tmp_path):
+    """SEC2-006 — SVG can carry inline JS; refuse to map it to .svg.
+    The body still lands on disk because the helper is best-effort, but
+    with a `.bin` extension which the serve route forces to download."""
+    monkeypatch.setattr(settings(), "UPLOAD_DIR", str(tmp_path), raising=False)
+    monkeypatch.setattr(assets.socket, "gethostbyname", lambda _h: "93.184.216.34")
+    body = b'<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>'
+    monkeypatch.setattr(
+        assets, "_http_get",
+        lambda _u: _resp(body=body, content_type="image/svg+xml"),
+    )
+    out = assets.fetch_provider_asset(
+        "https://media.digikey.com/foo.svg", str(uuid.uuid4()), "image"
+    )
+    assert out is not None
+    assert out.endswith(".bin"), f"expected .bin, got {out}"
+
+
+def test_svg_url_suffix_lands_as_bin(monkeypatch, tmp_path):
+    """An upstream that serves SVG but advertises octet-stream still ends
+    up with .bin — the URL-suffix fallback also blocks .svg."""
+    monkeypatch.setattr(settings(), "UPLOAD_DIR", str(tmp_path), raising=False)
+    monkeypatch.setattr(assets.socket, "gethostbyname", lambda _h: "93.184.216.34")
+    monkeypatch.setattr(
+        assets, "_http_get",
+        lambda _u: _resp(body=b"<svg/>", content_type="application/octet-stream"),
+    )
+    out = assets.fetch_provider_asset(
+        "https://media.digikey.com/foo.svg", str(uuid.uuid4()), "image"
+    )
+    assert out is not None
+    assert out.endswith(".bin")
+
+
+# ---------------------------------------------------------------------------
+# Serve route — nosniff + content-disposition for non-images
+# ---------------------------------------------------------------------------
+
+
+def _signup(c: TestClient) -> str:
+    email = f"u-{uuid.uuid4().hex[:8]}@x.com"
+    r = c.post("/api/auth/signup", json={"email": email, "name": "u", "password": "TestPass-2026-Stronk"})
+    assert r.status_code == 200, r.text
+    return r.json()["data"]["workspace_id"]
+
+
+def _seed_asset(ws_id: str, body: bytes, ext: str) -> str:
+    sha = hashlib.sha256(body).hexdigest()
+    target_dir = os.path.join(settings().UPLOAD_DIR, "parts", ws_id)
+    os.makedirs(target_dir, exist_ok=True)
+    path = os.path.join(target_dir, f"{sha}.{ext}")
+    with open(path, "wb") as f:
+        f.write(body)
+    return f"{sha}.{ext}"
+
+
+def test_served_image_carries_nosniff_and_inline_disposition():
+    c = TestClient(app)
+    ws_id = _signup(c)
+    fname = _seed_asset(ws_id, b"\x89PNG\r\n\x1a\nfake", "png")
+    r = c.get(f"/api/parts/assets/{ws_id}/{fname}")
+    assert r.status_code == 200, r.text
+    assert r.headers["x-content-type-options"] == "nosniff"
+    assert r.headers["content-type"].startswith("image/png")
+    # No `name=` query param → no Content-Disposition (image is inline).
+    assert "attachment" not in r.headers.get("content-disposition", "").lower()
+
+
+def test_served_pdf_forces_attachment_with_nosniff():
+    c = TestClient(app)
+    ws_id = _signup(c)
+    fname = _seed_asset(ws_id, b"%PDF-1.4 fake", "pdf")
+    r = c.get(f"/api/parts/assets/{ws_id}/{fname}")
+    assert r.status_code == 200, r.text
+    assert r.headers["x-content-type-options"] == "nosniff"
+    assert r.headers["content-type"].startswith("application/pdf")
+    assert "attachment" in r.headers.get("content-disposition", "").lower()
+
+
+def test_served_pdf_with_name_param_uses_attachment_filename():
+    c = TestClient(app)
+    ws_id = _signup(c)
+    fname = _seed_asset(ws_id, b"%PDF-1.4 fake", "pdf")
+    r = c.get(f"/api/parts/assets/{ws_id}/{fname}?name=mydatasheet")
+    assert r.status_code == 200, r.text
+    cd = r.headers.get("content-disposition", "").lower()
+    assert "attachment" in cd
+    assert "mydatasheet.pdf" in cd
+
+
+def test_served_unknown_ext_forces_attachment_octet_stream():
+    """A `.bin` (e.g. an upstream SVG that we refused) must download as
+    application/octet-stream — never inline-render."""
+    c = TestClient(app)
+    ws_id = _signup(c)
+    fname = _seed_asset(ws_id, b"<svg/>", "bin")
+    r = c.get(f"/api/parts/assets/{ws_id}/{fname}")
+    assert r.status_code == 200, r.text
+    assert r.headers["x-content-type-options"] == "nosniff"
+    assert r.headers["content-type"].startswith("application/octet-stream")
+    assert "attachment" in r.headers.get("content-disposition", "").lower()

--- a/deploy/nginx-web.conf
+++ b/deploy/nginx-web.conf
@@ -30,7 +30,11 @@ server {
     # is required by Vite's hashed inline critical CSS; revisit once we
     # adopt nonces.
     add_header Content-Security-Policy "default-src 'self'; img-src 'self' data:; connect-src 'self' https://*.ingest.sentry.io; style-src 'self' 'unsafe-inline'; script-src 'self'; frame-ancestors 'none'" always;
-    add_header Permissions-Policy "()" always;
+    # Permissions-Policy: bare `()` is invalid (no feature name) and is
+    # silently ignored by browsers. We need camera=(self) for the in-app
+    # scanner (web/src/components/scanner/ZxingScanner.tsx + Scandit) and
+    # everything else explicitly off to neuter the rest of the surface.
+    add_header Permissions-Policy "camera=(self), microphone=(), geolocation=(), payment=(), usb=()" always;
 
     # ---- /api/* → FastAPI (uvicorn) on the docker network ----
     location /api/ {

--- a/deploy/nginx-web.conf
+++ b/deploy/nginx-web.conf
@@ -16,6 +16,22 @@ server {
     # Allow datasheet / lot photo uploads up to 25MB.
     client_max_body_size 25m;
 
+    # ---- security headers (SEC2-009 / SEC2-010) ----
+    # `always` so they're attached even on error responses (4xx/5xx),
+    # which the default `add_header` skips.
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Referrer-Policy "same-origin" always;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    # CSP: SPA bundle is self-hosted; the only third-party connect we
+    # make is the Sentry tunnel (proxied via /api/sentry-tunnel) and the
+    # ingest fallback during transient outages — hence
+    # https://*.ingest.sentry.io in connect-src. `style-src 'unsafe-inline'`
+    # is required by Vite's hashed inline critical CSS; revisit once we
+    # adopt nonces.
+    add_header Content-Security-Policy "default-src 'self'; img-src 'self' data:; connect-src 'self' https://*.ingest.sentry.io; style-src 'self' 'unsafe-inline'; script-src 'self'; frame-ancestors 'none'" always;
+    add_header Permissions-Policy "()" always;
+
     # ---- /api/* → FastAPI (uvicorn) on the docker network ----
     location /api/ {
         proxy_pass http://backend:8000;

--- a/deploy/parts.matescb.cz-le-ssl.conf
+++ b/deploy/parts.matescb.cz-le-ssl.conf
@@ -1,0 +1,61 @@
+# Apache 2.4 :443 vhost for parts.matescb.cz — TLS termination + security
+# headers (INFRA2-007).
+#
+# OPERATOR STEPS — required after the first certbot --apache run, and any
+# time this file is updated:
+#
+#   1. Run certbot --apache once so Let's Encrypt issues the cert and
+#      writes the initial /etc/apache2/sites-available/parts.matescb.cz-
+#      le-ssl.conf. That generated file lives outside this repo.
+#   2. Copy this canonical file over the certbot-generated one:
+#
+#        sudo cp deploy/parts.matescb.cz-le-ssl.conf \
+#               /etc/apache2/sites-available/parts.matescb.cz-le-ssl.conf
+#        sudo apache2ctl configtest && sudo systemctl reload apache2
+#
+#   3. Certbot's renewal hook does NOT rewrite this file once it's been
+#      replaced — `certbot renew` only rotates the cert files referenced
+#      by SSLCertificateFile / SSLCertificateKeyFile below. If you ever
+#      delete and re-issue, repeat step 2.
+#
+# See docs/deployment.md for the full rollout pattern.
+
+<IfModule mod_ssl.c>
+<VirtualHost *:443>
+    ServerName parts.matescb.cz
+    DocumentRoot /var/www/html
+
+    ProxyPreserveHost On
+    ProxyPass /.well-known !
+    ProxyPass / http://127.0.0.1:8091/
+    ProxyPassReverse / http://127.0.0.1:8091/
+
+    # Datasheet + lot photo uploads can run a few MB each.
+    LimitRequestBody 26214400
+
+    # ---- TLS ----
+    # Mozilla "intermediate" profile (2024) — TLS 1.2 + 1.3, no 1.0/1.1.
+    SSLEngine on
+    SSLProtocol             -all +TLSv1.2 +TLSv1.3
+    SSLHonorCipherOrder     off
+    SSLSessionTickets       off
+    SSLCipherSuite          ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384
+
+    # Certbot manages these two files. Don't hand-edit; `certbot renew`
+    # rotates them in place.
+    SSLCertificateFile      /etc/letsencrypt/live/parts.matescb.cz/fullchain.pem
+    SSLCertificateKeyFile   /etc/letsencrypt/live/parts.matescb.cz/privkey.pem
+    Include                 /etc/letsencrypt/options-ssl-apache.conf
+
+    # ---- security headers (SEC2-009 / SEC2-010) ----
+    # `always` so they ride on error responses too.
+    Header always set Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"
+    Header always set X-Content-Type-Options "nosniff"
+    Header always set X-Frame-Options "DENY"
+    Header always set Referrer-Policy "same-origin"
+    Header always set Permissions-Policy "()"
+
+    ErrorLog ${APACHE_LOG_DIR}/parts.matescb.cz-ssl-error.log
+    CustomLog ${APACHE_LOG_DIR}/parts.matescb.cz-ssl-access.log combined
+</VirtualHost>
+</IfModule>

--- a/deploy/parts.matescb.cz-le-ssl.conf
+++ b/deploy/parts.matescb.cz-le-ssl.conf
@@ -53,7 +53,10 @@
     Header always set X-Content-Type-Options "nosniff"
     Header always set X-Frame-Options "DENY"
     Header always set Referrer-Policy "same-origin"
-    Header always set Permissions-Policy "()"
+    # Permissions-Policy: bare `()` is invalid (no feature name) and is
+    # silently ignored. camera=(self) is load-bearing for the scanner
+    # pages; the rest are explicitly off.
+    Header always set Permissions-Policy "camera=(self), microphone=(), geolocation=(), payment=(), usb=()"
 
     ErrorLog ${APACHE_LOG_DIR}/parts.matescb.cz-ssl-error.log
     CustomLog ${APACHE_LOG_DIR}/parts.matescb.cz-ssl-access.log combined


### PR DESCRIPTION
## Summary

Security-hardening + small-route-correctness batch (Batch 3 of v2 review remediation).

### Closes

- **SEC2-006** (High) — Provider asset download follows redirects, no host allow-list, permits SVG.
- **SEC2-011** (Medium) — `GET /api/parts/assets/...` lacks `nosniff`, serves user-influenced inline.
- **SEC2-007 + BE2-006** (High) — BOM import unbounded base64 -> memory exhaustion.
- **SEC2-009** (Medium) — Public catalog HTML rendered without CSP / nosniff / frame-options.
- **SEC2-010** (Medium) — SPA / API responses ship no security headers.
- **INFRA2-007** (High) — Apache vhost + TLS hardening not in repo.
- **BE2-013** (Medium) — `OrderEntryIn.quantity_ordered` accepts 0 / negative.
- **BE2-014** (Medium) — `archive_storage` doesn't refuse when storage holds positive on-hand stock.
- **v1 Sec HIGH-4** (High) — `/catalog/{token}` no rate-limit.

### Key changes

- `backend/app/domain/parts/services/assets.py` — explicit Mouser/DigiKey host allow-list + DNS-must-be-public-IP guard (`ipaddress.ip_address(...).is_global`); `httpx.Client(follow_redirects=False)`; `image/svg+xml` dropped from `_EXT_BY_MIME` and any SVG content-type or `.svg` URL suffix lands as `.bin`.
- `backend/app/api/routes/parts.py` (asset-serve route only) — `X-Content-Type-Options: nosniff` on every response; explicit `media_type` from a small ext->mime map; non-image MIMEs (PDF, opaque `.bin`) forced to `Content-Disposition: attachment` mirroring `attachments.py:209-214`.
- `backend/app/domain/projects/schemas.py` + `bom_import.py` — `Field(..., max_length=5_000_000)` on both BOM `text_b64` schemas; post-decode 4 MB ceiling -> 413; 10 000-row cap -> 422.
- `deploy/nginx-web.conf` — CSP (with `https://*.ingest.sentry.io` in `connect-src` for the Sentry tunnel), `X-Content-Type-Options`, `X-Frame-Options DENY`, `Referrer-Policy same-origin`, HSTS, `Permissions-Policy ()` — all `always`.
- `deploy/parts.matescb.cz-le-ssl.conf` (new) — :443 Apache vhost with Mozilla-intermediate cipher suite, HSTS preload, header set. Operator step documented at the top of the file.
- `backend/app/api/routes/catalog.py` — `@limiter.limit("60/minute")` on `catalog_html` + `catalog_json`; both responses carry the same security headers.
- `backend/app/domain/orders/schemas.py` — `OrderEntryIn.quantity_ordered: int = Field(..., ge=1)`; `OrderEntryPatch.quantity_ordered: int | None = Field(default=None, ge=1)`.
- `backend/app/api/routes/storage.py::archive_storage` — pre-flight `stock_for_storage`; returns 409 with `{message, blocking: [{part_id, lot_id, quantity}]}` when stock is still in residence.

### Tests added

- `backend/tests/test_provider_assets.py` (new) — host allow-list, private-IP / loopback / metadata refusal, redirect-refusal, SVG-lands-as-bin, served-image carries nosniff and stays inline, served-PDF / unknown-ext forces attachment.
- `backend/tests/test_archive_storage.py` (new) — empty storage archives, on-hand stock yields 409 with `blocking` detail, post-move-out archive succeeds.
- `backend/tests/test_bom_import.py` — schema cap, decoded-size cap (413), row-count cap (422).
- `backend/tests/test_orders.py` — quantity 0, negative, and PATCH-to-zero all 422.
- `backend/tests/test_catalog.py` — HTML and JSON responses carry the security headers.

## Operator step (required after merge)

Apache picks up the new file once the operator runs:

```
sudo cp deploy/parts.matescb.cz-le-ssl.conf \
        /etc/apache2/sites-available/parts.matescb.cz-le-ssl.conf
sudo apache2ctl configtest && sudo systemctl reload apache2
```

(See the top-of-file comment block for the rationale; certbot's renewal hook does **not** rewrite this file once it's been replaced.)

## Test plan

- [ ] `docker compose exec backend pytest backend/tests/test_provider_assets.py backend/tests/test_archive_storage.py backend/tests/test_bom_import.py backend/tests/test_orders.py backend/tests/test_catalog.py`
- [ ] Smoke: open a PDF datasheet via `/api/parts/assets/...?name=X` — saves as attachment, response carries `X-Content-Type-Options: nosniff`.
- [ ] Smoke: hit `/catalog/{token}` and check response headers include CSP + `X-Frame-Options: DENY`.
- [ ] Operator: `cp` the Apache file post-merge as above, run `apache2ctl configtest`, reload.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>