### PR TITLE
fix(tests): savepoint-rolled-back db fixture (TEST-009)

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -60,6 +60,7 @@ testpaths = ["tests"]
 # TEST-007 / issue #109.
 markers = [
     "slow: long-running test (excluded by default; run with `-m slow`)",
+    "real_db: test needs independent committed DB connections instead of savepoint isolation",
 ]
 addopts = "-m 'not slow'"
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -7,7 +7,7 @@ import pytest
 from alembic import command
 from alembic.config import Config as AlembicConfig
 from fastapi.testclient import TestClient
-from sqlalchemy import create_engine, event
+from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
 
 # Set env BEFORE importing app modules so config picks up the test DB.
@@ -108,17 +108,25 @@ def engine():
 def db(engine, monkeypatch):
     """Per-test transactional session with savepoint rollback (TEST-009).
 
-    SQLAlchemy "Joining a Session into an External Transaction" pattern:
-      1. Open a connection and begin an outer transaction.
-      2. Bind a Session to that connection, opening a SAVEPOINT.
-      3. Listen for `after_transaction_end` to restart the savepoint
-         whenever inner code commits — that turns route-level
-         `db.commit()` calls (e.g. `app.core.deps:49,61`,
-         `app.api.routes.parts:1058`, `app.infra.db.get_db:36`) into
-         savepoint releases that the outer rollback still discards.
-      4. Roll back the outer transaction at teardown — every row written
-         during the test, including via raw `SessionLocal()` calls and
-         via FastAPI handlers, evaporates.
+    Canonical SQLAlchemy 2.x "Joining a Session into an External
+    Transaction" recipe — uses `join_transaction_mode="create_savepoint"`
+    instead of an `after_transaction_end` listener. With this mode the
+    Session opens a SAVEPOINT inside the connection-bound outer
+    transaction as its root, so:
+
+      * `s.commit()` / `s.rollback()` only ever touch session-internal
+        savepoints — they never end the outer transaction.
+      * Production `with db.begin_nested():` (see
+        `app/domain/stock/service.py:513,577`) opens a *deeper*
+        SAVEPOINT inside the session's root savepoint and unwinds
+        cleanly on context-manager exit. The previous listener-based
+        recipe re-entered `session.begin_nested()` while the SA
+        context manager was still in `__exit__`, raising
+        "Can't operate on closed transaction inside context manager"
+        (issue #148).
+      * Roll back the outer transaction at teardown — every row
+        written during the test, including via raw `SessionLocal()`
+        calls and via FastAPI handlers, evaporates.
 
     Also overrides `app.infra.db.SessionLocal` so in-test code that
     instantiates `SessionLocal()` directly (e.g. tests that backdoor
@@ -130,37 +138,25 @@ def db(engine, monkeypatch):
     connection = engine.connect()
     transaction = connection.begin()
     TestSession = sessionmaker(
-        bind=connection, autoflush=False, expire_on_commit=False, future=True
+        bind=connection,
+        join_transaction_mode="create_savepoint",
+        autoflush=False,
+        expire_on_commit=False,
+        future=True,
     )
     s = TestSession()
-    s.begin_nested()
-
-    @event.listens_for(s, "after_transaction_end")
-    def _restart_savepoint(session, trans):
-        # Canonical SQLAlchemy "Joining a Session into an External
-        # Transaction" pattern: only restart the SAVEPOINT once the
-        # session has popped all the way back out of nested
-        # transactions. Service code uses `with db.begin_nested():`
-        # internally (see `app/domain/stock/service.py:513,577`); when
-        # those inner SAVEPOINTs end we must NOT begin a fresh
-        # SAVEPOINT, or we'd reopen one inside an exiting context
-        # manager and SQLAlchemy raises "Can't operate on closed
-        # transaction inside context manager".
-        if trans.nested and not session.in_nested_transaction():
-            session.begin_nested()
 
     # Route any in-test direct `SessionLocal()` use to our connection so
     # raw-SQL backdoors (test_attachments, test_invitations, etc.) share
     # the rolled-back transaction.
     monkeypatch.setattr(_infra_db, "SessionLocal", TestSession)
 
-    # Route the FastAPI `get_db` dep to yield our session. We mirror
-    # the prod dep's commit/rollback semantics so route code that
-    # relies on the dep boundary (e.g. it doesn't call db.commit()
-    # itself and expects the dep to flush) still works. Each
-    # commit/rollback lands on the active SAVEPOINT and the listener
-    # opens a fresh one, so the outer transaction.rollback() at
-    # teardown still discards every write.
+    # Route the FastAPI `get_db` dep to yield the SAME session as the
+    # test fixture (not a fresh `TestSession()` per request) so HTTP
+    # writes and direct fixture writes share one savepoint stack.
+    # `s.commit()` / `s.rollback()` operate on session-internal
+    # savepoints under `create_savepoint` mode — they never end the
+    # connection-bound outer transaction, which the teardown rolls back.
     def _override_get_db():
         try:
             yield s

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -137,11 +137,16 @@ def db(engine, monkeypatch):
 
     @event.listens_for(s, "after_transaction_end")
     def _restart_savepoint(session, trans):
-        # When the inner SAVEPOINT (or a nested one) ends and we're
-        # still inside the outer transaction, open a fresh SAVEPOINT so
-        # the next commit/rollback inside the test code has somewhere
-        # to land.
-        if trans.nested and not trans._parent.nested:  # type: ignore[attr-defined]
+        # Canonical SQLAlchemy "Joining a Session into an External
+        # Transaction" pattern: only restart the SAVEPOINT once the
+        # session has popped all the way back out of nested
+        # transactions. Service code uses `with db.begin_nested():`
+        # internally (see `app/domain/stock/service.py:513,577`); when
+        # those inner SAVEPOINTs end we must NOT begin a fresh
+        # SAVEPOINT, or we'd reopen one inside an exiting context
+        # manager and SQLAlchemy raises "Can't operate on closed
+        # transaction inside context manager".
+        if trans.nested and not session.in_nested_transaction():
             session.begin_nested()
 
     # Route any in-test direct `SessionLocal()` use to our connection so
@@ -149,10 +154,13 @@ def db(engine, monkeypatch):
     # the rolled-back transaction.
     monkeypatch.setattr(_infra_db, "SessionLocal", TestSession)
 
-    # Route the FastAPI `get_db` dep to yield our session. Mirrors the
-    # commit-on-clean / rollback-on-exception semantics of the prod dep
-    # but commits land on a SAVEPOINT (restarted by the listener), so
-    # the outer transaction.rollback() still wins.
+    # Route the FastAPI `get_db` dep to yield our session. We mirror
+    # the prod dep's commit/rollback semantics so route code that
+    # relies on the dep boundary (e.g. it doesn't call db.commit()
+    # itself and expects the dep to flush) still works. Each
+    # commit/rollback lands on the active SAVEPOINT and the listener
+    # opens a fresh one, so the outer transaction.rollback() at
+    # teardown still discards every write.
     def _override_get_db():
         try:
             yield s

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -154,6 +154,8 @@ def db(request, engine, monkeypatch):
             yield real_session
         finally:
             real_session.close()
+            _reset_schema(engine)
+            _alembic_upgrade_head(settings().DATABASE_URL)
         return
 
     connection = engine.connect()

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -104,9 +104,16 @@ def engine():
     return eng
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def db(engine, monkeypatch):
     """Per-test transactional session with savepoint rollback (TEST-009).
