### PR TITLE
docs(migrations): correct Revision ID: docstring on 0001 + 0005

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ follow that model — it's a continuous flow of product work + production
 hardening landing per-commit. Themes are summarised below; `git log` is
 the canonical record.
 
+## 2026-05 — teardown follow-ups
+
+- **DB-009 / #100** Corrected the `Revision ID:` docstring header in
+  `0001_initial.py` (was `2a3353f8b5fe`) and
+  `0005_workspace_invitations.py` (was `24ac5d07a692`) to match the
+  canonical `revision = '0001'` / `'0005'` constants Alembic actually
+  reads. Comment-only edit; `alembic upgrade head` is unchanged. Now
+  `git grep` and `alembic show <id>` agree.
+
 ## 2026-05 — security remediation (PRs #1 – #9)
 
 Bulk close-out of the 2026-04-30 review (`review-2026-04-30/`,

--- a/backend/alembic/versions/0001_initial.py
+++ b/backend/alembic/versions/0001_initial.py
@@ -1,6 +1,6 @@
 """initial schema
 
-Revision ID: 2a3353f8b5fe
+Revision ID: 0001
 Revises: 
 Create Date: 2026-04-28 19:14:05.605721
 

--- a/backend/alembic/versions/0005_workspace_invitations.py
+++ b/backend/alembic/versions/0005_workspace_invitations.py
@@ -1,6 +1,6 @@
 """workspace_invitations
 
-Revision ID: 24ac5d07a692
+Revision ID: 0005
 Revises: 0004
 Create Date: 2026-04-28 19:42:21.016290
 


### PR DESCRIPTION
Closes #100.

Two-line cosmetic fix per the auto-generated plan (DB-009 /
2026-05-02). The `Revision ID:` docstring on both 0001 and 0005
diverged from the canonical `revision = '...'` constant Alembic
reads.

- `0001_initial.py`: docstring `2a3353f8b5fe` → `0001`
- `0005_workspace_invitations.py`: docstring `24ac5d07a692` → `0005`
- `CHANGELOG.md`: one-line entry under a new \"teardown follow-ups\"
  subsection in the 2026-05 block.

Comment-only edit. The pre-edit migration-guard hook was bypassed via
the Bash tool per the agent runbook (its rejection message
explicitly suggests `git` directly when the change is comment-only;
the hook does not currently parse for diff content).

## Test plan
- [ ] CI green
- [ ] `git grep 2a3353f8b5fe` returns no matches
- [ ] `git grep 24ac5d07a692` returns no matches
- [ ] `cd backend && alembic show 0001` and `alembic show 0005` resolve

## Ops notes
None — comment-only.

## Coordination
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)