### PR TITLE
fix(tests): bag_signature FE/BE drift contract (TEST-010)

### DIFF
--- a/backend/tests/test_bag_signature.py
+++ b/backend/tests/test_bag_signature.py
@@ -1,0 +1,133 @@
+"""Bag-signature re-scan correlation contract test (TEST-010).
+
+`bag_signature` is the only stable correlation between two scans of the
+same physical bag. The FE produces it (`web/src/lib/bagCode.ts::bagSignature`),
+the BE just stores it verbatim. The contract — every alternate decoder
+form of the same bag hashes to the same hex digest — lives in
+`web/src/lib/__fixtures__/bagSignatures.json`. The FE test in
+`bagCode.test.ts::bagSignature fixture parity` iterates that file; this
+file replays the same digests through the lookup endpoint so a drift
+on either side breaks exactly one of the two suites.
+
+We do NOT re-implement the FE normaliser in Python — taking that path
+would just move the trust boundary. Instead we use the pre-computed
+hex digests in the fixture as opaque inputs.
+"""
+from __future__ import annotations
+
+import json
+import uuid
+from pathlib import Path
+
+import pytest
+
+
+_FIXTURE_PATH = (
+    Path(__file__).resolve().parent.parent.parent
+    / "web" / "src" / "lib" / "__fixtures__" / "bagSignatures.json"
+)
+
+
+@pytest.fixture(scope="module")
+def fixture():
+    return json.loads(_FIXTURE_PATH.read_text())
+
+
+def _create_part(c, name="P"):
+    r = c.post("/api/parts", json={"name": name, "part_type": "local"})
+    assert r.status_code in (200, 201), r.text
+    return r.json()["data"]["id"]
+
+
+def _create_storage(c, name="Bin"):
+    r = c.post("/api/storage", json={"name": name})
+    assert r.status_code in (200, 201), r.text
+    return r.json()["data"]["id"]
+
+
+def _add_stock(c, part_id, storage_id, signature, qty=5):
+    r = c.post(
+        "/api/stock/add",
+        json={
+            "part_id": part_id,
+            "quantity": qty,
+            "storage_location_id": storage_id,
+            "bag_signature": signature,
+            "lot": {"name": "L1"},
+        },
+    )
+    assert r.status_code in (200, 201), r.text
+    return r.json()["data"]
+
+
+def test_rescan_returns_prior_entry(authed_client, fixture):
+    """Write a stock entry with the fixture's first signature, then GET
+    `/api/parts/by-bag-signature/{sig}` — the lookup must surface that
+    entry's part_id and quantity."""
+    bag = fixture["bags"][0]
+    sig = bag["expected_signature"]
+
+    part_id = _create_part(authed_client, name=f"P-{uuid.uuid4().hex[:6]}")
+    storage_id = _create_storage(authed_client, name=f"S-{uuid.uuid4().hex[:6]}")
+    _add_stock(authed_client, part_id, storage_id, sig, qty=7)
+
+    r = authed_client.get(f"/api/parts/by-bag-signature/{sig}")
+    assert r.status_code == 200, r.text
+    body = r.json()["data"]
+    assert body is not None
+    assert body["part_id"] == part_id
+    assert body["quantity"] == 7
+    assert body["storage_location_id"] == storage_id
+
+
+def test_rescan_via_alternate_decoder_form_hits_same_row(authed_client, fixture):
+    """Every entry in the fixture has multiple `raws` representing the
+    same physical bag through different decoders. They all share one
+    `expected_signature`. Persist via that digest, then look up via the
+    same digest a second time — must hit the same prior entry. This is
+    the FE/BE drift detector: if the FE normaliser changes such that
+    one of the alternate decodings no longer hashes to the fixture's
+    `expected_signature`, the FE vitest fails. If the BE somehow
+    started transforming `bag_signature` server-side, this test would
+    fail (it won't — the BE stores it verbatim, by design)."""
+    bag = next(b for b in fixture["bags"] if len(b["raws"]) > 1)
+    sig = bag["expected_signature"]
+
+    part_id = _create_part(authed_client, name=f"P-{uuid.uuid4().hex[:6]}")
+    storage_id = _create_storage(authed_client, name=f"S-{uuid.uuid4().hex[:6]}")
+    _add_stock(authed_client, part_id, storage_id, sig, qty=3)
+
+    # Two consecutive lookups must surface the same prior — pins that
+    # the lookup is idempotent and signature-keyed (not occurred_at
+    # tie-breakable by chance).
+    a = authed_client.get(f"/api/parts/by-bag-signature/{sig}").json()["data"]
+    b = authed_client.get(f"/api/parts/by-bag-signature/{sig}").json()["data"]
+    assert a is not None
+    assert a == b
+    assert a["part_id"] == part_id
+
+
+def test_distinct_bags_have_distinct_signatures(authed_client, fixture):
+    """A digest that no entry in the workspace shares must return
+    `data: null`, not surface an unrelated entry."""
+    # Use a fixture digest the workspace hasn't written.
+    # All bags have distinct hashes; pick one we haven't persisted.
+    sig_unwritten = fixture["bags"][1]["expected_signature"]
+
+    r = authed_client.get(f"/api/parts/by-bag-signature/{sig_unwritten}")
+    assert r.status_code == 200, r.text
+    assert r.json()["data"] is None
+
+
+def test_short_signature_is_quietly_rejected(authed_client):
+    """The endpoint guards against prefix-scan probing: only 64-char
+    alphanumeric digests get a real lookup; everything else returns
+    `data: null` without touching the DB."""
+    # length wrong: 3, 63, 65 — these violate `len(signature) != 64`.
+    # Note: a 64-char string with non-alnum could URL-decode oddly via
+    # the test client; rely on the length guard (the more important arm
+    # of the conditional) to pin behaviour here.
+    for junk in ["abc", "x" * 63, "Y" * 65]:
+        r = authed_client.get(f"/api/parts/by-bag-signature/{junk}")
+        assert r.status_code == 200, (junk, r.text)
+        assert r.json()["data"] is None, junk

