### PR TITLE
fix(scan): extract ScanImport types module (CQ-003 step 1/4)

### DIFF
--- a/web/src/routes/parts/ScanImport.tsx
+++ b/web/src/routes/parts/ScanImport.tsx
@@ -25,79 +25,19 @@ import type {
   Part,
   StorageLocation,
 } from "@/types";
-
-const PROVIDER_LABEL: Record<string, string> = {
-  mouser: "Mouser",
-  digikey: "DigiKey",
-  none: "no provider",
-};
-
-// Module-level constant — referenced by `<Scanner symbologies={...}>` below.
-// Inline `["DataMatrix", "QR"]` would be a fresh array on every render, which
-// (combined with effect deps in ScanditScanner / ZxingScanner) would tear
-// down and rebuild the multi-MB scanner SDK on every parent state change.
-// FE CRIT-2 in the 2026-04-30 review.
-const SCAN_IMPORT_SYMBOLOGIES = ["DataMatrix", "QR"] as const;
-
-type LookupState =
-  | { kind: "pending" }
-  | { kind: "duplicate"; existing: Part }
-  | { kind: "found"; result: NonNullable<MpnLookupResult["result"]>; provider: string }
-  // Same physical bag was imported earlier — surface the prior coordinates
-  // so the user can either open the part or consume from the lot inline.
-  | {
-      kind: "bag_rescan";
-      part_id: string;
-      lot_id: string | null;
-      storage_location_id: string | null;
-      quantity: number;
-    }
-  | { kind: "consumed"; partId: string; quantity: number }
-  | { kind: "error"; message: string };
-
-type Row = {
-  rowId: string;     // local id for rendering / dedup
-  bag: BagCode;      // every field the parser pulled off the bag
-  bagSig: string | null;  // sha256 of the raw bag — null when no Web Crypto / empty
-  quantity: number;  // editable, defaults to bag's Q if any
-  state: LookupState;
-};
-
-/** Loose, case-insensitive comparison so "Molex" matches "MOLEX INC."
- *  and "Yageo" matches "YAGEO Phycomp". Returns true when the two
- *  strings refer to the same manufacturer. */
-function manufacturerMatches(bagMfr: string | undefined, providerMfr: string | null | undefined): boolean {
-  if (!bagMfr || !providerMfr) return true;  // can't disagree if one is missing
-  const a = bagMfr.toLowerCase().replace(/\s+/g, " ").trim();
-  const b = providerMfr.toLowerCase().replace(/\s+/g, " ").trim();
-  return a.includes(b) || b.includes(a);
-}
-
-type ImportResultRow = {
-  mpn: string;
-  status: "created" | "duplicate" | "bag_rescan" | "lookup_failed" | "invalid";
-  part_id?: string;
-  quantity_added?: number;
-  stock_error?: string | null;
-  error?: string;
-};
-
-type ImportResponse = {
-  rows: ImportResultRow[];
-  summary: {
-    created: number;
-    duplicate: number;
-    bag_rescan: number;
-    lookup_failed: number;
-    invalid: number;
-  };
-  provider: string;
-};
-
-function newRowId(): string {
-  // crypto.randomUUID would also work but isn't guaranteed in older TLS hosts.
-  return Math.random().toString(36).slice(2) + Date.now().toString(36);
-}
+// Shared types + tiny utilities lifted into a co-located module so the
+// upcoming sub-component split (#119: ScanImportSession, ScanImportRowEditor,
+// ScanImportSubmit) can import them without re-declaring. Step 1 of 4.
+import {
+  PROVIDER_LABEL,
+  SCAN_IMPORT_SYMBOLOGIES,
+  manufacturerMatches,
+  newRowId,
+  type ImportResponse,
+  type ImportResultRow,
+  type LookupState,
+  type Row,
+} from "./ScanImport/types";
 
 // "Service Unavailable", "upstream unavailable (TimeoutException)",
 // "DigiKey rate limit reached", connection-resets — anything that's

