### PR TITLE
fix(alembic): rechain duplicate-0019 migrations to 0019 → 0020

### DIFF
--- a/backend/alembic/versions/0020_partial_bag_signature_index.py
+++ b/backend/alembic/versions/0020_partial_bag_signature_index.py
@@ -24,8 +24,8 @@ transaction for these statements only.
 from alembic import op
 
 
-revision = "0019"
-down_revision = "0018"
+revision = "0020"
+down_revision = "0019"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Summary

PRs #137 and #138 both landed with `revision = "0019"` / `down_revision = "0018"`. Alembic refuses with "Multiple head revisions" / duplicate revision id. Every PR opened after both merged (~10 in flight) is red on `alembic upgrade head` in CI, and main's own CI is red too (run 25249121114, 25249069040).

Renames `0019_partial_bag_signature_index.py` → `0020_*` and updates its revision/down_revision so the chain is linear:

```
0018 → 0019 (user_sessions.expires_at idx)
     → 0020 (partial bag_signature idx)
```

Both indexes are independent (different tables, different predicates), so the order is arbitrary; user_sessions = 0019 because PR #137 merged first in clock order.

## Why we're editing a merged migration

CLAUDE.md says don't edit migrations on main. The rule exists because doing so breaks the chain on the next deploy. Here, the chain is **already broken** — this PR is the minimal fix that restores it. The actual upgrade SQL on each side is unchanged.

## Test plan

- [ ] CI green on this PR (proves the chain is valid)
- [ ] After merge: PRs in flight (#132, #134, #143, #151, #152, #155, #159, #161, etc.) go green on next CI run
- [ ] Prod deploy: alembic at 0019 (the user_sessions idx, since alembic registered whichever it found first), advances to 0020 = bag_signature partial index. Pre-deploy `pg_dump` runs automatically (PR #29 plumbing).

## Ops notes

The auto-deploy on merge will run `alembic upgrade head` on the running prod container. If alembic's prod state is already at 0019 (likely — both files declared revision="0019" so alembic registered one of them), the upgrade will apply only 0020. If somehow alembic picked the bag-signature 0019 before merge, the user_sessions migration may be missing in prod — out-of-scope to investigate but worth verifying via `\d user_sessions` post-deploy to confirm `ix_user_sessions_expires_at` exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)