### PR TITLE
fix(db): partial bag_signature index (DB-008)

### DIFF
--- a/backend/alembic/versions/0019_partial_bag_signature_index.py
+++ b/backend/alembic/versions/0019_partial_bag_signature_index.py
@@ -1,0 +1,58 @@
+"""Partial bag_signature index (DB-008).
+
+Revision ID: 0019
+Revises: 0018
+Create Date: 2026-05-02
+
+The original index from `0012` (`ix_stock_ws_bag_signature` on
+`(workspace_id, bag_signature)`) had no predicate. Almost every
+`stock_entries` row has `bag_signature IS NULL` (only scan-import
+rows ever set it), so the index was bloated and paid an insert-time
+cost on every ledger write for entries that will never be looked up
+by the bag-rescan flow.
+
+This migration drops the existing non-partial index and recreates it
+as a partial index with `WHERE bag_signature IS NOT NULL`. Same name,
+same column ordering — only the predicate changes.
+
+Production note: `stock_entries` is the hottest write table; both
+`DROP INDEX` and `CREATE INDEX` run with `CONCURRENTLY` so writes
+aren't blocked. Concurrent index DDL cannot run inside a transaction,
+so we use alembic's `autocommit_block()` to escape the wrapping
+transaction for these statements only.
+"""
+from alembic import op
+
+
+revision = "0019"
+down_revision = "0018"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # CONCURRENTLY requires running outside any transaction. alembic's
+    # autocommit_block escapes the env.py transaction wrapper for the
+    # statements inside it.
+    with op.get_context().autocommit_block():
+        op.execute(
+            "DROP INDEX CONCURRENTLY IF EXISTS ix_stock_ws_bag_signature"
+        )
+        op.execute(
+            "CREATE INDEX CONCURRENTLY ix_stock_ws_bag_signature "
+            "ON stock_entries (workspace_id, bag_signature) "
+            "WHERE bag_signature IS NOT NULL"
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute(
+            "DROP INDEX CONCURRENTLY IF EXISTS ix_stock_ws_bag_signature"
+        )
+        # Recreate the original (non-partial) index so a downgrade
+        # leaves the schema in the same shape as it was after `0012`.
+        op.execute(
+            "CREATE INDEX CONCURRENTLY ix_stock_ws_bag_signature "
+            "ON stock_entries (workspace_id, bag_signature)"
+        )

--- a/backend/app/domain/stock/models.py
+++ b/backend/app/domain/stock/models.py
@@ -12,6 +12,7 @@ from sqlalchemy import (
     Numeric,
     String,
     Text,
+    text,
 )
 from sqlalchemy.dialects.postgresql import UUID
 
@@ -36,7 +37,16 @@ class StockEntry(Base):
         # the same bag up again should let the operator consume from
         # the lot it created instead of double-importing. See
         # alembic 0012 + bagSignature() in web/src/lib/bagCode.ts.
-        Index("ix_stock_ws_bag_signature", "workspace_id", "bag_signature"),
+        # Partial predicate (DB-008 / alembic 0019) — only scan-import
+        # rows ever populate `bag_signature`, so the index excludes the
+        # ~99% of NULL rows and stops paying insert-time cost on every
+        # ledger write.
+        Index(
+            "ix_stock_ws_bag_signature",
+            "workspace_id",
+            "bag_signature",
+            postgresql_where=text("bag_signature IS NOT NULL"),
+        ),
     )
 
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)

--- a/backend/tests/test_bag_signature_index.py
+++ b/backend/tests/test_bag_signature_index.py
@@ -1,0 +1,37 @@
+"""Pin the partial-index predicate on `ix_stock_ws_bag_signature`
+(DB-008 / alembic 0019).
+
+The original index from `0012` was non-partial and indexed every
+`stock_entries` row, even though only scan-import rows ever set
+`bag_signature`. `0019` drops + recreates it with a `WHERE
+bag_signature IS NOT NULL` predicate so the index doesn't pay an
+insert cost on the 99% of NULL rows.
+
+This test queries `pg_indexes` for the index def and asserts the
+predicate is present. If a future migration drops the predicate,
+this test fires.
+"""
+from __future__ import annotations
+
+from sqlalchemy import text
+
+from app.infra.db import SessionLocal
+
+
+def test_bag_signature_index_has_partial_predicate() -> None:
+    with SessionLocal() as s:
+        row = s.execute(
+            text(
+                "SELECT indexdef FROM pg_indexes "
+                "WHERE indexname = 'ix_stock_ws_bag_signature'"
+            )
+        ).fetchone()
+    assert row is not None, "index ix_stock_ws_bag_signature is missing"
+    indexdef = row[0]
+    # Postgres normalises the WHERE clause to upper or lower depending
+    # on Postgres version; case-insensitive match keeps this stable.
+    lowered = indexdef.lower()
+    assert "where" in lowered, f"non-partial index: {indexdef}"
+    assert "bag_signature is not null" in lowered, (
+        f"index predicate doesn't match expected: {indexdef}"
+    )


### PR DESCRIPTION
Closes #99.

v2 teardown DB-008. `ix_stock_ws_bag_signature` (added in `0012`) was non-partial — every `stock_entries` row sat in it even though `bag_signature` is only populated on scan-import (a tiny fraction). The ledger is the hottest write table, and a non-partial index pays insert-time cost for every row. New migration `0019` drops + recreates the same index name with `WHERE bag_signature IS NOT NULL`. Both ops use `CREATE INDEX CONCURRENTLY` inside `op.get_context().autocommit_block()` so prod's writes aren't blocked.

Model `__table_args__` Index() now carries `postgresql_where=text("bag_signature IS NOT NULL")` so future autogen sees it as in-sync.

## Test plan
- [ ] CI green (`pytest backend/tests/test_bag_signature_index.py` queries `pg_indexes` for the predicate)
- [ ] Manual on prod after deploy: `SELECT pg_relation_size('ix_stock_ws_bag_signature');` should drop substantially; `EXPLAIN` of a bag-signature lookup should still hit the index.

## Ops notes
- `pg_dump` before deploy (per CLAUDE.md). The migration uses CONCURRENTLY so writes don't block, but a backup is the standard belt-and-braces step for any index ddl on the ledger table.
- If autocommit_block fails on the prod Postgres for any reason, fallback path: apply the SQL manually outside CI window.

## Coordination
None. Out of scope: renaming the index, backfilling historical rows, prod-plan smoke check (ops step).

Generated with Claude Code