### PR TITLE
fix(infra): nginx Server header strip + CI traceback-leak check (#76)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,12 @@ jobs:
         working-directory: backend
         run: ruff check app --exit-zero
 
+      # SEC2-018: fast pre-pytest gate — fail if any HTTPException passes
+      # traceback / stack-trace data in its detail= argument.
+      - name: check-no-traceback-leaks
+        working-directory: backend
+        run: python scripts/check_no_traceback_leaks.py
+
       - name: pytest
         working-directory: backend
         env:

--- a/backend/scripts/check_no_traceback_leaks.py
+++ b/backend/scripts/check_no_traceback_leaks.py
@@ -1,0 +1,112 @@
+"""
+SEC2-018 — CI guard: no traceback/stack-trace data in HTTPException(detail=…).
+
+Uses the Python AST to walk every .py file under backend/app/ and flags any
+call where:
+
+  HTTPException(detail=<expr involving traceback / format_exc / __class__>)
+
+The check is intentionally conservative — it looks at the *source text* of
+the detail= argument, not runtime values, so it catches the most common
+accidental patterns without producing false negatives from multi-line strings.
+
+Exit code 0 → clean. Exit code 1 → at least one violation printed to stdout.
+"""
+
+import ast
+import sys
+from pathlib import Path
+
+# Keywords whose presence inside the detail= argument text indicates a
+# potential stack-trace leak.
+_LEAK_KEYWORDS = (
+    "traceback",
+    "format_exc",
+    "format_exception",
+    "__class__",
+    "exc_info",
+)
+
+
+def _detail_source(node: ast.Call, source_lines: list[str]) -> str | None:
+    """Return the source text of the `detail=` keyword argument, or None."""
+    for kw in node.keywords:
+        if kw.arg == "detail":
+            start = kw.value.col_offset
+            end_line = kw.value.end_lineno  # type: ignore[attr-defined]
+            end_col = kw.value.end_col_offset  # type: ignore[attr-defined]
+            if kw.value.lineno == end_line:  # type: ignore[attr-defined]
+                return source_lines[kw.value.lineno - 1][start:end_col]  # type: ignore[attr-defined]
+            # Multi-line: join from start to end
+            lines = []
+            for i in range(kw.value.lineno - 1, end_line):  # type: ignore[attr-defined]
+                lines.append(source_lines[i])
+            return "\n".join(lines)
+    return None
+
+
+def check_file(path: Path) -> list[tuple[int, str]]:
+    """Return list of (line_no, snippet) violations in *path*."""
+    source = path.read_text(encoding="utf-8")
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError:
+        return []
+
+    source_lines = source.splitlines()
+    violations: list[tuple[int, str]] = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        # Match HTTPException(…) — handle both bare name and attribute forms
+        func = node.func
+        is_http_exc = (
+            (isinstance(func, ast.Name) and func.id == "HTTPException")
+            or (isinstance(func, ast.Attribute) and func.attr == "HTTPException")
+        )
+        if not is_http_exc:
+            continue
+
+        detail_text = _detail_source(node, source_lines)
+        if detail_text is None:
+            continue
+
+        for keyword in _LEAK_KEYWORDS:
+            if keyword in detail_text:
+                violations.append((node.lineno, detail_text.strip()))
+                break  # one violation per call site is enough
+
+    return violations
+
+
+def main() -> int:
+    # Resolve app/ relative to this script's location:
+    # backend/scripts/check_no_traceback_leaks.py → backend/app/
+    scripts_dir = Path(__file__).resolve().parent
+    app_dir = scripts_dir.parent / "app"
+
+    if not app_dir.is_dir():
+        print(f"ERROR: app directory not found at {app_dir}", file=sys.stderr)
+        return 2
+
+    found_any = False
+    for py_file in sorted(app_dir.rglob("*.py")):
+        violations = check_file(py_file)
+        for lineno, snippet in violations:
+            rel = py_file.relative_to(scripts_dir.parent.parent)
+            print(f"{rel}:{lineno}: HTTPException detail leaks stack info: {snippet!r}")
+            found_any = True
+
+    if found_any:
+        print(
+            "\nFAIL: HTTPException(detail=…) contains traceback / stack-trace keywords.",
+            file=sys.stderr,
+        )
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/tests/test_no_traceback_leaks.py
+++ b/backend/tests/test_no_traceback_leaks.py
@@ -1,0 +1,103 @@
+"""
+SEC2-018 — Tests for check_no_traceback_leaks.py.
+
+Happy path: the real backend/app/ tree contains no HTTPException that leaks
+stack-trace data.
+
+Negative path: a synthetic .py file that *does* contain the forbidden pattern
+makes the script exit with code 1.
+"""
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+# Absolute path to the checker script so tests are independent of cwd.
+_SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "check_no_traceback_leaks.py"
+
+
+def _run_script(*extra_args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT), *extra_args],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_clean_app_tree_passes():
+    """The real backend/app/ directory must have no traceback leaks."""
+    result = _run_script()
+    assert result.returncode == 0, (
+        f"check_no_traceback_leaks found violations in backend/app/:\n"
+        f"{result.stdout}\n{result.stderr}"
+    )
+
+
+def test_offending_file_detected(tmp_path: Path):
+    """A .py file with HTTPException(detail=traceback.format_exc()) must be caught."""
+    import importlib.util
+
+    bad_py = tmp_path / "bad_module.py"
+    bad_py.write_text(
+        textwrap.dedent(
+            """\
+            import traceback
+            from fastapi import HTTPException
+
+            def bad_handler():
+                raise HTTPException(
+                    status_code=500,
+                    detail={"trace": traceback.format_exc()},
+                )
+            """
+        )
+    )
+
+    # Load checker via importlib so we don't need scripts/ on sys.path.
+    spec = importlib.util.spec_from_file_location("checker", _SCRIPT)
+    assert spec is not None
+    checker = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(checker)  # type: ignore[union-attr]
+
+    violations = checker.check_file(bad_py)
+    assert violations, (
+        "Expected check_file() to return violations for a file containing "
+        "traceback.format_exc() in HTTPException(detail=…), but got none."
+    )
+    # The violation should mention the leak keyword somewhere in the snippet.
+    _, snippet = violations[0]
+    assert "format_exc" in snippet or "traceback" in snippet
+
+
+def test_clean_file_not_flagged(tmp_path: Path):
+    """A file with a normal HTTPException(detail={…}) must not be flagged."""
+    good_py = tmp_path / "good_module.py"
+    good_py.write_text(
+        textwrap.dedent(
+            """\
+            from fastapi import HTTPException
+
+            def raise_404(name: str):
+                raise HTTPException(
+                    status_code=404,
+                    detail={"message": f"Part {name!r} not found"},
+                )
+            """
+        )
+    )
+
+    # Import and call check_file directly.
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("checker", _SCRIPT)
+    assert spec is not None
+    checker = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(checker)  # type: ignore[union-attr]
+
+    violations = checker.check_file(good_py)
+    assert violations == [], f"Unexpected violations in clean file: {violations}"

