### PR TITLE
fix(infra): container hardening — USER appuser, init service, cap_drop (#85)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,15 @@ them, that's the bug.
   ran as a separate (failing) shell command. Result: slowapi bucketed
   every client by the docker bridge IP. If you reformat the compose
   file, keep the array form.
+- **`backend-init` one-shot service handles `chown /data` before `backend`
+  starts.** The backend Dockerfile sets `USER appuser` (UID 1000); the
+  runtime container has no root privileges. Ownership of the `uploads`
+  named volume is fixed by `backend-init` (`restart: no`,
+  `command: ["sh","-c","chown -R 1000:1000 /data"]`) which runs as root
+  and exits cleanly. `backend` declares
+  `depends_on: backend-init: condition: service_completed_successfully`
+  so it waits for a clean exit. Don't reintroduce gosu or a root-prefixed
+  `command:` in the backend service — that was the pattern this replaced.
 - **Session cookie `secure` is gated on `APP_ENV == "prod"`** in
   `backend/app/api/routes/auth.py::_set_session_cookie`. Don't make it
   unconditional — local dev runs over HTTP and the cookie wouldn't

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -26,10 +26,11 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     PIP_NO_CACHE_DIR=1
 
 # libpq5 — psycopg C extension ABI dependency.
-# gosu  — compose command: chowns /data as root then drops to appuser.
 # curl  — healthcheck inside the container hits /api/health.
+# gosu removed — /data ownership is now fixed by the backend-init one-shot
+# service (see docker-compose.prod.yml) before this container starts.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        libpq5 gosu curl \
+        libpq5 curl \
     && rm -rf /var/lib/apt/lists/* \
     && useradd -r -u 1000 -m -d /home/appuser appuser \
     && mkdir -p /data/uploads \
@@ -52,11 +53,9 @@ COPY . .
 RUN pip install --no-cache-dir --no-deps -e .
 
 # /app stays root-owned (read-only at runtime; appuser doesn't need to
-# mutate the source tree). USER is intentionally NOT set here — the
-# compose `command:` starts as root so it can chown /data on first
-# mount, then `gosu appuser` drops privileges before exec'ing uvicorn.
+# mutate the source tree).
+USER appuser
 
 EXPOSE 8000
-# Default for direct `docker run`. Compose overrides with the alembic +
-# gosu + uvicorn one-liner; see docker-compose.prod.yml.
-CMD ["sh", "-c", "chown -R appuser:appuser /data 2>/dev/null || true; exec gosu appuser uvicorn app.main:app --host 0.0.0.0 --port 8000"]
+# Default for direct `docker run`. Compose overrides this; see docker-compose.prod.yml.
+CMD ["sh", "-c", "alembic upgrade head && exec uvicorn app.main:app --host 0.0.0.0 --port 8000"]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -37,6 +37,24 @@ services:
       interval: 5s
       timeout: 5s
       retries: 10
+    security_opt: ["no-new-privileges:true"]
+    cap_drop: ["ALL"]
+    cap_add: ["CHOWN", "SETUID", "SETGID", "FOWNER", "DAC_OVERRIDE"]
+
+  # One-shot init container: fixes /data ownership as root before backend
+  # starts. This replaces the old gosu trampoline that ran chown inside the
+  # backend container itself (requiring the runtime process to start as root).
+  # restart: no ensures it never loops; backend depends_on with
+  # service_completed_successfully gates startup on a clean exit.
+  backend-init:
+    build: ./backend
+    restart: "no"
+    command: ["sh", "-c", "chown -R 1000:1000 /data"]
+    volumes:
+      - uploads:/data/uploads
+    security_opt: ["no-new-privileges:true"]
+    cap_drop: ["ALL"]
+    cap_add: ["CHOWN"]
 
   backend:
     build: ./backend
@@ -88,6 +106,8 @@ services:
     depends_on:
       db:
         condition: service_healthy
+      backend-init:
+        condition: service_completed_successfully
     expose:
       - "8000"
     # INFRA2-002 / INFRA-001: a healthy container in compose's eyes means
@@ -118,22 +138,15 @@ services:
     # across argv boundaries (uvicorn was missing --proxy-headers
     # because the YAML kept the newline before it intact).
     #
-    # Boot sequence:
-    #   1. chown the upload volume to appuser. Idempotent — cheap when
-    #      already correct, fixes ownership the first time a fresh named
-    #      volume is mounted (Docker preserves the image's path ownership
-    #      on first creation) or when migrating from a previous root-only
-    #      image. Runs as root because the compose container's USER is
-    #      unset by design (see backend/Dockerfile).
-    #   2. exec gosu appuser <inner shell>. Drops privileges to UID 1000
-    #      for the rest of the process tree. From this point uvicorn and
-    #      alembic both run unprivileged.
-    #   3. alembic upgrade head, then exec uvicorn. Identical to before.
+    # Runs as appuser (UID 1000) — USER is set in the Dockerfile. The
+    # chown of /data is handled by the backend-init service above.
     # stop_grace_period: give Compose 30s before SIGKILL, matching
     # --timeout-graceful-shutdown 25 below (5s headroom so SIGKILL
     # never fires on a clean drain — see CLAUDE.md "Things that have bitten us").
     stop_grace_period: 30s
-    command: ["sh", "-c", "chown -R appuser:appuser /data 2>/dev/null || true; exec gosu appuser sh -c 'alembic upgrade head && exec uvicorn app.main:app --host 0.0.0.0 --port 8000 --workers 1 --proxy-headers --forwarded-allow-ips=* --timeout-graceful-shutdown 25'"]
+    command: ["sh", "-c", "alembic upgrade head && exec uvicorn app.main:app --host 0.0.0.0 --port 8000 --workers 1 --proxy-headers --forwarded-allow-ips=* --timeout-graceful-shutdown 25"]
+    security_opt: ["no-new-privileges:true"]
+    cap_drop: ["ALL"]
 
   web:
     build:
@@ -173,6 +186,9 @@ services:
     # parts.matescb.cz → 127.0.0.1:8091. See deploy/parts.matescb.cz.conf.
     ports:
       - "127.0.0.1:8091:80"
+    security_opt: ["no-new-privileges:true"]
+    cap_drop: ["ALL"]
+    cap_add: ["CHOWN", "SETUID", "SETGID", "NET_BIND_SERVICE"]
 
 volumes:
   db_data:


### PR DESCRIPTION
Closes #85

## Summary
- `backend/Dockerfile`: removes gosu, adds `USER appuser` (UID 1000), simplifies CMD — the runtime process no longer starts as root
- New `backend-init` one-shot service in `docker-compose.prod.yml`: runs `chown -R 1000:1000 /data` as root then exits (`restart: no`); replaces the old gosu trampoline
- `backend` service now `depends_on: backend-init: condition: service_completed_successfully` — clean handoff guaranteed before alembic/uvicorn start
- All three services (`db`, `backend-init`, `backend`, `web`) get `security_opt: ["no-new-privileges:true"]` + `cap_drop: ["ALL"]` with selective `cap_add` per service needs
- `CLAUDE.md` updated with the backend-init pattern in "Things that have bitten us"

Note: `read_only: true` deferred — not applied in this PR to avoid unexpected boot failures from tmpfs requirements in uvicorn/alembic.

## Tests
Backend: 465 passed, 1 skipped, 3 xfailed (no regressions)
Frontend: N/A

## Verify after deploy
- `docker exec backend id` → should show `uid=1000(appuser)`
- `docker compose -f docker-compose.prod.yml ps` → `backend-init` shows `Exited (0)`
- `docker compose -f docker-compose.prod.yml run --user 0 backend bash` → still works for ad-hoc root shell

🤖 Generated with [Claude Code](https://claude.com/claude-code)