### PR TITLE
fix(auth): index user_sessions.expires_at + periodic purge

### DIFF
--- a/backend/alembic/versions/0019_user_sessions_expires_at_idx.py
+++ b/backend/alembic/versions/0019_user_sessions_expires_at_idx.py
@@ -1,0 +1,49 @@
+"""Index user_sessions.expires_at + give the periodic cleanup task a
+seekable column.
+
+Revision ID: 0019
+Revises: 0018
+Create Date: 2026-05-02
+
+DB-007 / issue #98. Closes the unbounded-growth gap on `user_sessions`:
+prior to this migration the only index was `ix_user_sessions_user_id`,
+so any "delete expired" sweep was a full table scan. The plan was to
+keep these rows around forever — sessions were only deleted on explicit
+logout — so a long-running prod accumulates every expired row.
+
+Pairs with the lifespan-hook purge in `app/main.py` that runs
+`DELETE FROM user_sessions WHERE expires_at < now()` once an hour. The
+DELETE planner picks this index because every row has a non-null
+`expires_at`; no partial predicate is needed.
+
+NOTE on chain: this migration is numbered 0019 because main had 0018
+at the time of authoring. Several open PRs in adjacent batches may
+also want 0019 — if any of them lands first, rebase this onto the new
+head and bump both the filename and `revision = ...` to match. Don't
+edit a migration once it's on `main` (CLAUDE.md invariant).
+"""
+from __future__ import annotations
+
+from alembic import op
+
+
+revision = "0019"
+down_revision = "0018"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "ix_user_sessions_expires_at",
+        "user_sessions",
+        ["expires_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_user_sessions_expires_at",
+        table_name="user_sessions",
+    )

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -130,3 +130,34 @@ def revoke_all_user_sessions(db: Session, user_id) -> int:
     for r in rows:
         db.delete(r)
     return len(rows)
+
+
+def purge_expired_sessions(db: Session, *, now: datetime | None = None) -> int:
+    """Delete every session row whose `expires_at` is in the past.
+
+    Idempotent: safe to call repeatedly. Returns the number of rows
+    purged. Backed by `ix_user_sessions_expires_at` (alembic 0019), so
+    the DELETE is an index range scan, not a full table scan.
+
+    DB-007 / issue #98. Called on a one-hour cadence by the lifespan
+    hook in `app/main.py`. The plan was to keep these rows around
+    forever (sessions were only deleted on explicit logout); a
+    long-running prod accumulates every expired row otherwise.
+
+    Single-worker invariant (CLAUDE.md): uvicorn runs `--workers 1` in
+    prod, so the periodic task fires from exactly one process. If a
+    future deploy moves to multiple workers, every worker will run the
+    DELETE — that's still correct (idempotent + no contention because
+    the rows being deleted are already past expiry, no live request
+    can hold a lock on them) but a future Redis/multi-worker rewrite
+    should pick an explicit leader.
+    """
+    from app.domain.users.models import UserSession
+
+    cutoff = now or datetime.now(timezone.utc)
+    deleted = (
+        db.query(UserSession)
+        .filter(UserSession.expires_at < cutoff)
+        .delete(synchronize_session=False)
+    )
+    return int(deleted)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -13,6 +13,12 @@ class Settings(BaseSettings):
     SESSION_SECRET: str = "dev-secret-change-me"
     SESSION_COOKIE_NAME: str = "stockmgr_session"
     SESSION_LIFETIME_DAYS: int = 30
+    # Cadence (seconds) of the in-process expired-session purge driven
+    # by the FastAPI lifespan hook. DB-007 / issue #98. Knob exists so
+    # tests can shorten it; ops should not need to touch it. 0 disables
+    # the periodic task entirely (the migration's index still exists,
+    # so a future cron / one-off SQL still benefits).
+    SESSION_PURGE_INTERVAL_SECONDS: int = 3600
     UPLOAD_DIR: str = "/data/uploads"
     # Per-upload size cap. nginx (in web container) and Apache (in front)
     # both cap at 25 MiB, but FastAPI must enforce its own cap so a