--- a/deploy/nginx-web.conf
+++ b/deploy/nginx-web.conf
@@ -6,6 +6,8 @@
 #
 # Copied to /etc/nginx/conf.d/default.conf by web/Dockerfile.prod.
 
+server_tokens off;
+
 server {
     listen 80;
     server_name _;
@@ -46,6 +48,9 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Forwarded-Host  $host;
         proxy_read_timeout 60s;
+        # SEC2-018: strip the upstream "Server: uvicorn" header so the
+        # stack identity is not advertised to clients.
+        proxy_hide_header Server;
     }
 
     # Long cache for hashed assets emitted by Vite.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -424,3 +424,28 @@ docker run --rm \
 For point-in-time recovery, off-site replication, or retention policies look
 at `pgBackRest` or `barman` — proper tools for that job; this guide does not
 prescribe one.
+
+## Header hardening (SEC2-018)
+
+Two surfaces were tightened to avoid advertising the stack identity:
+
+**nginx `Server` header suppression.** uvicorn sets `Server: uvicorn` on every
+response. `deploy/nginx-web.conf` now suppresses this with:
+
+- `server_tokens off;` — prevents nginx from emitting its own version string
+  in the `Server` header and in default error pages.
+- `proxy_hide_header Server;` inside the `/api/` proxy block — drops the
+  upstream `Server: uvicorn` header before the response reaches the client.
+
+These directives are in the in-container nginx config that the `web` container
+runs (`web/Dockerfile.prod` copies it to `/etc/nginx/conf.d/default.conf`).
+They take effect on the next `docker compose up --build`.
+
+**CI traceback-leak guard.** `backend/scripts/check_no_traceback_leaks.py`
+walks `backend/app/` via the Python AST and fails if any
+`HTTPException(detail=…)` argument contains traceback-related identifiers
+(`traceback`, `format_exc`, `format_exception`, `exc_info`, `__class__`).
+The check runs as a fast step in `.github/workflows/ci.yml` before pytest,
+preventing accidental stack-trace exposure in error responses from ever
+reaching `main`. The corresponding tests live in
+`backend/tests/test_no_traceback_leaks.py`.


### PR DESCRIPTION
Closes #76

## Summary
- Adds `proxy_hide_header Server;` and `server_tokens off;` to `deploy/nginx-web.conf` to suppress uvicorn's stack identity from being advertised to clients (SEC2-018)
- Adds `backend/scripts/check_no_traceback_leaks.py` — AST-based CI guard that fails if any `HTTPException(detail=…)` argument contains traceback-related identifiers (`traceback`, `format_exc`, `format_exception`, `exc_info`, `__class__`)
- Wires the script as a fast pre-pytest step in `.github/workflows/ci.yml` so the gate runs on every PR
- Documents header hardening in `docs/deployment.md`

## Tests
- `backend/tests/test_no_traceback_leaks.py`: 3 tests (clean app tree passes, offending file detected, clean file not flagged) — all passed
- `python backend/scripts/check_no_traceback_leaks.py` returns exit 0 on the current codebase

## Test plan
- [ ] CI `check-no-traceback-leaks` step runs green in this PR
- [ ] `pytest tests/test_no_traceback_leaks.py` passes
- [ ] After merge, verify `Server` header is absent from API responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)