### PR TITLE
fix(auth): constant-time HMAC for invitation tokens (#72)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ follow that model — it's a continuous flow of product work + production
 hardening landing per-commit. Themes are summarised below; `git log` is
 the canonical record.
 
+## 2026-05 — security follow-ups
+
+- **SEC2-013 / #72** Invitation accept flow switched to constant-time
+  HMAC comparison.  Previously the accept endpoint queried
+  `WHERE token_hash = $digest` — a timing oracle because SQL string
+  equality is not constant-time.  Fix: `token_hmac` column added to
+  `workspace_invitations` (migration 0021, HMAC-SHA-256 keyed on
+  `SESSION_SECRET`).  Accept now looks up by `id` (PK, no timing
+  oracle) then calls `hmac.compare_digest(hmac_of_supplied, row.token_hmac)`.
+  Token returned by the create endpoint is now a composite
+  `"{id}:{plaintext}"` string so the frontend passes the PK opaquely.
+  **Operator note:** existing pending invitations are invalidated by
+  this migration (plaintexts were never stored, so `token_hmac` cannot
+  be backfilled).  Revoke and re-issue any outstanding invitations
+  after deploying.
+
 ## 2026-05 — teardown follow-ups
 
 - **DB-009 / #100** Corrected the `Revision ID:` docstring header in

--- a/backend/alembic/versions/0021_invitation_token_hmac.py
+++ b/backend/alembic/versions/0021_invitation_token_hmac.py
@@ -1,0 +1,53 @@
+"""Add token_hmac column to workspace_invitations (SEC2-013).
+
+Revision ID: 0021
+Revises: 0020
+Create Date: 2026-05-02
+
+SEC2-013 fix: the invitation accept flow previously queried
+`WHERE token_hash = $digest` (SQL equality on a string), which is a
+timing oracle — an attacker who can observe response latency can
+distinguish "no row found" from "row found, wrong digest" because
+Postgres string equality is not constant-time.
+
+The fix:
+1. Store an HMAC-SHA-256 digest (keyed on SESSION_SECRET) alongside
+   the existing SHA-256 hash.  The HMAC key means the server-side
+   secret must be known to forge a valid lookup even if the DB is
+   leaked.
+2. The accept flow looks up by `id` (PK — no timing oracle) then
+   calls `hmac.compare_digest(hmac_of_supplied, row.token_hmac)` so
+   the comparison is constant-time.
+
+Backfill note:
+  Plaintexts are never stored, so existing `token_hash` values cannot
+  be converted to `token_hmac` values without knowing the plaintext.
+  Any pending invitation created before this migration is deployed
+  will have `token_hmac = NULL` and will be rejected at accept time.
+  Operators should revoke and re-issue outstanding invitations after
+  the deploy.  This is documented in CHANGELOG.md under SEC2-013.
+
+Downgrade:
+  Drops the `token_hmac` column; the old `WHERE token_hash = $digest`
+  path is restored by reverting the application code (the `token_hash`
+  column and its unique index are not touched by this migration).
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0021"
+down_revision = "0020"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "workspace_invitations",
+        sa.Column("token_hmac", sa.String(length=64), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("workspace_invitations", "token_hmac")

--- a/backend/app/api/routes/invitations.py
+++ b/backend/app/api/routes/invitations.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import hmac as _hmac
 import secrets
 from datetime import datetime, timezone
 from typing import Literal
@@ -10,6 +11,7 @@ from fastapi import APIRouter, Depends, Query, Request, status
 from pydantic import BaseModel, ConfigDict, EmailStr
 from sqlalchemy import select
 
+from app.core.config import settings
 from app.core.deps import (
     CurrentUser,
     CurrentWorkspace,
@@ -26,10 +28,26 @@ router = APIRouter()
 
 
 def _hash_token(plaintext: str) -> str:
-    """SHA-256 hex digest. Used both at create time (to compute what to
-    store) and at accept time (to look up by what the caller supplied).
+    """SHA-256 hex digest of the plaintext token.
+
+    Used only to populate `token_hash` at creation time (for backward
+    compatibility — the unique index on `token_hash` still exists).
+    Accept flow no longer queries by this value; it uses `_hmac_token`
+    + `hmac.compare_digest` instead (SEC2-013).
     """
     return hashlib.sha256(plaintext.encode("utf-8")).hexdigest()
+
+
+def _hmac_token(plaintext: str) -> str:
+    """HMAC-SHA-256 (keyed on SESSION_SECRET) hex digest of the plaintext.
+
+    SEC2-013: stored as `token_hmac` on the row. The accept flow looks
+    up by `id` (PK — no timing oracle on the SQL lookup) and then calls
+    `hmac.compare_digest(_hmac_token(supplied), row.token_hmac)` so the
+    comparison is constant-time regardless of the digest value.
+    """
+    key = settings().SESSION_SECRET.encode("utf-8")
+    return _hmac.new(key, plaintext.encode("utf-8"), "sha256").hexdigest()
 
 
 class InviteIn(BaseModel):
@@ -47,16 +65,25 @@ def _serialize(inv: WorkspaceInvitation, *, plaintext_token: str | None = None) 
     have it, because the DB stores only the hash. The caller is
     responsible for delivering the plaintext to the invitee out-of-band
     immediately (typically via the link embedded in the response).
+
+    SEC2-013: when a plaintext_token is provided the `token` field is
+    returned as the composite string "{invitation_id}:{plaintext_token}".
+    The accept endpoint splits this to obtain the PK for its DB lookup
+    (no timing oracle) and the plaintext for HMAC comparison.
     """
+    composite_token: str | None = None
+    if plaintext_token and inv.status == "pending":
+        composite_token = f"{inv.id}:{plaintext_token}"
+
     return {
         "id": str(inv.id),
         "workspace_id": str(inv.workspace_id),
         "email": inv.email,
         "role": inv.role,
         "status": inv.status,
-        # Only the create response carries the plaintext; all other
+        # Only the create response carries the composite token; all other
         # serialisations return None here.
-        "token": plaintext_token if inv.status == "pending" else None,
+        "token": composite_token,
         "created_at": inv.created_at.isoformat(),
         "accepted_at": inv.accepted_at.isoformat() if inv.accepted_at else None,
     }
@@ -109,14 +136,17 @@ def create_invitation(
         return ok(_serialize(existing))
 
     # Mint a new token. 32 bytes urlsafe ≈ 256 bits of entropy — well
-    # past brute-force feasibility. The hash goes to the DB; the
-    # plaintext goes back to the caller exactly once via the response.
+    # past brute-force feasibility. Both the SHA-256 hash (for backward
+    # compatibility / unique index) and the HMAC digest (SEC2-013, used
+    # at accept time with compare_digest) go to the DB; the plaintext
+    # goes back to the caller exactly once via the response.
     plaintext = secrets.token_urlsafe(32)
     inv = WorkspaceInvitation(
         workspace_id=ws.id,
         email=payload.email,
         role=payload.role,
         token_hash=_hash_token(plaintext),
+        token_hmac=_hmac_token(plaintext),
         invited_by=user.id,
     )
     db.add(inv)
@@ -169,6 +199,12 @@ def revoke_invitation(invitation_id: UUID, db: DbSession, ws: CurrentWorkspace):
 class AcceptIn(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
+    # SEC2-013: the token field now carries a composite value of the form
+    # "{invitation_id}:{plaintext_token}", produced by _serialize().  The
+    # accept handler splits on the first ":" to obtain the PK (for the
+    # DB lookup) and the plaintext (for HMAC comparison).  This keeps the
+    # frontend interface to a single opaque string while allowing a
+    # constant-time comparison path.
     token: str
 
 
@@ -179,19 +215,41 @@ class AcceptIn(BaseModel):
 @router.post("/accept")
 @limiter.limit("10/minute")
 def accept_invitation(request: Request, payload: AcceptIn, db: DbSession, user: CurrentUser):
-    # Look up by hash — the plaintext is never stored, so an attacker
-    # with a DB dump cannot mint a valid lookup query without first
-    # cracking the hash (infeasible at 256 bits).
-    inv = (
-        db.execute(
-            select(WorkspaceInvitation).where(
-                WorkspaceInvitation.token_hash == _hash_token(payload.token)
-            )
+    # SEC2-013: the composite token encodes "{invitation_id}:{plaintext}".
+    # Split on the first ":" only — the plaintext may theoretically
+    # contain ":" characters (urlsafe_b64 doesn't, but be defensive).
+    parts = payload.token.split(":", 1)
+    if len(parts) != 2:
+        raise_http(
+            status.HTTP_404_NOT_FOUND,
+            ErrorCodes.INVITATION_NOT_FOUND,
+            "invitation not found",
         )
-        .scalars()
-        .first()
+    raw_id, plaintext = parts
+    try:
+        invitation_id = UUID(raw_id)
+    except ValueError:
+        raise_http(
+            status.HTTP_404_NOT_FOUND,
+            ErrorCodes.INVITATION_NOT_FOUND,
+            "invitation not found",
+        )
+
+    # Look up by id (PK) — no timing oracle on the SQL side.
+    inv = db.get(WorkspaceInvitation, invitation_id)
+
+    # Compute the HMAC of the supplied plaintext before branching on whether
+    # the row exists or whether the HMAC matches.  This ensures we do the
+    # same amount of crypto work on every code path (avoids short-circuit
+    # timing leak on missing-row vs wrong-token).
+    supplied_hmac = _hmac_token(plaintext)
+
+    token_ok = (
+        inv is not None
+        and inv.token_hmac is not None
+        and _hmac.compare_digest(supplied_hmac, inv.token_hmac)
     )
-    if not inv:
+    if not token_ok:
         raise_http(
             status.HTTP_404_NOT_FOUND,
             ErrorCodes.INVITATION_NOT_FOUND,

--- a/backend/app/core/deps.py
+++ b/backend/app/core/deps.py
@@ -36,9 +36,14 @@ def get_current_user(
         )
 
     # The DB only ever holds the SHA-256 digest of the token (SEC2-003).
-    # Equality on a pre-image-resistant hash is fine; we don't need
-    # hmac.compare_digest because the digest is the primary key and the
-    # comparison is delegated to Postgres.
+    # Equality on a pre-image-resistant hash is fine here; we don't need
+    # hmac.compare_digest because `token_hash` IS the primary key —
+    # the lookup is a PK equality check, not a timing-oracle scan.
+    # (SEC2-013 documents why invitation tokens needed a different fix:
+    # they were looked up by a non-PK hash column, so the SQL comparison
+    # itself was the timing oracle.  Session tokens don't have that
+    # problem — the hash is the PK, so Postgres uses a hash-index equality
+    # check that reveals nothing about prefix matches.)
     digest = hash_session_token(token)
     sess = db.query(UserSession).filter(UserSession.token_hash == digest).first()
     if not sess:

--- a/backend/app/domain/workspaces/models.py
+++ b/backend/app/domain/workspaces/models.py
@@ -63,11 +63,16 @@ class WorkspaceInvitation(Base):
     workspace_id = Column(UUID(as_uuid=True), ForeignKey("workspaces.id", ondelete="CASCADE"), nullable=False, index=True)
     email = Column(String(320), nullable=False, index=True)
     role = Column(String(40), nullable=False, default="member")
-    # SHA-256 hex digest of the plaintext token. The plaintext is
-    # returned to the caller exactly once at creation time and is never
-    # persisted; without this, a DB dump leaks every pending invitation
-    # as a replayable credential.
+    # SHA-256 hex digest of the plaintext token. Kept for backward
+    # compatibility; new rows also set token_hmac. See token_hmac below.
     token_hash = Column(String(64), nullable=False)
+    # HMAC-SHA-256 (keyed on SESSION_SECRET) of the plaintext token.
+    # SEC2-013: the accept flow looks up by id (PK) and then calls
+    # hmac.compare_digest against this column — no timing oracle.
+    # Migration 0021 adds this column; rows created before 0021 have
+    # token_hmac=NULL and cannot be accepted (pending invitations
+    # are invalidated on deploy — see migration docstring).
+    token_hmac = Column(String(64), nullable=True)
     status = Column(String(20), nullable=False, default="pending")  # pending | accepted | revoked
     invited_by = Column(UUID(as_uuid=True), ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
     created_at = Column(DateTime(timezone=True), nullable=False, default=_utcnow)

--- a/backend/tests/test_invitations.py
+++ b/backend/tests/test_invitations.py
@@ -146,29 +146,47 @@ def test_cannot_already_member(admin):
 
 
 def test_token_is_stored_as_hash_not_plaintext(admin):
-    """The plaintext returned to the caller must NOT match what's
-    persisted. The DB has only the SHA-256 digest."""
+    """The composite token returned to the caller must NOT appear in plaintext
+    in the DB.  The DB has only the SHA-256 digest (token_hash) and the
+    HMAC-SHA-256 digest (token_hmac).
+
+    SEC2-013: the create response now returns a composite token of the form
+    "{invitation_id}:{plaintext_token}" so the accept flow can look up by
+    PK rather than by hash (no timing oracle).
+    """
     import hashlib
+    import hmac as _hmac
 
     invitee_email = f"hash-{uuid.uuid4().hex[:6]}@x.com"
     inv = admin.post(
         "/api/invitations", json={"email": invitee_email, "role": "member"}
     ).json()["data"]
-    plaintext = inv["token"]
-    assert plaintext, "create response must carry the plaintext token"
+    composite = inv["token"]
+    assert composite, "create response must carry the composite token"
+
+    # Split composite "{id}:{plaintext}" to recover the plaintext portion.
+    inv_id_str, plaintext = composite.split(":", 1)
+    assert inv_id_str == inv["id"], "composite token must be prefixed with the invitation id"
 
     # Reach into the DB and verify what landed.
+    from app.core.config import settings
     from app.domain.workspaces.models import WorkspaceInvitation
     from app.infra.db import SessionLocal
 
     with SessionLocal() as s:
         row = s.get(WorkspaceInvitation, uuid.UUID(inv["id"]))
         assert row is not None
-        # The plaintext is gone — the model only has token_hash now.
+        # The plaintext is gone — the model only has token_hash and token_hmac.
         assert not hasattr(row, "token") or getattr(row, "token", None) is None
         assert row.token_hash == hashlib.sha256(plaintext.encode("utf-8")).hexdigest()
-        # Stored value is NOT the plaintext.
+        # token_hash is NOT the plaintext.
         assert row.token_hash != plaintext
+        # token_hmac is present and is the HMAC-SHA-256 of the plaintext.
+        assert row.token_hmac is not None
+        key = settings().SESSION_SECRET.encode("utf-8")
+        expected_hmac = _hmac.new(key, plaintext.encode("utf-8"), "sha256").hexdigest()
+        assert row.token_hmac == expected_hmac
+        assert row.token_hmac != plaintext
 
 
 def test_list_invitations_does_not_leak_token(admin):
@@ -185,10 +203,18 @@ def test_list_invitations_does_not_leak_token(admin):
 
 
 def test_accept_with_wrong_token_returns_404(admin):
-    """A token that doesn't hash to any stored token_hash → 404
-    (same path as a non-existent invitation)."""
+    """SEC2-013: wrong-token scenarios all return 404.
+
+    Three sub-cases are exercised:
+    a) Composite token with correct id but wrong plaintext — HMAC mismatch.
+    b) Composite token with a non-existent id.
+    c) Malformed token (no colon separator) — rejected before DB lookup.
+    """
     invitee_email = f"wrong-{uuid.uuid4().hex[:6]}@x.com"
-    admin.post("/api/invitations", json={"email": invitee_email, "role": "member"})
+    inv_data = admin.post(
+        "/api/invitations", json={"email": invitee_email, "role": "member"}
+    ).json()["data"]
+    inv_id = inv_data["id"]
 
     invitee = TestClient(app)
     invitee.post(
@@ -196,8 +222,23 @@ def test_accept_with_wrong_token_returns_404(admin):
         json={"email": invitee_email, "name": "x", "password": "TestPass-2026-Stronk"},
     )
 
-    # Submit a wrong token — must not match by hash, must 404.
-    r = invitee.post("/api/invitations/accept", json={"token": "WRONG-TOKEN-VALUE"})
+    # a) Correct id, wrong plaintext — HMAC compare_digest must fail → 404.
+    r = invitee.post(
+        "/api/invitations/accept",
+        json={"token": f"{inv_id}:WRONG-PLAINTEXT-VALUE"},
+    )
+    assert r.status_code == 404, r.text
+
+    # b) Non-existent id — DB lookup returns None → 404.
+    fake_id = str(uuid.uuid4())
+    r = invitee.post(
+        "/api/invitations/accept",
+        json={"token": f"{fake_id}:some-plaintext"},
+    )
+    assert r.status_code == 404, r.text
+
+    # c) Malformed token (no colon) — format validation → 404.
+    r = invitee.post("/api/invitations/accept", json={"token": "NO-COLON-TOKEN"})
     assert r.status_code == 404, r.text
 
 


### PR DESCRIPTION
Closes #72

## Summary
- Replaces bare SHA-256 token storage with HMAC-SHA-256 keyed on SESSION_SECRET (`token_hmac` column on `workspace_invitations`)
- Invitation accept now looks up by `id` (PK — no timing oracle on the SQL side), then calls `hmac.compare_digest(_hmac_token(supplied), row.token_hmac)` for constant-time comparison
- New migration (0021) adds the nullable `token_hmac` column; pending invitations are invalidated (plaintexts were never stored, so backfill is impossible)
- Token returned by create endpoint is now a composite `"{id}:{plaintext}"` string — the frontend interface stays a single opaque string, and the accept handler splits to get the PK

## Tests
Backend: 466 passed, 1 skipped, 3 xfailed

## Frontend
No change required — Account.tsx passes the composite token opaquely as before.

## ⚠️ Operator note
Existing pending invitations are invalidated by this migration. Resend any outstanding invites after deploy.