--- a/backend/app/domain/users/models.py
+++ b/backend/app/domain/users/models.py
@@ -41,4 +41,10 @@ class UserSession(Base):
     # A session idle past SESSION_IDLE_HOURS is rejected even if
     # `expires_at` (the absolute lifetime) is still in the future.
     last_used_at = Column(DateTime(timezone=True), nullable=False, default=_utcnow)
+    # `ix_user_sessions_expires_at` (alembic 0019) lives in the migration
+    # rather than `index=True` here so the periodic purge in
+    # `app/main.py::_periodic_session_purge` is an index range scan,
+    # not a seq scan. DB-007 / issue #98. Don't add `index=True` —
+    # SQLAlchemy would emit a redundant CREATE INDEX in a future
+    # autogenerate run.
     expires_at = Column(DateTime(timezone=True), nullable=False)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import asyncio
+import logging
 import os
+from contextlib import asynccontextmanager
 from urllib.parse import urlparse
 
 from fastapi import Depends, FastAPI, HTTPException, Request
@@ -122,6 +125,69 @@ from app.core.responses import http_exception_handler, validation_exception_hand
 
 _is_prod = settings().APP_ENV == "prod"
 
+_log = logging.getLogger(__name__)
+
+
+async def _periodic_session_purge(interval_seconds: int) -> None:
+    """Background task: every `interval_seconds` purge sessions whose
+    `expires_at` is in the past. DB-007 / issue #98.
+
+    Uses a fresh `SessionLocal()` each tick so the connection isn't
+    held across the sleep. The DELETE rides
+    `ix_user_sessions_expires_at` (alembic 0019).
+
+    Cancelled cleanly on app shutdown by the lifespan context manager
+    below — `asyncio.CancelledError` is the normal exit path; anything
+    else gets logged.
+    """
+    from app.core.auth import purge_expired_sessions
+    from app.infra.db import SessionLocal
+
+    while True:
+        try:
+            await asyncio.sleep(interval_seconds)
+            db = SessionLocal()
+            try:
+                n = purge_expired_sessions(db)
+                db.commit()
+                if n:
+                    _log.info("purge_expired_sessions: removed %d row(s)", n)
+            except Exception:  # noqa: BLE001 — keep the loop alive
+                db.rollback()
+                _log.exception("purge_expired_sessions failed; will retry next tick")
+            finally:
+                db.close()
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001 — never let the loop die silently
+            _log.exception("periodic session purge: unexpected error")
+
+
+@asynccontextmanager
+async def lifespan(_app: FastAPI):
+    """Spawn the background session-purge task on startup; cancel it on
+    shutdown. DB-007 / issue #98."""
+    interval = settings().SESSION_PURGE_INTERVAL_SECONDS
+    task: asyncio.Task | None = None
+    if interval > 0:
+        _log.info("purge_expired_sessions: scheduled every %ds", interval)
+        task = asyncio.create_task(
+            _periodic_session_purge(interval),
+            name="purge_expired_sessions",
+        )
+    try:
+        yield
+    finally:
+        if task is not None:
+            task.cancel()
+            try:
+                await task
+            except (asyncio.CancelledError, Exception):
+                # CancelledError is the normal shutdown path; anything
+                # else has already been logged inside the task.
+                pass
+
+
 app = FastAPI(
     title="Parts Inventory & Production Manager",
     version="0.1.0",
@@ -131,6 +197,7 @@ app = FastAPI(
     docs_url=None if _is_prod else "/docs",
     redoc_url=None if _is_prod else "/redoc",
     openapi_url=None if _is_prod else "/openapi.json",
+    lifespan=lifespan,
 )
 
 # Rate limiter wired before CORS so 429 responses still get the right headers.

--- a/backend/tests/test_session_cleanup.py
+++ b/backend/tests/test_session_cleanup.py
@@ -1,0 +1,77 @@
+"""Tests for `purge_expired_sessions` and the matching expires_at index
+(DB-007 / issue #98).
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import inspect
+
+from app.core.auth import hash_session_token, purge_expired_sessions
+from app.domain.users.models import User, UserSession
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _make_user(db) -> User:
+    u = User(
+        id=uuid.uuid4(),
+        email=f"sess-{uuid.uuid4().hex[:8]}@example.com",
+        name="Test",
+        password_hash="$argon2id$dummy",
+    )
+    db.add(u)
+    db.flush()
+    return u
+
+
+def _make_session(db, *, user_id, expires_at: datetime) -> UserSession:
+    token = uuid.uuid4().hex
+    row = UserSession(
+        token_hash=hash_session_token(token),
+        user_id=user_id,
+        expires_at=expires_at,
+    )
+    db.add(row)
+    db.flush()
+    return row
+
+
+def test_purge_expired_sessions_drops_only_past_rows(db):
+    user = _make_user(db)
+    past = _make_session(db, user_id=user.id, expires_at=_utcnow() - timedelta(hours=1))
+    future = _make_session(db, user_id=user.id, expires_at=_utcnow() + timedelta(hours=1))
+
+    deleted = purge_expired_sessions(db)
+    db.commit()
+
+    assert deleted == 1
+    remaining_hashes = {
+        row.token_hash for row in db.query(UserSession).all()
+    }
+    assert past.token_hash not in remaining_hashes
+    assert future.token_hash in remaining_hashes
+
+
+def test_purge_expired_sessions_is_idempotent(db):
+    user = _make_user(db)
+    _make_session(db, user_id=user.id, expires_at=_utcnow() - timedelta(minutes=5))
+
+    first = purge_expired_sessions(db)
+    db.commit()
+    second = purge_expired_sessions(db)
+    db.commit()
+
+    assert first == 1
+    assert second == 0
+
+
+def test_user_sessions_expires_at_index_exists(db):
+    """The matching index from migration 0019 must exist — without it
+    the purge query is a seq scan."""
+    insp = inspect(db.get_bind())
+    index_names = {ix["name"] for ix in insp.get_indexes("user_sessions")}
+    assert "ix_user_sessions_expires_at" in index_names


### PR DESCRIPTION
Closes #98.

Per the auto-generated plan (DB-007 / 2026-05-02). Closes the
unbounded-growth gap on `user_sessions`: prior to this PR the only
index was `ix_user_sessions_user_id`, so `DELETE WHERE expires_at <
now()` was a full table scan and there was no scheduled cleanup.

- Alembic 0019 creates `ix_user_sessions_expires_at`.
- `app/core/auth.py::purge_expired_sessions(db, *, now=None) -> int`
  is the new helper. Idempotent.
- `app/main.py` gains an async `lifespan` context manager that spawns
  a background task running the purge every
  `SESSION_PURGE_INTERVAL_SECONDS` (default 3600). The task uses a
  fresh `SessionLocal()` each tick — connection isn't held across the
  sleep. Cancelled cleanly on shutdown.
- New tests in `backend/tests/test_session_cleanup.py`.

## Test plan
- [ ] CI green (pytest covers the helper + the index existence)
- [ ] Manual: `EXPLAIN DELETE FROM user_sessions WHERE expires_at < now()`
      shows an index scan after this lands
- [ ] Manual: backend startup logs include
      `purge_expired_sessions: scheduled every 3600s`

## Ops notes
- The lifespan hook is the first long-lived background task in the
  app. Verify `--workers 1` (CLAUDE.md invariant) before promoting
  enforcement; multi-worker would run the DELETE from every worker
  (still correct but wasteful).
- `SESSION_PURGE_INTERVAL_SECONDS=0` disables the scheduled task; the
  index still helps a manual / future-cron sweep.

## Coordination
Migration is numbered 0019 because main is at 0018 at the time of
authoring. **Several adjacent open PRs may also want 0019** (per the
locked-constraints document). If any of them lands before this one,
rebase onto the new head and bump both the filename and
`revision = "..."` to match. Touches `app/main.py` like #92 (proxy
read timeout) but in a different region — no conflict expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)