### PR TITLE
fix(db): explicit SQLAlchemy connection pool sizing (#67)

### DIFF
--- a/backend/app/infra/db.py
+++ b/backend/app/infra/db.py
@@ -12,7 +12,31 @@ class Base(DeclarativeBase):
     pass
 
 
-_engine = create_engine(settings().DATABASE_URL, future=True, pool_pre_ping=True)
+# Connection pool sizing — BE2-023
+#
+# Prod runs --workers 1 (see CLAUDE.md).  With a single process the
+# effective ceiling is pool_size + max_overflow = 30 connections, well
+# within Postgres's default max_connections=100.  If we ever bump
+# --workers we must revisit these numbers (or switch to PgBouncer).
+#
+#   pool_size=10       headroom over the implicit default of 5
+#   max_overflow=20    burst capacity; connections above pool_size are
+#                      closed when released rather than returned to pool
+#   pool_recycle=1800  recycle connections after 30 min — below most
+#                      cloud-provider idle-TCP-kill defaults (~60 min)
+#   pool_timeout=30    raise PoolTimeout rather than hanging forever
+#                      when all connections are checked out
+#   pool_pre_ping=True round-trip SELECT 1 on checkout; drops silently
+#                      recycled connections instead of surfacing an error
+_engine = create_engine(
+    settings().DATABASE_URL,
+    future=True,
+    pool_pre_ping=True,
+    pool_size=10,
+    max_overflow=20,
+    pool_recycle=1800,
+    pool_timeout=30,
+)
 SessionLocal = sessionmaker(bind=_engine, autoflush=False, expire_on_commit=False, future=True)
 
 

--- a/backend/tests/test_engine_pool_config.py
+++ b/backend/tests/test_engine_pool_config.py
@@ -1,0 +1,37 @@
+"""Assert that the SQLAlchemy engine is created with explicit pool sizing.
+
+BE2-023: pool defaults (5+10) are too small for future worker bumps and
+give no signal on exhaustion.  These tests pin the values so an accidental
+revert is caught by CI rather than discovered in prod under load.
+"""
+from __future__ import annotations
+
+from app.infra.db import get_engine
+
+
+def test_pool_size():
+    """pool_size controls the persistent connection count kept open."""
+    assert get_engine().pool.size() == 10
+
+
+def test_max_overflow():
+    """max_overflow allows burst connections beyond pool_size."""
+    assert get_engine().pool._max_overflow == 20
+
+
+def test_pool_recycle():
+    """pool_recycle=1800 s recycles connections after 30 min, below
+    cloud-provider idle-TCP-kill defaults."""
+    assert get_engine().pool._recycle == 1800
+
+
+def test_pool_timeout():
+    """pool_timeout=30 s raises PoolTimeout fast on exhaustion instead
+    of hanging indefinitely."""
+    assert get_engine().pool._timeout == 30
+
+
+def test_pool_pre_ping():
+    """pool_pre_ping must stay True — it drops silently recycled
+    connections on checkout instead of surfacing them as errors."""
+    assert get_engine().pool._pre_ping is True


### PR DESCRIPTION
Closes #67

## Summary
- Set `pool_size=10`, `max_overflow=20`, `pool_recycle=1800`, `pool_timeout=30` on the module-level `_engine` in `backend/app/infra/db.py`
- Added a comment block documenting the `--workers 1` assumption and trade-offs per CLAUDE.md
- Added `backend/tests/test_engine_pool_config.py` asserting each pool config value

## Tests
Backend: 482 passed, 1 skipped, 3 xfailed
Frontend build: N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)