--- a/web/src/routes/parts/ScanImport/types.ts
+++ b/web/src/routes/parts/ScanImport/types.ts
@@ -1,0 +1,90 @@
+/**
+ * Shared types + small utilities for the ScanImport route.
+ *
+ * `web/src/routes/parts/ScanImport.tsx` is 731 lines (CQ-003 / #119)
+ * and is being split into co-located sub-components (ScanImportSession,
+ * ScanImportRowEditor, ScanImportSubmit). This file is the seam: the
+ * orchestration root and the future sub-components all reach for the
+ * same `Row`, `LookupState`, `ImportResponse`, etc. shapes.
+ *
+ * No behaviour change. Subsequent step PRs (extract camera + lookup
+ * loop, extract row editor, extract submit panel) import from here.
+ */
+import type { BagCode } from "@/lib/bagCode";
+import type { MpnLookupResult, Part } from "@/types";
+
+export const PROVIDER_LABEL: Record<string, string> = {
+  mouser: "Mouser",
+  digikey: "DigiKey",
+  none: "no provider",
+};
+
+// Module-level constant — referenced by `<Scanner symbologies={...}>`.
+// Inline `["DataMatrix", "QR"]` would be a fresh array on every render,
+// which (combined with effect deps in ScanditScanner / ZxingScanner)
+// would tear down and rebuild the multi-MB scanner SDK on every parent
+// state change. FE CRIT-2 in the 2026-04-30 review.
+export const SCAN_IMPORT_SYMBOLOGIES = ["DataMatrix", "QR"] as const;
+
+export type LookupState =
+  | { kind: "pending" }
+  | { kind: "duplicate"; existing: Part }
+  | { kind: "found"; result: NonNullable<MpnLookupResult["result"]>; provider: string }
+  // Same physical bag was imported earlier — surface the prior coordinates
+  // so the user can either open the part or consume from the lot inline.
+  | {
+      kind: "bag_rescan";
+      part_id: string;
+      lot_id: string | null;
+      storage_location_id: string | null;
+      quantity: number;
+    }
+  | { kind: "consumed"; partId: string; quantity: number }
+  | { kind: "error"; message: string };
+
+export type Row = {
+  rowId: string;     // local id for rendering / dedup
+  bag: BagCode;      // every field the parser pulled off the bag
+  bagSig: string | null;  // sha256 of the raw bag — null when no Web Crypto / empty
+  quantity: number;  // editable, defaults to bag's Q if any
+  state: LookupState;
+};
+
+export type ImportResultRow = {
+  mpn: string;
+  status: "created" | "duplicate" | "bag_rescan" | "lookup_failed" | "invalid";
+  part_id?: string;
+  quantity_added?: number;
+  stock_error?: string | null;
+  error?: string;
+};
+
+export type ImportResponse = {
+  rows: ImportResultRow[];
+  summary: {
+    created: number;
+    duplicate: number;
+    bag_rescan: number;
+    lookup_failed: number;
+    invalid: number;
+  };
+  provider: string;
+};
+
+/** Loose, case-insensitive comparison so "Molex" matches "MOLEX INC."
+ *  and "Yageo" matches "YAGEO Phycomp". Returns true when the two
+ *  strings refer to the same manufacturer. */
+export function manufacturerMatches(
+  bagMfr: string | undefined,
+  providerMfr: string | null | undefined,
+): boolean {
+  if (!bagMfr || !providerMfr) return true;  // can't disagree if one is missing
+  const a = bagMfr.toLowerCase().replace(/\s+/g, " ").trim();
+  const b = providerMfr.toLowerCase().replace(/\s+/g, " ").trim();
+  return a.includes(b) || b.includes(a);
+}
+
+export function newRowId(): string {
+  // crypto.randomUUID would also work but isn't guaranteed in older TLS hosts.
+  return Math.random().toString(36).slice(2) + Date.now().toString(36);
+}


### PR DESCRIPTION
Closes #119 step 1.

`web/src/routes/parts/ScanImport.tsx` is 731 lines. The plan splits it into co-located sub-components (`ScanImportSession`, `ScanImportRowEditor`, `ScanImportSubmit`) under a folder + `index.tsx` form. This PR is the first step: lift the shared types and tiny utilities into `./ScanImport/types.ts` so the upcoming sub-components can import them without re-declaring.

## Summary
Lifted to `web/src/routes/parts/ScanImport/types.ts`:
- `Row`, `LookupState`, `ImportResultRow`, `ImportResponse` types
- `PROVIDER_LABEL` constant
- `SCAN_IMPORT_SYMBOLOGIES` (the load-bearing module-level symbology constant — inline arrays would tear down the multi-MB scanner SDK on every render; FE CRIT-2)
- `manufacturerMatches` and `newRowId` helpers

`ScanImport.tsx` imports them from `./ScanImport/types` instead of declaring them locally. Zero behaviour change. Same scan-import flow, same dedup keys, same API call shape.

## Remaining steps (deferred to follow-up PRs per the agent-batch's "land FIRST sub-step" rule)
- step 2: extract camera + lookup-with-retry pipeline into `ScanImportSession.tsx`
- step 3: extract `ScanCard` / `BagRescanCard` / `FoundDetails` into `ScanImportRowEditor.tsx`
- step 4: extract storage picker + CTA + summary into `ScanImportSubmit.tsx`, then rename `ScanImport.tsx` → `ScanImport/index.tsx`

## Test plan
- [ ] CI green — `npm run build` (which runs `tsc -b` and Vite bundle)
- [ ] `npm test` — vitest stays green
- [ ] Manual: scan a known bag in dev, observe same UX (camera fires, row pops in, lookup succeeds, "Import (n)" enables, summary banner appears)
- [ ] Manual: re-scan a previously-imported bag, observe `BagRescanCard` still renders

## Ops notes
None. Pure structural refactor, no migration, no API change.

## Coordination
- Coordinates with #118 (parts.py split) — this is the FE side; URL `/api/parts/bulk-import-from-scan` and the `bag_signature: r.bagSig ?? undefined` payload shape stay byte-identical.
- No file overlap with this batch's other PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)