### PR TITLE
fix(users): add assert_user_deletable guard for owned workspaces

### DIFF
--- a/backend/app/domain/users/service.py
+++ b/backend/app/domain/users/service.py
@@ -1,0 +1,55 @@
+"""User-domain service helpers.
+
+Currently scoped to ownership-deletion preconditions (DB-013 / issue
+#104). When a `DELETE /api/users/{id}` endpoint eventually lands, it
+must call :func:`assert_user_deletable` before issuing the SQL ``DELETE``;
+``workspaces.owner_user_id`` carries ``ondelete='RESTRICT'`` so a raw
+delete of a workspace owner would otherwise bubble a Postgres
+``ForeignKeyViolation`` into a generic 500. The guard surfaces a clean
+409 with the list of owned workspaces so the caller (UI or admin tool)
+can prompt for ownership reassignment.
+
+See ``docs/ARCHITECTURE.md`` (Future work) for the operational
+runbook.
+"""
+from __future__ import annotations
+
+import uuid
+
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from app.domain.workspaces.models import Workspace
+
+
+def assert_user_deletable(db: Session, user_id: uuid.UUID) -> None:
+    """Raise 409 if the user owns one or more workspaces.
+
+    The ``RESTRICT`` FK on ``workspaces.owner_user_id`` is the database
+    safety net; this guard is the user-friendly layer on top. The
+    response surfaces the owned workspace ids/names so the caller can
+    either reassign ownership or hard-delete the workspaces first.
+
+    The check covers *every* workspace the user owns regardless of any
+    future ``archived_at`` flag: the FK fires on archived rows just the
+    same. If/when soft-archive lands on workspaces, this helper does
+    not need to change.
+    """
+    owned = (
+        db.query(Workspace.id, Workspace.name)
+        .filter(Workspace.owner_user_id == user_id)
+        .order_by(Workspace.created_at.asc())
+        .all()
+    )
+    if not owned:
+        return
+    raise HTTPException(
+        status_code=409,
+        detail={
+            "message": "user owns workspaces",
+            "code": "owns_workspaces",
+            "workspaces": [
+                {"id": str(ws_id), "name": ws_name} for ws_id, ws_name in owned
+            ],
+        },
+    )

