### PR TITLE
fix(ui): global 401 + workspace-keyed cache + DataTable cleanup + scanner tokens

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense } from "react";
-import { Navigate, Outlet, Route, Routes } from "react-router-dom";
+import { Navigate, Outlet, Route, Routes, useLocation } from "react-router-dom";
 import { AuthProvider, useAuth } from "@/lib/auth";
 import AppShell from "@/components/layout/AppShell";
 import { ConfirmDialogProvider } from "@/components/ConfirmDialog";
@@ -113,8 +113,12 @@ const WorkspaceSettings = lazy(() => import("@/routes/settings/Workspace"));
  */
 function Gate() {
   const { me, loading } = useAuth();
+  const location = useLocation();
   if (loading) return <div className="p-6 text-muted">Loading…</div>;
-  if (!me) return <Navigate to="/login" replace />;
+  // Preserve the deep-link target across the login round-trip so a user
+  // who hits /parts/abc123 with no session lands back there after
+  // signing in (FE2-010).
+  if (!me) return <Navigate to="/login" replace state={{ from: location }} />;
   return (
     <AppShell>
       <Outlet />

--- a/web/src/components/ActivityTimeline.tsx
+++ b/web/src/components/ActivityTimeline.tsx
@@ -14,7 +14,7 @@ import {
 } from "lucide-react";
 import type { ReactNode } from "react";
 import { api } from "@/lib/api";
-import { wsKey } from "@/lib/queryKeys";
+import { useWsKey } from "@/lib/queryKeys";
 
 type ActivityKind =
   | "stock"
@@ -137,7 +137,7 @@ function summary(e: ActivityEntry): string {
 
 export default function ActivityTimeline({ endpoint }: Props) {
   const { data, isLoading } = useQuery({
-    queryKey: wsKey("activity", endpoint),
+    queryKey: useWsKey("activity", endpoint),
     queryFn: () => api.get<ActivityEntry[]>(endpoint),
   });
 

--- a/web/src/components/ActivityTimeline.tsx
+++ b/web/src/components/ActivityTimeline.tsx
@@ -14,6 +14,7 @@ import {
 } from "lucide-react";
 import type { ReactNode } from "react";
 import { api } from "@/lib/api";
+import { wsKey } from "@/lib/queryKeys";
 
 type ActivityKind =
   | "stock"
@@ -136,7 +137,7 @@ function summary(e: ActivityEntry): string {
 
 export default function ActivityTimeline({ endpoint }: Props) {
   const { data, isLoading } = useQuery({
-    queryKey: ["activity", endpoint],
+    queryKey: wsKey("activity", endpoint),
     queryFn: () => api.get<ActivityEntry[]>(endpoint),
   });
 

--- a/web/src/components/AttachmentsPanel.tsx
+++ b/web/src/components/AttachmentsPanel.tsx
@@ -3,7 +3,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { Trash2, Download, UploadCloud, Paperclip } from "lucide-react";
 import { api, ApiError } from "@/lib/api";
-import { wsKey } from "@/lib/queryKeys";
+import { useWsKey } from "@/lib/queryKeys";
 import { useConfirm } from "@/components/ConfirmDialog";
 
 type Attachment = {
@@ -33,7 +33,7 @@ function humanSize(bytes: number): string {
 export default function AttachmentsPanel({ objectType, objectId, canWrite }: Props) {
   const confirm = useConfirm();
   const qc = useQueryClient();
-  const queryKey = wsKey("attachments", objectType, objectId);
+  const queryKey = useWsKey("attachments", objectType, objectId);
   const { data, isLoading } = useQuery({
     queryKey,
     queryFn: () =>

--- a/web/src/components/AttachmentsPanel.tsx
+++ b/web/src/components/AttachmentsPanel.tsx
@@ -3,6 +3,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { Trash2, Download, UploadCloud, Paperclip } from "lucide-react";
 import { api, ApiError } from "@/lib/api";
+import { wsKey } from "@/lib/queryKeys";
 import { useConfirm } from "@/components/ConfirmDialog";
 
 type Attachment = {
@@ -32,7 +33,7 @@ function humanSize(bytes: number): string {
 export default function AttachmentsPanel({ objectType, objectId, canWrite }: Props) {
   const confirm = useConfirm();
   const qc = useQueryClient();
-  const queryKey = ["attachments", objectType, objectId];
+  const queryKey = wsKey("attachments", objectType, objectId);
   const { data, isLoading } = useQuery({
     queryKey,
     queryFn: () =>

--- a/web/src/components/CommandPalette.tsx
+++ b/web/src/components/CommandPalette.tsx
@@ -14,7 +14,7 @@ import {
   Warehouse,
 } from "lucide-react";
 import { api } from "@/lib/api";
-import { wsKey } from "@/lib/queryKeys";
+import { useWsKey } from "@/lib/queryKeys";
 
 type SearchData = {
   parts: { id: string; name: string; mpn: string | null }[];
@@ -46,7 +46,7 @@ export default function CommandPalette() {
   }, []);
 
   const { data: results } = useQuery({
-    queryKey: wsKey("cp-search", q),
+    queryKey: useWsKey("cp-search", q),
     queryFn: () => api.get<SearchData>(`/search?q=${encodeURIComponent(q)}`),
     enabled: open && q.trim().length >= 2,
     staleTime: 30_000,

--- a/web/src/components/CommandPalette.tsx
+++ b/web/src/components/CommandPalette.tsx
@@ -14,6 +14,7 @@ import {
   Warehouse,
 } from "lucide-react";
 import { api } from "@/lib/api";
+import { wsKey } from "@/lib/queryKeys";
 
 type SearchData = {
   parts: { id: string; name: string; mpn: string | null }[];
@@ -45,7 +46,7 @@ export default function CommandPalette() {
   }, []);
 
   const { data: results } = useQuery({
-    queryKey: ["cp-search", q],
+    queryKey: wsKey("cp-search", q),
     queryFn: () => api.get<SearchData>(`/search?q=${encodeURIComponent(q)}`),
     enabled: open && q.trim().length >= 2,
     staleTime: 30_000,

--- a/web/src/components/DataTable.test.tsx
+++ b/web/src/components/DataTable.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * Pinning tests for DataTable's CSV export + selection-prune helpers.
+ *
+ * The component-level concerns (effect prunes selected on rows change,
+ * effect resets on tableId change) are exercised through the pure
+ * helpers extracted from the component. The repo doesn't carry a DOM
+ * testing harness (no `@testing-library/react`, no jsdom env), and
+ * adding one is out of scope per the constraints — so we keep the
+ * tests pure and deterministic.
+ */
+import { describe, expect, it } from "vitest";
+import { buildCsv, escapeCsvCell, pruneSelection } from "./DataTable";
+
+describe("escapeCsvCell — formula injection mitigation", () => {
+  it("prefixes a leading '=' with a quote", () => {
+    expect(escapeCsvCell("=SUM(A1:A2)")).toBe(`"'=SUM(A1:A2)"`);
+  });
+
+  it("prefixes leading '+' / '-' / '@' / TAB / CR", () => {
+    expect(escapeCsvCell("+1")).toBe(`"'+1"`);
+    expect(escapeCsvCell("-cmd")).toBe(`"'-cmd"`);
+    expect(escapeCsvCell("@import")).toBe(`"'@import"`);
+    expect(escapeCsvCell("\tnah")).toBe(`"'\tnah"`);
+  });
+
+  it("does not neutralise numbers — only string cells get the prefix", () => {
+    // Negative numbers are legitimate, not formulas — so a *numeric*
+    // -5 stays "-5", whereas a *string* "-5" gets the leading quote.
+    expect(escapeCsvCell(-5)).toBe(`"-5"`);
+    expect(escapeCsvCell("-5")).toBe(`"'-5"`);
+  });
+
+  it("doubles embedded quotes per RFC 4180", () => {
+    expect(escapeCsvCell('he said "hi"')).toBe(`"he said ""hi"""`);
+  });
+
+  it("renders null / undefined as empty cells", () => {
+    expect(escapeCsvCell(null)).toBe(`""`);
+    expect(escapeCsvCell(undefined)).toBe(`""`);
+  });
+
+  it("handles plain text without modification", () => {
+    expect(escapeCsvCell("hello world")).toBe(`"hello world"`);
+  });
+
+  it("preserves embedded CR/LF inside the cell (round-trip safety)", () => {
+    // The cell itself can contain \r\n; the row separator is also
+    // \r\n. Quotes are RFC-4180-compliant so the embedded newlines
+    // round-trip rather than splitting the row.
+    expect(escapeCsvCell("line1\r\nline2")).toBe(`"line1\r\nline2"`);
+  });
+});
+
+describe("buildCsv", () => {
+  it("starts with a UTF-8 BOM so Excel detects encoding", () => {
+    const csv = buildCsv(["a"], [["x"]]);
+    expect(csv.charCodeAt(0)).toBe(0xfeff);
+  });
+
+  it("uses CRLF as the line terminator", () => {
+    const csv = buildCsv(["a", "b"], [["1", "2"], ["3", "4"]]);
+    // strip BOM
+    const body = csv.slice(1);
+    expect(body).toBe(`"a","b"\r\n"1","2"\r\n"3","4"`);
+  });
+
+  it("neutralises a leading-`=` cell anywhere in the body", () => {
+    const csv = buildCsv(["formula"], [["=SUM(1,1)"]]);
+    expect(csv).toContain(`"'=SUM(1,1)"`);
+  });
+
+  it("round-trips embedded CRLF inside a cell", () => {
+    const csv = buildCsv(["multiline"], [["a\r\nb"]]);
+    // The header row + one body row, with the embedded \r\n preserved
+    // inside the quoted cell rather than splitting into two records.
+    expect(csv.slice(1)).toBe(`"multiline"\r\n"a\r\nb"`);
+  });
+});
+
+describe("pruneSelection", () => {
+  it("removes ids that are no longer in the row list", () => {
+    const sel = new Set(["a", "b", "c"]);
+    const next = pruneSelection(sel, ["a", "c", "d"]);
+    expect([...next].sort()).toEqual(["a", "c"]);
+  });
+
+  it("returns an empty set when no rows survive", () => {
+    expect(pruneSelection(new Set(["x"]), [])).toEqual(new Set());
+  });
+
+  it("preserves order-independence between input set and rows", () => {
+    const sel = new Set(["a", "b"]);
+    const next = pruneSelection(sel, ["b", "a"]);
+    expect(next.has("a")).toBe(true);
+    expect(next.has("b")).toBe(true);
+  });
+});

--- a/web/src/components/DataTable.tsx
+++ b/web/src/components/DataTable.tsx
@@ -2,6 +2,55 @@ import { ReactNode, useEffect, useMemo, useState } from "react";
 import { Rows3, Rows4 } from "lucide-react";
 import { cn } from "@/lib/cn";
 
+// ---------------------------------------------------------------------
+// CSV-export helpers — extracted so they can be unit-tested without
+// rendering the table. The hardening is per FE2-008:
+//
+//   1. Excel formula-injection mitigation: any cell whose first char is
+//      `=`, `+`, `-`, `@`, or a leading tab/CR (per CWE-1236) gets
+//      prefixed with a single quote, which neutralises the formula
+//      while still being readable.
+//   2. Doubled quotes for embedded `"` (RFC 4180).
+//   3. CRLF line terminators so Excel and Windows text editors don't
+//      smush rows together.
+//   4. UTF-8 BOM up front so Excel auto-detects the encoding instead
+//      of mangling non-ASCII to mojibake.
+// ---------------------------------------------------------------------
+
+const FORMULA_INJECTION_LEADERS = new Set(["=", "+", "-", "@", "\t", "\r"]);
+
+export function escapeCsvCell(raw: unknown): string {
+  // null / undefined → empty cell. Booleans + numbers get stringified
+  // verbatim (no leading-`-` neutralisation needed for negatives —
+  // those are legitimate numeric data, but Excel still treats them as
+  // formula-leading text. We only neutralise *string* cells whose first
+  // char is risky, since those are the user-supplied free-form fields.)
+  if (raw == null) return '""';
+  let s = String(raw);
+  if (s.length > 0 && FORMULA_INJECTION_LEADERS.has(s[0]) && typeof raw === "string") {
+    s = "'" + s;
+  }
+  return `"${s.replaceAll('"', '""')}"`;
+}
+
+export function buildCsv(headers: string[], rows: string[][]): string {
+  const head = headers.map(h => escapeCsvCell(h)).join(",");
+  const body = rows.map(r => r.map(c => escapeCsvCell(c)).join(",")).join("\r\n");
+  // U+FEFF BOM so Excel detects UTF-8 instead of misreading as cp1252.
+  return "﻿" + head + "\r\n" + body;
+}
+
+/** Prune a selection set to ids that still appear in the row list. */
+export function pruneSelection(
+  selected: ReadonlySet<string>,
+  rowIds: ReadonlyArray<string>,
+): Set<string> {
+  const visible = new Set(rowIds);
+  const next = new Set<string>();
+  for (const id of selected) if (visible.has(id)) next.add(id);
+  return next;
+}
+
 export type Align = "left" | "right" | "center";
 
 export type Column<T> = {
@@ -99,6 +148,30 @@ export function DataTable<T>({
     savePersisted(tableId, { hidden, density });
   }, [tableId, hidden, density]);
 
+  // FE2-007 — clear the selection set whenever the table changes
+  // identity. Without this, navigating from /parts to /orders carried
+  // a stale selection of part ids that no longer mapped to anything,
+  // and the bulk-action button would happily try to delete random
+  // rows from the new view.
+  useEffect(() => {
+    setSelected(new Set());
+  }, [tableId]);
+
+  // FE2-007 — prune ids of rows that no longer exist after a refetch
+  // or filter narrowing. The bulk-delete dialog reads from `selected`,
+  // so leaving stale ids in here meant the action could attempt to
+  // delete items the user couldn't see.
+  const allRowIds = useMemo(() => rows.map(r => rowKey(r)), [rows, rowKey]);
+  useEffect(() => {
+    setSelected(prev => {
+      const pruned = pruneSelection(prev, allRowIds);
+      // Only update state if something actually changed (avoids an
+      // infinite re-render loop when the row list is stable).
+      if (pruned.size === prev.size) return prev;
+      return pruned;
+    });
+  }, [allRowIds]);
+
   const filtered = useMemo(() => {
     const q = search.trim().toLowerCase();
     if (!q) return rows;
@@ -131,21 +204,46 @@ export function DataTable<T>({
   const padCls = density === "compact" ? "py-1" : "py-2";
   const textCls = density === "compact" ? "text-[13px]" : "text-sm";
 
+  function cellText(c: Column<T>, r: T): string {
+    // Prefer the structured accessor — it returns the raw scalar
+    // (string / number / bool) without React-rendered HTML.
+    if (c.accessor) {
+      const v = c.accessor(r);
+      return v == null ? "" : String(v);
+    }
+    // No accessor + no render: dumb-key access (matches the on-screen
+    // table cell). Avoid `[object Object]` for non-scalars by checking
+    // the type before stringifying.
+    if (!c.render) {
+      const v = (r as any)[c.key];
+      if (v == null) return "";
+      const t = typeof v;
+      if (t === "string" || t === "number" || t === "boolean") return String(v);
+      return "";
+    }
+    // Render-only column with no accessor — we have no safe way to
+    // pull text out of an arbitrary ReactNode without rendering it,
+    // so return empty rather than `[object Object]`. Authors who
+    // want a column to round-trip through CSV should set `accessor`.
+    return "";
+  }
+
   function exportCsv() {
-    const head = visibleCols.map(c => `"${c.header.replaceAll('"', '""')}"`).join(",");
-    const lines = sorted.map(r =>
-      visibleCols
-        .map(c => {
-          const v = c.accessor ? c.accessor(r) : (r as any)[c.key];
-          return `"${String(v ?? "").replaceAll('"', '""')}"`;
-        })
-        .join(",")
-    );
-    const blob = new Blob([head + "\n" + lines.join("\n")], { type: "text/csv;charset=utf-8" });
+    const head = visibleCols.map(c => c.header);
+    const body = sorted.map(r => visibleCols.map(c => cellText(c, r)));
+    const csv = buildCsv(head, body);
+    const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
-    a.href = URL.createObjectURL(blob);
+    a.href = url;
     a.download = (exportFilename || "export") + ".csv";
+    document.body.appendChild(a);
     a.click();
+    a.remove();
+    // Free the blob URL once the click has been dispatched. Browsers
+    // can keep the reference around forever otherwise (memory leak on
+    // long-lived sessions that export repeatedly).
+    URL.revokeObjectURL(url);
   }
 
   // All currently-filtered/sorted ids — used for select-all semantics

--- a/web/src/components/QueryStateBoundary.tsx
+++ b/web/src/components/QueryStateBoundary.tsx
@@ -1,0 +1,57 @@
+import { ReactNode } from "react";
+import { AlertTriangle } from "lucide-react";
+import { ApiError } from "@/lib/api";
+
+/**
+ * Render-time error fallback for list pages.
+ *
+ * Pre-fix, a failed list query just resolved to `data === undefined`
+ * and the page rendered as if the workspace were empty (FE2-001).
+ * Wrapping the page body in this boundary surfaces a banner when
+ * `query.isError` is true, with a Retry button that calls
+ * `query.refetch()`.
+ *
+ * 401 is handled centrally — the QueryCache `onError` in main.tsx
+ * fires the auth bus, which redirects to /login. We don't render the
+ * banner for 401 because the redirect is happening anyway and a
+ * flash of "couldn't load" would confuse the user mid-bounce.
+ */
+type QueryLike = {
+  isError: boolean;
+  error: unknown;
+  refetch: () => unknown;
+  isFetching: boolean;
+};
+
+export default function QueryStateBoundary({
+  query,
+  resourceLabel,
+  children,
+}: {
+  query: QueryLike;
+  resourceLabel: string;
+  children: ReactNode;
+}) {
+  const is401 = query.error instanceof ApiError && query.error.status === 401;
+  if (query.isError && !is401) {
+    const msg = query.error instanceof Error ? query.error.message : "Unknown error";
+    return (
+      <div className="card p-4 flex items-start gap-3 text-sm">
+        <AlertTriangle size={18} className="text-warning shrink-0 mt-0.5" />
+        <div className="flex-1">
+          <div className="font-medium text-text">Couldn't load {resourceLabel}.</div>
+          <div className="text-muted mt-0.5">{msg}</div>
+        </div>
+        <button
+          type="button"
+          className="btn"
+          disabled={query.isFetching}
+          onClick={() => query.refetch()}
+        >
+          {query.isFetching ? "Retrying…" : "Retry"}
+        </button>
+      </div>
+    );
+  }
+  return <>{children}</>;
+}

--- a/web/src/components/__tests__/wsKey-handlers.test.tsx
+++ b/web/src/components/__tests__/wsKey-handlers.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * Pinning test for the Rules-of-Hooks fix on PR #33.
+ *
+ * Background: `wsKey()` (now `useWsKey()`) reads `useAuth()` and is
+ * therefore a React hook. The original PR called it from event
+ * handlers (`onClick`, mutation `onSuccess`, …), which run outside
+ * React's dispatch window — every such call threw "Invalid hook call"
+ * the moment the user touched the button. The whole mutation surface
+ * (archive, move, add stock, receive order, etc.) crashed on click.
+ *
+ * The fix is to keep `useWsKey()` for render bodies and use the
+ * vanilla `wsKeyOf(workspaceId, ...)` from event handlers, after
+ * capturing `workspaceId` from `useAuth()` at render time.
+ *
+ * The repo has no `@testing-library/react` and no jsdom env (per
+ * `web/src/components/DataTable.test.tsx`'s preamble). Adding either
+ * is out of scope per the PR's constraint of no new deps. Instead
+ * this pin asserts the contract directly:
+ *
+ *   1. `wsKeyOf(...)` is a vanilla function — calling it outside any
+ *      React render does NOT throw, and the shape matches the prefix
+ *      every cache lookup expects.
+ *   2. `useWsKey(...)` IS a hook — calling it bare from a handler-
+ *      style callback throws (which is exactly the regression PR #33
+ *      shipped on the first pass). The fact that this throws is *the
+ *      reason* every mutation was crashing.
+ *   3. A handler closure that captures `workspaceId` and builds keys
+ *      via `wsKeyOf` works without any React dispatcher in scope —
+ *      this models the post-fix call site (`qc.invalidateQueries({
+ *      queryKey: wsKeyOf(workspaceId, "parts") })`).
+ *
+ * Together these cover the "no Invalid hook call" assertion the PR
+ * comment asked for, without dragging in jsdom + RTL just to render
+ * a click target.
+ */
+import { describe, expect, it } from "vitest";
+import { useWsKey, wsKeyOf, wsScope } from "@/lib/queryKeys";
+
+describe("wsKeyOf — vanilla helper is safe in event handlers", () => {
+  it("returns the workspace-prefixed key without touching React", () => {
+    expect(wsKeyOf("ws-1", "parts")).toEqual(["ws", "ws-1", "parts"]);
+    expect(wsKeyOf("ws-1", "part", "abc", "stock")).toEqual([
+      "ws",
+      "ws-1",
+      "part",
+      "abc",
+      "stock",
+    ]);
+  });
+
+  it("collapses null / undefined workspaceId to 'none' so pre-bootstrap keys don't collide", () => {
+    expect(wsKeyOf(null, "parts")).toEqual(["ws", "none", "parts"]);
+    expect(wsKeyOf(undefined, "parts")).toEqual(["ws", "none", "parts"]);
+  });
+
+  it("wsScope is the workspace-only prefix used for blanket invalidation", () => {
+    expect(wsScope("ws-1")).toEqual(["ws", "ws-1"]);
+    expect(wsScope(null)).toEqual(["ws", "none"]);
+  });
+});
+
+describe("useWsKey — hook nature", () => {
+  it("throws when called outside a React render (proves it must NOT be in handlers)", () => {
+    // This is exactly the failure mode PR #33 shipped on the first
+    // pass: every `onClick={() => qc.invalidateQueries({ queryKey:
+    // wsKey(...) })}` would land here. React's dispatcher is null
+    // outside render, so `useContext(AuthCtx)` blows up with the
+    // "Invalid hook call" / "null is not an object" message.
+    expect(() => useWsKey("parts")).toThrow();
+  });
+});
+
+describe("handler closure — the post-fix call shape", () => {
+  it("captures workspaceId at render and uses wsKeyOf inside the handler without throwing", () => {
+    // Model what every mutation site now does: pull workspaceId from
+    // useAuth() at render time, then close over it from the handler.
+    const workspaceId = "ws-42";
+
+    function onArchiveClick() {
+      // No hook call here — wsKeyOf is a vanilla function. This is
+      // what the cache invalidation in PartsList / OrderDetail /
+      // BuildDetail / Workspace / etc. now does.
+      return wsKeyOf(workspaceId, "parts");
+    }
+
+    // Calling the handler outside of any React render must NOT throw
+    // — that's the whole point of the rename + sweep.
+    expect(() => onArchiveClick()).not.toThrow();
+    expect(onArchiveClick()).toEqual(["ws", "ws-42", "parts"]);
+  });
+
+  it("nested handlers (e.g. mutation onSuccess) still work because the closure is plain JS", () => {
+    const workspaceId = "ws-7";
+    let invalidatedKey: unknown[] | null = null;
+    function fakeMutation(onSuccess: () => void) {
+      onSuccess();
+    }
+    fakeMutation(() => {
+      invalidatedKey = wsKeyOf(workspaceId, "order", "abc");
+    });
+    expect(invalidatedKey).toEqual(["ws", "ws-7", "order", "abc"]);
+  });
+});

--- a/web/src/components/layout/AppShell.tsx
+++ b/web/src/components/layout/AppShell.tsx
@@ -1,8 +1,9 @@
-import { ReactNode, useEffect, useState } from "react";
+import { ReactNode, useEffect, useRef, useState } from "react";
 import { Link, NavLink, useLocation } from "react-router-dom";
 import {
   BarChart3,
   Boxes,
+  Check,
   ChevronDown,
   FolderKanban,
   Hammer,
@@ -15,11 +16,13 @@ import {
   Warehouse,
   X,
 } from "lucide-react";
+import { useIsMutating } from "@tanstack/react-query";
 import { useAuth } from "@/lib/auth";
 import { cn } from "@/lib/cn";
 import Brand from "@/components/Brand";
 import CommandPalette from "@/components/CommandPalette";
 import ThemeToggle from "@/components/ThemeToggle";
+import { useConfirm } from "@/components/ConfirmDialog";
 
 type NavItem = { to: string; label: string; icon: typeof Boxes };
 
@@ -77,16 +80,11 @@ export default function AppShell({ children }: { children: ReactNode }) {
             </h1>
 
             <div className="ml-auto flex items-center gap-2">
-              <select
-                className="input max-w-[200px]"
-                value={workspaceId ?? ""}
-                onChange={(e) => switchWorkspace(e.target.value)}
-                aria-label="Switch workspace"
-              >
-                {me?.workspaces.map(w => (
-                  <option key={w.id} value={w.id}>{w.name}</option>
-                ))}
-              </select>
+              <WorkspaceSwitcher
+                workspaces={me?.workspaces ?? []}
+                workspaceId={workspaceId}
+                onSwitch={switchWorkspace}
+              />
               <ThemeToggle />
               <UserMenu
                 open={userOpen}
@@ -100,6 +98,107 @@ export default function AppShell({ children }: { children: ReactNode }) {
 
         <main className="flex-1 px-4 py-4 min-w-0">{children}</main>
       </div>
+    </div>
+  );
+}
+
+/**
+ * Workspace switcher (FE2-002).
+ *
+ * Pre-fix this was a bare `<select onChange>` which fired on every
+ * keyboard arrow press, clobbering the user's session if they were
+ * just exploring the dropdown. It also offered no chance to cancel
+ * mid-mutation. Now:
+ *
+ *  - Clicks toggle a button-driven menu; only an explicit click on a
+ *    target workspace triggers the switch.
+ *  - If a mutation is in flight (`useIsMutating()`), we ask the user
+ *    to confirm — switching mid-edit drops cache + redirects, which
+ *    can throw away unsaved work.
+ */
+function WorkspaceSwitcher({
+  workspaces,
+  workspaceId,
+  onSwitch,
+}: {
+  workspaces: { id: string; name: string }[];
+  workspaceId: string | null;
+  onSwitch: (id: string) => Promise<void>;
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const confirm = useConfirm();
+  const mutating = useIsMutating();
+  const current = workspaces.find(w => w.id === workspaceId);
+
+  // Close on outside click / Esc.
+  useEffect(() => {
+    if (!open) return;
+    function onClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    document.addEventListener("mousedown", onClick);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onClick);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  async function pick(id: string) {
+    setOpen(false);
+    if (id === workspaceId) return;
+    if (mutating > 0) {
+      const ok = await confirm({
+        title: "Switch workspace?",
+        message:
+          "A save is in progress. Switching now will discard pending changes from this view.",
+        confirmLabel: "Switch",
+        severity: "warning",
+      });
+      if (!ok) return;
+    }
+    await onSwitch(id);
+  }
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        type="button"
+        onClick={() => setOpen(o => !o)}
+        className="btn-ghost btn-sm inline-flex items-center gap-1.5 max-w-[220px]"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label="Switch workspace"
+      >
+        <span className="truncate">{current?.name ?? "Workspace"}</span>
+        <ChevronDown size={14} className={cn("transition-transform", open && "rotate-180")} />
+      </button>
+      {open && (
+        <div
+          className="absolute right-0 top-full mt-1 z-30 card p-1 min-w-[220px]"
+          role="menu"
+        >
+          {workspaces.length === 0 && (
+            <div className="px-3 py-1.5 text-xs text-muted">No workspaces.</div>
+          )}
+          {workspaces.map(w => (
+            <button
+              key={w.id}
+              type="button"
+              onClick={() => pick(w.id)}
+              className="w-full flex items-center gap-2 px-3 py-1.5 rounded text-sm text-text hover:bg-panel2"
+              role="menuitem"
+            >
+              <span className="flex-1 truncate text-left">{w.name}</span>
+              {w.id === workspaceId && <Check size={14} className="text-accent" />}
+            </button>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/components/scanner/Scanner.tsx
+++ b/web/src/components/scanner/Scanner.tsx
@@ -1,6 +1,7 @@
 import { lazy, Suspense } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api";
+import { wsKey } from "@/lib/queryKeys";
 
 type WsScanner = {
   scanner: "zxing" | "scandit";
@@ -40,7 +41,7 @@ export default function Scanner({ onScan, className, symbologies }: Props) {
   // Same query key as Settings → Workspace, so the cache is shared across
   // scanner mounts and the settings page.
   const { data: ws, isLoading } = useQuery({
-    queryKey: ["ws", "current"],
+    queryKey: wsKey("ws", "current"),
     queryFn: () => api.get<WsScanner>("/workspaces/current"),
   });
 
@@ -54,8 +55,12 @@ export default function Scanner({ onScan, className, symbologies }: Props) {
     if (!ws.has_scanner_license_key) {
       return (
         <div className={className ?? "flex flex-col h-[70vh]"}>
-          <div className="flex-1 flex items-center justify-center bg-bg-soft rounded-md p-6 text-center">
-            <div className="max-w-sm text-sm text-text-muted">
+          {/* `bg-bg-soft` and `text-text-muted` were stale tokens — neither
+              exists in `tailwind.config.js`, so the panel rendered with a
+              transparent background and inherited text colour. The
+              defined tokens are `bg-panel2` and `text-muted` (FE2-009). */}
+          <div className="flex-1 flex items-center justify-center bg-panel2 rounded-md p-6 text-center">
+            <div className="max-w-sm text-sm text-muted">
               <p className="mb-2 font-medium text-text">Scandit license key missing.</p>
               <p>
                 Set one in <strong className="text-text">Settings → Workspace → Scanner</strong>,
@@ -103,7 +108,7 @@ function ScanditScannerWithKey({
   symbologies?: ReadonlyArray<LicensedSymbology>;
 }) {
   const { data, isLoading, error } = useQuery({
-    queryKey: ["ws", "scanner", "license-key"],
+    queryKey: wsKey("ws", "scanner", "license-key"),
     queryFn: () => api.get<{ license_key: string }>("/workspaces/current/scanner-license-key"),
   });
   if (isLoading) return <div className={className}>Fetching license…</div>;

--- a/web/src/components/scanner/Scanner.tsx
+++ b/web/src/components/scanner/Scanner.tsx
@@ -1,7 +1,7 @@
 import { lazy, Suspense } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api";
-import { wsKey } from "@/lib/queryKeys";
+import { useWsKey } from "@/lib/queryKeys";
 
 type WsScanner = {
   scanner: "zxing" | "scandit";
@@ -41,7 +41,7 @@ export default function Scanner({ onScan, className, symbologies }: Props) {
   // Same query key as Settings → Workspace, so the cache is shared across
   // scanner mounts and the settings page.
   const { data: ws, isLoading } = useQuery({
-    queryKey: wsKey("ws", "current"),
+    queryKey: useWsKey("ws", "current"),
     queryFn: () => api.get<WsScanner>("/workspaces/current"),
   });
 
@@ -108,7 +108,7 @@ function ScanditScannerWithKey({
   symbologies?: ReadonlyArray<LicensedSymbology>;
 }) {
   const { data, isLoading, error } = useQuery({
-    queryKey: wsKey("ws", "scanner", "license-key"),
+    queryKey: useWsKey("ws", "scanner", "license-key"),
     queryFn: () => api.get<{ license_key: string }>("/workspaces/current/scanner-license-key"),
   });
   if (isLoading) return <div className={className}>Fetching license…</div>;

--- a/web/src/components/scanner/ZxingScanner.tsx
+++ b/web/src/components/scanner/ZxingScanner.tsx
@@ -453,7 +453,9 @@ export default function ZxingScanner({ onScan, className, symbologies }: Props) 
           autoPlay
         />
         {status.kind === "perm" && (
-          <div className="absolute inset-0 flex flex-col items-center justify-center p-6 text-center bg-bg-soft text-text">
+          // `bg-bg-soft` is not defined in tailwind.config.js — replaced
+          // with the existing `bg-panel2` token (FE2-009).
+          <div className="absolute inset-0 flex flex-col items-center justify-center p-6 text-center bg-panel2 text-text">
             <div className="text-2xl mb-2" aria-hidden>📷</div>
             <p className="max-w-sm text-sm mb-4">{status.text}</p>
             <button

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -84,30 +84,53 @@ async function parsedRequest<S extends ZodType>(
   return result.data;
 }
 
+/**
+ * Optional per-call extras the wrappers thread through to fetch():
+ *
+ * - `signal` lets a caller hand in an AbortController so an unmount or
+ *   stale-effect cleanup can cancel an in-flight request (v1 FE HIGH-4).
+ *   `useQuery` already provides `signal` via its `queryFn` argument; this
+ *   makes the wrappers usable from raw `useEffect` blocks too.
+ */
+export type ApiOptions = { signal?: AbortSignal };
+
 export const api = {
   // --- legacy untyped flavour ---
-  get: <T>(p: string) => request<T>(p),
-  post: <T>(p: string, body?: any) =>
-    request<T>(p, { method: "POST", body: body !== undefined ? JSON.stringify(body) : undefined }),
-  patch: <T>(p: string, body?: any) =>
-    request<T>(p, { method: "PATCH", body: body !== undefined ? JSON.stringify(body) : undefined }),
-  delete: <T>(p: string) => request<T>(p, { method: "DELETE" }),
-  upload: <T>(p: string, form: FormData) => request<T>(p, { method: "POST", body: form }),
+  get: <T>(p: string, opts?: ApiOptions) => request<T>(p, { signal: opts?.signal }),
+  post: <T>(p: string, body?: any, opts?: ApiOptions) =>
+    request<T>(p, {
+      method: "POST",
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+      signal: opts?.signal,
+    }),
+  patch: <T>(p: string, body?: any, opts?: ApiOptions) =>
+    request<T>(p, {
+      method: "PATCH",
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+      signal: opts?.signal,
+    }),
+  delete: <T>(p: string, opts?: ApiOptions) =>
+    request<T>(p, { method: "DELETE", signal: opts?.signal }),
+  upload: <T>(p: string, form: FormData, opts?: ApiOptions) =>
+    request<T>(p, { method: "POST", body: form, signal: opts?.signal }),
 
   // --- zod-validating flavour ---
   parsed: {
-    get: <S extends ZodType>(p: string, schema: S) => parsedRequest(p, schema),
-    post: <S extends ZodType>(p: string, schema: S, body?: any) =>
+    get: <S extends ZodType>(p: string, schema: S, opts?: ApiOptions) =>
+      parsedRequest(p, schema, { signal: opts?.signal }),
+    post: <S extends ZodType>(p: string, schema: S, body?: any, opts?: ApiOptions) =>
       parsedRequest(p, schema, {
         method: "POST",
         body: body !== undefined ? JSON.stringify(body) : undefined,
+        signal: opts?.signal,
       }),
-    patch: <S extends ZodType>(p: string, schema: S, body?: any) =>
+    patch: <S extends ZodType>(p: string, schema: S, body?: any, opts?: ApiOptions) =>
       parsedRequest(p, schema, {
         method: "PATCH",
         body: body !== undefined ? JSON.stringify(body) : undefined,
+        signal: opts?.signal,
       }),
-    delete: <S extends ZodType>(p: string, schema: S) =>
-      parsedRequest(p, schema, { method: "DELETE" }),
+    delete: <S extends ZodType>(p: string, schema: S, opts?: ApiOptions) =>
+      parsedRequest(p, schema, { method: "DELETE", signal: opts?.signal }),
   },
 };

--- a/web/src/lib/auth.tsx
+++ b/web/src/lib/auth.tsx
@@ -1,6 +1,17 @@
-import { createContext, ReactNode, useContext, useEffect, useState } from "react";
+import {
+  createContext,
+  ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { useNavigate, useLocation } from "react-router-dom";
+import { useQueryClient } from "@tanstack/react-query";
 import * as Sentry from "@sentry/react";
 import { api, ApiError } from "./api";
+import { authBus } from "./queryKeys";
 import { MeSchema, type Me } from "./schemas";
 
 export type { Me };
@@ -22,8 +33,21 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [workspaceId, setWorkspaceId] = useState<string | null>(
     localStorage.getItem("workspaceId")
   );
+  const qc = useQueryClient();
+  const nav = useNavigate();
+  const location = useLocation();
 
-  async function refresh() {
+  // The bootstrap effect fires once and the closure it captures keeps
+  // pointing at the *original* `workspaceId` forever — if we ever
+  // referenced it from inside refresh() through a closure we'd see a
+  // stale value (v1 FE HIGH-1). Holding it in a ref means the latest
+  // workspaceId is always reachable without recreating the effect.
+  const workspaceIdRef = useRef(workspaceId);
+  useEffect(() => {
+    workspaceIdRef.current = workspaceId;
+  }, [workspaceId]);
+
+  const refresh = useCallback(async () => {
     setLoading(true);
     try {
       // Parsed boundary: schema mismatch on /auth/me would cascade into
@@ -31,14 +55,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       const data = await api.parsed.get("/auth/me", MeSchema);
       setMe(data);
       // Pipe the user's identity into Sentry so events can be deduped
-      // by user (FE MED-10). We send the id + email; the backend's
-      // before_send scrubber strips request bodies and tenant headers,
-      // and Sentry's "send default PII" already handles IP, so this is
-      // additive identification, not new exfiltration.
+      // by user (FE MED-10).
       Sentry.setUser({ id: data.user.id, email: data.user.email });
-      if (!workspaceId && data.workspaces[0]) {
-        setWorkspaceId(data.workspaces[0].id);
-        localStorage.setItem("workspaceId", data.workspaces[0].id);
+      // Read the latest workspaceId via ref — refresh() may be called
+      // long after the provider mounted, and a stale closure here used
+      // to clobber a freshly-switched workspace with the boot value.
+      if (!workspaceIdRef.current && data.workspaces[0]) {
+        const first = data.workspaces[0].id;
+        setWorkspaceId(first);
+        localStorage.setItem("workspaceId", first);
       }
     } catch (e) {
       // 401 is the unauthenticated path (no log noise). Anything else
@@ -52,9 +77,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     } finally {
       setLoading(false);
     }
-  }
+  }, []);
 
-  async function logout() {
+  const logout = useCallback(async () => {
     try {
       await api.post("/auth/logout");
     } catch {}
@@ -62,19 +87,78 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setMe(null);
     setWorkspaceId(null);
     Sentry.setUser(null);
-  }
+    qc.clear();
+  }, [qc]);
 
-  async function switchWorkspace(id: string) {
-    await api.post(`/workspaces/${id}/switch`);
-    localStorage.setItem("workspaceId", id);
-    setWorkspaceId(id);
-    window.location.reload();
-  }
+  const switchWorkspace = useCallback(
+    async (id: string) => {
+      // Cookie session is updated server-side; await it before flushing
+      // the cache so the next refetch reads the new workspace.
+      await api.post(`/workspaces/${id}/switch`);
+      localStorage.setItem("workspaceId", id);
+      // Drop every cached query — the workspace-scoped key prefix means
+      // stale data wouldn't bleed across, but freeing the memory and
+      // forcing a clean refetch is the right move on switch (FE2-003).
+      qc.clear();
+      setWorkspaceId(id);
+      // Land on the home view rather than reloading the page — a full
+      // reload tore down WebSocket / scanner state for no benefit
+      // (FE2-002).
+      nav("/parts", { replace: true });
+    },
+    [qc, nav],
+  );
 
+  // Initial bootstrap — run once on mount. Cleanup aborts the in-flight
+  // /auth/me if the provider unmounts mid-request (v1 FE HIGH-4).
   useEffect(() => {
-    refresh();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    const ctrl = new AbortController();
+    (async () => {
+      try {
+        const data = await api.parsed.get("/auth/me", MeSchema, { signal: ctrl.signal });
+        setMe(data);
+        Sentry.setUser({ id: data.user.id, email: data.user.email });
+        if (!workspaceIdRef.current && data.workspaces[0]) {
+          const first = data.workspaces[0].id;
+          setWorkspaceId(first);
+          localStorage.setItem("workspaceId", first);
+        }
+      } catch (e) {
+        if (!(e instanceof ApiError && e.status === 401)) {
+          // Aborted fetches throw DOMException("AbortError") — ignore.
+          if (!(e instanceof Error && e.name === "AbortError")) {
+            Sentry.captureException(e);
+          }
+        }
+        setMe(null);
+        Sentry.setUser(null);
+      } finally {
+        setLoading(false);
+      }
+    })();
+    return () => ctrl.abort();
   }, []);
+
+  // Subscribe to the auth bus so a 401 thrown by *any* query or
+  // mutation drops session state and bounces the user to /login. The
+  // 401 handler in main.tsx fires the event; this effect translates it
+  // into navigation. Keeping the redirect inside React (rather than the
+  // QueryCache callback) means we still have access to the router and
+  // can preserve the deep-link via location state (FE2-001 + FE2-010).
+  useEffect(() => {
+    return authBus.on((event) => {
+      if (event !== "unauthorized") return;
+      // Avoid stomping on the login/signup pages — there's nowhere to
+      // bounce to and we'd loop the redirect.
+      if (location.pathname === "/login" || location.pathname === "/signup") return;
+      localStorage.removeItem("workspaceId");
+      setMe(null);
+      setWorkspaceId(null);
+      Sentry.setUser(null);
+      qc.clear();
+      nav("/login", { replace: true, state: { from: location } });
+    });
+  }, [nav, qc, location]);
 
   return (
     <AuthCtx.Provider value={{ me, loading, refresh, logout, workspaceId, switchWorkspace }}>

--- a/web/src/lib/queryKeys.ts
+++ b/web/src/lib/queryKeys.ts
@@ -12,8 +12,11 @@
  *
  *  1. Every query key is now prefixed with `["ws", <workspaceId>, …]`,
  *     so TanStack treats two different workspaces as distinct caches.
- *     Callers build keys with `wsKey("parts", ...)` instead of
- *     `["parts", ...]`.
+ *     Callers build keys inside render with `useWsKey("parts", ...)`
+ *     instead of `["parts", ...]`. Outside render (event handlers,
+ *     mutation `onSuccess`, etc.) use `wsKeyOf(workspaceId, ...)` —
+ *     `useWsKey` is a hook (it reads `useAuth()`), so calling it from
+ *     a click handler crashes with "Invalid hook call".
  *
  *  2. On workspace switch we still call `qc.clear()` to free the old
  *     cache (no point keeping it around), but the prefix means even
@@ -31,11 +34,14 @@ import { useAuth } from "./auth";
 
 /**
  * Build a query key scoped to the active workspace. Reads `workspaceId`
- * from `useAuth()` so it must be called inside a render. The prefix is
- * `["ws", <id-or-"none">]`; null / undefined collapse to "none" so SSR
- * or pre-bootstrap renders don't collide with real workspace caches.
+ * from `useAuth()` so it MUST be called inside a function component
+ * render body (it's a hook). The prefix is `["ws", <id-or-"none">]`;
+ * null / undefined collapse to "none" so SSR or pre-bootstrap renders
+ * don't collide with real workspace caches. The `use` prefix makes the
+ * hook nature loud — for event handlers and mutation callbacks use
+ * `wsKeyOf(workspaceId, ...)` instead.
  */
-export function wsKey(...rest: unknown[]): unknown[] {
+export function useWsKey(...rest: unknown[]): unknown[] {
   const { workspaceId } = useAuth();
   return ["ws", workspaceId ?? "none", ...rest];
 }

--- a/web/src/lib/queryKeys.ts
+++ b/web/src/lib/queryKeys.ts
@@ -1,0 +1,84 @@
+/**
+ * Workspace-scoped TanStack Query keys.
+ *
+ * Why this exists: every list query is implicitly tenant-bound (the
+ * backend filters by the cookie's session workspace), but the cache key
+ * was just `["parts"]`, `["orders"]`, … — so when the user switched
+ * workspace, the in-memory cache from the *previous* workspace served
+ * the next render before refetch landed. That's a multi-tenant data
+ * leak waiting to happen (FE2-004 / v1 FE HIGH-8).
+ *
+ * The fix is twofold:
+ *
+ *  1. Every query key is now prefixed with `["ws", <workspaceId>, …]`,
+ *     so TanStack treats two different workspaces as distinct caches.
+ *     Callers build keys with `wsKey("parts", ...)` instead of
+ *     `["parts", ...]`.
+ *
+ *  2. On workspace switch we still call `qc.clear()` to free the old
+ *     cache (no point keeping it around), but the prefix means even
+ *     without that step a refetch never reads the wrong tenant's data.
+ *
+ * The auth bus piggybacks here because the 401 handler at QueryClient
+ * construction time has no React context — it needs a vanilla pub/sub
+ * to nudge `<AuthProvider>` to drop session state and `<App>` to redirect.
+ */
+import { useAuth } from "./auth";
+
+// ---------------------------------------------------------------------
+// Workspace-keyed query helpers
+// ---------------------------------------------------------------------
+
+/**
+ * Build a query key scoped to the active workspace. Reads `workspaceId`
+ * from `useAuth()` so it must be called inside a render. The prefix is
+ * `["ws", <id-or-"none">]`; null / undefined collapse to "none" so SSR
+ * or pre-bootstrap renders don't collide with real workspace caches.
+ */
+export function wsKey(...rest: unknown[]): unknown[] {
+  const { workspaceId } = useAuth();
+  return ["ws", workspaceId ?? "none", ...rest];
+}
+
+/**
+ * Vanilla (non-hook) variant for places that already hold the
+ * workspaceId in scope and just want to build a key. Mostly used by
+ * `qc.invalidateQueries(...)` after a mutation if the caller already
+ * has the auth context.
+ */
+export function wsKeyOf(workspaceId: string | null | undefined, ...rest: unknown[]): unknown[] {
+  return ["ws", workspaceId ?? "none", ...rest];
+}
+
+/** Top-level prefix for blanket invalidation of the active workspace. */
+export function wsScope(workspaceId: string | null | undefined): unknown[] {
+  return ["ws", workspaceId ?? "none"];
+}
+
+// ---------------------------------------------------------------------
+// Auth bus — pub/sub for cross-cutting auth events fired from places
+// that don't sit inside the React tree (e.g. QueryCache.onError).
+// ---------------------------------------------------------------------
+
+type AuthEvent = "unauthorized";
+type Listener = (event: AuthEvent) => void;
+
+const listeners = new Set<Listener>();
+
+export const authBus = {
+  emit(event: AuthEvent) {
+    for (const fn of listeners) {
+      try {
+        fn(event);
+      } catch {
+        // Listener throws shouldn't break other listeners.
+      }
+    }
+  },
+  on(fn: Listener): () => void {
+    listeners.add(fn);
+    return () => {
+      listeners.delete(fn);
+    };
+  },
+};

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -4,19 +4,48 @@ import "./instrument";
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  MutationCache,
+  QueryCache,
+  QueryClient,
+  QueryClientProvider,
+} from "@tanstack/react-query";
 import * as Sentry from "@sentry/react";
 import App from "./App";
 import { ThemeProvider, bootTheme } from "./lib/theme";
 import ThemedToaster from "./components/ThemedToaster";
+import { ApiError } from "./lib/api";
+import { authBus } from "./lib/queryKeys";
 import "./index.css";
 
 // Apply the persisted/system theme class on <html> before mount to avoid a
 // flash of the wrong theme.
 bootTheme();
 
+/**
+ * Centralised 401 handler (FE2-001).
+ *
+ * Pre-fix, every list page caught an `ApiError(401, …)` locally and
+ * rendered an empty list — the user couldn't tell whether their
+ * session had expired or the workspace really was empty. Now any 401
+ * thrown by a query or mutation fires a single `authBus.emit("unauthorized")`
+ * which `<AuthProvider>` listens for to drop session state and `<App>`
+ * uses to redirect to /login while preserving the original location.
+ *
+ * The handler runs outside React, so we can't use `useNavigate()` here.
+ * The auth bus pattern keeps this dependency-free and avoids tight
+ * coupling to the router layer.
+ */
+function on401(err: unknown) {
+  if (err instanceof ApiError && err.status === 401) {
+    authBus.emit("unauthorized");
+  }
+}
+
 const queryClient = new QueryClient({
   defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false } },
+  queryCache: new QueryCache({ onError: on401 }),
+  mutationCache: new MutationCache({ onError: on401 }),
 });
 
 ReactDOM.createRoot(document.getElementById("root")!).render(

--- a/web/src/routes/auth/Login.tsx
+++ b/web/src/routes/auth/Login.tsx
@@ -1,16 +1,23 @@
 import { useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useLocation, useNavigate, type Location } from "react-router-dom";
 import { api, ApiError } from "@/lib/api";
 import { useAuth } from "@/lib/auth";
 import AuthShell from "./AuthShell";
 
 export default function Login() {
   const nav = useNavigate();
+  const location = useLocation();
   const { refresh } = useAuth();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [err, setErr] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
+
+  // `from` is set by `<Gate>` (and by the 401 handler in auth.tsx) when
+  // an authed page bounced the user here. Replay the original target on
+  // success rather than always landing them on /parts (FE2-010).
+  const fromLoc = (location.state as { from?: Location } | null)?.from;
+  const fromPath = fromLoc ? `${fromLoc.pathname}${fromLoc.search}${fromLoc.hash}` : null;
 
   async function submit(e: React.FormEvent) {
     e.preventDefault();
@@ -19,7 +26,7 @@ export default function Login() {
     try {
       await api.post("/auth/login", { email, password });
       await refresh();
-      nav("/parts");
+      nav(fromPath || "/parts", { replace: true });
     } catch (e) {
       setErr(e instanceof ApiError ? e.message : "Login failed");
     } finally {

--- a/web/src/routes/auth/Signup.tsx
+++ b/web/src/routes/auth/Signup.tsx
@@ -1,11 +1,12 @@
 import { useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useLocation, useNavigate, type Location } from "react-router-dom";
 import { api, ApiError } from "@/lib/api";
 import { useAuth } from "@/lib/auth";
 import AuthShell from "./AuthShell";
 
 export default function Signup() {
   const nav = useNavigate();
+  const location = useLocation();
   const { refresh } = useAuth();
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
@@ -13,6 +14,11 @@ export default function Signup() {
   const [workspaceName, setWorkspaceName] = useState("");
   const [err, setErr] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
+
+  // Mirror the Login deep-link replay so a user who hit a protected
+  // route, signed up instead of in, still lands on the original target.
+  const fromLoc = (location.state as { from?: Location } | null)?.from;
+  const fromPath = fromLoc ? `${fromLoc.pathname}${fromLoc.search}${fromLoc.hash}` : null;
 
   async function submit(e: React.FormEvent) {
     e.preventDefault();
@@ -26,7 +32,7 @@ export default function Signup() {
         workspace_name: workspaceName || undefined,
       });
       await refresh();
-      nav("/parts");
+      nav(fromPath || "/parts", { replace: true });
     } catch (e) {
       setErr(e instanceof ApiError ? e.message : "Signup failed");
     } finally {

--- a/web/src/routes/builds/BuildCreate.tsx
+++ b/web/src/routes/builds/BuildCreate.tsx
@@ -2,14 +2,14 @@ import { useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { api, ApiError } from "@/lib/api";
-import { wsKey } from "@/lib/queryKeys";
+import { useWsKey } from "@/lib/queryKeys";
 import type { Build, Project } from "@/types";
 
 export default function BuildCreate() {
   const nav = useNavigate();
   const [params] = useSearchParams();
   const { data: projects } = useQuery({
-    queryKey: wsKey("projects"),
+    queryKey: useWsKey("projects"),
     queryFn: () => api.get<Project[]>("/projects"),
   });
   const [name, setName] = useState("");

--- a/web/src/routes/builds/BuildCreate.tsx
+++ b/web/src/routes/builds/BuildCreate.tsx
@@ -2,13 +2,14 @@ import { useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { api, ApiError } from "@/lib/api";
+import { wsKey } from "@/lib/queryKeys";
 import type { Build, Project } from "@/types";
 
 export default function BuildCreate() {
   const nav = useNavigate();
   const [params] = useSearchParams();
   const { data: projects } = useQuery({
-    queryKey: ["projects"],
+    queryKey: wsKey("projects"),
     queryFn: () => api.get<Project[]>("/projects"),
   });
   const [name, setName] = useState("");

--- a/web/src/routes/builds/BuildDetail.tsx
+++ b/web/src/routes/builds/BuildDetail.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { api, ApiError } from "@/lib/api";
+import { wsKey } from "@/lib/queryKeys";
 import EntityHeader from "@/components/EntityHeader";
 import AttachmentsPanel from "@/components/AttachmentsPanel";
 import ActivityTimeline from "@/components/ActivityTimeline";
@@ -18,23 +19,23 @@ export default function BuildDetail() {
   const nav = useNavigate();
 
   const { data } = useQuery({
-    queryKey: ["build", buildId],
+    queryKey: wsKey("build", buildId),
     queryFn: () => api.get<DetailOut>(`/builds/${buildId}`),
     enabled: !!buildId,
   });
   const projectId = data?.build.project_id;
   const { data: project } = useQuery({
-    queryKey: ["project", projectId],
+    queryKey: wsKey("project", projectId),
     queryFn: () => api.get<Project>(`/projects/${projectId}`),
     enabled: !!projectId,
   });
   const { data: entries } = useQuery({
-    queryKey: ["project", projectId, "entries"],
+    queryKey: wsKey("project", projectId, "entries"),
     queryFn: () => api.get<ProjectEntry[]>(`/projects/${projectId}/entries`),
     enabled: !!projectId,
   });
-  const { data: parts } = useQuery({ queryKey: ["parts"], queryFn: () => api.get<Part[]>("/parts") });
-  const { data: storage } = useQuery({ queryKey: ["storage"], queryFn: () => api.get<StorageLocation[]>("/storage") });
+  const { data: parts } = useQuery({ queryKey: wsKey("parts"), queryFn: () => api.get<Part[]>("/parts") });
+  const { data: storage } = useQuery({ queryKey: wsKey("storage"), queryFn: () => api.get<StorageLocation[]>("/storage") });
 
   // consumption plan: project_entry_id → list of consume rows
   const [plan, setPlan] = useState<Record<string, ConsumeRow[]>>({});
@@ -87,8 +88,8 @@ export default function BuildDetail() {
         return;
       }
       await api.post(`/builds/${buildId}/consume`, { lines });
-      qc.invalidateQueries({ queryKey: ["build", buildId] });
-      qc.invalidateQueries({ queryKey: ["parts"] });
+      qc.invalidateQueries({ queryKey: wsKey("build", buildId) });
+      qc.invalidateQueries({ queryKey: wsKey("parts") });
       toast.success("Build complete — stock decremented.");
     } catch (e) {
       const m = e instanceof ApiError ? e.message : "Build failed";
@@ -101,8 +102,8 @@ export default function BuildDetail() {
 
   async function doArchive() {
     await api.post(`/builds/${buildId}/${build.archived_at ? "restore" : "archive"}`);
-    qc.invalidateQueries({ queryKey: ["build", buildId] });
-    qc.invalidateQueries({ queryKey: ["builds"] });
+    qc.invalidateQueries({ queryKey: wsKey("build", buildId) });
+    qc.invalidateQueries({ queryKey: wsKey("builds") });
     if (!build.archived_at) nav("/builds");
   }
 

--- a/web/src/routes/builds/BuildDetail.tsx
+++ b/web/src/routes/builds/BuildDetail.tsx
@@ -3,7 +3,8 @@ import { useNavigate, useParams } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { api, ApiError } from "@/lib/api";
-import { wsKey } from "@/lib/queryKeys";
+import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
+import { useAuth } from "@/lib/auth";
 import EntityHeader from "@/components/EntityHeader";
 import AttachmentsPanel from "@/components/AttachmentsPanel";
 import ActivityTimeline from "@/components/ActivityTimeline";
@@ -17,25 +18,26 @@ export default function BuildDetail() {
   const { buildId } = useParams<{ buildId: string }>();
   const qc = useQueryClient();
   const nav = useNavigate();
+  const { workspaceId } = useAuth();
 
   const { data } = useQuery({
-    queryKey: wsKey("build", buildId),
+    queryKey: useWsKey("build", buildId),
     queryFn: () => api.get<DetailOut>(`/builds/${buildId}`),
     enabled: !!buildId,
   });
   const projectId = data?.build.project_id;
   const { data: project } = useQuery({
-    queryKey: wsKey("project", projectId),
+    queryKey: useWsKey("project", projectId),
     queryFn: () => api.get<Project>(`/projects/${projectId}`),
     enabled: !!projectId,
   });
   const { data: entries } = useQuery({
-    queryKey: wsKey("project", projectId, "entries"),
+    queryKey: useWsKey("project", projectId, "entries"),
     queryFn: () => api.get<ProjectEntry[]>(`/projects/${projectId}/entries`),
     enabled: !!projectId,
   });
-  const { data: parts } = useQuery({ queryKey: wsKey("parts"), queryFn: () => api.get<Part[]>("/parts") });
-  const { data: storage } = useQuery({ queryKey: wsKey("storage"), queryFn: () => api.get<StorageLocation[]>("/storage") });
+  const { data: parts } = useQuery({ queryKey: useWsKey("parts"), queryFn: () => api.get<Part[]>("/parts") });
+  const { data: storage } = useQuery({ queryKey: useWsKey("storage"), queryFn: () => api.get<StorageLocation[]>("/storage") });
 
   // consumption plan: project_entry_id → list of consume rows
   const [plan, setPlan] = useState<Record<string, ConsumeRow[]>>({});
@@ -88,8 +90,8 @@ export default function BuildDetail() {
         return;
       }
       await api.post(`/builds/${buildId}/consume`, { lines });
-      qc.invalidateQueries({ queryKey: wsKey("build", buildId) });
-      qc.invalidateQueries({ queryKey: wsKey("parts") });
+      qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "build", buildId) });
+      qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "parts") });
       toast.success("Build complete — stock decremented.");
     } catch (e) {
       const m = e instanceof ApiError ? e.message : "Build failed";
@@ -102,8 +104,8 @@ export default function BuildDetail() {
 
   async function doArchive() {
     await api.post(`/builds/${buildId}/${build.archived_at ? "restore" : "archive"}`);
-    qc.invalidateQueries({ queryKey: wsKey("build", buildId) });
-    qc.invalidateQueries({ queryKey: wsKey("builds") });
+    qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "build", buildId) });
+    qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "builds") });
     if (!build.archived_at) nav("/builds");
   }
 

--- a/web/src/routes/builds/BuildsList.tsx
+++ b/web/src/routes/builds/BuildsList.tsx
@@ -2,7 +2,7 @@ import { Link, NavLink, useNavigate } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { Hammer } from "lucide-react";
 import { api } from "@/lib/api";
-import { wsKey } from "@/lib/queryKeys";
+import { useWsKey } from "@/lib/queryKeys";
 import { DataTable } from "@/components/DataTable";
 import EmptyState from "@/components/EmptyState";
 import QueryStateBoundary from "@/components/QueryStateBoundary";
@@ -18,12 +18,12 @@ const STATUS_BADGES: Record<Build["status"], string> = {
 export default function BuildsList({ archived = false }: { archived?: boolean }) {
   const nav = useNavigate();
   const query = useQuery({
-    queryKey: wsKey("builds", { archived }),
+    queryKey: useWsKey("builds", { archived }),
     queryFn: () => api.get<Build[]>(`/builds${archived ? "?archived=true" : ""}`),
   });
   const { data } = query;
   const { data: projects } = useQuery({
-    queryKey: wsKey("projects"),
+    queryKey: useWsKey("projects"),
     queryFn: () => api.get<Project[]>("/projects"),
   });
   const projectsById = new Map(projects?.map(p => [p.id, p]) ?? []);

--- a/web/src/routes/builds/BuildsList.tsx
+++ b/web/src/routes/builds/BuildsList.tsx
@@ -2,8 +2,10 @@ import { Link, NavLink, useNavigate } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { Hammer } from "lucide-react";
 import { api } from "@/lib/api";
+import { wsKey } from "@/lib/queryKeys";
 import { DataTable } from "@/components/DataTable";
 import EmptyState from "@/components/EmptyState";
+import QueryStateBoundary from "@/components/QueryStateBoundary";
 import type { Build, Project } from "@/types";
 
 const STATUS_BADGES: Record<Build["status"], string> = {
@@ -15,12 +17,13 @@ const STATUS_BADGES: Record<Build["status"], string> = {
 
 export default function BuildsList({ archived = false }: { archived?: boolean }) {
   const nav = useNavigate();
-  const { data } = useQuery({
-    queryKey: ["builds", { archived }],
+  const query = useQuery({
+    queryKey: wsKey("builds", { archived }),
     queryFn: () => api.get<Build[]>(`/builds${archived ? "?archived=true" : ""}`),
   });
+  const { data } = query;
   const { data: projects } = useQuery({
-    queryKey: ["projects"],
+    queryKey: wsKey("projects"),
     queryFn: () => api.get<Project[]>("/projects"),
   });
   const projectsById = new Map(projects?.map(p => [p.id, p]) ?? []);
@@ -32,6 +35,7 @@ export default function BuildsList({ archived = false }: { archived?: boolean })
         <NavLink to="/builds/archived" className={({ isActive }) => "btn " + (isActive ? "border-accent/50 text-accent" : "")}>Archived</NavLink>
         <Link to="/builds/create" className="btn-primary ml-auto">+ Build</Link>
       </div>
+      <QueryStateBoundary query={query} resourceLabel="builds">
       <DataTable
         rows={data ?? []}
         rowKey={r => r.id}
@@ -76,6 +80,7 @@ export default function BuildsList({ archived = false }: { archived?: boolean })
           },
         ]}
       />
+      </QueryStateBoundary>
     </div>
   );
 }

--- a/web/src/routes/lots/LotDetail.tsx
+++ b/web/src/routes/lots/LotDetail.tsx
@@ -2,14 +2,16 @@ import { Outlet, useParams, useNavigate } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { api } from "@/lib/api";
+import { useAuth } from "@/lib/auth";
+import { wsKey, wsScope } from "@/lib/queryKeys";
 import EntityHeader from "@/components/EntityHeader";
 import SubNav from "@/components/SubNav";
 import type { Lot, Part, StockEntry, StorageLocation } from "@/types";
 
 export function LotLayout() {
   const { lotId } = useParams<{ lotId: string }>();
-  const { data } = useQuery({ queryKey: ["lot", lotId], queryFn: () => api.get<Lot>(`/lots/${lotId}`), enabled: !!lotId });
-  const { data: parts } = useQuery({ queryKey: ["parts"], queryFn: () => api.get<Part[]>("/parts") });
+  const { data } = useQuery({ queryKey: wsKey("lot", lotId), queryFn: () => api.get<Lot>(`/lots/${lotId}`), enabled: !!lotId });
+  const { data: parts } = useQuery({ queryKey: wsKey("parts"), queryFn: () => api.get<Part[]>("/parts") });
   if (!data) return <div className="text-muted">Loading…</div>;
   const part = parts?.find(p => p.id === data.part_id);
   const items = [
@@ -33,7 +35,7 @@ export function LotLayout() {
 
 export function LotInfo() {
   const { lotId } = useParams();
-  const { data } = useQuery({ queryKey: ["lot", lotId], queryFn: () => api.get<Lot>(`/lots/${lotId}`), enabled: !!lotId });
+  const { data } = useQuery({ queryKey: wsKey("lot", lotId), queryFn: () => api.get<Lot>(`/lots/${lotId}`), enabled: !!lotId });
   if (!data) return null;
   return (
     <div className="card p-4 max-w-2xl space-y-2 text-sm">
@@ -52,7 +54,8 @@ export function LotMove() {
   const { lotId } = useParams<{ lotId: string }>();
   const nav = useNavigate();
   const qc = useQueryClient();
-  const { data: storage } = useQuery({ queryKey: ["storage"], queryFn: () => api.get<StorageLocation[]>("/storage") });
+  const { workspaceId } = useAuth();
+  const { data: storage } = useQuery({ queryKey: wsKey("storage"), queryFn: () => api.get<StorageLocation[]>("/storage") });
   const [dest, setDest] = useState("");
   const [qty, setQty] = useState<number>(0);
   const [split, setSplit] = useState(false);
@@ -64,7 +67,7 @@ export function LotMove() {
       quantity: qty,
       split_lot: split,
     });
-    qc.invalidateQueries();
+    qc.invalidateQueries({ queryKey: wsScope(workspaceId) });
     nav(`/lots/${lotId}/info`);
   }
   return (
@@ -92,12 +95,13 @@ export function LotMove() {
 export function LotAdjust() {
   const { lotId } = useParams();
   const qc = useQueryClient();
+  const { workspaceId } = useAuth();
   const [actual, setActual] = useState<number>(0);
   const [comments, setComments] = useState("");
   async function submit(e: React.FormEvent) {
     e.preventDefault();
     await api.post(`/lots/${lotId}/adjust-count`, { actual_quantity: actual, comments });
-    qc.invalidateQueries();
+    qc.invalidateQueries({ queryKey: wsScope(workspaceId) });
   }
   return (
     <form onSubmit={submit} className="card p-4 max-w-xl space-y-3">
@@ -116,7 +120,7 @@ export function LotAdjust() {
 
 export function LotHistory() {
   const { lotId } = useParams();
-  const { data } = useQuery({ queryKey: ["lot", lotId, "history"], queryFn: () => api.get<StockEntry[]>(`/lots/${lotId}/history`) });
+  const { data } = useQuery({ queryKey: wsKey("lot", lotId, "history"), queryFn: () => api.get<StockEntry[]>(`/lots/${lotId}/history`) });
   return (
     <div className="card overflow-hidden">
       <table className="table">

--- a/web/src/routes/lots/LotDetail.tsx
+++ b/web/src/routes/lots/LotDetail.tsx
@@ -3,15 +3,15 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { api } from "@/lib/api";
 import { useAuth } from "@/lib/auth";
-import { wsKey, wsScope } from "@/lib/queryKeys";
+import { useWsKey, wsScope } from "@/lib/queryKeys";
 import EntityHeader from "@/components/EntityHeader";
 import SubNav from "@/components/SubNav";
 import type { Lot, Part, StockEntry, StorageLocation } from "@/types";
 
 export function LotLayout() {
   const { lotId } = useParams<{ lotId: string }>();
-  const { data } = useQuery({ queryKey: wsKey("lot", lotId), queryFn: () => api.get<Lot>(`/lots/${lotId}`), enabled: !!lotId });
-  const { data: parts } = useQuery({ queryKey: wsKey("parts"), queryFn: () => api.get<Part[]>("/parts") });
+  const { data } = useQuery({ queryKey: useWsKey("lot", lotId), queryFn: () => api.get<Lot>(`/lots/${lotId}`), enabled: !!lotId });
+  const { data: parts } = useQuery({ queryKey: useWsKey("parts"), queryFn: () => api.get<Part[]>("/parts") });
   if (!data) return <div className="text-muted">Loading…</div>;
   const part = parts?.find(p => p.id === data.part_id);
   const items = [
@@ -35,7 +35,7 @@ export function LotLayout() {
 
 export function LotInfo() {
   const { lotId } = useParams();
-  const { data } = useQuery({ queryKey: wsKey("lot", lotId), queryFn: () => api.get<Lot>(`/lots/${lotId}`), enabled: !!lotId });
+  const { data } = useQuery({ queryKey: useWsKey("lot", lotId), queryFn: () => api.get<Lot>(`/lots/${lotId}`), enabled: !!lotId });
   if (!data) return null;
   return (
     <div className="card p-4 max-w-2xl space-y-2 text-sm">
@@ -55,7 +55,7 @@ export function LotMove() {
   const nav = useNavigate();
   const qc = useQueryClient();
   const { workspaceId } = useAuth();
-  const { data: storage } = useQuery({ queryKey: wsKey("storage"), queryFn: () => api.get<StorageLocation[]>("/storage") });
+  const { data: storage } = useQuery({ queryKey: useWsKey("storage"), queryFn: () => api.get<StorageLocation[]>("/storage") });
   const [dest, setDest] = useState("");
   const [qty, setQty] = useState<number>(0);
   const [split, setSplit] = useState(false);
@@ -120,7 +120,7 @@ export function LotAdjust() {
 
 export function LotHistory() {
   const { lotId } = useParams();
-  const { data } = useQuery({ queryKey: wsKey("lot", lotId, "history"), queryFn: () => api.get<StockEntry[]>(`/lots/${lotId}/history`) });
+  const { data } = useQuery({ queryKey: useWsKey("lot", lotId, "history"), queryFn: () => api.get<StockEntry[]>(`/lots/${lotId}/history`) });
   return (
     <div className="card overflow-hidden">
       <table className="table">

--- a/web/src/routes/orders/OrderDetail.tsx
+++ b/web/src/routes/orders/OrderDetail.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { api, ApiError } from "@/lib/api";
+import { wsKey } from "@/lib/queryKeys";
 import EntityHeader from "@/components/EntityHeader";
 import { DataTable } from "@/components/DataTable";
 import AttachmentsPanel from "@/components/AttachmentsPanel";
@@ -19,12 +20,12 @@ export default function OrderDetail() {
   const confirm = useConfirm();
 
   const { data } = useQuery({
-    queryKey: ["order", orderId],
+    queryKey: wsKey("order", orderId),
     queryFn: () => api.get<DetailOut>(`/orders/${orderId}`),
     enabled: !!orderId,
   });
-  const { data: parts } = useQuery({ queryKey: ["parts"], queryFn: () => api.get<Part[]>("/parts") });
-  const { data: storage } = useQuery({ queryKey: ["storage"], queryFn: () => api.get<StorageLocation[]>("/storage") });
+  const { data: parts } = useQuery({ queryKey: wsKey("parts"), queryFn: () => api.get<Part[]>("/parts") });
+  const { data: storage } = useQuery({ queryKey: wsKey("storage"), queryFn: () => api.get<StorageLocation[]>("/storage") });
 
   const partsById = new Map(parts?.map(p => [p.id, p]) ?? []);
   const storageById = new Map(storage?.map(s => [s.id, s]) ?? []);
@@ -60,7 +61,7 @@ export default function OrderDetail() {
       setNewName("");
       setNewQty(1);
       setNewPrice("");
-      qc.invalidateQueries({ queryKey: ["order", orderId] });
+      qc.invalidateQueries({ queryKey: wsKey("order", orderId) });
     } catch (e) {
       setErr(e instanceof ApiError ? e.message : "Failed");
     }
@@ -70,7 +71,7 @@ export default function OrderDetail() {
     if (!(await confirm({ message: "Delete this entry?", severity: "danger" }))) return;
     try {
       await api.delete(`/orders/${orderId}/entries/${entryId}`);
-      qc.invalidateQueries({ queryKey: ["order", orderId] });
+      qc.invalidateQueries({ queryKey: wsKey("order", orderId) });
       toast.success("Entry deleted.");
     } catch (e) {
       toast.error(e instanceof ApiError ? e.message : "Delete failed");
@@ -99,8 +100,8 @@ export default function OrderDetail() {
         lines,
       });
       setReceiveLines({});
-      qc.invalidateQueries({ queryKey: ["order", orderId] });
-      qc.invalidateQueries({ queryKey: ["parts"] });
+      qc.invalidateQueries({ queryKey: wsKey("order", orderId) });
+      qc.invalidateQueries({ queryKey: wsKey("parts") });
       toast.success(`Received ${totalQty} unit${totalQty === 1 ? "" : "s"}.`);
     } catch (e) {
       const msg = e instanceof ApiError ? e.message : "Receive failed";
@@ -114,8 +115,8 @@ export default function OrderDetail() {
   async function doArchive() {
     const wasArchived = !!order.archived_at;
     await api.post(`/orders/${orderId}/${wasArchived ? "restore" : "archive"}`);
-    qc.invalidateQueries({ queryKey: ["order", orderId] });
-    qc.invalidateQueries({ queryKey: ["orders"] });
+    qc.invalidateQueries({ queryKey: wsKey("order", orderId) });
+    qc.invalidateQueries({ queryKey: wsKey("orders") });
     toast.success(wasArchived ? "Order restored." : "Order archived.");
     if (!order.archived_at) nav("/orders");
   }

--- a/web/src/routes/orders/OrderDetail.tsx
+++ b/web/src/routes/orders/OrderDetail.tsx
@@ -3,7 +3,8 @@ import { useNavigate, useParams } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { api, ApiError } from "@/lib/api";
-import { wsKey } from "@/lib/queryKeys";
+import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
+import { useAuth } from "@/lib/auth";
 import EntityHeader from "@/components/EntityHeader";
 import { DataTable } from "@/components/DataTable";
 import AttachmentsPanel from "@/components/AttachmentsPanel";
@@ -18,14 +19,15 @@ export default function OrderDetail() {
   const qc = useQueryClient();
   const nav = useNavigate();
   const confirm = useConfirm();
+  const { workspaceId } = useAuth();
 
   const { data } = useQuery({
-    queryKey: wsKey("order", orderId),
+    queryKey: useWsKey("order", orderId),
     queryFn: () => api.get<DetailOut>(`/orders/${orderId}`),
     enabled: !!orderId,
   });
-  const { data: parts } = useQuery({ queryKey: wsKey("parts"), queryFn: () => api.get<Part[]>("/parts") });
-  const { data: storage } = useQuery({ queryKey: wsKey("storage"), queryFn: () => api.get<StorageLocation[]>("/storage") });
+  const { data: parts } = useQuery({ queryKey: useWsKey("parts"), queryFn: () => api.get<Part[]>("/parts") });
+  const { data: storage } = useQuery({ queryKey: useWsKey("storage"), queryFn: () => api.get<StorageLocation[]>("/storage") });
 
   const partsById = new Map(parts?.map(p => [p.id, p]) ?? []);
   const storageById = new Map(storage?.map(s => [s.id, s]) ?? []);
@@ -61,7 +63,7 @@ export default function OrderDetail() {
       setNewName("");
       setNewQty(1);
       setNewPrice("");
-      qc.invalidateQueries({ queryKey: wsKey("order", orderId) });
+      qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "order", orderId) });
     } catch (e) {
       setErr(e instanceof ApiError ? e.message : "Failed");
     }
@@ -71,7 +73,7 @@ export default function OrderDetail() {
     if (!(await confirm({ message: "Delete this entry?", severity: "danger" }))) return;
     try {
       await api.delete(`/orders/${orderId}/entries/${entryId}`);
-      qc.invalidateQueries({ queryKey: wsKey("order", orderId) });
+      qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "order", orderId) });
       toast.success("Entry deleted.");
     } catch (e) {
       toast.error(e instanceof ApiError ? e.message : "Delete failed");
@@ -100,8 +102,8 @@ export default function OrderDetail() {
         lines,
       });
       setReceiveLines({});
-      qc.invalidateQueries({ queryKey: wsKey("order", orderId) });
-      qc.invalidateQueries({ queryKey: wsKey("parts") });
+      qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "order", orderId) });
+      qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "parts") });
       toast.success(`Received ${totalQty} unit${totalQty === 1 ? "" : "s"}.`);
     } catch (e) {
       const msg = e instanceof ApiError ? e.message : "Receive failed";
@@ -115,8 +117,8 @@ export default function OrderDetail() {
   async function doArchive() {
     const wasArchived = !!order.archived_at;
     await api.post(`/orders/${orderId}/${wasArchived ? "restore" : "archive"}`);
-    qc.invalidateQueries({ queryKey: wsKey("order", orderId) });
-    qc.invalidateQueries({ queryKey: wsKey("orders") });
+    qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "order", orderId) });
+    qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "orders") });
     toast.success(wasArchived ? "Order restored." : "Order archived.");
     if (!order.archived_at) nav("/orders");
   }

--- a/web/src/routes/orders/OrdersList.tsx
+++ b/web/src/routes/orders/OrdersList.tsx
@@ -2,7 +2,7 @@ import { Link, NavLink, useNavigate } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { ShoppingCart } from "lucide-react";
 import { api } from "@/lib/api";
-import { wsKey } from "@/lib/queryKeys";
+import { useWsKey } from "@/lib/queryKeys";
 import { DataTable } from "@/components/DataTable";
 import EmptyState from "@/components/EmptyState";
 import QueryStateBoundary from "@/components/QueryStateBoundary";
@@ -19,7 +19,7 @@ const STATUS_BADGES: Record<Order["status"], string> = {
 export default function OrdersList({ archived = false }: { archived?: boolean }) {
   const nav = useNavigate();
   const query = useQuery({
-    queryKey: wsKey("orders", { archived }),
+    queryKey: useWsKey("orders", { archived }),
     queryFn: () => api.get<Order[]>(`/orders${archived ? "?archived=true" : ""}`),
   });
   const { data } = query;

--- a/web/src/routes/orders/OrdersList.tsx
+++ b/web/src/routes/orders/OrdersList.tsx
@@ -2,8 +2,10 @@ import { Link, NavLink, useNavigate } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { ShoppingCart } from "lucide-react";
 import { api } from "@/lib/api";
+import { wsKey } from "@/lib/queryKeys";
 import { DataTable } from "@/components/DataTable";
 import EmptyState from "@/components/EmptyState";
+import QueryStateBoundary from "@/components/QueryStateBoundary";
 import type { Order } from "@/types";
 
 const STATUS_BADGES: Record<Order["status"], string> = {
@@ -16,10 +18,11 @@ const STATUS_BADGES: Record<Order["status"], string> = {
 
 export default function OrdersList({ archived = false }: { archived?: boolean }) {
   const nav = useNavigate();
-  const { data } = useQuery({
-    queryKey: ["orders", { archived }],
+  const query = useQuery({
+    queryKey: wsKey("orders", { archived }),
     queryFn: () => api.get<Order[]>(`/orders${archived ? "?archived=true" : ""}`),
   });
+  const { data } = query;
 
   return (
     <div>
@@ -28,6 +31,7 @@ export default function OrdersList({ archived = false }: { archived?: boolean })
         <NavLink to="/orders/archived" className={({ isActive }) => "btn " + (isActive ? "border-accent/50 text-accent" : "")}>Archived</NavLink>
         <Link to="/orders/create" className="btn-primary ml-auto">+ Order</Link>
       </div>
+      <QueryStateBoundary query={query} resourceLabel="orders">
       <DataTable
         rows={data ?? []}
         rowKey={r => r.id}
@@ -79,6 +83,7 @@ export default function OrdersList({ archived = false }: { archived?: boolean })
           },
         ]}
       />
+      </QueryStateBoundary>
     </div>
   );
 }

--- a/web/src/routes/parts/LotsList.tsx
+++ b/web/src/routes/parts/LotsList.tsx
@@ -2,20 +2,24 @@ import { useQuery } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
 import { Package } from "lucide-react";
 import { api } from "@/lib/api";
+import { wsKey } from "@/lib/queryKeys";
 import type { Lot, Part } from "@/types";
 import { DataTable } from "@/components/DataTable";
 import EmptyState from "@/components/EmptyState";
 import PartsTopNav from "@/components/PartsTopNav";
+import QueryStateBoundary from "@/components/QueryStateBoundary";
 
 export default function LotsList() {
-  const { data } = useQuery({ queryKey: ["lots"], queryFn: () => api.get<Lot[]>("/lots") });
-  const { data: parts } = useQuery({ queryKey: ["parts"], queryFn: () => api.get<Part[]>("/parts") });
+  const query = useQuery({ queryKey: wsKey("lots"), queryFn: () => api.get<Lot[]>("/lots") });
+  const { data } = query;
+  const { data: parts } = useQuery({ queryKey: wsKey("parts"), queryFn: () => api.get<Part[]>("/parts") });
   const partName = new Map(parts?.map(p => [p.id, p.name]) ?? []);
   const nav = useNavigate();
 
   return (
     <div>
       <PartsTopNav />
+      <QueryStateBoundary query={query} resourceLabel="lots">
       <DataTable
         rows={data ?? []}
         rowKey={r => r.id}
@@ -38,6 +42,7 @@ export default function LotsList() {
           { key: "created_at", header: "Created", accessor: r => r.created_at, render: r => new Date(r.created_at).toLocaleDateString() },
         ]}
       />
+      </QueryStateBoundary>
     </div>
   );
 }

--- a/web/src/routes/parts/LotsList.tsx
+++ b/web/src/routes/parts/LotsList.tsx
@@ -2,7 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
 import { Package } from "lucide-react";
 import { api } from "@/lib/api";
-import { wsKey } from "@/lib/queryKeys";
+import { useWsKey } from "@/lib/queryKeys";
 import type { Lot, Part } from "@/types";
 import { DataTable } from "@/components/DataTable";
 import EmptyState from "@/components/EmptyState";
@@ -10,9 +10,9 @@ import PartsTopNav from "@/components/PartsTopNav";
 import QueryStateBoundary from "@/components/QueryStateBoundary";
 
 export default function LotsList() {
-  const query = useQuery({ queryKey: wsKey("lots"), queryFn: () => api.get<Lot[]>("/lots") });
+  const query = useQuery({ queryKey: useWsKey("lots"), queryFn: () => api.get<Lot[]>("/lots") });
   const { data } = query;
-  const { data: parts } = useQuery({ queryKey: wsKey("parts"), queryFn: () => api.get<Part[]>("/parts") });
+  const { data: parts } = useQuery({ queryKey: useWsKey("parts"), queryFn: () => api.get<Part[]>("/parts") });
   const partName = new Map(parts?.map(p => [p.id, p.name]) ?? []);
   const nav = useNavigate();
 

--- a/web/src/routes/parts/PartCreate.tsx
+++ b/web/src/routes/parts/PartCreate.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { api, ApiError } from "@/lib/api";
 import { useQuery } from "@tanstack/react-query";
+import { wsKey } from "@/lib/queryKeys";
 import type { MpnLookupResult, ProviderSpec, StorageLocation } from "@/types";
 import MpnLookup from "@/components/MpnLookup";
 
@@ -36,7 +37,7 @@ export default function PartCreate() {
   const [imageUrl, setImageUrl] = useState<string | null>(null);
   const [specs, setSpecs] = useState<ProviderSpec[]>([]);
   const [hasLookup, setHasLookup] = useState(false);
-  const { data: storage } = useQuery({ queryKey: ["storage"], queryFn: () => api.get<StorageLocation[]>("/storage") });
+  const { data: storage } = useQuery({ queryKey: wsKey("storage"), queryFn: () => api.get<StorageLocation[]>("/storage") });
 
   function set<K extends keyof typeof form>(k: K, v: (typeof form)[K]) {
     setForm(f => ({ ...f, [k]: v }));

--- a/web/src/routes/parts/PartCreate.tsx
+++ b/web/src/routes/parts/PartCreate.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { api, ApiError } from "@/lib/api";
 import { useQuery } from "@tanstack/react-query";
-import { wsKey } from "@/lib/queryKeys";
+import { useWsKey } from "@/lib/queryKeys";
 import type { MpnLookupResult, ProviderSpec, StorageLocation } from "@/types";
 import MpnLookup from "@/components/MpnLookup";
 
@@ -37,7 +37,7 @@ export default function PartCreate() {
   const [imageUrl, setImageUrl] = useState<string | null>(null);
   const [specs, setSpecs] = useState<ProviderSpec[]>([]);
   const [hasLookup, setHasLookup] = useState(false);
-  const { data: storage } = useQuery({ queryKey: wsKey("storage"), queryFn: () => api.get<StorageLocation[]>("/storage") });
+  const { data: storage } = useQuery({ queryKey: useWsKey("storage"), queryFn: () => api.get<StorageLocation[]>("/storage") });
 
   function set<K extends keyof typeof form>(k: K, v: (typeof form)[K]) {
     setForm(f => ({ ...f, [k]: v }));

--- a/web/src/routes/parts/PartsList.tsx
+++ b/web/src/routes/parts/PartsList.tsx
@@ -5,7 +5,8 @@ import { toast } from "sonner";
 import { Boxes, ImageOff, Trash2 } from "lucide-react";
 import { api, ApiError } from "@/lib/api";
 import { PartsListSchema } from "@/lib/schemas";
-import { wsKey } from "@/lib/queryKeys";
+import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
+import { useAuth } from "@/lib/auth";
 import { DataTable } from "@/components/DataTable";
 import EmptyState from "@/components/EmptyState";
 import PartsTopNav from "@/components/PartsTopNav";
@@ -16,7 +17,8 @@ export default function PartsList({ archived = false }: { archived?: boolean }) 
   const nav = useNavigate();
   const qc = useQueryClient();
   const confirm = useConfirm();
-  const partsKey = wsKey("parts", { archived });
+  const { workspaceId } = useAuth();
+  const partsKey = useWsKey("parts", { archived });
   const [busy, setBusy] = useState(false);
   const query = useQuery({
     queryKey: partsKey,
@@ -51,7 +53,7 @@ export default function PartsList({ archived = false }: { archived?: boolean }) 
         "/parts/bulk-delete",
         { part_ids: ids },
       );
-      qc.invalidateQueries({ queryKey: wsKey("parts") });
+      qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "parts") });
       clear();
       toast.success(
         res.archived_ids.length === ids.length

--- a/web/src/routes/parts/PartsList.tsx
+++ b/web/src/routes/parts/PartsList.tsx
@@ -5,32 +5,53 @@ import { toast } from "sonner";
 import { Boxes, ImageOff, Trash2 } from "lucide-react";
 import { api, ApiError } from "@/lib/api";
 import { PartsListSchema } from "@/lib/schemas";
+import { wsKey } from "@/lib/queryKeys";
 import { DataTable } from "@/components/DataTable";
 import EmptyState from "@/components/EmptyState";
 import PartsTopNav from "@/components/PartsTopNav";
-import type { Part } from "@/types";
+import { useConfirm } from "@/components/ConfirmDialog";
+import QueryStateBoundary from "@/components/QueryStateBoundary";
 
 export default function PartsList({ archived = false }: { archived?: boolean }) {
   const nav = useNavigate();
   const qc = useQueryClient();
-  const [confirming, setConfirming] = useState<{ ids: string[]; clear: () => void } | null>(null);
+  const confirm = useConfirm();
+  const partsKey = wsKey("parts", { archived });
   const [busy, setBusy] = useState(false);
-  const { data, isLoading } = useQuery({
-    queryKey: ["parts", { archived }],
+  const query = useQuery({
+    queryKey: partsKey,
     queryFn: () =>
       api.parsed.get(`/parts${archived ? "?archived=true" : ""}`, PartsListSchema),
   });
-
-  const partsById = new Map((data ?? []).map(p => [p.id, p]));
+  const { data, isLoading } = query;
 
   async function doDelete(ids: string[], clear: () => void) {
+    // Build a friendly preview of the first few names for the dialog —
+    // mirrors the pre-fix overlay UX without rolling our own modal
+    // (FE2-005).
+    const partsById = new Map((data ?? []).map(p => [p.id, p]));
+    const previewLines = ids
+      .slice(0, 12)
+      .map(id => partsById.get(id)?.name ?? id)
+      .join("\n");
+    const more = ids.length > 12 ? `\n…and ${ids.length - 12} more` : "";
+    const ok = await confirm({
+      title: `Archive ${ids.length} part${ids.length === 1 ? "" : "s"}?`,
+      message:
+        "Stock history is preserved. Archived parts can be restored from the Archived view.\n\n" +
+        previewLines +
+        more,
+      severity: "danger",
+      confirmLabel: "Archive",
+    });
+    if (!ok) return;
     setBusy(true);
     try {
       const res = await api.post<{ archived_ids: string[]; skipped: number }>(
         "/parts/bulk-delete",
         { part_ids: ids },
       );
-      qc.invalidateQueries({ queryKey: ["parts"] });
+      qc.invalidateQueries({ queryKey: wsKey("parts") });
       clear();
       toast.success(
         res.archived_ids.length === ids.length
@@ -41,7 +62,6 @@ export default function PartsList({ archived = false }: { archived?: boolean }) 
       toast.error(e instanceof ApiError ? e.message : "Bulk delete failed");
     } finally {
       setBusy(false);
-      setConfirming(null);
     }
   }
 
@@ -55,9 +75,10 @@ export default function PartsList({ archived = false }: { archived?: boolean }) 
           </>
         }
       />
-      {isLoading ? (
-        <div className="text-muted">Loading…</div>
-      ) : (
+      <QueryStateBoundary query={query} resourceLabel="parts">
+        {isLoading ? (
+          <div className="text-muted">Loading…</div>
+        ) : (
         <DataTable
           rows={data ?? []}
           rowKey={(r) => r.id}
@@ -69,7 +90,7 @@ export default function PartsList({ archived = false }: { archived?: boolean }) 
               type="button"
               className="btn-danger inline-flex items-center gap-1.5"
               disabled={busy}
-              onClick={() => setConfirming({ ids, clear })}
+              onClick={() => doDelete(ids, clear)}
             >
               <Trash2 size={14} />
               Delete ({ids.length})
@@ -121,59 +142,8 @@ export default function PartsList({ archived = false }: { archived?: boolean }) 
             { key: "reserved", header: "Reserved", accessor: r => r.reserved ?? 0, width: "100px", hidden: true },
           ]}
         />
-      )}
-
-      {confirming && (
-        <div
-          className="fixed inset-0 z-30 flex items-center justify-center bg-black/40"
-          onClick={() => !busy && setConfirming(null)}
-        >
-          <div
-            className="card p-4 max-w-md w-full mx-4 space-y-3"
-            onClick={e => e.stopPropagation()}
-          >
-            <h3 className="text-md font-semibold">
-              Archive {confirming.ids.length} part{confirming.ids.length === 1 ? "" : "s"}?
-            </h3>
-            <p className="text-sm text-muted">
-              Stock history is preserved. Archived parts can be restored from
-              the Archived view.
-            </p>
-            <ul className="text-xs text-muted max-h-48 overflow-auto space-y-0.5">
-              {confirming.ids.slice(0, 12).map(id => {
-                const p = partsById.get(id);
-                return (
-                  <li key={id} className="font-mono">
-                    {p ? p.name : id}
-                  </li>
-                );
-              })}
-              {confirming.ids.length > 12 && (
-                <li className="italic">…and {confirming.ids.length - 12} more</li>
-              )}
-            </ul>
-            <div className="flex justify-end gap-2 pt-1">
-              <button
-                type="button"
-                className="btn"
-                disabled={busy}
-                onClick={() => setConfirming(null)}
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                className="btn-danger inline-flex items-center gap-1.5"
-                disabled={busy}
-                onClick={() => doDelete(confirming.ids, confirming.clear)}
-              >
-                <Trash2 size={14} />
-                {busy ? "Archiving…" : "Archive"}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
+        )}
+      </QueryStateBoundary>
     </div>
   );
 }

--- a/web/src/routes/parts/ScanImport.tsx
+++ b/web/src/routes/parts/ScanImport.tsx
@@ -17,7 +17,8 @@ import {
 } from "lucide-react";
 import Scanner, { ScanResult } from "@/components/scanner/Scanner";
 import { api, ApiError } from "@/lib/api";
-import { wsKey } from "@/lib/queryKeys";
+import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
+import { useAuth } from "@/lib/auth";
 import { parseBagCode, bagLotName, bagComments, bagSignature, type BagCode } from "@/lib/bagCode";
 import type {
   MpnLookupResult,
@@ -155,6 +156,7 @@ async function lookupMpnWithRetry(mpn: string): Promise<MpnLookupResult> {
 export default function ScanImport() {
   const nav = useNavigate();
   const qc = useQueryClient();
+  const { workspaceId } = useAuth();
   const [searchParams] = useSearchParams();
   const [rows, setRows] = useState<Row[]>([]);
   // Pre-select the storage when arriving via /storage/<id> "Scan into here"
@@ -178,7 +180,7 @@ export default function ScanImport() {
   }, [searchParams]);
 
   const { data: storages } = useQuery({
-    queryKey: wsKey("storage"),
+    queryKey: useWsKey("storage"),
     queryFn: () => api.get<StorageLocation[]>("/storage"),
   });
 
@@ -265,8 +267,8 @@ export default function ScanImport() {
             : r,
         ),
       );
-      qc.invalidateQueries({ queryKey: wsKey("part", st.part_id) });
-      qc.invalidateQueries({ queryKey: wsKey("part", st.part_id, "stock") });
+      qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "part", st.part_id) });
+      qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "part", st.part_id, "stock") });
       toast.success(`Removed ${quantity} from this bag.`);
     } catch (e) {
       toast.error(e instanceof ApiError ? e.message : "Quick-remove failed");

--- a/web/src/routes/parts/ScanImport.tsx
+++ b/web/src/routes/parts/ScanImport.tsx
@@ -17,6 +17,7 @@ import {
 } from "lucide-react";
 import Scanner, { ScanResult } from "@/components/scanner/Scanner";
 import { api, ApiError } from "@/lib/api";
+import { wsKey } from "@/lib/queryKeys";
 import { parseBagCode, bagLotName, bagComments, bagSignature, type BagCode } from "@/lib/bagCode";
 import type {
   MpnLookupResult,
@@ -177,7 +178,7 @@ export default function ScanImport() {
   }, [searchParams]);
 
   const { data: storages } = useQuery({
-    queryKey: ["storage-locations"],
+    queryKey: wsKey("storage"),
     queryFn: () => api.get<StorageLocation[]>("/storage"),
   });
 
@@ -264,8 +265,8 @@ export default function ScanImport() {
             : r,
         ),
       );
-      qc.invalidateQueries({ queryKey: ["part", st.part_id] });
-      qc.invalidateQueries({ queryKey: ["part", st.part_id, "stock"] });
+      qc.invalidateQueries({ queryKey: wsKey("part", st.part_id) });
+      qc.invalidateQueries({ queryKey: wsKey("part", st.part_id, "stock") });
       toast.success(`Removed ${quantity} from this bag.`);
     } catch (e) {
       toast.error(e instanceof ApiError ? e.message : "Quick-remove failed");

--- a/web/src/routes/parts/StockHistory.tsx
+++ b/web/src/routes/parts/StockHistory.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { ScrollText } from "lucide-react";
 import { api } from "@/lib/api";
+import { wsKey } from "@/lib/queryKeys";
 import type { Part, StockEntry, StorageLocation } from "@/types";
 import { DataTable } from "@/components/DataTable";
 import EmptyState from "@/components/EmptyState";
@@ -8,9 +9,9 @@ import PartsTopNav from "@/components/PartsTopNav";
 import { Link } from "react-router-dom";
 
 export default function StockHistory() {
-  const { data } = useQuery({ queryKey: ["stock-history"], queryFn: () => api.get<StockEntry[]>("/stock/history?limit=500") });
-  const { data: parts } = useQuery({ queryKey: ["parts"], queryFn: () => api.get<Part[]>("/parts") });
-  const { data: storage } = useQuery({ queryKey: ["storage"], queryFn: () => api.get<StorageLocation[]>("/storage") });
+  const { data } = useQuery({ queryKey: wsKey("stock-history"), queryFn: () => api.get<StockEntry[]>("/stock/history?limit=500") });
+  const { data: parts } = useQuery({ queryKey: wsKey("parts"), queryFn: () => api.get<Part[]>("/parts") });
+  const { data: storage } = useQuery({ queryKey: wsKey("storage"), queryFn: () => api.get<StorageLocation[]>("/storage") });
   const partName = new Map(parts?.map(p => [p.id, p.name]) ?? []);
   const sName = new Map(storage?.map(s => [s.id, s.name]) ?? []);
   return (

--- a/web/src/routes/parts/StockHistory.tsx
+++ b/web/src/routes/parts/StockHistory.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { ScrollText } from "lucide-react";
 import { api } from "@/lib/api";
-import { wsKey } from "@/lib/queryKeys";
+import { useWsKey } from "@/lib/queryKeys";
 import type { Part, StockEntry, StorageLocation } from "@/types";
 import { DataTable } from "@/components/DataTable";
 import EmptyState from "@/components/EmptyState";
@@ -9,9 +9,9 @@ import PartsTopNav from "@/components/PartsTopNav";
 import { Link } from "react-router-dom";
 
 export default function StockHistory() {
-  const { data } = useQuery({ queryKey: wsKey("stock-history"), queryFn: () => api.get<StockEntry[]>("/stock/history?limit=500") });
-  const { data: parts } = useQuery({ queryKey: wsKey("parts"), queryFn: () => api.get<Part[]>("/parts") });
-  const { data: storage } = useQuery({ queryKey: wsKey("storage"), queryFn: () => api.get<StorageLocation[]>("/storage") });
+  const { data } = useQuery({ queryKey: useWsKey("stock-history"), queryFn: () => api.get<StockEntry[]>("/stock/history?limit=500") });
+  const { data: parts } = useQuery({ queryKey: useWsKey("parts"), queryFn: () => api.get<Part[]>("/parts") });
+  const { data: storage } = useQuery({ queryKey: useWsKey("storage"), queryFn: () => api.get<StorageLocation[]>("/storage") });
   const partName = new Map(parts?.map(p => [p.id, p.name]) ?? []);
   const sName = new Map(storage?.map(s => [s.id, s.name]) ?? []);
   return (

--- a/web/src/routes/parts/detail/PartAddStock.tsx
+++ b/web/src/routes/parts/detail/PartAddStock.tsx
@@ -2,13 +2,14 @@ import { useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { api, ApiError } from "@/lib/api";
+import { wsKey } from "@/lib/queryKeys";
 import type { StorageLocation } from "@/types";
 
 export default function PartAddStock() {
   const { partId } = useParams<{ partId: string }>();
   const nav = useNavigate();
   const qc = useQueryClient();
-  const { data: storage } = useQuery({ queryKey: ["storage"], queryFn: () => api.get<StorageLocation[]>("/storage") });
+  const { data: storage } = useQuery({ queryKey: wsKey("storage"), queryFn: () => api.get<StorageLocation[]>("/storage") });
   const [qty, setQty] = useState<number>(0);
   const [location, setLocation] = useState("");
   const [priceMode, setPriceMode] = useState<"none" | "per_component" | "entire_lot">("none");
@@ -42,8 +43,8 @@ export default function PartAddStock() {
       }
       if (lotName || serial) payload.lot = { name: lotName || undefined, serial_number: serial || undefined };
       await api.post("/stock/add", payload);
-      qc.invalidateQueries({ queryKey: ["part", partId] });
-      qc.invalidateQueries({ queryKey: ["parts"] });
+      qc.invalidateQueries({ queryKey: wsKey("part", partId) });
+      qc.invalidateQueries({ queryKey: wsKey("parts") });
       nav(`/parts/${partId}/stock`);
     } catch (e) {
       setErr(e instanceof ApiError ? e.message : "Failed");

--- a/web/src/routes/parts/detail/PartAddStock.tsx
+++ b/web/src/routes/parts/detail/PartAddStock.tsx
@@ -2,14 +2,16 @@ import { useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { api, ApiError } from "@/lib/api";
-import { wsKey } from "@/lib/queryKeys";
+import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
+import { useAuth } from "@/lib/auth";
 import type { StorageLocation } from "@/types";
 
 export default function PartAddStock() {
   const { partId } = useParams<{ partId: string }>();
   const nav = useNavigate();
   const qc = useQueryClient();
-  const { data: storage } = useQuery({ queryKey: wsKey("storage"), queryFn: () => api.get<StorageLocation[]>("/storage") });
+  const { workspaceId } = useAuth();
+  const { data: storage } = useQuery({ queryKey: useWsKey("storage"), queryFn: () => api.get<StorageLocation[]>("/storage") });
   const [qty, setQty] = useState<number>(0);
   const [location, setLocation] = useState("");
   const [priceMode, setPriceMode] = useState<"none" | "per_component" | "entire_lot">("none");
@@ -43,8 +45,8 @@ export default function PartAddStock() {
       }
       if (lotName || serial) payload.lot = { name: lotName || undefined, serial_number: serial || undefined };
       await api.post("/stock/add", payload);
-      qc.invalidateQueries({ queryKey: wsKey("part", partId) });
-      qc.invalidateQueries({ queryKey: wsKey("parts") });
+      qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "part", partId) });
+      qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "parts") });
       nav(`/parts/${partId}/stock`);
     } catch (e) {
       setErr(e instanceof ApiError ? e.message : "Failed");

--- a/web/src/routes/parts/detail/PartHistory.tsx
+++ b/web/src/routes/parts/detail/PartHistory.tsx
@@ -1,20 +1,21 @@
 import { useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api";
+import { wsKey } from "@/lib/queryKeys";
 import type { StockEntry, StorageLocation } from "@/types";
 import { DataTable } from "@/components/DataTable";
 
 export default function PartHistory() {
   const { partId } = useParams();
   const { data } = useQuery({
-    queryKey: ["part", partId, "history"],
+    queryKey: wsKey("part", partId, "history"),
     queryFn: async () => {
       // history endpoint is global; filter client-side by part for now
       const rows = await api.get<StockEntry[]>("/stock/history?limit=1000");
       return rows.filter(r => r.part_id === partId);
     },
   });
-  const { data: storage } = useQuery({ queryKey: ["storage"], queryFn: () => api.get<StorageLocation[]>("/storage") });
+  const { data: storage } = useQuery({ queryKey: wsKey("storage"), queryFn: () => api.get<StorageLocation[]>("/storage") });
   const sName = new Map(storage?.map(s => [s.id, s.name]) ?? []);
   return (
     <DataTable

--- a/web/src/routes/parts/detail/PartHistory.tsx
+++ b/web/src/routes/parts/detail/PartHistory.tsx
@@ -1,21 +1,21 @@
 import { useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api";
-import { wsKey } from "@/lib/queryKeys";
+import { useWsKey } from "@/lib/queryKeys";
 import type { StockEntry, StorageLocation } from "@/types";
 import { DataTable } from "@/components/DataTable";
 
 export default function PartHistory() {
   const { partId } = useParams();
   const { data } = useQuery({
-    queryKey: wsKey("part", partId, "history"),
+    queryKey: useWsKey("part", partId, "history"),
     queryFn: async () => {
       // history endpoint is global; filter client-side by part for now
       const rows = await api.get<StockEntry[]>("/stock/history?limit=1000");
       return rows.filter(r => r.part_id === partId);
     },
   });
-  const { data: storage } = useQuery({ queryKey: wsKey("storage"), queryFn: () => api.get<StorageLocation[]>("/storage") });
+  const { data: storage } = useQuery({ queryKey: useWsKey("storage"), queryFn: () => api.get<StorageLocation[]>("/storage") });
   const sName = new Map(storage?.map(s => [s.id, s.name]) ?? []);
   return (
     <DataTable

--- a/web/src/routes/parts/detail/PartInfo.tsx
+++ b/web/src/routes/parts/detail/PartInfo.tsx
@@ -4,7 +4,8 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { ExternalLink, FileText, Loader2, RefreshCw } from "lucide-react";
 import { api, ApiError } from "@/lib/api";
-import { wsKey } from "@/lib/queryKeys";
+import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
+import { useAuth } from "@/lib/auth";
 import type { CustomFieldRow, Part } from "@/types";
 
 const PROVIDER_LABEL: Record<string, string> = {
@@ -51,8 +52,9 @@ function isStale(iso: string | null): boolean {
 export default function PartInfo() {
   const { part } = useOutletContext<{ part: Part }>();
   const qc = useQueryClient();
+  const { workspaceId } = useAuth();
   const { data: cf } = useQuery({
-    queryKey: wsKey("part", part.id, "custom-fields"),
+    queryKey: useWsKey("part", part.id, "custom-fields"),
     queryFn: () =>
       api.get<CustomFieldRow[]>(`/custom-fields/by-object/part/${part.id}`),
   });
@@ -81,8 +83,8 @@ export default function PartInfo() {
       } else {
         toast.message(r.message || "No upstream match.");
       }
-      qc.invalidateQueries({ queryKey: wsKey("part", part.id) });
-      qc.invalidateQueries({ queryKey: wsKey("part", part.id, "custom-fields") });
+      qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "part", part.id) });
+      qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "part", part.id, "custom-fields") });
     } catch (e) {
       toast.error(e instanceof ApiError ? e.message : "Refresh failed");
     } finally {

--- a/web/src/routes/parts/detail/PartInfo.tsx
+++ b/web/src/routes/parts/detail/PartInfo.tsx
@@ -4,6 +4,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { ExternalLink, FileText, Loader2, RefreshCw } from "lucide-react";
 import { api, ApiError } from "@/lib/api";
+import { wsKey } from "@/lib/queryKeys";
 import type { CustomFieldRow, Part } from "@/types";
 
 const PROVIDER_LABEL: Record<string, string> = {
@@ -51,7 +52,7 @@ export default function PartInfo() {
   const { part } = useOutletContext<{ part: Part }>();
   const qc = useQueryClient();
   const { data: cf } = useQuery({
-    queryKey: ["part", part.id, "custom-fields"],
+    queryKey: wsKey("part", part.id, "custom-fields"),
     queryFn: () =>
       api.get<CustomFieldRow[]>(`/custom-fields/by-object/part/${part.id}`),
   });
@@ -80,8 +81,8 @@ export default function PartInfo() {
       } else {
         toast.message(r.message || "No upstream match.");
       }
-      qc.invalidateQueries({ queryKey: ["part", part.id] });
-      qc.invalidateQueries({ queryKey: ["part", part.id, "custom-fields"] });
+      qc.invalidateQueries({ queryKey: wsKey("part", part.id) });
+      qc.invalidateQueries({ queryKey: wsKey("part", part.id, "custom-fields") });
     } catch (e) {
       toast.error(e instanceof ApiError ? e.message : "Refresh failed");
     } finally {

--- a/web/src/routes/parts/detail/PartLayout.tsx
+++ b/web/src/routes/parts/detail/PartLayout.tsx
@@ -1,7 +1,7 @@
 import { Outlet, useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api";
-import { wsKey } from "@/lib/queryKeys";
+import { useWsKey } from "@/lib/queryKeys";
 import EntityHeader from "@/components/EntityHeader";
 import SubNav from "@/components/SubNav";
 import type { Part } from "@/types";
@@ -9,7 +9,7 @@ import type { Part } from "@/types";
 export default function PartLayout() {
   const { partId } = useParams<{ partId: string }>();
   const { data: part } = useQuery({
-    queryKey: wsKey("part", partId),
+    queryKey: useWsKey("part", partId),
     queryFn: () => api.get<Part>(`/parts/${partId}`),
     enabled: !!partId,
   });

--- a/web/src/routes/parts/detail/PartLayout.tsx
+++ b/web/src/routes/parts/detail/PartLayout.tsx
@@ -1,6 +1,7 @@
 import { Outlet, useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api";
+import { wsKey } from "@/lib/queryKeys";
 import EntityHeader from "@/components/EntityHeader";
 import SubNav from "@/components/SubNav";
 import type { Part } from "@/types";
@@ -8,7 +9,7 @@ import type { Part } from "@/types";
 export default function PartLayout() {
   const { partId } = useParams<{ partId: string }>();
   const { data: part } = useQuery({
-    queryKey: ["part", partId],
+    queryKey: wsKey("part", partId),
     queryFn: () => api.get<Part>(`/parts/${partId}`),
     enabled: !!partId,
   });

--- a/web/src/routes/parts/detail/PartLots.tsx
+++ b/web/src/routes/parts/detail/PartLots.tsx
@@ -1,13 +1,14 @@
 import { useParams, useNavigate } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api";
+import { wsKey } from "@/lib/queryKeys";
 import type { Lot } from "@/types";
 import { DataTable } from "@/components/DataTable";
 
 export default function PartLots() {
   const { partId } = useParams();
   const nav = useNavigate();
-  const { data } = useQuery({ queryKey: ["part", partId, "lots"], queryFn: () => api.get<Lot[]>(`/parts/${partId}/lots`) });
+  const { data } = useQuery({ queryKey: wsKey("part", partId, "lots"), queryFn: () => api.get<Lot[]>(`/parts/${partId}/lots`) });
   return (
     <DataTable
       rows={data ?? []}

--- a/web/src/routes/parts/detail/PartLots.tsx
+++ b/web/src/routes/parts/detail/PartLots.tsx
@@ -1,14 +1,14 @@
 import { useParams, useNavigate } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api";
-import { wsKey } from "@/lib/queryKeys";
+import { useWsKey } from "@/lib/queryKeys";
 import type { Lot } from "@/types";
 import { DataTable } from "@/components/DataTable";
 
 export default function PartLots() {
   const { partId } = useParams();
   const nav = useNavigate();
-  const { data } = useQuery({ queryKey: wsKey("part", partId, "lots"), queryFn: () => api.get<Lot[]>(`/parts/${partId}/lots`) });
+  const { data } = useQuery({ queryKey: useWsKey("part", partId, "lots"), queryFn: () => api.get<Lot[]>(`/parts/${partId}/lots`) });
   return (
     <DataTable
       rows={data ?? []}

--- a/web/src/routes/parts/detail/PartMembers.tsx
+++ b/web/src/routes/parts/detail/PartMembers.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useParams } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { api, ApiError } from "@/lib/api";
+import { wsKey } from "@/lib/queryKeys";
 import type { Part } from "@/types";
 
 type Member = { id: string; member_part_id: string };
@@ -10,10 +11,10 @@ export default function PartMembers() {
   const { partId } = useParams();
   const qc = useQueryClient();
   const { data: members } = useQuery({
-    queryKey: ["part", partId, "members"],
+    queryKey: wsKey("part", partId, "members"),
     queryFn: () => api.get<Member[]>(`/parts/${partId}/members`),
   });
-  const { data: parts } = useQuery({ queryKey: ["parts"], queryFn: () => api.get<Part[]>("/parts") });
+  const { data: parts } = useQuery({ queryKey: wsKey("parts"), queryFn: () => api.get<Part[]>("/parts") });
   const partsById = new Map(parts?.map(p => [p.id, p]) ?? []);
 
   const [pick, setPick] = useState("");
@@ -25,14 +26,14 @@ export default function PartMembers() {
     try {
       await api.post(`/parts/${partId}/members`, { member_part_id: pick });
       setPick("");
-      qc.invalidateQueries({ queryKey: ["part", partId, "members"] });
+      qc.invalidateQueries({ queryKey: wsKey("part", partId, "members") });
     } catch (e) {
       setErr(e instanceof ApiError ? e.message : "Failed");
     }
   }
   async function remove(mid: string) {
     await api.delete(`/parts/${partId}/members/${mid}`);
-    qc.invalidateQueries({ queryKey: ["part", partId, "members"] });
+    qc.invalidateQueries({ queryKey: wsKey("part", partId, "members") });
   }
 
   return (

--- a/web/src/routes/parts/detail/PartMembers.tsx
+++ b/web/src/routes/parts/detail/PartMembers.tsx
@@ -2,7 +2,8 @@ import { useState } from "react";
 import { useParams } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { api, ApiError } from "@/lib/api";
-import { wsKey } from "@/lib/queryKeys";
+import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
+import { useAuth } from "@/lib/auth";
 import type { Part } from "@/types";
 
 type Member = { id: string; member_part_id: string };
@@ -10,11 +11,12 @@ type Member = { id: string; member_part_id: string };
 export default function PartMembers() {
   const { partId } = useParams();
   const qc = useQueryClient();
+  const { workspaceId } = useAuth();
   const { data: members } = useQuery({
-    queryKey: wsKey("part", partId, "members"),
+    queryKey: useWsKey("part", partId, "members"),
     queryFn: () => api.get<Member[]>(`/parts/${partId}/members`),
   });
-  const { data: parts } = useQuery({ queryKey: wsKey("parts"), queryFn: () => api.get<Part[]>("/parts") });
+  const { data: parts } = useQuery({ queryKey: useWsKey("parts"), queryFn: () => api.get<Part[]>("/parts") });
   const partsById = new Map(parts?.map(p => [p.id, p]) ?? []);
 
   const [pick, setPick] = useState("");
@@ -26,14 +28,14 @@ export default function PartMembers() {
     try {
       await api.post(`/parts/${partId}/members`, { member_part_id: pick });
       setPick("");
-      qc.invalidateQueries({ queryKey: wsKey("part", partId, "members") });
+      qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "part", partId, "members") });
     } catch (e) {
       setErr(e instanceof ApiError ? e.message : "Failed");
     }
   }
   async function remove(mid: string) {
     await api.delete(`/parts/${partId}/members/${mid}`);
-    qc.invalidateQueries({ queryKey: wsKey("part", partId, "members") });
+    qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "part", partId, "members") });
   }
 
   return (

--- a/web/src/routes/parts/detail/PartMoveStock.tsx
+++ b/web/src/routes/parts/detail/PartMoveStock.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { api, ApiError } from "@/lib/api";
+import { wsKey } from "@/lib/queryKeys";
 import type { StorageLocation } from "@/types";
 
 type StockRow = {
@@ -21,15 +22,15 @@ export default function PartMoveStock() {
   const nav = useNavigate();
   const qc = useQueryClient();
   const { data: storage } = useQuery({
-    queryKey: ["storage"],
+    queryKey: wsKey("storage"),
     queryFn: () => api.get<StorageLocation[]>("/storage"),
   });
   const { data: stock } = useQuery({
-    queryKey: ["part", partId, "stock"],
+    queryKey: wsKey("part", partId, "stock"),
     queryFn: () => api.get<StockResp>(`/parts/${partId}/stock`),
   });
   const { data: lots } = useQuery({
-    queryKey: ["part", partId, "lots"],
+    queryKey: wsKey("part", partId, "lots"),
     queryFn: () => api.get<Lot[]>(`/parts/${partId}/lots`),
   });
 
@@ -94,8 +95,8 @@ export default function PartMoveStock() {
         split_lot: split,
         comments: comments || undefined,
       });
-      qc.invalidateQueries({ queryKey: ["part", partId] });
-      qc.invalidateQueries({ queryKey: ["part", partId, "stock"] });
+      qc.invalidateQueries({ queryKey: wsKey("part", partId) });
+      qc.invalidateQueries({ queryKey: wsKey("part", partId, "stock") });
       nav(`/parts/${partId}/stock`);
     } catch (e) {
       setErr(e instanceof ApiError ? e.message : "Failed");

--- a/web/src/routes/parts/detail/PartMoveStock.tsx
+++ b/web/src/routes/parts/detail/PartMoveStock.tsx
@@ -2,7 +2,8 @@ import { useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { api, ApiError } from "@/lib/api";
-import { wsKey } from "@/lib/queryKeys";
+import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
+import { useAuth } from "@/lib/auth";
 import type { StorageLocation } from "@/types";
 
 type StockRow = {
@@ -21,16 +22,17 @@ export default function PartMoveStock() {
   const { partId } = useParams<{ partId: string }>();
   const nav = useNavigate();
   const qc = useQueryClient();
+  const { workspaceId } = useAuth();
   const { data: storage } = useQuery({
-    queryKey: wsKey("storage"),
+    queryKey: useWsKey("storage"),
     queryFn: () => api.get<StorageLocation[]>("/storage"),
   });
   const { data: stock } = useQuery({
-    queryKey: wsKey("part", partId, "stock"),
+    queryKey: useWsKey("part", partId, "stock"),
     queryFn: () => api.get<StockResp>(`/parts/${partId}/stock`),
   });
   const { data: lots } = useQuery({
-    queryKey: wsKey("part", partId, "lots"),
+    queryKey: useWsKey("part", partId, "lots"),
     queryFn: () => api.get<Lot[]>(`/parts/${partId}/lots`),
   });
 
@@ -95,8 +97,8 @@ export default function PartMoveStock() {
         split_lot: split,
         comments: comments || undefined,
       });
-      qc.invalidateQueries({ queryKey: wsKey("part", partId) });
-      qc.invalidateQueries({ queryKey: wsKey("part", partId, "stock") });
+      qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "part", partId) });
+      qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "part", partId, "stock") });
       nav(`/parts/${partId}/stock`);
     } catch (e) {
       setErr(e instanceof ApiError ? e.message : "Failed");

--- a/web/src/routes/parts/detail/PartOther.tsx
+++ b/web/src/routes/parts/detail/PartOther.tsx
@@ -1,22 +1,30 @@
 import { useNavigate, useOutletContext, useParams } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api";
+import { useAuth } from "@/lib/auth";
+import { wsScope } from "@/lib/queryKeys";
 import type { Part } from "@/types";
 
 export default function PartOther() {
   const { part } = useOutletContext<{ part: Part }>();
   const { partId } = useParams();
   const qc = useQueryClient();
+  const { workspaceId } = useAuth();
   const nav = useNavigate();
 
+  // Bare `qc.invalidateQueries()` (no key) used to nuke the entire
+  // cache, including queries for unrelated workspaces and any in-flight
+  // background data. We now scope invalidation to the active
+  // workspace's prefix so we keep the workspace-keyed cache useful and
+  // don't blow away unrelated data.
   async function archive() {
     await api.post(`/parts/${partId}/archive`);
-    qc.invalidateQueries();
+    qc.invalidateQueries({ queryKey: wsScope(workspaceId) });
     nav("/parts");
   }
   async function restore() {
     await api.post(`/parts/${partId}/restore`);
-    qc.invalidateQueries();
+    qc.invalidateQueries({ queryKey: wsScope(workspaceId) });
   }
 
   return (

--- a/web/src/routes/parts/detail/PartRemoveStock.tsx
+++ b/web/src/routes/parts/detail/PartRemoveStock.tsx
@@ -2,7 +2,8 @@ import { useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { api, ApiError } from "@/lib/api";
-import { wsKey } from "@/lib/queryKeys";
+import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
+import { useAuth } from "@/lib/auth";
 import type { StorageLocation } from "@/types";
 
 type StockRow = {
@@ -23,16 +24,17 @@ export default function PartRemoveStock() {
   const { partId } = useParams<{ partId: string }>();
   const nav = useNavigate();
   const qc = useQueryClient();
+  const { workspaceId } = useAuth();
   const { data: storage } = useQuery({
-    queryKey: wsKey("storage"),
+    queryKey: useWsKey("storage"),
     queryFn: () => api.get<StorageLocation[]>("/storage"),
   });
   const { data: stock } = useQuery({
-    queryKey: wsKey("part", partId, "stock"),
+    queryKey: useWsKey("part", partId, "stock"),
     queryFn: () => api.get<StockResp>(`/parts/${partId}/stock`),
   });
   const { data: lots } = useQuery({
-    queryKey: wsKey("part", partId, "lots"),
+    queryKey: useWsKey("part", partId, "lots"),
     queryFn: () => api.get<Lot[]>(`/parts/${partId}/lots`),
   });
 
@@ -92,8 +94,8 @@ export default function PartRemoveStock() {
       if (selected.storage_location_id) payload.storage_location_id = selected.storage_location_id;
       if (selected.lot_id) payload.lot_id = selected.lot_id;
       await api.post("/stock/remove", payload);
-      qc.invalidateQueries({ queryKey: wsKey("part", partId) });
-      qc.invalidateQueries({ queryKey: wsKey("part", partId, "stock") });
+      qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "part", partId) });
+      qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "part", partId, "stock") });
       nav(`/parts/${partId}/stock`);
     } catch (e) {
       setErr(e instanceof ApiError ? e.message : "Failed");

--- a/web/src/routes/parts/detail/PartRemoveStock.tsx
+++ b/web/src/routes/parts/detail/PartRemoveStock.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { api, ApiError } from "@/lib/api";
+import { wsKey } from "@/lib/queryKeys";
 import type { StorageLocation } from "@/types";
 
 type StockRow = {
@@ -23,15 +24,15 @@ export default function PartRemoveStock() {
   const nav = useNavigate();
   const qc = useQueryClient();
   const { data: storage } = useQuery({
-    queryKey: ["storage"],
+    queryKey: wsKey("storage"),
     queryFn: () => api.get<StorageLocation[]>("/storage"),
   });
   const { data: stock } = useQuery({
-    queryKey: ["part", partId, "stock"],
+    queryKey: wsKey("part", partId, "stock"),
     queryFn: () => api.get<StockResp>(`/parts/${partId}/stock`),
   });
   const { data: lots } = useQuery({
-    queryKey: ["part", partId, "lots"],
+    queryKey: wsKey("part", partId, "lots"),
     queryFn: () => api.get<Lot[]>(`/parts/${partId}/lots`),
   });
 
@@ -91,8 +92,8 @@ export default function PartRemoveStock() {
       if (selected.storage_location_id) payload.storage_location_id = selected.storage_location_id;
       if (selected.lot_id) payload.lot_id = selected.lot_id;
       await api.post("/stock/remove", payload);
-      qc.invalidateQueries({ queryKey: ["part", partId] });
-      qc.invalidateQueries({ queryKey: ["part", partId, "stock"] });
+      qc.invalidateQueries({ queryKey: wsKey("part", partId) });
+      qc.invalidateQueries({ queryKey: wsKey("part", partId, "stock") });
       nav(`/parts/${partId}/stock`);
     } catch (e) {
       setErr(e instanceof ApiError ? e.message : "Failed");

--- a/web/src/routes/parts/detail/PartSettings.tsx
+++ b/web/src/routes/parts/detail/PartSettings.tsx
@@ -2,13 +2,14 @@ import { useState } from "react";
 import { useOutletContext, useParams } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { api, ApiError } from "@/lib/api";
+import { wsKey } from "@/lib/queryKeys";
 import type { Part, StorageLocation } from "@/types";
 
 export default function PartSettings() {
   const { part } = useOutletContext<{ part: Part }>();
   const { partId } = useParams();
   const qc = useQueryClient();
-  const { data: storage } = useQuery({ queryKey: ["storage"], queryFn: () => api.get<StorageLocation[]>("/storage") });
+  const { data: storage } = useQuery({ queryKey: wsKey("storage"), queryFn: () => api.get<StorageLocation[]>("/storage") });
   const [low, setLow] = useState(part.low_stock_report_quantity?.toString() ?? "");
   const [attrPct, setAttrPct] = useState(String(part.attrition_percentage));
   const [attrMin, setAttrMin] = useState(String(part.attrition_min_quantity));
@@ -32,7 +33,7 @@ export default function PartSettings() {
         serialized,
         published,
       });
-      qc.invalidateQueries({ queryKey: ["part", partId] });
+      qc.invalidateQueries({ queryKey: wsKey("part", partId) });
     } catch (e) {
       setErr(e instanceof ApiError ? e.message : "Failed");
     } finally {

--- a/web/src/routes/parts/detail/PartSettings.tsx
+++ b/web/src/routes/parts/detail/PartSettings.tsx
@@ -2,14 +2,16 @@ import { useState } from "react";
 import { useOutletContext, useParams } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { api, ApiError } from "@/lib/api";
-import { wsKey } from "@/lib/queryKeys";
+import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
+import { useAuth } from "@/lib/auth";
 import type { Part, StorageLocation } from "@/types";
 
 export default function PartSettings() {
   const { part } = useOutletContext<{ part: Part }>();
   const { partId } = useParams();
   const qc = useQueryClient();
-  const { data: storage } = useQuery({ queryKey: wsKey("storage"), queryFn: () => api.get<StorageLocation[]>("/storage") });
+  const { workspaceId } = useAuth();
+  const { data: storage } = useQuery({ queryKey: useWsKey("storage"), queryFn: () => api.get<StorageLocation[]>("/storage") });
   const [low, setLow] = useState(part.low_stock_report_quantity?.toString() ?? "");
   const [attrPct, setAttrPct] = useState(String(part.attrition_percentage));
   const [attrMin, setAttrMin] = useState(String(part.attrition_min_quantity));
@@ -33,7 +35,7 @@ export default function PartSettings() {
         serialized,
         published,
       });
-      qc.invalidateQueries({ queryKey: wsKey("part", partId) });
+      qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "part", partId) });
     } catch (e) {
       setErr(e instanceof ApiError ? e.message : "Failed");
     } finally {

--- a/web/src/routes/parts/detail/PartSourcing.tsx
+++ b/web/src/routes/parts/detail/PartSourcing.tsx
@@ -5,7 +5,8 @@ import { toast } from "sonner";
 import { ExternalLink, RefreshCw } from "lucide-react";
 import { api, ApiError } from "@/lib/api";
 import { isCatalogKey } from "@/lib/providerCatalog";
-import { wsKey } from "@/lib/queryKeys";
+import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
+import { useAuth } from "@/lib/auth";
 import type { CustomFieldRow, Part } from "@/types";
 
 const PROVIDER_LABEL: Record<string, string> = {
@@ -31,10 +32,11 @@ const PROVIDER_SEARCH_URL: Record<string, (mpn: string) => string> = {
 export default function PartSourcing() {
   const { part } = useOutletContext<{ part: Part }>();
   const qc = useQueryClient();
+  const { workspaceId } = useAuth();
   const [refreshing, setRefreshing] = useState(false);
 
   const { data, isLoading } = useQuery({
-    queryKey: wsKey("part", part.id, "custom-fields"),
+    queryKey: useWsKey("part", part.id, "custom-fields"),
     queryFn: () =>
       api.get<CustomFieldRow[]>(`/custom-fields/by-object/part/${part.id}`),
   });
@@ -45,8 +47,8 @@ export default function PartSourcing() {
     setRefreshing(true);
     try {
       await api.post(`/parts/${part.id}/refresh-from-provider`);
-      qc.invalidateQueries({ queryKey: wsKey("part", part.id, "custom-fields") });
-      qc.invalidateQueries({ queryKey: wsKey("part", part.id) });
+      qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "part", part.id, "custom-fields") });
+      qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "part", part.id) });
       toast.success("Refreshed from provider.");
     } catch (e) {
       toast.error(e instanceof ApiError ? e.message : "Refresh failed");

--- a/web/src/routes/parts/detail/PartSourcing.tsx
+++ b/web/src/routes/parts/detail/PartSourcing.tsx
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 import { ExternalLink, RefreshCw } from "lucide-react";
 import { api, ApiError } from "@/lib/api";
 import { isCatalogKey } from "@/lib/providerCatalog";
+import { wsKey } from "@/lib/queryKeys";
 import type { CustomFieldRow, Part } from "@/types";
 
 const PROVIDER_LABEL: Record<string, string> = {
@@ -33,7 +34,7 @@ export default function PartSourcing() {
   const [refreshing, setRefreshing] = useState(false);
 
   const { data, isLoading } = useQuery({
-    queryKey: ["part", part.id, "custom-fields"],
+    queryKey: wsKey("part", part.id, "custom-fields"),
     queryFn: () =>
       api.get<CustomFieldRow[]>(`/custom-fields/by-object/part/${part.id}`),
   });
@@ -44,8 +45,8 @@ export default function PartSourcing() {
     setRefreshing(true);
     try {
       await api.post(`/parts/${part.id}/refresh-from-provider`);
-      qc.invalidateQueries({ queryKey: ["part", part.id, "custom-fields"] });
-      qc.invalidateQueries({ queryKey: ["part", part.id] });
+      qc.invalidateQueries({ queryKey: wsKey("part", part.id, "custom-fields") });
+      qc.invalidateQueries({ queryKey: wsKey("part", part.id) });
       toast.success("Refreshed from provider.");
     } catch (e) {
       toast.error(e instanceof ApiError ? e.message : "Refresh failed");

--- a/web/src/routes/parts/detail/PartSpecs.tsx
+++ b/web/src/routes/parts/detail/PartSpecs.tsx
@@ -5,7 +5,7 @@ import { toast } from "sonner";
 import { Plus, RotateCcw, Trash2 } from "lucide-react";
 import { api, ApiError } from "@/lib/api";
 import { isSpecKey } from "@/lib/providerCatalog";
-import { wsKey } from "@/lib/queryKeys";
+import { useWsKey } from "@/lib/queryKeys";
 import { useConfirm } from "@/components/ConfirmDialog";
 import type { CustomFieldRow, Part, SpecSource } from "@/types";
 
@@ -44,7 +44,7 @@ export default function PartSpecs() {
   const confirm = useConfirm();
   const { part } = useOutletContext<{ part: Part }>();
   const qc = useQueryClient();
-  const queryKey = wsKey("part", part.id, "custom-fields");
+  const queryKey = useWsKey("part", part.id, "custom-fields");
 
   const { data, isLoading } = useQuery({
     queryKey,

--- a/web/src/routes/parts/detail/PartSpecs.tsx
+++ b/web/src/routes/parts/detail/PartSpecs.tsx
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 import { Plus, RotateCcw, Trash2 } from "lucide-react";
 import { api, ApiError } from "@/lib/api";
 import { isSpecKey } from "@/lib/providerCatalog";
+import { wsKey } from "@/lib/queryKeys";
 import { useConfirm } from "@/components/ConfirmDialog";
 import type { CustomFieldRow, Part, SpecSource } from "@/types";
 
@@ -43,7 +44,7 @@ export default function PartSpecs() {
   const confirm = useConfirm();
   const { part } = useOutletContext<{ part: Part }>();
   const qc = useQueryClient();
-  const queryKey = ["part", part.id, "custom-fields"];
+  const queryKey = wsKey("part", part.id, "custom-fields");
 
   const { data, isLoading } = useQuery({
     queryKey,

--- a/web/src/routes/parts/detail/PartStock.tsx
+++ b/web/src/routes/parts/detail/PartStock.tsx
@@ -1,6 +1,7 @@
 import { useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api";
+import { wsKey } from "@/lib/queryKeys";
 import type { StorageLocation } from "@/types";
 
 type StockResp = {
@@ -11,10 +12,10 @@ type StockResp = {
 export default function PartStock() {
   const { partId } = useParams();
   const { data } = useQuery({
-    queryKey: ["part", partId, "stock"],
+    queryKey: wsKey("part", partId, "stock"),
     queryFn: () => api.get<StockResp>(`/parts/${partId}/stock`),
   });
-  const { data: storage } = useQuery({ queryKey: ["storage"], queryFn: () => api.get<StorageLocation[]>("/storage") });
+  const { data: storage } = useQuery({ queryKey: wsKey("storage"), queryFn: () => api.get<StorageLocation[]>("/storage") });
   const storageById = new Map(storage?.map(s => [s.id, s.name]) ?? []);
 
   if (!data) return <div className="text-muted">Loading…</div>;

--- a/web/src/routes/parts/detail/PartStock.tsx
+++ b/web/src/routes/parts/detail/PartStock.tsx
@@ -1,7 +1,7 @@
 import { useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api";
-import { wsKey } from "@/lib/queryKeys";
+import { useWsKey } from "@/lib/queryKeys";
 import type { StorageLocation } from "@/types";
 
 type StockResp = {
@@ -12,10 +12,10 @@ type StockResp = {
 export default function PartStock() {
   const { partId } = useParams();
   const { data } = useQuery({
-    queryKey: wsKey("part", partId, "stock"),
+    queryKey: useWsKey("part", partId, "stock"),
     queryFn: () => api.get<StockResp>(`/parts/${partId}/stock`),
   });
-  const { data: storage } = useQuery({ queryKey: wsKey("storage"), queryFn: () => api.get<StorageLocation[]>("/storage") });
+  const { data: storage } = useQuery({ queryKey: useWsKey("storage"), queryFn: () => api.get<StorageLocation[]>("/storage") });
   const storageById = new Map(storage?.map(s => [s.id, s.name]) ?? []);
 
   if (!data) return <div className="text-muted">Loading…</div>;

--- a/web/src/routes/parts/detail/PartSubstitutes.tsx
+++ b/web/src/routes/parts/detail/PartSubstitutes.tsx
@@ -2,7 +2,8 @@ import { useState } from "react";
 import { useParams } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api";
-import { wsKey } from "@/lib/queryKeys";
+import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
+import { useAuth } from "@/lib/auth";
 import type { Part } from "@/types";
 
 type Sub = { part_id: string; direction: string };
@@ -10,8 +11,9 @@ type Sub = { part_id: string; direction: string };
 export default function PartSubstitutes() {
   const { partId } = useParams();
   const qc = useQueryClient();
-  const { data: subs } = useQuery({ queryKey: wsKey("part", partId, "subs"), queryFn: () => api.get<Sub[]>(`/parts/${partId}/substitutes`) });
-  const { data: parts } = useQuery({ queryKey: wsKey("parts"), queryFn: () => api.get<Part[]>("/parts") });
+  const { workspaceId } = useAuth();
+  const { data: subs } = useQuery({ queryKey: useWsKey("part", partId, "subs"), queryFn: () => api.get<Sub[]>(`/parts/${partId}/substitutes`) });
+  const { data: parts } = useQuery({ queryKey: useWsKey("parts"), queryFn: () => api.get<Part[]>("/parts") });
   const partsById = new Map(parts?.map(p => [p.id, p]) ?? []);
   const [pick, setPick] = useState("");
 
@@ -19,11 +21,11 @@ export default function PartSubstitutes() {
     if (!pick) return;
     await api.post(`/parts/${partId}/substitutes`, { substitute_part_id: pick });
     setPick("");
-    qc.invalidateQueries({ queryKey: wsKey("part", partId, "subs") });
+    qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "part", partId, "subs") });
   }
   async function remove(id: string) {
     await api.delete(`/parts/${partId}/substitutes/${id}`);
-    qc.invalidateQueries({ queryKey: wsKey("part", partId, "subs") });
+    qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "part", partId, "subs") });
   }
 
   return (

--- a/web/src/routes/parts/detail/PartSubstitutes.tsx
+++ b/web/src/routes/parts/detail/PartSubstitutes.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useParams } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api";
+import { wsKey } from "@/lib/queryKeys";
 import type { Part } from "@/types";
 
 type Sub = { part_id: string; direction: string };
@@ -9,8 +10,8 @@ type Sub = { part_id: string; direction: string };
 export default function PartSubstitutes() {
   const { partId } = useParams();
   const qc = useQueryClient();
-  const { data: subs } = useQuery({ queryKey: ["part", partId, "subs"], queryFn: () => api.get<Sub[]>(`/parts/${partId}/substitutes`) });
-  const { data: parts } = useQuery({ queryKey: ["parts"], queryFn: () => api.get<Part[]>("/parts") });
+  const { data: subs } = useQuery({ queryKey: wsKey("part", partId, "subs"), queryFn: () => api.get<Sub[]>(`/parts/${partId}/substitutes`) });
+  const { data: parts } = useQuery({ queryKey: wsKey("parts"), queryFn: () => api.get<Part[]>("/parts") });
   const partsById = new Map(parts?.map(p => [p.id, p]) ?? []);
   const [pick, setPick] = useState("");
 
@@ -18,11 +19,11 @@ export default function PartSubstitutes() {
     if (!pick) return;
     await api.post(`/parts/${partId}/substitutes`, { substitute_part_id: pick });
     setPick("");
-    qc.invalidateQueries({ queryKey: ["part", partId, "subs"] });
+    qc.invalidateQueries({ queryKey: wsKey("part", partId, "subs") });
   }
   async function remove(id: string) {
     await api.delete(`/parts/${partId}/substitutes/${id}`);
-    qc.invalidateQueries({ queryKey: ["part", partId, "subs"] });
+    qc.invalidateQueries({ queryKey: wsKey("part", partId, "subs") });
   }
 
   return (

--- a/web/src/routes/projects/ProjectsList.tsx
+++ b/web/src/routes/projects/ProjectsList.tsx
@@ -2,16 +2,19 @@ import { Link, NavLink, useNavigate } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { FolderKanban } from "lucide-react";
 import { api } from "@/lib/api";
+import { wsKey } from "@/lib/queryKeys";
 import { DataTable } from "@/components/DataTable";
 import EmptyState from "@/components/EmptyState";
+import QueryStateBoundary from "@/components/QueryStateBoundary";
 import type { Project } from "@/types";
 
 export default function ProjectsList({ archived = false }: { archived?: boolean }) {
   const nav = useNavigate();
-  const { data } = useQuery({
-    queryKey: ["projects", { archived }],
+  const query = useQuery({
+    queryKey: wsKey("projects", { archived }),
     queryFn: () => api.get<Project[]>(`/projects${archived ? "?archived=true" : ""}`),
   });
+  const { data } = query;
   return (
     <div>
       <div className="flex items-center gap-1 mb-3">
@@ -19,6 +22,7 @@ export default function ProjectsList({ archived = false }: { archived?: boolean 
         <NavLink to="/projects/archived" className={({ isActive }) => "btn " + (isActive ? "border-accent/50 text-accent" : "")}>Archived</NavLink>
         <Link to="/projects/create" className="btn-primary ml-auto">+ Project</Link>
       </div>
+      <QueryStateBoundary query={query} resourceLabel="projects">
       <DataTable
         rows={data ?? []}
         rowKey={r => r.id}
@@ -47,6 +51,7 @@ export default function ProjectsList({ archived = false }: { archived?: boolean 
           { key: "updated_at", header: "Last updated", accessor: r => r.updated_at, render: r => new Date(r.updated_at).toLocaleString() },
         ]}
       />
+      </QueryStateBoundary>
     </div>
   );
 }

--- a/web/src/routes/projects/ProjectsList.tsx
+++ b/web/src/routes/projects/ProjectsList.tsx
@@ -2,7 +2,7 @@ import { Link, NavLink, useNavigate } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { FolderKanban } from "lucide-react";
 import { api } from "@/lib/api";
-import { wsKey } from "@/lib/queryKeys";
+import { useWsKey } from "@/lib/queryKeys";
 import { DataTable } from "@/components/DataTable";
 import EmptyState from "@/components/EmptyState";
 import QueryStateBoundary from "@/components/QueryStateBoundary";
@@ -11,7 +11,7 @@ import type { Project } from "@/types";
 export default function ProjectsList({ archived = false }: { archived?: boolean }) {
   const nav = useNavigate();
   const query = useQuery({
-    queryKey: wsKey("projects", { archived }),
+    queryKey: useWsKey("projects", { archived }),
     queryFn: () => api.get<Project[]>(`/projects${archived ? "?archived=true" : ""}`),
   });
   const { data } = query;

--- a/web/src/routes/projects/detail/ProjectBOM.tsx
+++ b/web/src/routes/projects/detail/ProjectBOM.tsx
@@ -2,7 +2,8 @@ import { useParams } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { FolderKanban } from "lucide-react";
 import { api } from "@/lib/api";
-import { wsKey } from "@/lib/queryKeys";
+import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
+import { useAuth } from "@/lib/auth";
 import type { Part, ProjectEntry } from "@/types";
 import { useState } from "react";
 import { DataTable } from "@/components/DataTable";
@@ -11,24 +12,25 @@ import EmptyState from "@/components/EmptyState";
 export default function ProjectBOM() {
   const { projectId } = useParams();
   const qc = useQueryClient();
+  const { workspaceId } = useAuth();
   const { data: entries } = useQuery({
-    queryKey: wsKey("project", projectId, "entries"),
+    queryKey: useWsKey("project", projectId, "entries"),
     queryFn: () => api.get<ProjectEntry[]>(`/projects/${projectId}/entries`),
   });
-  const { data: parts } = useQuery({ queryKey: wsKey("parts"), queryFn: () => api.get<Part[]>("/parts") });
+  const { data: parts } = useQuery({ queryKey: useWsKey("parts"), queryFn: () => api.get<Part[]>("/parts") });
   const partsById = new Map(parts?.map(p => [p.id, p]) ?? []);
 
   const [matching, setMatching] = useState<{ entryId: string; pick: string } | null>(null);
 
   async function match(entryId: string, partId: string) {
     await api.post(`/projects/${projectId}/entries/${entryId}/match`, { part_id: partId });
-    qc.invalidateQueries({ queryKey: wsKey("project", projectId, "entries") });
+    qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "project", projectId, "entries") });
     setMatching(null);
   }
 
   async function delEntry(entryId: string) {
     await api.delete(`/projects/${projectId}/entries/${entryId}`);
-    qc.invalidateQueries({ queryKey: wsKey("project", projectId, "entries") });
+    qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "project", projectId, "entries") });
   }
 
   return (

--- a/web/src/routes/projects/detail/ProjectBOM.tsx
+++ b/web/src/routes/projects/detail/ProjectBOM.tsx
@@ -2,6 +2,7 @@ import { useParams } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { FolderKanban } from "lucide-react";
 import { api } from "@/lib/api";
+import { wsKey } from "@/lib/queryKeys";
 import type { Part, ProjectEntry } from "@/types";
 import { useState } from "react";
 import { DataTable } from "@/components/DataTable";
@@ -11,23 +12,23 @@ export default function ProjectBOM() {
   const { projectId } = useParams();
   const qc = useQueryClient();
   const { data: entries } = useQuery({
-    queryKey: ["project", projectId, "entries"],
+    queryKey: wsKey("project", projectId, "entries"),
     queryFn: () => api.get<ProjectEntry[]>(`/projects/${projectId}/entries`),
   });
-  const { data: parts } = useQuery({ queryKey: ["parts"], queryFn: () => api.get<Part[]>("/parts") });
+  const { data: parts } = useQuery({ queryKey: wsKey("parts"), queryFn: () => api.get<Part[]>("/parts") });
   const partsById = new Map(parts?.map(p => [p.id, p]) ?? []);
 
   const [matching, setMatching] = useState<{ entryId: string; pick: string } | null>(null);
 
   async function match(entryId: string, partId: string) {
     await api.post(`/projects/${projectId}/entries/${entryId}/match`, { part_id: partId });
-    qc.invalidateQueries({ queryKey: ["project", projectId, "entries"] });
+    qc.invalidateQueries({ queryKey: wsKey("project", projectId, "entries") });
     setMatching(null);
   }
 
   async function delEntry(entryId: string) {
     await api.delete(`/projects/${projectId}/entries/${entryId}`);
-    qc.invalidateQueries({ queryKey: ["project", projectId, "entries"] });
+    qc.invalidateQueries({ queryKey: wsKey("project", projectId, "entries") });
   }
 
   return (

--- a/web/src/routes/projects/detail/ProjectBuilds.tsx
+++ b/web/src/routes/projects/detail/ProjectBuilds.tsx
@@ -2,6 +2,7 @@ import { Link, useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { Hammer } from "lucide-react";
 import { api } from "@/lib/api";
+import { wsKey } from "@/lib/queryKeys";
 import { DataTable } from "@/components/DataTable";
 import EmptyState from "@/components/EmptyState";
 import type { Build } from "@/types";
@@ -9,7 +10,7 @@ import type { Build } from "@/types";
 export default function ProjectBuilds() {
   const { projectId } = useParams<{ projectId: string }>();
   const { data } = useQuery({
-    queryKey: ["builds", { project: projectId }],
+    queryKey: wsKey("builds", { project: projectId }),
     queryFn: () => api.get<Build[]>(`/builds?project_id=${projectId}`),
     enabled: !!projectId,
   });

--- a/web/src/routes/projects/detail/ProjectBuilds.tsx
+++ b/web/src/routes/projects/detail/ProjectBuilds.tsx
@@ -2,7 +2,7 @@ import { Link, useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { Hammer } from "lucide-react";
 import { api } from "@/lib/api";
-import { wsKey } from "@/lib/queryKeys";
+import { useWsKey } from "@/lib/queryKeys";
 import { DataTable } from "@/components/DataTable";
 import EmptyState from "@/components/EmptyState";
 import type { Build } from "@/types";
@@ -10,7 +10,7 @@ import type { Build } from "@/types";
 export default function ProjectBuilds() {
   const { projectId } = useParams<{ projectId: string }>();
   const { data } = useQuery({
-    queryKey: wsKey("builds", { project: projectId }),
+    queryKey: useWsKey("builds", { project: projectId }),
     queryFn: () => api.get<Build[]>(`/builds?project_id=${projectId}`),
     enabled: !!projectId,
   });

--- a/web/src/routes/projects/detail/ProjectData.tsx
+++ b/web/src/routes/projects/detail/ProjectData.tsx
@@ -2,6 +2,7 @@ import { useOutletContext } from "react-router-dom";
 import { useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api";
+import { wsKey } from "@/lib/queryKeys";
 import type { Project } from "@/types";
 
 export default function ProjectData() {
@@ -12,7 +13,7 @@ export default function ProjectData() {
   const [notes, setNotes] = useState(project.notes_markdown ?? "");
   async function save() {
     await api.patch(`/projects/${project.id}`, { name, description: description || null, notes_markdown: notes || null });
-    qc.invalidateQueries({ queryKey: ["project", project.id] });
+    qc.invalidateQueries({ queryKey: wsKey("project", project.id) });
   }
   return (
     <div className="card p-4 max-w-2xl space-y-3">

--- a/web/src/routes/projects/detail/ProjectData.tsx
+++ b/web/src/routes/projects/detail/ProjectData.tsx
@@ -2,18 +2,20 @@ import { useOutletContext } from "react-router-dom";
 import { useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api";
-import { wsKey } from "@/lib/queryKeys";
+import { wsKeyOf } from "@/lib/queryKeys";
+import { useAuth } from "@/lib/auth";
 import type { Project } from "@/types";
 
 export default function ProjectData() {
   const { project } = useOutletContext<{ project: Project }>();
   const qc = useQueryClient();
+  const { workspaceId } = useAuth();
   const [name, setName] = useState(project.name);
   const [description, setDescription] = useState(project.description ?? "");
   const [notes, setNotes] = useState(project.notes_markdown ?? "");
   async function save() {
     await api.patch(`/projects/${project.id}`, { name, description: description || null, notes_markdown: notes || null });
-    qc.invalidateQueries({ queryKey: wsKey("project", project.id) });
+    qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "project", project.id) });
   }
   return (
     <div className="card p-4 max-w-2xl space-y-3">

--- a/web/src/routes/projects/detail/ProjectImport.tsx
+++ b/web/src/routes/projects/detail/ProjectImport.tsx
@@ -3,7 +3,8 @@ import { useNavigate, useParams } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { api, ApiError } from "@/lib/api";
-import { wsKey } from "@/lib/queryKeys";
+import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
+import { useAuth } from "@/lib/auth";
 import { useConfirm, usePrompt } from "@/components/ConfirmDialog";
 
 type Preset = {
@@ -78,6 +79,7 @@ export default function ProjectImport() {
   const { projectId } = useParams<{ projectId: string }>();
   const nav = useNavigate();
   const qc = useQueryClient();
+  const { workspaceId } = useAuth();
   const [step, setStep] = useState<"upload" | "mapping" | "done">("upload");
   const [b64, setB64] = useState("");
   const [separator, setSeparator] = useState<string>(",");
@@ -90,7 +92,7 @@ export default function ProjectImport() {
   const [busy, setBusy] = useState(false);
   const [result, setResult] = useState<{ inserted: number; matched: number; unmatched: number } | null>(null);
   const { data: presets, refetch: refetchPresets } = useQuery({
-    queryKey: wsKey("bom-presets"),
+    queryKey: useWsKey("bom-presets"),
     queryFn: () => api.get<Preset[]>("/bom-presets"),
   });
 
@@ -183,7 +185,7 @@ export default function ProjectImport() {
         designator_separator: designatorSep,
       });
       setResult(res);
-      qc.invalidateQueries({ queryKey: wsKey("project", projectId, "entries") });
+      qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "project", projectId, "entries") });
       setStep("done");
     } catch (e) {
       setErr(e instanceof ApiError ? e.message : "Import failed");

--- a/web/src/routes/projects/detail/ProjectImport.tsx
+++ b/web/src/routes/projects/detail/ProjectImport.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { api, ApiError } from "@/lib/api";
+import { wsKey } from "@/lib/queryKeys";
 import { useConfirm, usePrompt } from "@/components/ConfirmDialog";
 
 type Preset = {
@@ -89,7 +90,7 @@ export default function ProjectImport() {
   const [busy, setBusy] = useState(false);
   const [result, setResult] = useState<{ inserted: number; matched: number; unmatched: number } | null>(null);
   const { data: presets, refetch: refetchPresets } = useQuery({
-    queryKey: ["bom-presets"],
+    queryKey: wsKey("bom-presets"),
     queryFn: () => api.get<Preset[]>("/bom-presets"),
   });
 
@@ -182,7 +183,7 @@ export default function ProjectImport() {
         designator_separator: designatorSep,
       });
       setResult(res);
-      qc.invalidateQueries({ queryKey: ["project", projectId, "entries"] });
+      qc.invalidateQueries({ queryKey: wsKey("project", projectId, "entries") });
       setStep("done");
     } catch (e) {
       setErr(e instanceof ApiError ? e.message : "Import failed");

--- a/web/src/routes/projects/detail/ProjectLayout.tsx
+++ b/web/src/routes/projects/detail/ProjectLayout.tsx
@@ -1,13 +1,14 @@
 import { Outlet, useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api";
+import { wsKey } from "@/lib/queryKeys";
 import EntityHeader from "@/components/EntityHeader";
 import SubNav from "@/components/SubNav";
 import type { Project } from "@/types";
 
 export default function ProjectLayout() {
   const { projectId } = useParams<{ projectId: string }>();
-  const { data } = useQuery({ queryKey: ["project", projectId], queryFn: () => api.get<Project>(`/projects/${projectId}`), enabled: !!projectId });
+  const { data } = useQuery({ queryKey: wsKey("project", projectId), queryFn: () => api.get<Project>(`/projects/${projectId}`), enabled: !!projectId });
   if (!data) return <div className="text-muted">Loading…</div>;
   const items = [
     { to: `/projects/${data.id}/data`, label: "Project info" },

--- a/web/src/routes/projects/detail/ProjectLayout.tsx
+++ b/web/src/routes/projects/detail/ProjectLayout.tsx
@@ -1,14 +1,14 @@
 import { Outlet, useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api";
-import { wsKey } from "@/lib/queryKeys";
+import { useWsKey } from "@/lib/queryKeys";
 import EntityHeader from "@/components/EntityHeader";
 import SubNav from "@/components/SubNav";
 import type { Project } from "@/types";
 
 export default function ProjectLayout() {
   const { projectId } = useParams<{ projectId: string }>();
-  const { data } = useQuery({ queryKey: wsKey("project", projectId), queryFn: () => api.get<Project>(`/projects/${projectId}`), enabled: !!projectId });
+  const { data } = useQuery({ queryKey: useWsKey("project", projectId), queryFn: () => api.get<Project>(`/projects/${projectId}`), enabled: !!projectId });
   if (!data) return <div className="text-muted">Loading…</div>;
   const items = [
     { to: `/projects/${data.id}/data`, label: "Project info" },

--- a/web/src/routes/projects/detail/ProjectOther.tsx
+++ b/web/src/routes/projects/detail/ProjectOther.tsx
@@ -1,20 +1,23 @@
 import { useNavigate, useOutletContext } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api";
+import { useAuth } from "@/lib/auth";
+import { wsScope } from "@/lib/queryKeys";
 import type { Project } from "@/types";
 
 export default function ProjectOther() {
   const { project } = useOutletContext<{ project: Project }>();
   const qc = useQueryClient();
+  const { workspaceId } = useAuth();
   const nav = useNavigate();
   async function arch() {
     await api.post(`/projects/${project.id}/archive`);
-    qc.invalidateQueries();
+    qc.invalidateQueries({ queryKey: wsScope(workspaceId) });
     nav("/projects");
   }
   async function restore() {
     await api.post(`/projects/${project.id}/restore`);
-    qc.invalidateQueries();
+    qc.invalidateQueries({ queryKey: wsScope(workspaceId) });
   }
   return (
     <div className="card p-4 max-w-xl">

--- a/web/src/routes/reports/Reports.tsx
+++ b/web/src/routes/reports/Reports.tsx
@@ -5,7 +5,7 @@ import { toast } from "sonner";
 import { BarChart3, ShoppingCart } from "lucide-react";
 import { api, ApiError } from "@/lib/api";
 import { useAuth } from "@/lib/auth";
-import { wsKey, wsKeyOf } from "@/lib/queryKeys";
+import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
 import { DataTable } from "@/components/DataTable";
 import EmptyState from "@/components/EmptyState";
 import type { Order, Project } from "@/types";
@@ -144,15 +144,15 @@ function KpiCard({
 
 function KpiStrip() {
   const { data: lowStock } = useQuery({
-    queryKey: wsKey("report", "low-stock"),
+    queryKey: useWsKey("report", "low-stock"),
     queryFn: () => api.get<LowStockRow[]>("/reports/low-stock"),
   });
   const { data: stockValue } = useQuery({
-    queryKey: wsKey("report", "stock-value"),
+    queryKey: useWsKey("report", "stock-value"),
     queryFn: () => api.get<StockValue>("/reports/stock-value"),
   });
   const { data: expiring } = useQuery({
-    queryKey: wsKey("report", "expiring", 30),
+    queryKey: useWsKey("report", "expiring", 30),
     queryFn: () => api.get<Expiring>("/reports/expiring-lots?days=30"),
   });
 
@@ -202,7 +202,7 @@ export function LowStockReport() {
   const { workspaceId } = useAuth();
   const [busy, setBusy] = useState(false);
   const { data, isLoading } = useQuery({
-    queryKey: wsKey("report", "low-stock"),
+    queryKey: useWsKey("report", "low-stock"),
     queryFn: () => api.get<LowStockRow[]>("/reports/low-stock"),
   });
   if (isLoading) return <div className="text-muted">Loading…</div>;
@@ -270,7 +270,7 @@ export function LowStockReport() {
 
 export function StockValueReport() {
   const { data, isLoading } = useQuery({
-    queryKey: wsKey("report", "stock-value"),
+    queryKey: useWsKey("report", "stock-value"),
     queryFn: () => api.get<StockValue>("/reports/stock-value"),
   });
   if (isLoading) return <div className="text-muted">Loading…</div>;
@@ -318,12 +318,12 @@ export function BomShortageReport() {
   const nav = useNavigate();
   const qc = useQueryClient();
   const { workspaceId } = useAuth();
-  const { data: projects } = useQuery({ queryKey: wsKey("projects"), queryFn: () => api.get<Project[]>("/projects") });
+  const { data: projects } = useQuery({ queryKey: useWsKey("projects"), queryFn: () => api.get<Project[]>("/projects") });
   const [projectId, setProjectId] = useState("");
   const [qty, setQty] = useState(1);
   const [busy, setBusy] = useState(false);
   const { data } = useQuery({
-    queryKey: wsKey("report", "bom", projectId, qty),
+    queryKey: useWsKey("report", "bom", projectId, qty),
     queryFn: () => api.get<Shortage>(`/reports/bom-shortage?project_id=${projectId}&quantity=${qty}`),
     enabled: !!projectId && qty > 0,
   });
@@ -407,7 +407,7 @@ export function BomShortageReport() {
 export function ExpiringLotsReport() {
   const [days, setDays] = useState(90);
   const { data } = useQuery({
-    queryKey: wsKey("report", "expiring", days),
+    queryKey: useWsKey("report", "expiring", days),
     queryFn: () => api.get<Expiring>(`/reports/expiring-lots?days=${days}`),
   });
   return (

--- a/web/src/routes/reports/Reports.tsx
+++ b/web/src/routes/reports/Reports.tsx
@@ -4,6 +4,8 @@ import { useQuery, useQueryClient, type QueryClient } from "@tanstack/react-quer
 import { toast } from "sonner";
 import { BarChart3, ShoppingCart } from "lucide-react";
 import { api, ApiError } from "@/lib/api";
+import { useAuth } from "@/lib/auth";
+import { wsKey, wsKeyOf } from "@/lib/queryKeys";
 import { DataTable } from "@/components/DataTable";
 import EmptyState from "@/components/EmptyState";
 import type { Order, Project } from "@/types";
@@ -58,6 +60,7 @@ async function createRestockOrder(
   lines: { part_id: string; quantity: number }[],
   nav: ReturnType<typeof useNavigate>,
   qc: QueryClient,
+  workspaceId: string | null,
 ): Promise<void> {
   if (lines.length === 0) return;
   try {
@@ -71,7 +74,7 @@ async function createRestockOrder(
       )
     );
     const failed = settled.filter(s => s.status === "rejected").length;
-    qc.invalidateQueries({ queryKey: ["orders"] });
+    qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "orders") });
     if (failed > 0) {
       toast.warning(
         `Order created — ${lines.length - failed} of ${lines.length} lines added; ${failed} failed.`
@@ -141,15 +144,15 @@ function KpiCard({
 
 function KpiStrip() {
   const { data: lowStock } = useQuery({
-    queryKey: ["report", "low-stock"],
+    queryKey: wsKey("report", "low-stock"),
     queryFn: () => api.get<LowStockRow[]>("/reports/low-stock"),
   });
   const { data: stockValue } = useQuery({
-    queryKey: ["report", "stock-value"],
+    queryKey: wsKey("report", "stock-value"),
     queryFn: () => api.get<StockValue>("/reports/stock-value"),
   });
   const { data: expiring } = useQuery({
-    queryKey: ["report", "expiring", 30],
+    queryKey: wsKey("report", "expiring", 30),
     queryFn: () => api.get<Expiring>("/reports/expiring-lots?days=30"),
   });
 
@@ -196,9 +199,10 @@ function KpiStrip() {
 export function LowStockReport() {
   const nav = useNavigate();
   const qc = useQueryClient();
+  const { workspaceId } = useAuth();
   const [busy, setBusy] = useState(false);
   const { data, isLoading } = useQuery({
-    queryKey: ["report", "low-stock"],
+    queryKey: wsKey("report", "low-stock"),
     queryFn: () => api.get<LowStockRow[]>("/reports/low-stock"),
   });
   if (isLoading) return <div className="text-muted">Loading…</div>;
@@ -213,6 +217,7 @@ export function LowStockReport() {
         rows.map(r => ({ part_id: r.part_id, quantity: Math.max(1, r.short_by) })),
         nav,
         qc,
+        workspaceId,
       );
     } finally {
       setBusy(false);
@@ -265,7 +270,7 @@ export function LowStockReport() {
 
 export function StockValueReport() {
   const { data, isLoading } = useQuery({
-    queryKey: ["report", "stock-value"],
+    queryKey: wsKey("report", "stock-value"),
     queryFn: () => api.get<StockValue>("/reports/stock-value"),
   });
   if (isLoading) return <div className="text-muted">Loading…</div>;
@@ -312,12 +317,13 @@ export function StockValueReport() {
 export function BomShortageReport() {
   const nav = useNavigate();
   const qc = useQueryClient();
-  const { data: projects } = useQuery({ queryKey: ["projects"], queryFn: () => api.get<Project[]>("/projects") });
+  const { workspaceId } = useAuth();
+  const { data: projects } = useQuery({ queryKey: wsKey("projects"), queryFn: () => api.get<Project[]>("/projects") });
   const [projectId, setProjectId] = useState("");
   const [qty, setQty] = useState(1);
   const [busy, setBusy] = useState(false);
   const { data } = useQuery({
-    queryKey: ["report", "bom", projectId, qty],
+    queryKey: wsKey("report", "bom", projectId, qty),
     queryFn: () => api.get<Shortage>(`/reports/bom-shortage?project_id=${projectId}&quantity=${qty}`),
     enabled: !!projectId && qty > 0,
   });
@@ -335,6 +341,7 @@ export function BomShortageReport() {
         shortages.map(r => ({ part_id: r.part_id, quantity: r.short_by })),
         nav,
         qc,
+        workspaceId,
       );
     } finally {
       setBusy(false);
@@ -400,7 +407,7 @@ export function BomShortageReport() {
 export function ExpiringLotsReport() {
   const [days, setDays] = useState(90);
   const { data } = useQuery({
-    queryKey: ["report", "expiring", days],
+    queryKey: wsKey("report", "expiring", days),
     queryFn: () => api.get<Expiring>(`/reports/expiring-lots?days=${days}`),
   });
   return (

--- a/web/src/routes/settings/Account.tsx
+++ b/web/src/routes/settings/Account.tsx
@@ -1,11 +1,9 @@
 import { useState } from "react";
-import { useQueryClient } from "@tanstack/react-query";
 import { api, ApiError } from "@/lib/api";
 import { useAuth } from "@/lib/auth";
 
 export default function Account() {
-  const { me } = useAuth();
-  const qc = useQueryClient();
+  const { me, refresh, switchWorkspace } = useAuth();
   const [token, setToken] = useState("");
   const [busy, setBusy] = useState(false);
   const [msg, setMsg] = useState<string | null>(null);
@@ -23,10 +21,11 @@ export default function Account() {
       );
       setMsg(`Joined "${out.workspace_name}" as ${out.role}.`);
       setToken("");
-      qc.invalidateQueries();
-      // Switch to the joined workspace
-      await api.post(`/workspaces/${out.workspace_id}/switch`);
-      window.location.reload();
+      // Refresh /auth/me so the new workspace appears in the picker,
+      // then route through `switchWorkspace` — that flushes the query
+      // cache and navigates without a full page reload (FE2-003).
+      await refresh();
+      await switchWorkspace(out.workspace_id);
     } catch (e) {
       setErr(e instanceof ApiError ? e.message : "Failed");
     } finally {

--- a/web/src/routes/settings/Workspace.tsx
+++ b/web/src/routes/settings/Workspace.tsx
@@ -3,6 +3,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { api, ApiError } from "@/lib/api";
 import { useAuth } from "@/lib/auth";
+import { wsKey, wsScope } from "@/lib/queryKeys";
 import { useConfirm } from "@/components/ConfirmDialog";
 
 type Ws = {
@@ -41,15 +42,15 @@ type Invitation = {
 
 export default function WorkspaceSettings() {
   const confirm = useConfirm();
-  const { me } = useAuth();
+  const { me, workspaceId, refresh, switchWorkspace } = useAuth();
   const qc = useQueryClient();
-  const { data: cur } = useQuery({ queryKey: ["ws", "current"], queryFn: () => api.get<Ws>("/workspaces/current") });
+  const { data: cur } = useQuery({ queryKey: wsKey("ws", "current"), queryFn: () => api.get<Ws>("/workspaces/current") });
   const { data: members, refetch: refetchMembers } = useQuery({
-    queryKey: ["ws", "members"],
+    queryKey: wsKey("ws", "members"),
     queryFn: () => api.get<Member[]>("/workspaces/members"),
   });
   const { data: invites, refetch: refetchInvites } = useQuery({
-    queryKey: ["ws", "invitations"],
+    queryKey: wsKey("ws", "invitations"),
     queryFn: () => api.get<Invitation[]>("/invitations"),
   });
   const [newName, setNewName] = useState("");
@@ -64,17 +65,24 @@ export default function WorkspaceSettings() {
 
   async function createWs() {
     if (!newName.trim()) return;
-    await api.post("/workspaces", { name: newName.trim() });
+    const created = await api.post<{ id: string }>("/workspaces", { name: newName.trim() });
     setNewName("");
-    qc.invalidateQueries();
-    window.location.reload();
+    // Refresh /auth/me so the picker lists the new workspace, then
+    // hop into it through the workspace-switch path. This replaces a
+    // full `window.location.reload()` (FE2-003).
+    await refresh();
+    if (created?.id) {
+      await switchWorkspace(created.id);
+    } else {
+      qc.invalidateQueries({ queryKey: wsScope(workspaceId) });
+    }
   }
 
   async function patch(body: Partial<Ws> & { regenerate_catalog_token?: boolean }) {
     setErr(null);
     try {
       await api.patch("/workspaces/current", body);
-      qc.invalidateQueries({ queryKey: ["ws", "current"] });
+      qc.invalidateQueries({ queryKey: wsKey("ws", "current") });
       toast.success("Workspace settings saved.");
     } catch (e) {
       const m = e instanceof ApiError ? e.message : "Failed";
@@ -317,7 +325,7 @@ export default function WorkspaceSettings() {
                       if (providerKey) body.parts_provider_api_key = providerKey;
                       if (providerSecret) body.parts_provider_api_secret = providerSecret;
                       await api.patch("/workspaces/current", body);
-                      qc.invalidateQueries({ queryKey: ["ws", "current"] });
+                      qc.invalidateQueries({ queryKey: wsKey("ws", "current") });
                       setProviderKey("");
                       setProviderSecret("");
                       toast.success("Credentials saved.");
@@ -347,7 +355,7 @@ export default function WorkspaceSettings() {
                           parts_provider_api_key: "",
                           parts_provider_api_secret: "",
                         });
-                        qc.invalidateQueries({ queryKey: ["ws", "current"] });
+                        qc.invalidateQueries({ queryKey: wsKey("ws", "current") });
                         toast.success("Credentials cleared.");
                       } catch (e) {
                         toast.error(e instanceof ApiError ? e.message : "Failed");
@@ -389,7 +397,7 @@ export default function WorkspaceSettings() {
                       await api.patch("/workspaces/current", {
                         parts_provider_api_key: providerKey,
                       });
-                      qc.invalidateQueries({ queryKey: ["ws", "current"] });
+                      qc.invalidateQueries({ queryKey: wsKey("ws", "current") });
                       setProviderKey("");
                       toast.success(providerKey ? "API key saved." : "API key cleared.");
                     } catch (e) {
@@ -451,8 +459,8 @@ export default function WorkspaceSettings() {
                       await api.patch("/workspaces/current", {
                         scanner_license_key: scannerLicense,
                       });
-                      qc.invalidateQueries({ queryKey: ["ws", "current"] });
-                      qc.invalidateQueries({ queryKey: ["ws", "scanner", "license-key"] });
+                      qc.invalidateQueries({ queryKey: wsKey("ws", "current") });
+                      qc.invalidateQueries({ queryKey: wsKey("ws", "scanner", "license-key") });
                       setScannerLicense("");
                       toast.success(scannerLicense ? "License key saved." : "License key cleared.");
                     } catch (e) {

--- a/web/src/routes/settings/Workspace.tsx
+++ b/web/src/routes/settings/Workspace.tsx
@@ -3,7 +3,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { api, ApiError } from "@/lib/api";
 import { useAuth } from "@/lib/auth";
-import { wsKey, wsScope } from "@/lib/queryKeys";
+import { useWsKey, wsKeyOf, wsScope } from "@/lib/queryKeys";
 import { useConfirm } from "@/components/ConfirmDialog";
 
 type Ws = {
@@ -44,13 +44,13 @@ export default function WorkspaceSettings() {
   const confirm = useConfirm();
   const { me, workspaceId, refresh, switchWorkspace } = useAuth();
   const qc = useQueryClient();
-  const { data: cur } = useQuery({ queryKey: wsKey("ws", "current"), queryFn: () => api.get<Ws>("/workspaces/current") });
+  const { data: cur } = useQuery({ queryKey: useWsKey("ws", "current"), queryFn: () => api.get<Ws>("/workspaces/current") });
   const { data: members, refetch: refetchMembers } = useQuery({
-    queryKey: wsKey("ws", "members"),
+    queryKey: useWsKey("ws", "members"),
     queryFn: () => api.get<Member[]>("/workspaces/members"),
   });
   const { data: invites, refetch: refetchInvites } = useQuery({
-    queryKey: wsKey("ws", "invitations"),
+    queryKey: useWsKey("ws", "invitations"),
     queryFn: () => api.get<Invitation[]>("/invitations"),
   });
   const [newName, setNewName] = useState("");
@@ -82,7 +82,7 @@ export default function WorkspaceSettings() {
     setErr(null);
     try {
       await api.patch("/workspaces/current", body);
-      qc.invalidateQueries({ queryKey: wsKey("ws", "current") });
+      qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "ws", "current") });
       toast.success("Workspace settings saved.");
     } catch (e) {
       const m = e instanceof ApiError ? e.message : "Failed";
@@ -325,7 +325,7 @@ export default function WorkspaceSettings() {
                       if (providerKey) body.parts_provider_api_key = providerKey;
                       if (providerSecret) body.parts_provider_api_secret = providerSecret;
                       await api.patch("/workspaces/current", body);
-                      qc.invalidateQueries({ queryKey: wsKey("ws", "current") });
+                      qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "ws", "current") });
                       setProviderKey("");
                       setProviderSecret("");
                       toast.success("Credentials saved.");
@@ -355,7 +355,7 @@ export default function WorkspaceSettings() {
                           parts_provider_api_key: "",
                           parts_provider_api_secret: "",
                         });
-                        qc.invalidateQueries({ queryKey: wsKey("ws", "current") });
+                        qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "ws", "current") });
                         toast.success("Credentials cleared.");
                       } catch (e) {
                         toast.error(e instanceof ApiError ? e.message : "Failed");
@@ -397,7 +397,7 @@ export default function WorkspaceSettings() {
                       await api.patch("/workspaces/current", {
                         parts_provider_api_key: providerKey,
                       });
-                      qc.invalidateQueries({ queryKey: wsKey("ws", "current") });
+                      qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "ws", "current") });
                       setProviderKey("");
                       toast.success(providerKey ? "API key saved." : "API key cleared.");
                     } catch (e) {
@@ -459,8 +459,8 @@ export default function WorkspaceSettings() {
                       await api.patch("/workspaces/current", {
                         scanner_license_key: scannerLicense,
                       });
-                      qc.invalidateQueries({ queryKey: wsKey("ws", "current") });
-                      qc.invalidateQueries({ queryKey: wsKey("ws", "scanner", "license-key") });
+                      qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "ws", "current") });
+                      qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "ws", "scanner", "license-key") });
                       setScannerLicense("");
                       toast.success(scannerLicense ? "License key saved." : "License key cleared.");
                     } catch (e) {

--- a/web/src/routes/storage/StorageDetail.tsx
+++ b/web/src/routes/storage/StorageDetail.tsx
@@ -3,7 +3,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { ScanLine } from "lucide-react";
 import { api } from "@/lib/api";
 import { useAuth } from "@/lib/auth";
-import { wsKey, wsScope } from "@/lib/queryKeys";
+import { useWsKey, wsKeyOf, wsScope } from "@/lib/queryKeys";
 import EntityHeader from "@/components/EntityHeader";
 import SubNav from "@/components/SubNav";
 import type { StorageLocation, Part, StockEntry } from "@/types";
@@ -12,7 +12,7 @@ import { DataTable } from "@/components/DataTable";
 export function StorageDetailLayout() {
   const { storageId } = useParams<{ storageId: string }>();
   const { data } = useQuery({
-    queryKey: wsKey("storage", storageId),
+    queryKey: useWsKey("storage", storageId),
     queryFn: () => api.get<StorageLocation>(`/storage/${storageId}`),
     enabled: !!storageId,
   });
@@ -59,10 +59,10 @@ export function StorageDetailLayout() {
 export function StorageInfo() {
   const { storageId } = useParams();
   const { data: rows } = useQuery({
-    queryKey: wsKey("storage", storageId, "parts"),
+    queryKey: useWsKey("storage", storageId, "parts"),
     queryFn: () => api.get<{ part_id: string; lot_id: string | null; quantity: number }[]>(`/storage/${storageId}/parts`),
   });
-  const { data: parts } = useQuery({ queryKey: wsKey("parts"), queryFn: () => api.get<Part[]>("/parts") });
+  const { data: parts } = useQuery({ queryKey: useWsKey("parts"), queryFn: () => api.get<Part[]>("/parts") });
   const partName = new Map(parts?.map(p => [p.id, p.name]) ?? []);
   return (
     <div className="card overflow-hidden">
@@ -90,10 +90,10 @@ export function StorageInfo() {
 export function StorageHistory() {
   const { storageId } = useParams();
   const { data } = useQuery({
-    queryKey: wsKey("storage", storageId, "history"),
+    queryKey: useWsKey("storage", storageId, "history"),
     queryFn: () => api.get<StockEntry[]>(`/storage/${storageId}/history`),
   });
-  const { data: parts } = useQuery({ queryKey: wsKey("parts"), queryFn: () => api.get<Part[]>("/parts") });
+  const { data: parts } = useQuery({ queryKey: useWsKey("parts"), queryFn: () => api.get<Part[]>("/parts") });
   const partName = new Map(parts?.map(p => [p.id, p.name]) ?? []);
   return (
     <DataTable
@@ -115,11 +115,12 @@ export function StorageHistory() {
 export function StorageSettings() {
   const { storageId } = useParams();
   const qc = useQueryClient();
-  const { data } = useQuery({ queryKey: wsKey("storage", storageId), queryFn: () => api.get<StorageLocation>(`/storage/${storageId}`), enabled: !!storageId });
+  const { workspaceId } = useAuth();
+  const { data } = useQuery({ queryKey: useWsKey("storage", storageId), queryFn: () => api.get<StorageLocation>(`/storage/${storageId}`), enabled: !!storageId });
   if (!data) return null;
   async function patch(field: string, v: any) {
     await api.patch(`/storage/${storageId}`, { [field]: v });
-    qc.invalidateQueries({ queryKey: wsKey("storage", storageId) });
+    qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "storage", storageId) });
   }
   return (
     <div className="card p-4 max-w-xl space-y-3">
@@ -144,7 +145,7 @@ export function StorageOther() {
   const nav = useNavigate();
   const qc = useQueryClient();
   const { workspaceId } = useAuth();
-  const { data } = useQuery({ queryKey: wsKey("storage", storageId), queryFn: () => api.get<StorageLocation>(`/storage/${storageId}`), enabled: !!storageId });
+  const { data } = useQuery({ queryKey: useWsKey("storage", storageId), queryFn: () => api.get<StorageLocation>(`/storage/${storageId}`), enabled: !!storageId });
   if (!data) return null;
   async function arch() {
     await api.post(`/storage/${storageId}/archive`);

--- a/web/src/routes/storage/StorageDetail.tsx
+++ b/web/src/routes/storage/StorageDetail.tsx
@@ -2,6 +2,8 @@ import { Link, Outlet, useParams, NavLink, useNavigate } from "react-router-dom"
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { ScanLine } from "lucide-react";
 import { api } from "@/lib/api";
+import { useAuth } from "@/lib/auth";
+import { wsKey, wsScope } from "@/lib/queryKeys";
 import EntityHeader from "@/components/EntityHeader";
 import SubNav from "@/components/SubNav";
 import type { StorageLocation, Part, StockEntry } from "@/types";
@@ -10,7 +12,7 @@ import { DataTable } from "@/components/DataTable";
 export function StorageDetailLayout() {
   const { storageId } = useParams<{ storageId: string }>();
   const { data } = useQuery({
-    queryKey: ["storage", storageId],
+    queryKey: wsKey("storage", storageId),
     queryFn: () => api.get<StorageLocation>(`/storage/${storageId}`),
     enabled: !!storageId,
   });
@@ -57,10 +59,10 @@ export function StorageDetailLayout() {
 export function StorageInfo() {
   const { storageId } = useParams();
   const { data: rows } = useQuery({
-    queryKey: ["storage", storageId, "parts"],
+    queryKey: wsKey("storage", storageId, "parts"),
     queryFn: () => api.get<{ part_id: string; lot_id: string | null; quantity: number }[]>(`/storage/${storageId}/parts`),
   });
-  const { data: parts } = useQuery({ queryKey: ["parts"], queryFn: () => api.get<Part[]>("/parts") });
+  const { data: parts } = useQuery({ queryKey: wsKey("parts"), queryFn: () => api.get<Part[]>("/parts") });
   const partName = new Map(parts?.map(p => [p.id, p.name]) ?? []);
   return (
     <div className="card overflow-hidden">
@@ -88,10 +90,10 @@ export function StorageInfo() {
 export function StorageHistory() {
   const { storageId } = useParams();
   const { data } = useQuery({
-    queryKey: ["storage", storageId, "history"],
+    queryKey: wsKey("storage", storageId, "history"),
     queryFn: () => api.get<StockEntry[]>(`/storage/${storageId}/history`),
   });
-  const { data: parts } = useQuery({ queryKey: ["parts"], queryFn: () => api.get<Part[]>("/parts") });
+  const { data: parts } = useQuery({ queryKey: wsKey("parts"), queryFn: () => api.get<Part[]>("/parts") });
   const partName = new Map(parts?.map(p => [p.id, p.name]) ?? []);
   return (
     <DataTable
@@ -113,11 +115,11 @@ export function StorageHistory() {
 export function StorageSettings() {
   const { storageId } = useParams();
   const qc = useQueryClient();
-  const { data } = useQuery({ queryKey: ["storage", storageId], queryFn: () => api.get<StorageLocation>(`/storage/${storageId}`), enabled: !!storageId });
+  const { data } = useQuery({ queryKey: wsKey("storage", storageId), queryFn: () => api.get<StorageLocation>(`/storage/${storageId}`), enabled: !!storageId });
   if (!data) return null;
   async function patch(field: string, v: any) {
     await api.patch(`/storage/${storageId}`, { [field]: v });
-    qc.invalidateQueries({ queryKey: ["storage", storageId] });
+    qc.invalidateQueries({ queryKey: wsKey("storage", storageId) });
   }
   return (
     <div className="card p-4 max-w-xl space-y-3">
@@ -141,16 +143,17 @@ export function StorageOther() {
   const { storageId } = useParams();
   const nav = useNavigate();
   const qc = useQueryClient();
-  const { data } = useQuery({ queryKey: ["storage", storageId], queryFn: () => api.get<StorageLocation>(`/storage/${storageId}`), enabled: !!storageId });
+  const { workspaceId } = useAuth();
+  const { data } = useQuery({ queryKey: wsKey("storage", storageId), queryFn: () => api.get<StorageLocation>(`/storage/${storageId}`), enabled: !!storageId });
   if (!data) return null;
   async function arch() {
     await api.post(`/storage/${storageId}/archive`);
-    qc.invalidateQueries();
+    qc.invalidateQueries({ queryKey: wsScope(workspaceId) });
     nav("/storage");
   }
   async function restore() {
     await api.post(`/storage/${storageId}/restore`);
-    qc.invalidateQueries();
+    qc.invalidateQueries({ queryKey: wsScope(workspaceId) });
   }
   return (
     <div className="card p-4 max-w-xl">

--- a/web/src/routes/storage/StorageList.tsx
+++ b/web/src/routes/storage/StorageList.tsx
@@ -2,6 +2,7 @@ import { Link, NavLink, useNavigate } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { Warehouse } from "lucide-react";
 import { api } from "@/lib/api";
+import { wsKey } from "@/lib/queryKeys";
 import { DataTable } from "@/components/DataTable";
 import EmptyState from "@/components/EmptyState";
 import type { StorageLocation } from "@/types";
@@ -9,7 +10,7 @@ import type { StorageLocation } from "@/types";
 export default function StorageList({ archived = false }: { archived?: boolean }) {
   const nav = useNavigate();
   const { data } = useQuery({
-    queryKey: ["storage", { archived }],
+    queryKey: wsKey("storage", { archived }),
     queryFn: () => api.get<StorageLocation[]>(`/storage${archived ? "?archived=true" : ""}`),
   });
   return (

--- a/web/src/routes/storage/StorageList.tsx
+++ b/web/src/routes/storage/StorageList.tsx
@@ -2,7 +2,7 @@ import { Link, NavLink, useNavigate } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { Warehouse } from "lucide-react";
 import { api } from "@/lib/api";
-import { wsKey } from "@/lib/queryKeys";
+import { useWsKey } from "@/lib/queryKeys";
 import { DataTable } from "@/components/DataTable";
 import EmptyState from "@/components/EmptyState";
 import type { StorageLocation } from "@/types";
@@ -10,7 +10,7 @@ import type { StorageLocation } from "@/types";
 export default function StorageList({ archived = false }: { archived?: boolean }) {
   const nav = useNavigate();
   const { data } = useQuery({
-    queryKey: wsKey("storage", { archived }),
+    queryKey: useWsKey("storage", { archived }),
     queryFn: () => api.get<StorageLocation[]>(`/storage${archived ? "?archived=true" : ""}`),
   });
   return (


### PR DESCRIPTION
## Summary

- Wires a global 401 handler at `QueryClient` construction so every authed query/mutation that 401s clears session state and bounces the user to `/login` with the original location preserved as `state.from`. Login + Signup replay that target on success.
- Workspace switch now flushes the React Query cache (`qc.clear()`) and navigates to `/parts` instead of doing a full `window.location.reload()`. The `<select>` in `AppShell` is replaced by an explicit-click dropdown menu; if a mutation is in flight when you try to switch, `useConfirm` asks first.
- Every TanStack query key is prefixed with `["ws", workspaceId, …]` via the new `wsKey()` helper in `web/src/lib/queryKeys.ts`. Every bare `qc.invalidateQueries()` (no key) is replaced with a workspace-scoped prefix — those used to nuke the entire cache.
- DataTable hardening: selection set prunes when rows change and resets on `tableId` change; CSV export gets a UTF-8 BOM, CRLF terminators, formula-injection neutralisation (`=`, `+`, `-`, `@`, TAB, CR), and `URL.revokeObjectURL()` after the click. New `web/src/components/DataTable.test.tsx` pins the helpers (14 tests).
- `<QueryStateBoundary>` renders a "couldn't load — retry" banner instead of a silent empty list on Parts / Orders / Builds / Projects / Lots.
- PartsList bulk-delete now goes through `useConfirm` (no more hand-rolled overlay).
- Scanner panels swap stale `bg-bg-soft` / `text-text-muted` classes for the existing `bg-panel2` / `text-muted` tokens (Scanner.tsx + ZxingScanner.tsx).
- `lib/api.ts` now accepts an optional `AbortSignal`; `AuthProvider` aborts the bootstrap `/auth/me` on unmount. Stale-closure bug in the bootstrap effect fixed via a ref.

## What this PR closes

| ID | What |
|---|---|
| FE2-001 | global 401 handler |
| FE2-002 | workspace switcher needs explicit click + confirm |
| FE2-003 | workspace switch flushes cache + drops `window.location.reload` |
| FE2-004 | every query key includes workspaceId |
| FE2-005 | PartsList bulk-delete via `useConfirm` |
| FE2-007 | DataTable selection prune + reset on tableId change |
| FE2-008 | DataTable CSV: BOM, CRLF, formula-injection mitigation, revokeObjectURL |
| FE2-009 | Scanner Tailwind tokens (`bg-bg-soft` → `bg-panel2`, `text-text-muted` → `text-muted`) |
| FE2-010 | login deep-link preservation |
| v1 FE HIGH-1 | auth bootstrap stale closure → ref |
| v1 FE HIGH-4 | api.ts AbortSignal + unmount abort |
| v1 FE HIGH-7 | bare `qc.invalidateQueries()` replaced with key-prefixed calls |
| v1 FE HIGH-8 | query keys workspace-scoped |

## Test plan

- [x] `cd web && npm run build` — `tsc -b` + `vite build` both green
- [x] `cd web && npm test` — 33/33 pass (14 new DataTable tests)
- [ ] Manual: `/api/me` returns 401 → user redirected to `/login` with deep-link preserved → after sign-in lands back on the original URL
- [ ] Manual: open scanner → switch workspace → scanner re-fetches license key (cache flushed)
- [ ] Manual: PartsList bulk-select 5 rows, click Delete → ConfirmDialog appears with the part names → confirm archives
- [ ] Manual: export a list to CSV → opens in Excel without mojibake; a row whose first char is `=` is rendered as text, not evaluated

🤖 Generated with [Claude Code](https://claude.com/claude-code)