### PR TITLE
fix(ci): TLS verify=False guard + CLAUDE.md invariant (#78)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,16 @@ jobs:
         working-directory: backend
         run: python scripts/check_no_traceback_leaks.py
 
+      # SEC2-020: reject any verify=False/trust_env=False/ssl=False in httpx
+      # calls. Annotate with # noqa: tls-verify if the bypass is intentional.
+      - name: TLS verify guard
+        working-directory: backend
+        run: |
+          if grep -RnE "verify=False|trust_env=False|ssl=False" app/ --include="*.py" | grep -v "# noqa: tls-verify"; then
+            echo "ERROR: Found verify=False/trust_env=False/ssl=False in httpx calls. Annotate with # noqa: tls-verify if intentional."
+            exit 1
+          fi
+
       - name: pytest
         working-directory: backend
         env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,9 @@ them, that's the bug.
   PartSourcing tabs split on this boundary; the same key list lives
   server-side in `backend/app/domain/parts/services/provider.py`.
   Adding a new catalog field needs both sides.
+- **No `verify=False` on httpx clients.** CI greps for `verify=False`,
+  `trust_env=False`, `ssl=False` under `backend/app/`. Annotate with
+  `# noqa: tls-verify` if intentional (e.g. internal test doubles).
 
 ## Things that have bitten us — don't undo
 


### PR DESCRIPTION
Closes #78

## Summary
- Adds CI grep step (`TLS verify guard`) in the `backend-tests` job that fails if `verify=False`, `trust_env=False`, or `ssl=False` appear in `backend/app/**/*.py`
- Whitelist pattern: annotate with `# noqa: tls-verify` for intentional bypasses (e.g. internal test doubles)
- Adds matching Hard invariant bullet to `CLAUDE.md` so future contributors know the rule before CI catches them

## Tests
Backend: N/A (CI config + docs only — no Python runtime changes)
Frontend: N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)