+
+    Autouse so every test gets the savepoint + dependency-override even
+    when it doesn't declare `db` as a parameter — otherwise tests that
+    skip the fixture run their HTTP signups through the real `get_db`
+    against the real engine, and the rows persist across tests
+    (issue #148: `test_session_hashing` saw 255 leftover UserSession
+    rows). Tests that need the session reference still request `db`.
 
     Canonical SQLAlchemy 2.x "Joining a Session into an External
     Transaction" recipe — uses `join_transaction_mode="create_savepoint"`

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -109,8 +109,8 @@ def engine():
     return eng
 
 
-@pytest.fixture
-def db(engine, monkeypatch):
+@pytest.fixture(autouse=True)
+def db(request, engine, monkeypatch):
     """Per-test transactional session with savepoint rollback (TEST-009).
 
     Canonical SQLAlchemy 2.x "Joining a Session into an External
@@ -140,6 +140,22 @@ def db(engine, monkeypatch):
     `client` / `authed_client` see the same rolled-back state, closing
     the foot-gun where HTTP tests inherited cross-test state.
     """
+    if request.node.get_closest_marker("real_db"):
+        _reset_schema(engine)
+        _alembic_upgrade_head(settings().DATABASE_URL)
+        RealSession = sessionmaker(
+            bind=engine,
+            autoflush=False,
+            expire_on_commit=False,
+            future=True,
+        )
+        real_session = RealSession()
+        try:
+            yield real_session
+        finally:
+            real_session.close()
+        return
+
     connection = engine.connect()
     transaction = connection.begin()
     TestSession = sessionmaker(

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -7,8 +7,8 @@ import pytest
 from alembic import command
 from alembic.config import Config as AlembicConfig
 from fastapi.testclient import TestClient
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import Session, sessionmaker
 
 # Set env BEFORE importing app modules so config picks up the test DB.
 # This exercises the explicit-DATABASE_URL-override branch in
@@ -51,7 +51,8 @@ _tc_mod.TestClient.__init__ = _patched_init  # type: ignore[method-assign]
 
 from app.core.config import settings  # noqa: E402
 import app.domain.all_models  # noqa: F401,E402
-from app.infra.db import Base  # noqa: E402
+from app.infra import db as _infra_db  # noqa: E402
+from app.infra.db import Base, get_db  # noqa: E402
 from app.main import app  # noqa: E402
 
 
@@ -73,11 +74,18 @@ def _alembic_upgrade_head(database_url: str) -> None:
     cfg = AlembicConfig(str(_BACKEND_ROOT / "alembic.ini"))
     cfg.set_main_option("script_location", str(_BACKEND_ROOT / "alembic"))
     cfg.set_main_option("sqlalchemy.url", database_url)
-    command.upgrade(cfg, "head")
+    command.upgrade(cfg, "heads")
 
 
 @pytest.fixture(scope="session", autouse=True)
 def engine():
+    """Session-scope engine: schema is migrated to head exactly once.
+
+    Replaces the previous per-test `_reset_schema()` + Alembic upgrade
+    that cost 4-8 minutes of pytest wall time across the full suite
+    (TEST-009). Per-test isolation now comes from the savepoint-rolled-
+    back `db` fixture below.
+    """
     eng = create_engine(settings().DATABASE_URL, future=True)
     # ensure DB exists by trying a connection; if it fails, create it via maintenance DB
     try:
@@ -97,19 +105,80 @@ def engine():
 
 
 @pytest.fixture
-def db(engine):
-    _reset_schema(engine)
-    _alembic_upgrade_head(settings().DATABASE_URL)
-    Session = sessionmaker(bind=engine, autoflush=False, expire_on_commit=False, future=True)
-    s = Session()
+def db(engine, monkeypatch):
+    """Per-test transactional session with savepoint rollback (TEST-009).
+
+    SQLAlchemy "Joining a Session into an External Transaction" pattern:
+      1. Open a connection and begin an outer transaction.
+      2. Bind a Session to that connection, opening a SAVEPOINT.
+      3. Listen for `after_transaction_end` to restart the savepoint
+         whenever inner code commits — that turns route-level
+         `db.commit()` calls (e.g. `app.core.deps:49,61`,
+         `app.api.routes.parts:1058`, `app.infra.db.get_db:36`) into
+         savepoint releases that the outer rollback still discards.
+      4. Roll back the outer transaction at teardown — every row written
+         during the test, including via raw `SessionLocal()` calls and
+         via FastAPI handlers, evaporates.
+
+    Also overrides `app.infra.db.SessionLocal` so in-test code that
+    instantiates `SessionLocal()` directly (e.g. tests that backdoor
+    state via raw SQL) stays inside the same outer transaction. And
+    overrides `app.dependency_overrides[get_db]` so HTTP tests via
+    `client` / `authed_client` see the same rolled-back state, closing
+    the foot-gun where HTTP tests inherited cross-test state.
+    """
+    connection = engine.connect()
+    transaction = connection.begin()
+    TestSession = sessionmaker(
+        bind=connection, autoflush=False, expire_on_commit=False, future=True
+    )
+    s = TestSession()
+    s.begin_nested()
+
+    @event.listens_for(s, "after_transaction_end")
+    def _restart_savepoint(session, trans):
+        # When the inner SAVEPOINT (or a nested one) ends and we're
+        # still inside the outer transaction, open a fresh SAVEPOINT so
+        # the next commit/rollback inside the test code has somewhere
+        # to land.
+        if trans.nested and not trans._parent.nested:  # type: ignore[attr-defined]
+            session.begin_nested()
+
+    # Route any in-test direct `SessionLocal()` use to our connection so
+    # raw-SQL backdoors (test_attachments, test_invitations, etc.) share
+    # the rolled-back transaction.
+    monkeypatch.setattr(_infra_db, "SessionLocal", TestSession)
+
+    # Route the FastAPI `get_db` dep to yield our session. Mirrors the
+    # commit-on-clean / rollback-on-exception semantics of the prod dep
+    # but commits land on a SAVEPOINT (restarted by the listener), so
+    # the outer transaction.rollback() still wins.
+    def _override_get_db():
+        try:
+            yield s
+            s.commit()
+        except Exception:
+            s.rollback()
+            raise
+
+    app.dependency_overrides[get_db] = _override_get_db
     try:
         yield s
     finally:
+        app.dependency_overrides.pop(get_db, None)
         s.close()
+        transaction.rollback()
+        connection.close()
 
 
 @pytest.fixture
-def client():
+def client(db):
+    """HTTP client tied to the per-test transactional session.
+
+    Depends on `db` so every HTTP test gets a clean DB by construction.
+    Previously `client` did not depend on `db`, so cross-test state
+    bled when a test forgot to declare `db` (TEST-009 foot-gun).
+    """
     return TestClient(app)
 
 
@@ -119,7 +188,11 @@ from tests._factories import signup_user as _signup  # noqa: E402,F401
 
 
 @pytest.fixture
-def authed_client():
+def authed_client(db):
+    """Authenticated HTTP client tied to the per-test transactional session.
+
+    Depends on `db` for the same isolation reason as `client`.
+    """
     c = TestClient(app)
     _signup(c)
     return c
@@ -137,3 +210,32 @@ def _mock_hibp(monkeypatch):
 
     with _mock.patch("app.core.auth._hibp_check"):
         yield
+
+
+# ---------------------------------------------------------------------------
+# Opt-out for tests that need real cross-connection commits.
+#
+# `test_stock_concurrency.py` spawns threads that each open their own
+# `TestClient(app)` and need to observe each other's writes — that's
+# fundamentally incompatible with a single shared rolled-back
+# connection. Such tests should request `real_db` (autouse mode flag)
+# instead of `db`; this fixture skips the savepoint plumbing, runs a
+# real `_reset_schema()` + `_alembic_upgrade_head()` for the test, and
+# leaves prod `SessionLocal` / `get_db` untouched. Slow per-test (~1-2s)
+# but only used by the handful of concurrency / cross-connection tests.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def real_db(engine):
+    """Hard-reset DB fixture for tests that need real commits across
+    connections (e.g. threading / advisory-lock tests). Slow; do not
+    use unless the savepoint pattern can't model the test."""
+    _reset_schema(engine)
+    _alembic_upgrade_head(settings().DATABASE_URL)
+    Session = sessionmaker(bind=engine, autoflush=False, expire_on_commit=False, future=True)
+    s = Session()
+    try:
+        yield s
+    finally:
+        s.close()

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -104,16 +104,9 @@ def engine():
     return eng
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def db(engine, monkeypatch):
     """Per-test transactional session with savepoint rollback (TEST-009).
-
-    Autouse so every test gets the savepoint + dependency-override even
-    when it doesn't declare `db` as a parameter — otherwise tests that
-    skip the fixture run their HTTP signups through the real `get_db`
-    against the real engine, and the rows persist across tests
-    (issue #148: `test_session_hashing` saw 255 leftover UserSession
-    rows). Tests that need the session reference still request `db`.
 
     Canonical SQLAlchemy 2.x "Joining a Session into an External
     Transaction" recipe — uses `join_transaction_mode="create_savepoint"`

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -173,6 +173,8 @@ def db(request, engine, monkeypatch):
     # raw-SQL backdoors (test_attachments, test_invitations, etc.) share
     # the rolled-back transaction.
     monkeypatch.setattr(_infra_db, "SessionLocal", TestSession)
+    if getattr(request.module, "SessionLocal", None) is not None:
+        monkeypatch.setattr(request.module, "SessionLocal", TestSession)
 
     # Route the FastAPI `get_db` dep to yield the SAME session as the
     # test fixture (not a fresh `TestSession()` per request) so HTTP

--- a/backend/tests/test_builds_consume_concurrency.py
+++ b/backend/tests/test_builds_consume_concurrency.py
@@ -24,6 +24,9 @@ from fastapi.testclient import TestClient
 from app.main import app
 
 
+pytestmark = pytest.mark.real_db
+
+
 def _signup(c: TestClient) -> None:
     r = c.post(
         "/api/auth/signup",

--- a/backend/tests/test_fixture_isolation.py
+++ b/backend/tests/test_fixture_isolation.py
@@ -1,0 +1,33 @@
+"""Tests for TEST-009 — fixture isolation via SAVEPOINT rollback.
+
+Two ordered tests: the first writes a row, the second tries to write
+the same row again. Before the savepoint-rollback fix, the second
+would fail with 409 because the first had committed. After the fix,
+both succeed because the first test's transaction is rolled back at
+teardown.
+
+These pin the per-test isolation contract for HTTP tests through
+`client` / `authed_client`, both of which now depend on `db`.
+"""
+from __future__ import annotations
+
+
+_ISOLATION_EMAIL = "iso-test-fixture@example.com"
+
+
+def test_a_writes_a_user(client):
+    r = client.post(
+        "/api/auth/signup",
+        json={"email": _ISOLATION_EMAIL, "name": "Iso A", "password": "TestPass-2026-Stronk"},
+    )
+    assert r.status_code == 200, r.text
+
+
+def test_b_does_not_see_user_from_a(client):
+    # Without the savepoint rollback, this would return 409
+    # because test_a committed the row to the real DB.
+    r = client.post(
+        "/api/auth/signup",
+        json={"email": _ISOLATION_EMAIL, "name": "Iso B", "password": "TestPass-2026-Stronk"},
+    )
+    assert r.status_code == 200, r.text

--- a/backend/tests/test_invitation_accept_race.py
+++ b/backend/tests/test_invitation_accept_race.py
@@ -17,6 +17,9 @@ from fastapi.testclient import TestClient
 from app.main import app
 
 
+pytestmark = pytest.mark.real_db
+
+
 def _signup(c: TestClient, email: str | None = None) -> tuple[str, str]:
     email = email or f"u-{uuid.uuid4().hex[:8]}@x.com"
     r = c.post(

--- a/backend/tests/test_invitation_create_race.py
+++ b/backend/tests/test_invitation_create_race.py
@@ -18,6 +18,9 @@ from fastapi.testclient import TestClient
 from app.main import app
 
 
+pytestmark = pytest.mark.real_db
+
+
 def _signup(c: TestClient, email: str | None = None) -> tuple[str, str]:
     email = email or f"u-{uuid.uuid4().hex[:8]}@x.com"
     r = c.post(

--- a/backend/tests/test_orders_receive_concurrency.py
+++ b/backend/tests/test_orders_receive_concurrency.py
@@ -26,6 +26,9 @@ from fastapi.testclient import TestClient
 from app.main import app
 
 
+pytestmark = pytest.mark.real_db
+
+
 def _signup(c: TestClient) -> None:
     r = c.post(
         "/api/auth/signup",

--- a/backend/tests/test_stock_concurrency.py
+++ b/backend/tests/test_stock_concurrency.py
@@ -31,6 +31,9 @@ from tests._factories import (
 )
 
 
+pytestmark = pytest.mark.real_db
+
+
 @pytest.fixture
 def authed():
     c = TestClient(app)

--- a/docs/development.md
+++ b/docs/development.md
@@ -41,8 +41,31 @@ TEST_DATABASE_URL="postgresql+psycopg://stockmgr:stockmgr@127.0.0.1:5432/stockmg
     .venv/bin/python -m pytest -q
 ```
 
-The `tests/conftest.py` fixture nukes & recreates the public schema between
-tests, so re-running the suite does not require manual cleanup.
+### Fixture isolation
+
+`tests/conftest.py` runs Alembic to head **once per pytest session** (in
+the session-scope `engine` fixture). Per-test isolation comes from the
+SQLAlchemy "Joining a Session into an External Transaction" pattern:
+the `db` fixture opens a connection, begins an outer transaction, opens
+a SAVEPOINT, and listens for `after_transaction_end` to restart the
+savepoint whenever inner code commits. At teardown the outer
+transaction is rolled back, so every row written during the test
+evaporates — including writes made by route handlers that call
+`db.commit()` (those land on a SAVEPOINT, not the outer transaction).
+
+`client` and `authed_client` both depend on `db`, so HTTP tests get
+clean state by construction. Direct `SessionLocal()` use inside a test
+also lands on the same connection (we monkey-patch `SessionLocal` for
+the duration of the test).
+
+The one exception is tests that need real cross-connection commits —
+`test_stock_concurrency.py` spawns threads that each open a separate
+HTTP client and need to see each other's writes. That file rolls its
+own `authed` fixture and goes through the production code paths; if
+you write a similar test, request the `real_db` fixture instead of
+`db`. `real_db` does a hard schema reset and Alembic upgrade and is
+~1000× slower per test — only use it when the savepoint pattern truly
+can't model the test.
 
 ### Slow tests
 


### PR DESCRIPTION
Closes #111.

Move Alembic migration to session scope (runs once instead of 244x), and switch per-test isolation to SQLAlchemy's "Joining a Session into an External Transaction" savepoint pattern. `client` and `authed_client` now depend on `db`, closing the foot-gun where HTTP tests inherited cross-test state.

## Summary
- `engine` fixture stays session-scope autouse: schema reset + Alembic upgrade run **once** per pytest session.
- `db` fixture: open a connection, begin outer transaction, open a SAVEPOINT, register `after_transaction_end` listener to restart the savepoint on inner commits. Teardown rolls back the outer transaction. Monkey-patches `app.infra.db.SessionLocal` so direct `SessionLocal()` use in test bodies (test_attachments, test_invitations, etc.) shares the same connection. Overrides `app.dependency_overrides[get_db]` so HTTP requests during the test land on the same rolled-back session.
- `client` and `authed_client` now depend on `db` — HTTP tests get a clean DB by construction.
- New `real_db` fixture for tests that genuinely need real cross-connection commits.
- New `tests/test_fixture_isolation.py` pins the contract.
- `docs/development.md` documents the pattern + when to reach for `real_db`.

## Test plan
- [ ] CI green — full backend pytest matrix
- [ ] Wall-clock noticeably down (target: under 60s on a developer laptop, vs multi-minute today)
- [ ] `tests/test_fixture_isolation.py` passes (the savepoint actually rolls back)
- [ ] `tests/test_workspace_isolation.py`, `tests/test_parts_mpn_unique.py`, `tests/test_stock_concurrency.py` still green — these exercise tx semantics
- [ ] `tests/test_db_tx.py` still green — its local `client` fixture goes through prod paths and verifies the prod `get_db` boundary

## Ops notes
None. Pure test infra.

## Coordination
- Coordinates with #109 (migration round-trip) — that issue can opt into `real_db` for the downgrade/upgrade cycle.
- No file overlap with #112-#120 in this batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)