--- a/backend/tests/test_user_deletion_guard.py
+++ b/backend/tests/test_user_deletion_guard.py
@@ -1,0 +1,102 @@
+"""Regression for DB-013 / issue #104.
+
+`workspaces.owner_user_id` carries `ondelete='RESTRICT'`. Today there is
+no `DELETE /api/users/{id}` endpoint, but the guard helper in
+`app.domain.users.service.assert_user_deletable` is the user-friendly
+layer above the FK: any future delete path must call it first so the
+caller sees a structured 409 with the list of owned workspaces instead
+of a Postgres `ForeignKeyViolation` bubbling to a 500.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from fastapi import HTTPException
+
+from app.domain.users.models import User
+from app.domain.users.service import assert_user_deletable
+from app.domain.workspaces.models import Workspace, WorkspaceMember
+
+
+def _make_user(db, email_suffix: str = "") -> User:
+    suffix = email_suffix or uuid.uuid4().hex[:8]
+    u = User(
+        email=f"u-{suffix}@example.com",
+        name="Tester",
+        password_hash="x" * 60,
+    )
+    db.add(u)
+    db.flush()
+    return u
+
+
+def _make_workspace(db, owner: User, name: str = "WS") -> Workspace:
+    ws = Workspace(name=name, kind="organization", owner_user_id=owner.id)
+    db.add(ws)
+    db.flush()
+    return ws
+
+
+def test_assert_user_deletable_ok_when_no_owned_workspaces(db):
+    """User who owns nothing passes the guard cleanly — no exception."""
+    u = _make_user(db)
+    db.commit()
+
+    # Must return None, not raise.
+    result = assert_user_deletable(db, u.id)
+    assert result is None
+
+
+def test_assert_user_deletable_raises_409_for_workspace_owner(db):
+    """Owning a single workspace surfaces a structured 409 detail."""
+    owner = _make_user(db)
+    ws = _make_workspace(db, owner, name="Acme")
+    db.commit()
+
+    with pytest.raises(HTTPException) as exc_info:
+        assert_user_deletable(db, owner.id)
+
+    assert exc_info.value.status_code == 409
+    detail = exc_info.value.detail
+    assert isinstance(detail, dict)
+    assert detail.get("code") == "owns_workspaces"
+    assert detail.get("message") == "user owns workspaces"
+    workspaces = detail.get("workspaces") or []
+    assert len(workspaces) == 1
+    assert workspaces[0]["id"] == str(ws.id)
+    assert workspaces[0]["name"] == "Acme"
+
+
+def test_assert_user_deletable_lists_every_owned_workspace(db):
+    """Multi-workspace ownership returns all of them in 409 detail."""
+    owner = _make_user(db)
+    ws1 = _make_workspace(db, owner, name="One")
+    ws2 = _make_workspace(db, owner, name="Two")
+    db.commit()
+
+    with pytest.raises(HTTPException) as exc_info:
+        assert_user_deletable(db, owner.id)
+
+    detail = exc_info.value.detail
+    assert isinstance(detail, dict)
+    ids = {w["id"] for w in detail["workspaces"]}
+    assert ids == {str(ws1.id), str(ws2.id)}
+
+
+def test_assert_user_deletable_ignores_membership_in_others_workspaces(db):
+    """A user who is only a *member* (not owner) of someone else's
+    workspace passes the guard. The check is strictly on
+    `owner_user_id`, not membership."""
+    owner = _make_user(db, "owner")
+    member_only = _make_user(db, "member")
+    ws = _make_workspace(db, owner, name="Owned by other")
+    db.add(
+        WorkspaceMember(
+            workspace_id=ws.id, user_id=member_only.id, role="member", status="active"
+        )
+    )
+    db.commit()
+
+    # The member-only user owns nothing → guard passes.
+    assert assert_user_deletable(db, member_only.id) is None

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -219,6 +219,17 @@ are not yet viewer-gated; that's a deliberate follow-up.
 
 ## Future work (not implemented)
 
+- **User deletion** — there is no `DELETE /api/users/{id}` endpoint
+  today. `workspaces.owner_user_id` carries `ondelete='RESTRICT'` (every
+  other user-facing FK is `SET NULL` for audit columns or `CASCADE` for
+  membership), so the workspace owner row cannot disappear without an
+  ownership reassignment. When the endpoint lands it must call
+  `app.domain.users.service.assert_user_deletable(db, user_id)` *before*
+  issuing the SQL delete; the helper raises a structured 409 with
+  `{ code: "owns_workspaces", workspaces: [...] }` so the caller can
+  prompt for reassign-or-archive instead of letting a Postgres
+  `ForeignKeyViolation` bubble into a 500. See
+  `tests/test_user_deletion_guard.py` for the contract.
 - **Per-endpoint RBAC tightening** — Phase 10 introduced roles and
   invitations and gates the member-management surface. Mutating data
   endpoints (parts/stock/projects/…) currently sit behind a single


### PR DESCRIPTION
Closes #104 (DB-013, v2 teardown).

`workspaces.owner_user_id` is the only user-facing FK with
`ondelete='RESTRICT'`. There is no user-delete endpoint today, but the
next time one lands, deleting an owner would bubble a Postgres
`ForeignKeyViolation` into a 500. This PR adds the service-layer guard
`assert_user_deletable(db, user_id)` that surfaces a structured 409
(`code: owns_workspaces`, `workspaces: [...]`), pins it with tests, and
documents the reassign-or-archive workflow in
`docs/ARCHITECTURE.md` (Future work). No schema or endpoint change.

## Test plan
- [ ] CI green
- [ ] `pytest -k user_deletion_guard` green (4 cases: no-owned, single owned, multi owned, member-only)

## Ops notes
none — no migration, no endpoint, no behavioural change to existing flows.

## Coordination
none — does not touch other v2-teardown issues in this batch (#105, #114-#117).

🤖 Generated with [Claude Code](https://claude.com/claude-code)