--- a/web/src/lib/__fixtures__/bagSignatures.json
+++ b/web/src/lib/__fixtures__/bagSignatures.json
@@ -1,0 +1,53 @@
+{
+  "_": "Contract document for the bag_signature SHA-256 (TEST-010). Each entry's `raws` are alternate decodings of the same physical bag. They MUST hash to `expected_signature`. The FE test in bagCode.test.ts iterates this fixture; the BE test in tests/test_bag_signature.py replays the same digests through /api/parts/by-bag-signature/{sig}. If either side's normalisation drifts, exactly one of the two tests breaks. DO NOT regenerate the digests without understanding why — the digest IS the contract.",
+  "bags": [
+    {
+      "label": "Mouser real bag — 98266-0897 qty 3, two decoders (scandit raw control chars vs zxing pictograms)",
+      "expected_signature": "c517cbe704991b7bd5acc0f826a3dfe7d72d5594e2645383143910a5c5385aa6",
+      "expected_mpn": "98266-0897",
+      "expected_quantity": 3,
+      "raws": [
+        "[)>\u001e06\u001d1P98266-0897\u001dQ3\u001dK#44861 A #44920\u001e\u0004",
+        "[)>␞06␝1P98266-0897␝Q3␝K#44861␠A␠#44920␞␄"
+      ]
+    },
+    {
+      "label": "Synthetic — FOO-1 with trailing GS, scandit + zxing forms",
+      "expected_signature": "7477cb68fc7756f6786d56aeab8c7d48db958f67b398e1ab71658deef719d476",
+      "expected_mpn": "FOO-1",
+      "raws": [
+        "[)>\u001e06\u001d1PFOO-1\u001d",
+        "[)>␞06␝1PFOO-1␝"
+      ]
+    },
+    {
+      "label": "Plain MPN 1D-barcode case — leading/trailing whitespace gets trimmed",
+      "expected_signature": "13e05c75cdcf4dd4cb3d57948f5638a5b1f4188e9e20150c011909c19414d69f",
+      "expected_mpn": "STM32F103C8T6",
+      "raws": [
+        "STM32F103C8T6",
+        "  STM32F103C8T6  ",
+        "\tSTM32F103C8T6\n"
+      ]
+    },
+    {
+      "label": "Full bag — MPN + quantity + date code + lot",
+      "expected_signature": "872091bb99b70daf94bb15c7ca0088538c3cfe2147a325aee36a94670ea720bf",
+      "expected_mpn": "CAP123",
+      "expected_quantity": 100,
+      "raws": [
+        "[)>\u001e06\u001d1PCAP123\u001dQ100\u001d10D2412\u001d1TAB12\u001e\u0004"
+      ]
+    }
+  ],
+  "distinct_pairs_must_differ": [
+    [
+      "[)>\u001e06\u001d1PFOO-1\u001d",
+      "[)>\u001e06\u001d1PFOO-2\u001d"
+    ],
+    [
+      "STM32F103C8T6",
+      "STM32F103C8T7"
+    ]
+  ]
+}

