### PR TITLE
test: extract shared test factories (TEST-012, #114)

### DIFF
--- a/backend/tests/_factories.py
+++ b/backend/tests/_factories.py
@@ -1,0 +1,126 @@
+"""Shared test factories.
+
+Thin wrappers around the HTTP API — NOT direct DB inserts — so that
+workspace-isolation, RBAC, and validation paths still get exercised by
+every test. Each factory:
+
+* asserts the call was 2xx,
+* returns the most useful field (an id, a response, etc).
+
+We deliberately avoid factory-boy / faker here (see issue #114): plain
+functions keep the dependency surface small and the call sites obvious.
+
+If a test needs richer data (extra fields, non-default flags), pass them
+as ``**extra`` — every factory forwards unknown kwargs to the request
+body so call sites stay one line.
+"""
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from fastapi.testclient import TestClient
+
+
+__all__ = [
+    "DEFAULT_PASSWORD",
+    "signup_user",
+    "create_part",
+    "create_storage",
+    "add_stock",
+    "create_project_with_bom",
+]
+
+
+# Single source of truth for the password used across the test suite.
+# Must satisfy the strength rule in
+# ``app.api.routes.auth._validate_password_strength``.
+DEFAULT_PASSWORD = "TestPass-2026-Stronk"
+
+
+def signup_user(
+    client: TestClient,
+    email: str | None = None,
+    name: str = "Tester",
+    password: str = DEFAULT_PASSWORD,
+) -> Any:
+    """Sign up a fresh user. Returns the raw response so call sites can
+    pull whatever they need (``workspace_id``, ``user_id``, etc)."""
+    email = email or f"u-{uuid.uuid4().hex[:8]}@example.com"
+    r = client.post(
+        "/api/auth/signup",
+        json={"email": email, "name": name, "password": password},
+    )
+    assert r.status_code == 200, r.text
+    return r
+
+
+def create_part(client: TestClient, name: str = "P", **extra: Any) -> str:
+    """Create a local part. Extra kwargs (mpn, manufacturer, …) ride
+    along in the request body. Returns the part id."""
+    body: dict[str, Any] = {"name": name, "part_type": "local"}
+    body.update(extra)
+    r = client.post("/api/parts", json=body)
+    assert r.status_code in (200, 201), r.text
+    return r.json()["data"]["id"]
+
+
+def create_storage(client: TestClient, name: str = "Bin", **extra: Any) -> str:
+    """Create a storage location. Returns the storage id."""
+    body: dict[str, Any] = {"name": name}
+    body.update(extra)
+    r = client.post("/api/storage", json=body)
+    assert r.status_code in (200, 201), r.text
+    return r.json()["data"]["id"]
+
+
+def add_stock(
+    client: TestClient,
+    part_id: str,
+    qty: int,
+    storage_id: str | None = None,
+    lot_name: str | None = None,
+    **extra: Any,
+) -> Any:
+    """Add ``qty`` to a part (optionally pinned to a storage / lot).
+
+    Returns the raw response. Call sites that need the entry payload
+    can do ``add_stock(...).json()["data"]``.
+    """
+    body: dict[str, Any] = {"part_id": part_id, "quantity": qty}
+    if storage_id is not None:
+        body["storage_location_id"] = storage_id
+    if lot_name is not None:
+        body["lot"] = {"name": lot_name}
+    body.update(extra)
+    r = client.post("/api/stock/add", json=body)
+    assert r.status_code == 200, r.text
+    return r
+
+
+def create_project_with_bom(
+    client: TestClient,
+    project_name: str,
+    bom: list[dict[str, Any]],
+) -> str:
+    """Create a project and attach BOM entries.
+
+    ``bom`` is a list of dicts shaped like
+    ``{part_id, quantity, dnp?, name?}``.
+    Returns the project id.
+    """
+    r = client.post("/api/projects", json={"name": project_name})
+    assert r.status_code in (200, 201), r.text
+    pid = r.json()["data"]["id"]
+    for row in bom:
+        r = client.post(
+            f"/api/projects/{pid}/entries",
+            json={
+                "part_id": row.get("part_id"),
+                "quantity": row["quantity"],
+                "dnp": row.get("dnp", False),
+                "name": row.get("name"),
+            },
+        )
+        assert r.status_code in (200, 201), r.text
+    return pid

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-import uuid
 from pathlib import Path
 
 import pytest
@@ -111,11 +110,9 @@ def client():
     return TestClient(app)
 
 
-def _signup(client: TestClient, email: str | None = None, name: str = "Tester"):
-    email = email or f"u-{uuid.uuid4().hex[:8]}@example.com"
-    r = client.post("/api/auth/signup", json={"email": email, "name": name, "password": "TestPass-2026-Stronk"})
-    assert r.status_code == 200, r.text
-    return r
+# Re-export the canonical signup factory under the legacy `_signup` name
+# so any test still importing it from `conftest` keeps working.
+from tests._factories import signup_user as _signup  # noqa: E402,F401
 
 
 @pytest.fixture

--- a/backend/tests/test_builds.py
+++ b/backend/tests/test_builds.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import uuid
+
 import pytest
 from fastapi.testclient import TestClient
 

--- a/backend/tests/test_builds.py
+++ b/backend/tests/test_builds.py
@@ -1,61 +1,23 @@
 from __future__ import annotations
 
-import uuid
-
 import pytest
 from fastapi.testclient import TestClient
 
 from app.main import app
+from tests._factories import (
+    add_stock as _add_stock,
+    create_part as _create_part,
+    create_project_with_bom as _create_project_with_bom,
+    create_storage as _create_storage,
+    signup_user,
+)
 
 
 @pytest.fixture
 def authed():
     c = TestClient(app)
-    r = c.post(
-        "/api/auth/signup",
-        json={"email": f"u-{uuid.uuid4().hex[:8]}@x.com", "name": "u", "password": "TestPass-2026-Stronk"},
-    )
-    assert r.status_code == 200, r.text
+    signup_user(c)
     return c
-
-
-def _create_part(c, name, **extra):
-    r = c.post("/api/parts", json={"name": name, "part_type": "local", **extra})
-    assert r.status_code in (200, 201), r.text
-    return r.json()["data"]["id"]
-
-
-def _create_storage(c, name="Shelf"):
-    r = c.post("/api/storage", json={"name": name})
-    assert r.status_code in (200, 201)
-    return r.json()["data"]["id"]
-
-
-def _add_stock(c, part_id, qty, storage_id=None):
-    body = {"part_id": part_id, "quantity": qty}
-    if storage_id:
-        body["storage_location_id"] = storage_id
-    r = c.post("/api/stock/add", json=body)
-    assert r.status_code == 200, r.text
-
-
-def _create_project_with_bom(c, project_name, bom):
-    """bom is a list of dicts: {part_id, quantity, dnp?}."""
-    r = c.post("/api/projects", json={"name": project_name})
-    assert r.status_code in (200, 201)
-    pid = r.json()["data"]["id"]
-    for row in bom:
-        r = c.post(
-            f"/api/projects/{pid}/entries",
-            json={
-                "part_id": row.get("part_id"),
-                "quantity": row["quantity"],
-                "dnp": row.get("dnp", False),
-                "name": row.get("name"),
-            },
-        )
-        assert r.status_code in (200, 201), r.text
-    return pid
 
 
 def test_shortage_analysis_flags_short(authed):

--- a/backend/tests/test_factories_smoke.py
+++ b/backend/tests/test_factories_smoke.py
@@ -1,0 +1,53 @@
+"""Smoke regression for the shared test factories.
+
+Cheap pin against signature drift in `tests/_factories.py`. If a factory
+is renamed or its return shape changes, this test fails before any of
+the 30+ call sites do.
+"""
+from __future__ import annotations
+
+import uuid
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+from tests._factories import (
+    add_stock,
+    create_part,
+    create_project_with_bom,
+    create_storage,
+    signup_user,
+)
+
+
+def _is_uuid(value: str) -> bool:
+    try:
+        uuid.UUID(value)
+    except (TypeError, ValueError):
+        return False
+    return True
+
+
+def test_factories_round_trip_against_real_api():
+    c = TestClient(app)
+    r = signup_user(c)
+    assert r.status_code == 200
+    assert _is_uuid(r.json()["data"]["workspace_id"])
+
+    part_id = create_part(c, name="Smoke part")
+    assert _is_uuid(part_id)
+
+    storage_id = create_storage(c, name="Smoke bin")
+    assert _is_uuid(storage_id)
+
+    add_resp = add_stock(c, part_id, 10, storage_id=storage_id, lot_name="L1")
+    assert add_resp.status_code == 200
+    entry = add_resp.json()["data"]
+    assert _is_uuid(entry["lot_id"])
+
+    project_id = create_project_with_bom(
+        c,
+        "Smoke project",
+        [{"part_id": part_id, "quantity": 1}],
+    )
+    assert _is_uuid(project_id)

--- a/backend/tests/test_orders.py
+++ b/backend/tests/test_orders.py
@@ -1,17 +1,10 @@
 from __future__ import annotations
 
-import uuid
-
 import pytest
 from fastapi.testclient import TestClient
 
 from app.main import app
-
-
-def _signup(c: TestClient, email: str | None = None):
-    email = email or f"u-{uuid.uuid4().hex[:8]}@x.com"
-    r = c.post("/api/auth/signup", json={"email": email, "name": "u", "password": "TestPass-2026-Stronk"})
-    assert r.status_code == 200, r.text
+from tests._factories import signup_user as _signup
 
 
 @pytest.fixture

--- a/backend/tests/test_stock_concurrency.py
+++ b/backend/tests/test_stock_concurrency.py
@@ -23,46 +23,25 @@ from sqlalchemy import text
 from app.main import app
 
 
-def _signup(c: TestClient) -> str:
-    r = c.post(
-        "/api/auth/signup",
-        json={"email": f"u-{uuid.uuid4().hex[:8]}@x.com", "name": "u", "password": "TestPass-2026-Stronk"},
-    )
-    assert r.status_code == 200, r.text
-    return r.json()["data"]["workspace_id"]
+from tests._factories import (
+    add_stock as _factory_add_stock,
+    create_part as _create_part,
+    create_storage as _create_storage,
+    signup_user,
+)
 
 
 @pytest.fixture
 def authed():
     c = TestClient(app)
-    _signup(c)
+    signup_user(c)
     return c
 
 
-def _create_storage(c, name="Bin"):
-    r = c.post("/api/storage", json={"name": name})
-    assert r.status_code in (200, 201)
-    return r.json()["data"]["id"]
-
-
-def _create_part(c, name="P"):
-    r = c.post("/api/parts", json={"name": name, "part_type": "local"})
-    assert r.status_code in (200, 201)
-    return r.json()["data"]["id"]
-
-
 def _add_stock(c, part_id, qty, storage_id, lot_name="L"):
-    r = c.post(
-        "/api/stock/add",
-        json={
-            "part_id": part_id,
-            "quantity": qty,
-            "storage_location_id": storage_id,
-            "lot": {"name": lot_name},
-        },
-    )
-    assert r.status_code in (200, 201), r.text
-    return r.json()["data"]
+    return _factory_add_stock(
+        c, part_id, qty, storage_id=storage_id, lot_name=lot_name
+    ).json()["data"]
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_workspace_isolation.py
+++ b/backend/tests/test_workspace_isolation.py
@@ -7,10 +7,16 @@ from fastapi.testclient import TestClient
 from app.main import app
 
 
-def _signup(c: TestClient, email: str):
-    r = c.post("/api/auth/signup", json={"email": email, "name": "u", "password": "TestPass-2026-Stronk"})
-    assert r.status_code == 200, r.text
-    return r.json()["data"]["workspace_id"]
+from tests._factories import (
+    add_stock as _factory_add_stock,
+    create_part as _create_part,
+    create_storage as _create_storage,
+    signup_user,
+)
+
+
+def _signup(c: TestClient, email: str) -> str:
+    return signup_user(c, email=email).json()["data"]["workspace_id"]
 
 
 def test_workspace_isolation():
@@ -127,18 +133,6 @@ def _two_workspaces():
     return a, b
 
 
-def _create_part(c: TestClient, name: str = "P") -> str:
-    r = c.post("/api/parts", json={"name": name, "part_type": "local"})
-    assert r.status_code in (200, 201), r.text
-    return r.json()["data"]["id"]
-
-
-def _create_storage(c: TestClient, name: str = "Bin") -> str:
-    r = c.post("/api/storage", json={"name": name})
-    assert r.status_code in (200, 201), r.text
-    return r.json()["data"]["id"]
-
-
 def _add_stock(
     c: TestClient,
     *,
@@ -147,12 +141,13 @@ def _add_stock(
     quantity: int = 5,
     lot_name: str = "L",
 ) -> dict:
-    body: dict = {"part_id": part_id, "quantity": quantity, "lot": {"name": lot_name}}
-    if storage_id:
-        body["storage_location_id"] = storage_id
-    r = c.post("/api/stock/add", json=body)
-    assert r.status_code in (200, 201), r.text
-    return r.json()["data"]
+    return _factory_add_stock(
+        c,
+        part_id,
+        quantity,
+        storage_id=storage_id,
+        lot_name=lot_name,
+    ).json()["data"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #114.

Introduces `backend/tests/_factories.py` with thin HTTP-API wrappers
(`signup_user`, `create_part`, `create_storage`, `add_stock`,
`create_project_with_bom`). Migrates the four cited test files plus
`conftest.py::_signup` to delegate through the shared module, and adds
a smoke regression so factory signature drift fails fast.

Per the locked plan: no factory-boy/faker, no `@testing-library/react`
(skipped web factories — coordinated with #108 / #128).

## Test plan
- [ ] CI green
- [ ] Manual: `pytest -k factories_smoke` and `pytest tests/test_builds.py tests/test_orders.py tests/test_stock_concurrency.py tests/test_workspace_isolation.py`

## Ops notes
none.

## Coordination
- #108 / #128 own the RTL stack — this PR avoids touching `web/` per the locked plan.
- Remaining 30+ test files still have inlined helpers; sweep them in a follow-up if low-risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)