### PR TITLE
refactor: shared utcnow utility (CQ-001, #117)

### DIFF
--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import hmac as _hmac
 import secrets
-from datetime import datetime, timedelta, timezone
+from datetime import timedelta
 from uuid import UUID
 
 from app.core.time import utcnow
@@ -158,7 +158,7 @@ def signup(
         db.add(WorkspaceMember(workspace_id=ws.id, user_id=user.id, role="owner", status="active"))
 
         sess = create_session_row(db, user.id)
-        user.last_login_at = datetime.now(timezone.utc)
+        user.last_login_at = utcnow()
 
         _set_session_cookie(response, sess.token)
         log.info("signup (immediate)", extra={"user_id": str(user.id), "workspace_id": str(ws.id)})
@@ -170,7 +170,7 @@ def signup(
 
     # Reap expired pending rows for this email before checking for an
     # active pending one, so old unverified attempts don't block a retry.
-    cutoff = datetime.now(timezone.utc) - timedelta(hours=_VERIFY_TTL_HOURS)
+    cutoff = utcnow() - timedelta(hours=_VERIFY_TTL_HOURS)
     db.query(PendingUser).filter(
         PendingUser.email == payload.email,
         PendingUser.created_at < cutoff,
@@ -275,7 +275,7 @@ def verify(
             "verification link already used",
         )
 
-    cutoff = datetime.now(timezone.utc) - timedelta(hours=_VERIFY_TTL_HOURS)
+    cutoff = utcnow() - timedelta(hours=_VERIFY_TTL_HOURS)
     if pending.created_at < cutoff:
         raise_http(
             status.HTTP_400_BAD_REQUEST,
@@ -292,7 +292,7 @@ def verify(
         )
 
     # Promote: create User + Workspace + WorkspaceMember in one transaction.
-    pending.verified_at = datetime.now(timezone.utc)
+    pending.verified_at = utcnow()
 
     user = User(
         email=pending.email,

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -5,6 +5,8 @@ import secrets
 from datetime import datetime, timedelta, timezone
 from uuid import UUID
 
+from app.core.time import utcnow
+
 from fastapi import APIRouter, Request, Response, status
 from pydantic import BaseModel, ConfigDict, EmailStr, Field
 
@@ -317,7 +319,7 @@ def verify(
     )
 
     sess = create_session_row(db, user.id)
-    user.last_login_at = datetime.now(timezone.utc)
+    user.last_login_at = utcnow()
 
     _set_session_cookie(response, sess.token)
     log.info(
@@ -387,7 +389,7 @@ def login(
     # SEC2-015 — session rotation on login.
     revoke_all_user_sessions(db, user.id)
     sess = create_session_row(db, user.id)
-    user.last_login_at = datetime.now(timezone.utc)
+    user.last_login_at = utcnow()
     _set_session_cookie(response, sess.token)
     log.info("login", extra={"user_id": str(user.id)})
     return ok({"user": {"id": str(user.id), "email": user.email, "name": user.name}})

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -5,8 +5,6 @@ import secrets
 from datetime import timedelta
 from uuid import UUID
 
-from app.core.time import utcnow
-
 from fastapi import APIRouter, Request, Response, status
 from pydantic import BaseModel, ConfigDict, EmailStr, Field
 
@@ -29,6 +27,7 @@ from app.core.logging import get_logger
 from app.core.mail import send_verification_email
 from app.core.ratelimit import limiter
 from app.core.responses import Envelope, ok
+from app.core.time import utcnow
 from app.domain.users.models import PendingUser, User
 from app.domain.workspaces.models import Workspace, WorkspaceMember
 

--- a/backend/app/api/routes/builds.py
+++ b/backend/app/api/routes/builds.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from app.core.time import utcnow
+
 from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, Query, Request, status
@@ -143,7 +144,7 @@ def archive_build(build_id: UUID, db: DbSession, ws: CurrentWorkspace, user: Cur
         db, Build, build_id, ws=ws, user=user, role="admin", label="build"
     )
     release_reservations(db, workspace_id=ws.id, user_id=user.id, build=b)
-    b.archived_at = datetime.now(timezone.utc)
+    b.archived_at = utcnow()
     return ok(None, "archived")
 
 

--- a/backend/app/api/routes/builds.py
+++ b/backend/app/api/routes/builds.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from app.core.time import utcnow
-
 from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, Query, Request, status
@@ -11,6 +9,7 @@ from app.api._helpers import require_resource_access
 from app.api.routes._activity import _DEFAULT_LIMIT, _MAX_LIMIT, build_activity
 from app.core.deps import CurrentUser, CurrentWorkspace, DbSession
 from app.core.responses import ok
+from app.core.time import utcnow
 from app.domain.builds.models import Build
 from app.domain.builds.schemas import BuildCreateIn, BuildPatchIn, ConsumeIn
 from app.domain.builds.service import (

--- a/backend/app/api/routes/invitations.py
+++ b/backend/app/api/routes/invitations.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from app.core.time import utcnow
-
 import hashlib
 import hmac as _hmac
 import secrets
@@ -23,6 +21,7 @@ from app.core.deps import (
 from app.core.errors import ErrorCodes, raise_http
 from app.core.ratelimit import limiter
 from app.core.responses import ok
+from app.core.time import utcnow
 from app.domain.audit.service import log as _audit_log
 from app.domain.users.models import User
 from app.domain.workspaces.models import Workspace, WorkspaceInvitation, WorkspaceMember

--- a/backend/app/api/routes/invitations.py
+++ b/backend/app/api/routes/invitations.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+from app.core.time import utcnow
+
 import hashlib
 import hmac as _hmac
 import secrets
-from datetime import datetime, timezone
 from typing import Literal
 from uuid import UUID
 
@@ -367,7 +368,7 @@ def accept_invitation(request: Request, payload: AcceptIn, db: DbSession, user: 
         )
         db.add(new_member)
     inv.status = "accepted"
-    inv.accepted_at = datetime.now(timezone.utc)
+    inv.accepted_at = utcnow()
     inv.accepted_by = user_id
 
     # Wrap the membership insert in a savepoint so that two concurrent
@@ -404,7 +405,7 @@ def accept_invitation(request: Request, payload: AcceptIn, db: DbSession, user: 
         fresh_inv = db.get(WorkspaceInvitation, inv_id)
         if fresh_inv and fresh_inv.status != "accepted":
             fresh_inv.status = "accepted"
-            fresh_inv.accepted_at = datetime.now(timezone.utc)
+            fresh_inv.accepted_at = utcnow()
             fresh_inv.accepted_by = user_id
 
     workspace = db.get(Workspace, inv_workspace_id)

--- a/backend/app/api/routes/orders.py
+++ b/backend/app/api/routes/orders.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from app.core.time import utcnow
-
 from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, Query, Request, status
@@ -11,6 +9,7 @@ from app.api._helpers import assert_child_in_parent, require_resource_access
 from app.api.routes._activity import _DEFAULT_LIMIT, _MAX_LIMIT, build_activity
 from app.core.deps import CurrentUser, CurrentWorkspace, DbSession
 from app.core.responses import ok
+from app.core.time import utcnow
 from app.domain.orders.models import Order, OrderEntry
 from app.domain.stock.models import StockEntry
 from app.domain.orders.schemas import (

--- a/backend/app/api/routes/orders.py
+++ b/backend/app/api/routes/orders.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from app.core.time import utcnow
+
 from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, Query, Request, status
@@ -174,7 +175,7 @@ def archive_order(order_id: UUID, db: DbSession, ws: CurrentWorkspace, user: Cur
     o = require_resource_access(
         db, Order, order_id, ws=ws, user=user, role="admin", label="order"
     )
-    o.archived_at = datetime.now(timezone.utc)
+    o.archived_at = utcnow()
     return ok(None, "archived")
 
 

--- a/backend/app/api/routes/parts.py
+++ b/backend/app/api/routes/parts.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 import re
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Any
 from uuid import UUID
 
@@ -23,6 +23,7 @@ from app.core.pagination import decode_cursor, paginate
 from app.core.ratelimit import limiter, workspace_key
 from app.core.responses import Envelope, ok
 from app.core.secrets import decrypt
+from app.core.time import utcnow
 from app.domain.audit.service import log as _audit_log
 from app.domain.custom_fields.models import CustomField
 from app.domain.parts.models import Part, PartMetaMember, PartSubstitute
@@ -396,7 +397,7 @@ def archive_part(
     user: CurrentUser,
 ):
     p = require_resource_access(db, Part, part_id, ws=ws, user=user, role="admin", label="part")
-    p.archived_at = datetime.now(timezone.utc)
+    p.archived_at = utcnow()
     _audit_log(
         db,
         ws=ws,
@@ -458,7 +459,7 @@ def bulk_delete_parts(
                                truly missing OR owned by another workspace
                                — deliberately indistinguishable).
     """
-    now = datetime.now(timezone.utc)
+    now = utcnow()
     requested = set(payload.part_ids)
 
     rows = (
@@ -797,7 +798,7 @@ def refresh_from_provider(
             p.description = new_desc
     p.linked_provider = provider.name
     p.linked_external_id = r.get("mpn") or p.linked_external_id
-    p.last_refresh_at = datetime.now(timezone.utc)
+    p.last_refresh_at = utcnow()
     p.updated_by = user.id
 
     # Reconcile spec rows. For each provider-supplied (key, value):
@@ -1145,7 +1146,7 @@ def _import_one_scan_row(
         serialized=False,
         linked_provider=provider_name,
         linked_external_id=(r.get("mpn") or mpn),
-        last_refresh_at=datetime.now(timezone.utc),
+        last_refresh_at=utcnow(),
         description_locally_edited=False,
         created_by=user.id,
         updated_by=user.id,

--- a/backend/app/api/routes/projects.py
+++ b/backend/app/api/routes/projects.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from app.core.time import utcnow
+
 from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, Query, status
@@ -123,7 +124,7 @@ def archive_project(project_id: UUID, db: DbSession, ws: CurrentWorkspace, user:
     p = require_resource_access(
         db, Project, project_id, ws=ws, user=user, role="admin", label="project"
     )
-    p.archived_at = datetime.now(timezone.utc)
+    p.archived_at = utcnow()
     return ok(None, "archived")
 
 

--- a/backend/app/api/routes/projects.py
+++ b/backend/app/api/routes/projects.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from app.core.time import utcnow
-
 from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, Query, status
@@ -11,6 +9,7 @@ from sqlalchemy import or_, select
 from app.api._helpers import assert_child_in_parent, assert_in_workspace, require_resource_access
 from app.core.deps import CurrentUser, CurrentWorkspace, DbSession
 from app.core.responses import ok
+from app.core.time import utcnow
 from app.domain.parts.models import Part
 from app.domain.projects import bom_import as bom
 from app.domain.projects.models import Project, ProjectEntry

--- a/backend/app/api/routes/storage.py
+++ b/backend/app/api/routes/storage.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from app.core.time import utcnow
+
 from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, Query, status
@@ -139,7 +140,7 @@ def archive_storage(storage_id: UUID, db: DbSession, ws: CurrentWorkspace, user:
                 "blocking": blocking,
             },
         )
-    s.archived_at = datetime.now(timezone.utc)
+    s.archived_at = utcnow()
     return ok(None, "archived")
 
 

--- a/backend/app/api/routes/storage.py
+++ b/backend/app/api/routes/storage.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from app.core.time import utcnow
-
 from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, Query, status
@@ -11,6 +9,7 @@ from sqlalchemy import or_, select
 from app.api._helpers import require_resource_access
 from app.core.deps import CurrentUser, CurrentWorkspace, DbSession
 from app.core.responses import ok
+from app.core.time import utcnow
 from app.domain.storage.models import StorageLocation
 from app.domain.stock.service import (
     history_for_storage,

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -311,7 +311,7 @@ def purge_expired_sessions(db: Session, *, now: datetime | None = None) -> int:
     """
     from app.domain.users.models import UserSession
 
-    cutoff = now or datetime.now(timezone.utc)
+    cutoff = now or utcnow()
     deleted = (
         db.query(UserSession)
         .filter(UserSession.expires_at < cutoff)

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -249,13 +249,11 @@ def check_login_lockout(db: Session, *, email: str) -> bool:
     query — no short-circuit on "user not found" — so the response
     time doesn't reveal whether the email exists.
     """
-    from datetime import timedelta
-
     from sqlalchemy import or_
 
     from app.domain.users.models import User, UserLoginFailure
 
-    cutoff = datetime.now(timezone.utc) - timedelta(minutes=LOCKOUT_WINDOW_MINUTES)
+    cutoff = utcnow() - timedelta(minutes=LOCKOUT_WINDOW_MINUTES)
     email_hash = _hash_email_for_lockout(email)
     user = db.query(User).filter(User.email == email).first()
     user_id = user.id if user else None

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -4,7 +4,7 @@ import hashlib
 import logging
 import secrets
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 
 import httpx
 from argon2 import PasswordHasher
@@ -12,6 +12,7 @@ from argon2.exceptions import VerifyMismatchError
 from sqlalchemy.orm import Session
 
 from app.core.config import settings
+from app.core.time import utcnow
 
 _log = logging.getLogger(__name__)
 
@@ -143,7 +144,7 @@ def hash_session_token(token: str) -> str:
 
 
 def session_expires_at() -> datetime:
-    return datetime.now(timezone.utc) + timedelta(days=settings().SESSION_LIFETIME_DAYS)
+    return utcnow() + timedelta(days=settings().SESSION_LIFETIME_DAYS)
 
 
 @dataclass

--- a/backend/app/core/deps.py
+++ b/backend/app/core/deps.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import timedelta
 from typing import Annotated
 from uuid import UUID
 
@@ -10,6 +10,7 @@ from sqlalchemy.orm import Session
 from app.core.auth import hash_session_token
 from app.core.config import settings
 from app.core.errors import ErrorCodes, raise_http
+from app.core.time import utcnow
 from app.domain.users.models import User, UserSession
 from app.domain.workspaces.models import Workspace, WorkspaceMember
 from app.infra.db import get_db
@@ -52,7 +53,7 @@ def get_current_user(
             ErrorCodes.AUTH_INVALID_SESSION,
             "invalid session",
         )
-    now = datetime.now(timezone.utc)
+    now = utcnow()
     if sess.expires_at and sess.expires_at < now:
         raise_http(
             status.HTTP_401_UNAUTHORIZED,

--- a/backend/app/core/time.py
+++ b/backend/app/core/time.py
@@ -1,0 +1,19 @@
+"""Shared time utility (CQ-001 / issue #117).
+
+Centralises ``datetime.now(timezone.utc)`` so we only have one callsite
+to mock when freezegun-style time travel arrives, and so the SQLAlchemy
+``default=utcnow`` reads as a clear "use the same one everyone else
+does".
+
+Keep this file intentionally tiny. No caching, no monkeypatch hooks —
+freezegun substitutes ``datetime.now`` itself, which is the right
+boundary.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+
+def utcnow() -> datetime:
+    """Return the current time as a tz-aware UTC datetime."""
+    return datetime.now(timezone.utc)

--- a/backend/app/domain/_mixins.py
+++ b/backend/app/domain/_mixins.py
@@ -1,14 +1,11 @@
 from __future__ import annotations
 
 import uuid
-from datetime import datetime, timezone
 
 from sqlalchemy import Column, DateTime, ForeignKey
 from sqlalchemy.dialects.postgresql import UUID
 
-
-def _utcnow() -> datetime:
-    return datetime.now(timezone.utc)
+from app.core.time import utcnow
 
 
 class WorkspaceOwned:
@@ -16,8 +13,8 @@ class WorkspaceOwned:
 
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     workspace_id = Column(UUID(as_uuid=True), ForeignKey("workspaces.id", ondelete="CASCADE"), nullable=False, index=True)
-    created_at = Column(DateTime(timezone=True), nullable=False, default=_utcnow)
-    updated_at = Column(DateTime(timezone=True), nullable=False, default=_utcnow, onupdate=_utcnow)
+    created_at = Column(DateTime(timezone=True), nullable=False, default=utcnow)
+    updated_at = Column(DateTime(timezone=True), nullable=False, default=utcnow, onupdate=utcnow)
     created_by = Column(UUID(as_uuid=True), ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
     updated_by = Column(UUID(as_uuid=True), ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
     archived_at = Column(DateTime(timezone=True), nullable=True, index=True)

--- a/backend/app/domain/audit/models.py
+++ b/backend/app/domain/audit/models.py
@@ -2,16 +2,12 @@
 from __future__ import annotations
 
 import uuid
-from datetime import datetime, timezone
 
 from sqlalchemy import Column, DateTime, ForeignKey, Text
 from sqlalchemy.dialects.postgresql import ARRAY, UUID
 
+from app.core.time import utcnow
 from app.infra.db import Base
-
-
-def _utcnow() -> datetime:
-    return datetime.now(timezone.utc)
 
 
 class AuditLog(Base):
@@ -35,4 +31,4 @@ class AuditLog(Base):
     target_ids = Column(ARRAY(UUID(as_uuid=True)), nullable=True)
     comment = Column(Text, nullable=True)
     request_id = Column(Text, nullable=True)
-    created_at = Column(DateTime(timezone=True), nullable=False, default=_utcnow)
+    created_at = Column(DateTime(timezone=True), nullable=False, default=utcnow)

--- a/backend/app/domain/builds/service.py
+++ b/backend/app/domain/builds/service.py
@@ -6,7 +6,6 @@ an associated sub-assembly part, a 'build_produce' row + a Lot tagged
 source_type='build', source_build_id=build.id."""
 from __future__ import annotations
 
-from datetime import datetime, timezone
 from decimal import Decimal
 from math import ceil
 from uuid import UUID
@@ -15,6 +14,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.core.logging import get_logger
+from app.core.time import utcnow
 from app.domain.builds.models import Build
 from app.domain.builds.schemas import ConsumeIn
 
@@ -29,10 +29,6 @@ from app.domain.storage.models import StorageLocation
 
 class BuildError(Exception):
     pass
-
-
-def _now() -> datetime:
-    return datetime.now(timezone.utc)
 
 
 def _required(entry: ProjectEntry, part: Part | None, build_qty: int) -> int:
@@ -173,7 +169,7 @@ def apply_reservations(
         workspace_id=workspace_id,
         part_ids=[e.part_id for e in consumable if e.part_id is not None],
     )
-    now = _now()
+    now = utcnow()
     written = 0
     for e in consumable:
         part = db.get(Part, e.part_id)
@@ -240,7 +236,7 @@ def release_reservations(
             .where(StockEntry.related_entry_id.is_not(None))
         ).scalars()
     )
-    now = _now()
+    now = utcnow()
     written = 0
     for r in reserve_rows:
         if r.id in released_ids:
@@ -343,7 +339,7 @@ def consume(
     # Sum requested quantity per (entry, part) so we can validate against required
     requested_by_entry: dict[UUID, int] = {}
     consumed_entries: list[StockEntry] = []
-    now = _now()
+    now = utcnow()
 
     for line in payload.lines:
         e = entries_by_id.get(line.project_entry_id)

--- a/backend/app/domain/orders/service.py
+++ b/backend/app/domain/orders/service.py
@@ -3,12 +3,12 @@ the order_id/order_entry_id, and creates a Lot per receipt with
 source_type='purchase' + source_order_id."""
 from __future__ import annotations
 
-from datetime import datetime, timezone
 from uuid import UUID
 
 from sqlalchemy.orm import Session
 
 from app.core.logging import get_logger
+from app.core.time import utcnow
 from app.domain.lots.models import Lot
 from app.domain.orders.models import Order, OrderEntry
 
@@ -23,10 +23,6 @@ from app.domain.workspaces.models import Workspace
 
 class OrderError(Exception):
     pass
-
-
-def _now() -> datetime:
-    return datetime.now(timezone.utc)
 
 
 def _order_status(entries: list[OrderEntry]) -> str:
@@ -72,7 +68,7 @@ def receive(
         part_ids=[e.part_id for e in entries_by_id.values() if e.part_id is not None],
     )
 
-    received_at = _now()
+    received_at = utcnow()
     created_lots: list[Lot] = []
     created_entries: list[StockEntry] = []
 

--- a/backend/app/domain/stock/models.py
+++ b/backend/app/domain/stock/models.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import uuid
-from datetime import datetime, timezone
 
 from sqlalchemy import (
     Column,
@@ -16,11 +15,8 @@ from sqlalchemy import (
 )
 from sqlalchemy.dialects.postgresql import UUID
 
+from app.core.time import utcnow
 from app.infra.db import Base
-
-
-def _utcnow() -> datetime:
-    return datetime.now(timezone.utc)
 
 
 class StockEntry(Base):
@@ -86,6 +82,6 @@ class StockEntry(Base):
     # set by the scan-import flow. Used to recognise re-scans so the
     # operator can consume from this bag's lot instead of double-importing.
     bag_signature = Column(String(64), nullable=True)
-    occurred_at = Column(DateTime(timezone=True), nullable=False, default=_utcnow)
+    occurred_at = Column(DateTime(timezone=True), nullable=False, default=utcnow)
     created_by = Column(UUID(as_uuid=True), ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
-    created_at = Column(DateTime(timezone=True), nullable=False, default=_utcnow)
+    created_at = Column(DateTime(timezone=True), nullable=False, default=utcnow)

--- a/backend/app/domain/stock/service.py
+++ b/backend/app/domain/stock/service.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import uuid
-from datetime import date, datetime, timezone
+from datetime import date
 from decimal import Decimal
 from typing import Iterable
 from uuid import UUID
@@ -10,6 +10,7 @@ from uuid import UUID
 from sqlalchemy import and_, func, or_, select, text
 from sqlalchemy.orm import Session
 
+from app.core.time import utcnow
 from app.domain.lots.models import Lot
 from app.domain.parts.models import Part
 from app.domain.stock.models import StockEntry
@@ -40,9 +41,6 @@ class StockConflictError(StockError):
         self.constraint = constraint
         self.storage_location_id = storage_location_id
 
-
-def _now() -> datetime:
-    return datetime.now(timezone.utc)
 
 
 def _belongs(obj, workspace_id: UUID) -> bool:
@@ -483,7 +481,7 @@ def add_stock(
         operation_type="add",
         comments=payload.comments,
         bag_signature=payload.bag_signature,
-        occurred_at=_now(),
+        occurred_at=utcnow(),
         created_by=user_id,
     )
     db.add(entry)
@@ -534,7 +532,7 @@ def remove_stock(
         status="on_hand",
         operation_type="remove",
         comments=payload.comments,
-        occurred_at=_now(),
+        occurred_at=utcnow(),
         created_by=user_id,
     )
     db.add(entry)
@@ -644,7 +642,7 @@ def move_stock(
                 operation_type="move_out",
                 related_entry_id=None,
                 comments=payload.comments,
-                occurred_at=_now(),
+                occurred_at=utcnow(),
                 created_by=user_id,
             )
             db.add(out_entry)
@@ -660,7 +658,7 @@ def move_stock(
                 operation_type="move_in",
                 related_entry_id=out_id,
                 comments=payload.comments,
-                occurred_at=_now(),
+                occurred_at=utcnow(),
                 created_by=user_id,
             )
             db.add(in_entry)
@@ -687,7 +685,7 @@ def move_stock(
             operation_type="move_out",
             related_entry_id=None,  # set after the IN row exists
             comments=payload.comments,
-            occurred_at=_now(),
+            occurred_at=utcnow(),
             created_by=user_id,
         )
         db.add(out_entry)
@@ -703,7 +701,7 @@ def move_stock(
             operation_type="move_in",
             related_entry_id=out_id,
             comments=payload.comments,
-            occurred_at=_now(),
+            occurred_at=utcnow(),
             created_by=user_id,
         )
         db.add(in_entry)
@@ -758,7 +756,7 @@ def adjust_stock(
         status="on_hand",
         operation_type="adjust",
         comments=payload.comments,
-        occurred_at=_now(),
+        occurred_at=utcnow(),
         created_by=user_id,
     )
     db.add(entry)

--- a/backend/app/domain/users/models.py
+++ b/backend/app/domain/users/models.py
@@ -77,7 +77,7 @@ class UserLoginFailure(Base):
     # so we can count failures for unknown-email attempts without storing
     # PII and without revealing whether the address exists in the DB.
     email_hash = Column(String(64), nullable=False, index=True)
-    occurred_at = Column(DateTime(timezone=True), nullable=False, default=_utcnow, index=True)
+    occurred_at = Column(DateTime(timezone=True), nullable=False, default=utcnow, index=True)
     client_ip = Column(String(45), nullable=True)  # IPv4 or IPv6
 
 
@@ -102,7 +102,7 @@ class PendingUser(Base):
     name = Column(String(200), nullable=False)
     password_hash = Column(String(500), nullable=False)
     workspace_name = Column(String(200), nullable=True)
-    created_at = Column(DateTime(timezone=True), nullable=False, default=_utcnow)
+    created_at = Column(DateTime(timezone=True), nullable=False, default=utcnow)
     # HMAC-SHA-256 (keyed on SESSION_SECRET) of the plaintext verification
     # token.  The plaintext is sent to the user's email and never stored.
     # Verification compares hmac.compare_digest(hmac_of_supplied, this col)

--- a/backend/app/domain/users/models.py
+++ b/backend/app/domain/users/models.py
@@ -1,16 +1,12 @@
 from __future__ import annotations
 
 import uuid
-from datetime import datetime, timezone
 
 from sqlalchemy import Column, DateTime, ForeignKey, String, Text
 from sqlalchemy.dialects.postgresql import UUID
 
+from app.core.time import utcnow
 from app.infra.db import Base
-
-
-def _utcnow() -> datetime:
-    return datetime.now(timezone.utc)
 
 
 class User(Base):
@@ -22,7 +18,7 @@ class User(Base):
     password_hash = Column(String(500), nullable=False)
     locale = Column(String(20), nullable=False, default="en")
     timezone = Column(String(64), nullable=False, default="UTC")
-    created_at = Column(DateTime(timezone=True), nullable=False, default=_utcnow)
+    created_at = Column(DateTime(timezone=True), nullable=False, default=utcnow)
     last_login_at = Column(DateTime(timezone=True), nullable=True)
 
 
@@ -36,11 +32,11 @@ class UserSession(Base):
     # hashing landed in 0014 (SEC2-003).
     token_hash = Column(String(64), primary_key=True)
     user_id = Column(UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
-    created_at = Column(DateTime(timezone=True), nullable=False, default=_utcnow)
+    created_at = Column(DateTime(timezone=True), nullable=False, default=utcnow)
     # Sliding expiry (SEC2-015): bumped on every successful auth lookup.
     # A session idle past SESSION_IDLE_HOURS is rejected even if
     # `expires_at` (the absolute lifetime) is still in the future.
-    last_used_at = Column(DateTime(timezone=True), nullable=False, default=_utcnow)
+    last_used_at = Column(DateTime(timezone=True), nullable=False, default=utcnow)
     # `ix_user_sessions_expires_at` (alembic 0019) lives in the migration
     # rather than `index=True` here so the periodic purge in
     # `app/main.py::_periodic_session_purge` is an index range scan,

--- a/backend/app/domain/workspaces/models.py
+++ b/backend/app/domain/workspaces/models.py
@@ -1,17 +1,13 @@
 from __future__ import annotations
 
 import uuid
-from datetime import datetime, timezone
 
 import sqlalchemy as sa
 from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Index, String, UniqueConstraint, text
 from sqlalchemy.dialects.postgresql import UUID
 
+from app.core.time import utcnow
 from app.infra.db import Base
-
-
-def _utcnow() -> datetime:
-    return datetime.now(timezone.utc)
 
 
 class Workspace(Base):
@@ -53,7 +49,7 @@ class Workspace(Base):
     # royalty-free default; 'scandit' is opt-in and consumes scanner_license_key.
     scanner = Column(String(40), nullable=False, default="zxing")  # zxing | scandit
     scanner_license_key = Column(String(4096), nullable=True)
-    created_at = Column(DateTime(timezone=True), nullable=False, default=_utcnow)
+    created_at = Column(DateTime(timezone=True), nullable=False, default=utcnow)
 
 
 class WorkspaceMember(Base):
@@ -67,7 +63,7 @@ class WorkspaceMember(Base):
     user_id = Column(UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
     role = Column(String(40), nullable=False, default="member")  # owner | admin | member | viewer
     status = Column(String(20), nullable=False, default="active")  # invited | active | disabled
-    created_at = Column(DateTime(timezone=True), nullable=False, default=_utcnow)
+    created_at = Column(DateTime(timezone=True), nullable=False, default=utcnow)
 
 
 class WorkspaceInvitation(Base):
@@ -103,6 +99,6 @@ class WorkspaceInvitation(Base):
     token_hmac = Column(String(64), nullable=True)
     status = Column(String(20), nullable=False, default="pending")  # pending | accepted | revoked
     invited_by = Column(UUID(as_uuid=True), ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
-    created_at = Column(DateTime(timezone=True), nullable=False, default=_utcnow)
+    created_at = Column(DateTime(timezone=True), nullable=False, default=utcnow)
     accepted_at = Column(DateTime(timezone=True), nullable=True)
     accepted_by = Column(UUID(as_uuid=True), ForeignKey("users.id", ondelete="SET NULL"), nullable=True)

--- a/backend/tests/test_utcnow.py
+++ b/backend/tests/test_utcnow.py
@@ -34,6 +34,20 @@ def test_utcnow_is_non_decreasing():
     assert b >= a
 
 
+def _is_shared_utcnow(default_arg) -> bool:
+    """Identity-or-by-name match. SQLAlchemy may copy a mixin's
+    `Column` per-subclass and the copy can hold a separate function
+    reference (depending on declarative internals); compare on
+    qualified name so the test pins "the shared utcnow" without
+    depending on the exact module-import identity."""
+    if default_arg is utcnow:
+        return True
+    return (
+        getattr(default_arg, "__module__", None) == "app.core.time"
+        and getattr(default_arg, "__qualname__", None) == "utcnow"
+    )
+
+
 def test_models_use_shared_utcnow_default():
     """The same callable backs every Column(default=...) — pin it so a
     future refactor can't silently re-fork the time helper."""
@@ -51,10 +65,10 @@ def test_models_use_shared_utcnow_default():
     ]
     for col in columns:
         assert col.default is not None, f"{col} has no default"
-        assert col.default.arg is utcnow, (
-            f"{col} default is {col.default.arg}, expected app.core.time.utcnow"
+        assert _is_shared_utcnow(col.default.arg), (
+            f"{col} default is {col.default.arg!r}, expected app.core.time.utcnow"
         )
 
     # onupdate path on the audited mixin
     assert WorkspaceOwned.updated_at.onupdate is not None
-    assert WorkspaceOwned.updated_at.onupdate.arg is utcnow
+    assert _is_shared_utcnow(WorkspaceOwned.updated_at.onupdate.arg)

--- a/backend/tests/test_utcnow.py
+++ b/backend/tests/test_utcnow.py
@@ -1,0 +1,60 @@
+"""Pin the shared time utility (CQ-001 / issue #117).
+
+`app.core.time.utcnow` is the one place we ask the system clock for
+"now" — every model column default and every service-layer timestamp
+goes through it. This test asserts the basic contract and pins the
+SQLAlchemy `default=` wiring so a future fork (re-introducing a local
+`_utcnow`) breaks the test before it ships.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from app.core.time import utcnow
+from app.domain._mixins import WorkspaceOwned
+from app.domain.stock.models import StockEntry
+from app.domain.users.models import User, UserSession
+from app.domain.workspaces.models import (
+    Workspace,
+    WorkspaceInvitation,
+    WorkspaceMember,
+)
+
+
+def test_utcnow_returns_tz_aware_utc_datetime():
+    now = utcnow()
+    assert isinstance(now, datetime)
+    assert now.tzinfo is not None
+    assert now.utcoffset() == timezone.utc.utcoffset(now)
+
+
+def test_utcnow_is_non_decreasing():
+    a = utcnow()
+    b = utcnow()
+    assert b >= a
+
+
+def test_models_use_shared_utcnow_default():
+    """The same callable backs every Column(default=...) — pin it so a
+    future refactor can't silently re-fork the time helper."""
+    columns = [
+        WorkspaceOwned.created_at,
+        WorkspaceOwned.updated_at,
+        StockEntry.occurred_at,
+        StockEntry.created_at,
+        User.created_at,
+        UserSession.created_at,
+        UserSession.last_used_at,
+        Workspace.created_at,
+        WorkspaceMember.created_at,
+        WorkspaceInvitation.created_at,
+    ]
+    for col in columns:
+        assert col.default is not None, f"{col} has no default"
+        assert col.default.arg is utcnow, (
+            f"{col} default is {col.default.arg}, expected app.core.time.utcnow"
+        )
+
+    # onupdate path on the audited mixin
+    assert WorkspaceOwned.updated_at.onupdate is not None
+    assert WorkspaceOwned.updated_at.onupdate.arg is utcnow


### PR DESCRIPTION
Closes #117.

Centralises `datetime.now(timezone.utc)` into `app.core.time.utcnow`
and migrates ~25 callsites + 6 local `_utcnow`/`_now` helpers. Pure
refactor — runtime semantics unchanged.

Tests pin the SQLAlchemy `Column(default=...)` wiring so a future
re-fork of the helper breaks the build.

## Test plan
- [ ] CI green
- [ ] Manual: `pytest tests/test_utcnow.py -v` passes
- [ ] Manual: smoke any timestamp-stamping endpoint and confirm `created_at` / `updated_at` populate as before

## Ops notes
- Migrations untouched; no schema change.
- Freezegun adoption is a deliberate follow-up.

## Coordination
- No file overlap with #114, #115, #116, #122, #123.

🤖 Generated with [Claude Code](https://claude.com/claude-code)