--- a/web/src/lib/bagCode.test.ts
+++ b/web/src/lib/bagCode.test.ts
@@ -6,6 +6,7 @@
  */
 import { describe, it, expect } from "vitest";
 import { parseBagCode, bagLotName, bagComments, bagSignature } from "./bagCode";
+import bagSignaturesFixture from "./__fixtures__/bagSignatures.json";
 
 describe("parseBagCode — separator handling", () => {
   it("splits on real ASCII control separators (Scandit-shaped input)", () => {
@@ -111,6 +112,36 @@ describe("bagSignature", () => {
     expect(await bagSignature("")).toBeNull();
     expect(await bagSignature("   ")).toBeNull();
   });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture parity (TEST-010). The JSON fixture is the FE/BE drift contract:
+// every alternate decoding inside an entry MUST hash to `expected_signature`,
+// and the same digest is replayed on the BE in tests/test_bag_signature.py.
+// If anybody touches normalisation on either side, exactly one of the two
+// suites fails — and the fix is to update the fixture digest deliberately,
+// not to paper over the difference.
+// ---------------------------------------------------------------------------
+
+describe("bagSignature fixture parity", () => {
+  for (const bag of bagSignaturesFixture.bags) {
+    for (const [i, raw] of bag.raws.entries()) {
+      it(`hashes to expected digest — ${bag.label} [raw#${i}]`, async () => {
+        const sig = await bagSignature(raw);
+        expect(sig).toBe(bag.expected_signature);
+      });
+    }
+  }
+
+  for (const [i, [a, b]] of bagSignaturesFixture.distinct_pairs_must_differ.entries()) {
+    it(`distinct pair #${i} hashes to different signatures`, async () => {
+      const sa = await bagSignature(a);
+      const sb = await bagSignature(b);
+      expect(sa).not.toBe(sb);
+      expect(sa).toBeTruthy();
+      expect(sb).toBeTruthy();
+    });
+  }
 });
 
 describe("bagLotName / bagComments helpers", () => {


### PR DESCRIPTION
Closes #112.

Pin the `bag_signature` SHA-256 contract on both sides via a shared JSON fixture. The FE produces the digest (`web/src/lib/bagCode.ts`); the BE stores it verbatim and looks it up via `/api/parts/by-bag-signature/{sig}`. A silent change to the FE normaliser today breaks rescan UX with no test catching it.

## Summary
- New `web/src/lib/__fixtures__/bagSignatures.json` — each entry has alternate decoder forms (scandit raw control chars vs zxing pictograms) that MUST hash to the entry's `expected_signature`. The digest IS the contract.
- `bagCode.test.ts` — new `bagSignature fixture parity` block iterating every fixture entry + every distinct-pair.
- `tests/test_bag_signature.py` — full HTTP round-trip: write a stock entry with a fixture digest, GET `/api/parts/by-bag-signature/{sig}`, assert the prior entry surfaces. Plus the short-signature 64-char guard.

If the FE normaliser ever changes such that an alternate decoding no longer hashes to the fixture's expected digest, the FE vitest fails. If the BE ever starts transforming the signature server-side, the BE test fails. The two test suites can't drift apart silently.

## Test plan
- [ ] CI green — `npm test bagCode` and `pytest -k bag_signature`
- [ ] Manual smoke: change one rule in `bagCode.ts::normalizeControlPictures`, observe both suites fail (drift detector works)

## Ops notes
None. Pure test infra. No production code touched.

## Coordination
- No file overlap with this batch's other PRs.
- Adjacent to #99 (bag_signature partial index) — that's a migration; this test stays valid afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)