### PR TITLE
fix(infra): Docker log rotation — 10 MiB × 5 per container (#81)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -18,6 +18,11 @@ services:
   db:
     image: postgres:16-alpine
     restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"
     environment:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
@@ -33,6 +38,11 @@ services:
   backend:
     build: ./backend
     restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"
     environment:
       DATABASE_URL: postgresql+psycopg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
       SESSION_SECRET: ${SESSION_SECRET}
@@ -129,6 +139,11 @@ services:
         SENTRY_ORG: ${SENTRY_ORG:-}
         SENTRY_PROJECT: ${SENTRY_PROJECT:-}
     restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"
     # `service_healthy` (rather than the bare `- backend`) makes the web
     # container hold off until the backend's healthcheck reports green.
     # Closes the post-deploy 502 window where nginx was already serving


### PR DESCRIPTION
Closes #81

## Summary
- Adds `logging:` block (driver: json-file, max-size: 10m, max-file: 5) to `db`, `backend`, and `web` services in `docker-compose.prod.yml`
- Caps total log storage at ~50 MB per container instead of unbounded growth
- `backend` service `command:` line left completely untouched (single-line JSON array form preserved per CLAUDE.md)

## Tests
N/A — compose config change only. Verification after deploy:
```
docker inspect <container> | jq '.[0].HostConfig.LogConfig'
```

## Notes
- backend `command:` line preserved as single-line JSON array exec form per CLAUDE.md "Things that have bitten us"