### PR TITLE
refactor(responses): generic Envelope[T] typing (CQ-007, #123)

### DIFF
--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -19,7 +19,7 @@ from app.core.deps import CurrentUser, DbSession
 from app.core.errors import ErrorCodes, raise_http
 from app.core.logging import get_logger
 from app.core.ratelimit import limiter
-from app.core.responses import ok
+from app.core.responses import Envelope, ok
 from app.domain.users.models import User
 from app.domain.workspaces.models import Workspace, WorkspaceMember
 
@@ -63,7 +63,9 @@ def _set_session_cookie(response: Response, token: str) -> None:
 # spam / reputation signal than a forgotten password.
 @router.post("/signup")
 @limiter.limit("5/hour")
-def signup(request: Request, payload: SignupIn, response: Response, db: DbSession):
+def signup(
+    request: Request, payload: SignupIn, response: Response, db: DbSession
+) -> Envelope[dict]:
     try:
         validate_password_strength(payload.password)
     except WeakPasswordError as exc:
@@ -102,7 +104,9 @@ def signup(request: Request, payload: SignupIn, response: Response, db: DbSessio
 # their password, far short of viable for online password stuffing.
 @router.post("/login")
 @limiter.limit("10/minute")
-def login(request: Request, payload: LoginIn, response: Response, db: DbSession):
+def login(
+    request: Request, payload: LoginIn, response: Response, db: DbSession
+) -> Envelope[dict]:
     user = db.query(User).filter(User.email == payload.email).first()
     if not user or not verify_password(user.password_hash, payload.password):
         # Log failures (without the password). Useful for spotting
@@ -127,7 +131,7 @@ def login(request: Request, payload: LoginIn, response: Response, db: DbSession)
 
 
 @router.post("/logout")
-def logout(request: Request, response: Response, db: DbSession):
+def logout(request: Request, response: Response, db: DbSession) -> Envelope[None]:
     cookie_name = settings().SESSION_COOKIE_NAME
     token = request.cookies.get(cookie_name)
     if token:
@@ -138,7 +142,7 @@ def logout(request: Request, response: Response, db: DbSession):
 
 
 @router.get("/me")
-def me(user: CurrentUser, db: DbSession):
+def me(user: CurrentUser, db: DbSession) -> Envelope[dict]:
     memberships = (
         db.query(WorkspaceMember)
         .filter(WorkspaceMember.user_id == user.id, WorkspaceMember.status == "active")

--- a/backend/app/api/routes/parts.py
+++ b/backend/app/api/routes/parts.py
@@ -23,7 +23,7 @@ from app.api.routes._parts_shared import (
 )
 from app.core.config import settings
 from app.core.deps import CurrentUser, CurrentWorkspace, DbSession, require_role
-from app.core.responses import ok
+from app.core.responses import Envelope, ok
 from app.core.secrets import decrypt
 from app.domain.custom_fields.models import CustomField
 from app.domain.parts.models import Part, PartMetaMember, PartSubstitute
@@ -141,7 +141,7 @@ def list_parts(
     archived: bool = Query(default=False),
     mpn: str | None = Query(default=None),
     limit: int = Query(default=200, le=1000),
-):
+) -> Envelope[list[dict]]:
     stmt = select(Part).where(Part.workspace_id == ws.id)
     stmt = stmt.where(Part.archived_at.is_(None) if not archived else Part.archived_at.is_not(None))
     if mpn:
@@ -174,7 +174,9 @@ def list_parts(
 
 
 @router.post("", status_code=status.HTTP_201_CREATED)
-def create_part(payload: PartIn, db: DbSession, ws: CurrentWorkspace, user: CurrentUser):
+def create_part(
+    payload: PartIn, db: DbSession, ws: CurrentWorkspace, user: CurrentUser
+) -> Envelope[dict]:
     # Name defaults to MPN when blank — paste-an-MPN-and-go workflow.
     # At least one of the two has to be set; the partial unique index on
     # (workspace_id, mpn) enforces no-duplicate-MPN at the DB level, but

--- a/backend/app/api/routes/stock.py
+++ b/backend/app/api/routes/stock.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from fastapi import APIRouter, HTTPException, Query, status
 
 from app.core.deps import CurrentUser, CurrentWorkspace, DbSession
-from app.core.responses import ok
+from app.core.responses import Envelope, ok
 from app.domain.stock.schemas import (
     AddStockIn,
     AdjustStockIn,
@@ -45,7 +45,9 @@ def _serialize_entry(e):
 
 
 @router.post("/add")
-def add(payload: AddStockIn, db: DbSession, ws: CurrentWorkspace, user: CurrentUser):
+def add(
+    payload: AddStockIn, db: DbSession, ws: CurrentWorkspace, user: CurrentUser
+) -> Envelope[dict]:
     try:
         e = add_stock(db, workspace_id=ws.id, user_id=user.id, payload=payload)
     except StockError as exc:
@@ -54,7 +56,9 @@ def add(payload: AddStockIn, db: DbSession, ws: CurrentWorkspace, user: CurrentU
 
 
 @router.post("/remove")
-def remove(payload: RemoveStockIn, db: DbSession, ws: CurrentWorkspace, user: CurrentUser):
+def remove(
+    payload: RemoveStockIn, db: DbSession, ws: CurrentWorkspace, user: CurrentUser
+) -> Envelope[dict]:
     try:
         e = remove_stock(db, workspace_id=ws.id, user_id=user.id, payload=payload)
     except StockError as exc:

--- a/backend/app/core/responses.py
+++ b/backend/app/core/responses.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Generic, TypedDict, TypeVar, cast
 
 from fastapi import HTTPException, Request, status
 from fastapi.responses import JSONResponse
@@ -10,12 +10,70 @@ from app.core.logging import get_logger
 _log = get_logger(__name__)
 
 
-def ok(data: Any = None, message: str = "OK") -> dict[str, Any]:
-    return {"data": data, "status": {"category": "ok", "message": message}}
+# ---------------------------------------------------------------------------
+# Typed envelope (CQ-007 / issue #123).
+#
+# The `{data, status}` API envelope is a hard invariant — see CLAUDE.md
+# and `docs/ARCHITECTURE.md` § API conventions. Before this change the
+# helpers returned `dict[str, Any]`, which meant route signatures lost
+# all information about *what* `data` actually was. The new generic
+# `Envelope[T]` annotation is purely a typing aid: at runtime the
+# helpers still return a plain ``dict`` so error paths can spread
+# unknown keys (e.g. ``existing_id`` on 409) onto the top level without
+# tripping a strict schema.
+#
+# This is intentionally a `TypedDict` rather than a Pydantic
+# `BaseModel`:
+#  * runtime cost stays at the dict level — no validation, no
+#    serialization round-trip,
+#  * OpenAPI doesn't render an opaque `Envelope` schema across every
+#    untyped route (we'd lose the existing per-endpoint shape info),
+#  * the ``message`` extension on `Status` lets us extend the error
+#    payload with arbitrary keys (the http exception handler already
+#    spreads them).
+# ---------------------------------------------------------------------------
 
 
-def err(category: str, message: str, errors: list[dict] | None = None) -> dict[str, Any]:
-    body: dict[str, Any] = {"data": None, "status": {"category": category, "message": message}}
+T = TypeVar("T")
+
+
+class Status(TypedDict):
+    category: str
+    message: str
+
+
+class Envelope(TypedDict, Generic[T]):
+    data: T | None
+    status: Status
+
+
+# Concrete error-side envelope. Routes that surface structured 4xx
+# extras (e.g. ``existing_id`` on a 409 conflict) keep doing so via
+# ``raise HTTPException(detail={...})``; the http exception handler
+# spreads them onto the top level so we don't need to enumerate them
+# here. Annotated as ``dict[str, Any]`` to make that explicit.
+ErrorEnvelope = dict[str, Any]
+
+
+def ok(data: T | None = None, message: str = "OK") -> Envelope[T]:
+    """Wrap a payload in the standard `{data, status}` envelope.
+
+    Returns a plain dict at runtime; the `Envelope[T]` annotation is
+    purely for static analysis. Route handlers that already declare a
+    Pydantic ``*Out`` schema can annotate their return type as
+    ``Envelope[PartOut]`` (or similar) to propagate that shape.
+    """
+    return cast(
+        Envelope[T],
+        {"data": data, "status": {"category": "ok", "message": message}},
+    )
+
+
+def err(category: str, message: str, errors: list[dict] | None = None) -> ErrorEnvelope:
+    """Build an error envelope. Mirrors :func:`ok` but allows arbitrary
+    extra keys (the FastAPI exception handler spreads structured
+    ``detail`` dicts onto the top level)."""
+    body: ErrorEnvelope = {"data": None, "status": {"category": category, "message": message}}
     if errors is not None:
         body["errors"] = errors
     return body

--- a/backend/tests/test_envelope_typing.py
+++ b/backend/tests/test_envelope_typing.py
@@ -1,0 +1,63 @@
+"""Unit-level pin for the typed envelope helpers (CQ-007 / issue #123).
+
+The runtime shape contract is already covered by `test_envelope.py`
+(TEST-008 / #110). This file only asserts that the new `Envelope[T]`
+typing aid in `app.core.responses` doesn't mutate the runtime payload —
+the FE depends on the exact `{data, status}` keys, so any future tweak
+of the helpers must keep this true.
+"""
+from __future__ import annotations
+
+from app.core.responses import Envelope, ErrorEnvelope, Status, err, ok
+
+
+def test_ok_envelope_runtime_shape():
+    body = ok({"id": "abc"})
+    assert body["data"] == {"id": "abc"}
+    assert body["status"]["category"] == "ok"
+    assert body["status"]["message"] == "OK"
+    assert set(body.keys()) == {"data", "status"}
+
+
+def test_ok_envelope_none_payload():
+    body = ok(None, "logged out")
+    assert body["data"] is None
+    assert body["status"]["message"] == "logged out"
+
+
+def test_ok_envelope_with_message():
+    body = ok({"k": 1}, "all good")
+    assert body["data"] == {"k": 1}
+    assert body["status"]["message"] == "all good"
+
+
+def test_err_envelope_runtime_shape():
+    body = err("conflict", "duplicate mpn")
+    assert body["data"] is None
+    assert body["status"]["category"] == "conflict"
+    assert body["status"]["message"] == "duplicate mpn"
+    assert set(body.keys()) == {"data", "status"}
+
+
+def test_err_envelope_with_errors_list():
+    body = err("validation_error", "bad", errors=[{"field": "x", "message": "missing"}])
+    assert body["errors"] == [{"field": "x", "message": "missing"}]
+
+
+def test_status_typed_dict_keys():
+    """`Status` must keep `{category, message}` exactly. Other keys
+    would silently change the FE contract."""
+    # `Status` is a TypedDict, so its `__required_keys__` is the full
+    # set of fields. Pin both keys.
+    assert Status.__required_keys__ == frozenset({"category", "message"})
+
+
+def test_envelope_typed_dict_keys():
+    assert Envelope.__required_keys__ == frozenset({"data", "status"})
+
+
+def test_error_envelope_is_open_dict():
+    """`ErrorEnvelope` must be a plain `dict[str, Any]` alias so the
+    http exception handler can spread `existing_id`/etc. onto the top
+    level without tripping a strict schema."""
+    assert getattr(ErrorEnvelope, "__origin__", None) is dict

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,6 +158,14 @@ The frontend's `lib/api.ts` unwraps `data` automatically and throws
 `add_exception_handler` calls in `main.py` translate FastAPI's
 `HTTPException` and Pydantic `ValidationError` into them.
 
+`responses.ok()` is generic over the payload type — annotate a route's
+return as `Envelope[PartOut]` (or `Envelope[list[PartOut]]`,
+`Envelope[None]`, …) to propagate the inner shape through static type
+checking. The runtime payload is still a plain dict; the `Envelope[T]`
+type alias is a `TypedDict[Generic[T]]` so error paths can spread
+extra keys (e.g. `existing_id` on a 409) onto the top level without
+tripping any schema strictness. CQ-007 (#123).
+
 ## Domain decomposition
 
 | Domain | Tables | Service / endpoints |


### PR DESCRIPTION
Closes #123. Lands the typing infrastructure for the `{data, status}`
envelope; the runtime payload shape is unchanged.

- `responses.ok()` / `responses.err()` are re-typed to return `Envelope[T]` / `ErrorEnvelope`.
- `Envelope[T]` is a `TypedDict[Generic[T]]` (lighter than a Pydantic `BaseModel`; doesn't muddy OpenAPI for un-typed routes).
- `ErrorEnvelope = dict[str, Any]` stays open so the http exception handler can spread structured `HTTPException(detail=...)` keys (e.g. `existing_id` on 409) onto the top level.
- Exemplar migrations: `auth.signup/login/logout/me`, `parts.list/create`, `stock.add/remove`. Per plan, the other 100+ handlers stay un-typed for now.

## Test plan
- [ ] CI green (especially the existing `test_envelope.py` from #128)
- [ ] Manual: `pytest tests/test_envelope_typing.py -v`
- [ ] Manual: open `/docs` and confirm typed routes still render schemas; un-typed routes unaffected.

## Ops notes
- No runtime change. Same JSON keys. FE untouched.

## Coordination
- #110 (PR #128) owns the runtime shape test; landed and unaffected by this typing change.
- #125 owns the `raise_http()` wrapper / error conventions on the same file. This PR keeps `err()` / `ErrorEnvelope` open-dict so #125's structured-error work has somewhere to land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)