### PR TITLE
test(ci): pin CI workflow shape (TEST-014, #116)

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -31,6 +31,9 @@ dependencies = [
 dev = [
     "pytest>=8.3",
     "pytest-asyncio>=0.24",
+    # Used by tests/test_ci_workflow.py (TEST-014 / issue #116) to parse
+    # .github/workflows/ci.yml. Test-only — runtime app doesn't import yaml.
+    "pyyaml>=6.0",
 ]
 
 [build-system]

--- a/backend/tests/test_ci_workflow.py
+++ b/backend/tests/test_ci_workflow.py
@@ -1,0 +1,61 @@
+"""Pin the load-bearing shape of the CI workflow (TEST-014 / issue #116).
+
+Pre-investigation in the issue's implementation plan confirmed that
+`.github/workflows/ci.yml` already triggers on `pull_request:`, runs
+pytest against Postgres-16, and gates `deploy` on green
+`backend-tests` + `web-build`. This test makes that contract explicit
+so a future workflow rewrite can't silently drop the PR gate (which
+would let backend regressions ship to prod via the `main` push trigger).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_CI_PATH = _REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def _load() -> dict:
+    assert _CI_PATH.exists(), f"missing CI workflow at {_CI_PATH}"
+    return yaml.safe_load(_CI_PATH.read_text())
+
+
+def test_ci_runs_on_pull_request():
+    """Every PR must be gated by CI — not just `main` pushes."""
+    data = _load()
+    # PyYAML deserialises the bare `on:` key as Python's `True`.
+    on = data.get("on") or data.get(True)
+    assert on is not None, "no `on:` block in ci.yml"
+    assert "pull_request" in on, "ci.yml does not trigger on pull_request"
+
+
+def test_backend_tests_job_runs_pytest():
+    data = _load()
+    job = data["jobs"]["backend-tests"]
+    runs = [step.get("run", "") for step in job["steps"] if "run" in step]
+    assert any("pytest" in r for r in runs), (
+        "no `pytest` invocation found in backend-tests steps"
+    )
+
+
+def test_web_build_job_exists():
+    data = _load()
+    assert "web-build" in data["jobs"], "missing web-build job"
+
+
+def test_deploy_gates_on_green_main():
+    data = _load()
+    deploy = data["jobs"]["deploy"]
+    cond = deploy.get("if", "")
+    assert "refs/heads/main" in cond, "deploy is not pinned to main branch"
+    assert "github.event_name == 'push'" in cond, (
+        "deploy is not pinned to push events"
+    )
+    needs = deploy.get("needs", [])
+    if isinstance(needs, str):
+        needs = [needs]
+    assert "backend-tests" in needs, "deploy does not depend on backend-tests"
+    assert "web-build" in needs, "deploy does not depend on web-build"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -247,6 +247,27 @@ Replace the SHA in the `uses:` line; keep the tag in the trailing comment.
 Pin-bumps are normal-stream PRs (no special review gate); only bump on a
 genuine version intent.
 
+### Required status checks
+
+Even though the `backend-tests` and `web-build` jobs run on every PR
+(`pull_request:` trigger), GitHub will still let a contributor merge a
+red PR unless branch protection is configured. To make the gate
+load-bearing:
+
+1. GitHub UI → Settings → Branches → Branch protection rules → Add rule.
+2. Branch name pattern: `main`.
+3. Tick **Require status checks to pass before merging** and pick
+   `backend-tests` plus `web-build` from the list (they only appear
+   after their first successful run).
+4. Optional: tick **Require branches to be up to date before merging**
+   if you want a fresh-rebase requirement on top.
+
+Without this, a PR with a red `backend-tests` check is still mergeable
+via the normal GitHub UI — the auto-deploy then ships a known-broken
+build to prod. Pin via this rule once and forget. (Recorded as part of
+TEST-014 / issue #116; the `tests/test_ci_workflow.py` regression test
+asserts the workflow shape but cannot configure repo settings.)
+
 ### Optional: gate deploys behind a human reviewer
 
 The `deploy` job has `environment: production` set. By default this just


### PR DESCRIPTION
Closes #116.

The pre-investigation in the implementation plan confirmed the
workflow already gates PRs correctly. This PR pins the shape so a
future rewrite cannot silently drop the gate, and documents the
branch-protection rule operators must enable for the gate to be
enforced on merge.

- `backend/tests/test_ci_workflow.py` — asserts PR trigger, pytest
  presence, and `deploy.if` / `deploy.needs`.
- `backend/pyproject.toml` — adds pyyaml to dev extras (parse only).
- `docs/deployment.md` — adds Required status checks subsection.

## Test plan
- [ ] CI green
- [ ] Manual: `pytest tests/test_ci_workflow.py -v` passes locally
- [ ] Manual: confirm Settings → Branches has `backend-tests` + `web-build` listed as required (operator action; outside this PR's source-tree scope)

## Ops notes
- Required status checks are repo-settings, not source. Configure once per the deployment doc.

## Coordination
- #115 also touches `ci.yml` (adds `--cov` to pytest). The shape test asserts `"pytest" in run`, not equality, so the two PRs are compatible in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)