### PR TITLE
fix(workspace): assert_child_in_parent helper + match_entry isolation (#66)

### DIFF
--- a/backend/app/api/_helpers.py
+++ b/backend/app/api/_helpers.py
@@ -4,7 +4,7 @@ from functools import lru_cache
 from typing import TypeVar
 from uuid import UUID
 
-from fastapi import status
+from fastapi import HTTPException, status
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
@@ -94,6 +94,44 @@ def assert_polymorphic_in_workspace(
             object_type=object_type,
         )
     return assert_in_workspace(db, Model, object_id, workspace_id, label=object_type)
+
+
+def assert_child_in_parent(
+    db: Session,
+    Model: type[T],
+    child_id: UUID,
+    parent,
+    *,
+    parent_fk: str,
+    label: str,
+) -> T:
+    """Look up a child row that must belong to both the given parent and the
+    parent's workspace.
+
+    A single query covers workspace isolation + parent-FK check so neither
+    can be bypassed independently. Returns the row on success; raises 404 if
+    the row does not exist, belongs to another workspace, or belongs to a
+    different parent object.
+
+    This is the canonical shape for nested-resource endpoints like
+    PATCH /projects/{project_id}/entries/{entry_id} — the previous hand-rolled
+    `db.get(Child, id) + manual workspace_id + parent_id` pattern let a
+    caller in workspace B pass a foreign entry_id and have it silently
+    matched against workspace A's parent (BE2-021).
+    """
+    row = db.execute(
+        select(Model).where(
+            Model.id == child_id,
+            Model.workspace_id == parent.workspace_id,
+            getattr(Model, parent_fk) == parent.id,
+        )
+    ).scalar_one_or_none()
+    if row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"{label} not found",
+        )
+    return row
 
 
 def require_resource_access(

--- a/backend/app/api/routes/orders.py
+++ b/backend/app/api/routes/orders.py
@@ -6,7 +6,7 @@ from uuid import UUID
 from fastapi import APIRouter, HTTPException, Query, status
 from sqlalchemy import or_, select
 
-from app.api._helpers import require_resource_access
+from app.api._helpers import assert_child_in_parent, require_resource_access
 from app.api.routes._activity import build_activity
 from app.core.deps import CurrentUser, CurrentWorkspace, DbSession
 from app.core.responses import ok
@@ -222,9 +222,7 @@ def add_entry(order_id: UUID, payload: OrderEntryIn, db: DbSession, ws: CurrentW
 @router.patch("/{order_id}/entries/{entry_id}")
 def patch_entry(order_id: UUID, entry_id: UUID, payload: OrderEntryPatch, db: DbSession, ws: CurrentWorkspace, user: CurrentUser):
     o = _get_order(db, ws.id, order_id)
-    e = db.get(OrderEntry, entry_id)
-    if not e or e.workspace_id != ws.id or e.order_id != o.id:
-        raise HTTPException(status_code=404, detail="entry not found")
+    e = assert_child_in_parent(db, OrderEntry, entry_id, o, parent_fk="order_id", label="entry")
     data = payload.model_dump(exclude_unset=True)
     if "quantity_ordered" in data and data["quantity_ordered"] is not None:
         if data["quantity_ordered"] < e.quantity_received:
@@ -241,9 +239,7 @@ def patch_entry(order_id: UUID, entry_id: UUID, payload: OrderEntryPatch, db: Db
 @router.delete("/{order_id}/entries/{entry_id}")
 def del_entry(order_id: UUID, entry_id: UUID, db: DbSession, ws: CurrentWorkspace):
     o = _get_order(db, ws.id, order_id)
-    e = db.get(OrderEntry, entry_id)
-    if not e or e.workspace_id != ws.id or e.order_id != o.id:
-        raise HTTPException(status_code=404, detail="entry not found")
+    e = assert_child_in_parent(db, OrderEntry, entry_id, o, parent_fk="order_id", label="entry")
     if e.quantity_received > 0:
         raise HTTPException(status_code=400, detail="cannot delete entry with received stock")
     db.delete(e)

--- a/backend/app/api/routes/projects.py
+++ b/backend/app/api/routes/projects.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, HTTPException, Query, status
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy import or_, select
 
-from app.api._helpers import assert_in_workspace, require_resource_access
+from app.api._helpers import assert_child_in_parent, assert_in_workspace, require_resource_access
 from app.core.deps import CurrentUser, CurrentWorkspace, DbSession
 from app.core.responses import ok
 from app.domain.parts.models import Part
@@ -195,9 +195,7 @@ def add_entry(project_id: UUID, payload: BomEntryIn, db: DbSession, ws: CurrentW
 @router.patch("/{project_id}/entries/{entry_id}")
 def patch_entry(project_id: UUID, entry_id: UUID, payload: BomEntryPatch, db: DbSession, ws: CurrentWorkspace, user: CurrentUser):
     p = _get(db, ws.id, project_id)
-    e = db.get(ProjectEntry, entry_id)
-    if not e or e.workspace_id != ws.id or e.project_id != p.id:
-        raise HTTPException(status_code=404, detail="entry not found")
+    e = assert_child_in_parent(db, ProjectEntry, entry_id, p, parent_fk="project_id", label="entry")
     data = payload.model_dump(exclude_unset=True)
     # Same archived-part guard as add_entry — patch-binds an archived
     # part into the BOM would be the BE2-016 vector via PATCH.
@@ -214,9 +212,7 @@ def patch_entry(project_id: UUID, entry_id: UUID, payload: BomEntryPatch, db: Db
 @router.delete("/{project_id}/entries/{entry_id}")
 def del_entry(project_id: UUID, entry_id: UUID, db: DbSession, ws: CurrentWorkspace):
     p = _get(db, ws.id, project_id)
-    e = db.get(ProjectEntry, entry_id)
-    if not e or e.workspace_id != ws.id or e.project_id != p.id:
-        raise HTTPException(status_code=404, detail="entry not found")
+    e = assert_child_in_parent(db, ProjectEntry, entry_id, p, parent_fk="project_id", label="entry")
     db.delete(e)
     return ok(None)
 
@@ -246,14 +242,9 @@ class MatchEntryIn(BaseModel):
 
 @router.post("/{project_id}/entries/{entry_id}/match")
 def match_entry(project_id: UUID, entry_id: UUID, payload: MatchEntryIn, db: DbSession, ws: CurrentWorkspace, user: CurrentUser):
-    from app.domain.parts.models import Part
     p = _get(db, ws.id, project_id)
-    e = db.get(ProjectEntry, entry_id)
-    if not e or e.workspace_id != ws.id or e.project_id != p.id:
-        raise HTTPException(status_code=404, detail="entry not found")
-    part = db.get(Part, payload.part_id)
-    if not part or part.workspace_id != ws.id:
-        raise HTTPException(status_code=404, detail="part not found")
+    e = assert_child_in_parent(db, ProjectEntry, entry_id, p, parent_fk="project_id", label="entry")
+    part = assert_in_workspace(db, Part, payload.part_id, ws.id, label="part")
     if part.archived_at is not None:
         # Match the new add/patch_entry guard — match-bind an archived
         # part is the same BE2-016 vector with a different verb.

--- a/backend/tests/test_workspace_isolation.py
+++ b/backend/tests/test_workspace_isolation.py
@@ -737,3 +737,94 @@ def test_part_activity_does_not_leak_cross_workspace_id():
     # B's activity probe on A's part must 404, not return A's events.
     r = b.get(f"/api/parts/{pa}/activity")
     assert r.status_code == 404, r.text
+
+
+# ---------------------------------------------------------------------------
+# BE2-021: assert_child_in_parent — foreign entry_id on project and order
+# entry routes must 404, not silently operate on rows from another workspace.
+# ---------------------------------------------------------------------------
+
+
+def test_project_entry_foreign_entry_id_is_404():
+    """PATCH / DELETE / match on a project entry must reject a foreign
+    entry_id (one owned by workspace A) when called from workspace B.
+    Without assert_child_in_parent the old db.get(ProjectEntry, id) path
+    returned the row and wrote it — a cross-tenant write vector."""
+    a, b = _two_workspaces()
+    part_a = _create_part(a, "A-Part")
+    part_b = _create_part(b, "B-Part")
+
+    # A creates a project + entry.
+    proj_a = a.post("/api/projects", json={"name": "PA"}).json()["data"]["id"]
+    entry_a = a.post(
+        f"/api/projects/{proj_a}/entries",
+        json={"entry_type": "part", "part_id": part_a, "quantity": 1},
+    ).json()["data"]["id"]
+
+    # B creates their own project so the project_id in the URL is valid for B.
+    proj_b = b.post("/api/projects", json={"name": "PB"}).json()["data"]["id"]
+
+    # B uses their own project_id but A's entry_id — must 404 for all verbs.
+    r = b.patch(
+        f"/api/projects/{proj_b}/entries/{entry_a}",
+        json={"quantity": 99},
+    )
+    assert r.status_code == 404, r.text
+
+    r = b.delete(f"/api/projects/{proj_b}/entries/{entry_a}")
+    assert r.status_code == 404, r.text
+
+    r = b.post(
+        f"/api/projects/{proj_b}/entries/{entry_a}/match",
+        json={"part_id": part_b},
+    )
+    assert r.status_code == 404, r.text
+
+
+def test_order_entry_foreign_entry_id_is_404():
+    """PATCH / DELETE on an order entry must reject a foreign entry_id.
+    Without assert_child_in_parent, db.get(OrderEntry, id) returned the
+    cross-workspace row and let it be mutated."""
+    a, b = _two_workspaces()
+    part_a = _create_part(a, "A-Part")
+
+    # A creates an order + entry.
+    order_a = a.post("/api/orders", json={"name": "OA"}).json()["data"]["id"]
+    entry_a = a.post(
+        f"/api/orders/{order_a}/entries",
+        json={"name": "widget", "quantity_ordered": 5},
+    ).json()["data"]["id"]
+
+    # B creates their own order so the order_id in the URL is valid for B.
+    order_b = b.post("/api/orders", json={"name": "OB"}).json()["data"]["id"]
+
+    # B uses their own order_id but A's entry_id — must 404 for all verbs.
+    r = b.patch(
+        f"/api/orders/{order_b}/entries/{entry_a}",
+        json={"quantity_ordered": 99},
+    )
+    assert r.status_code == 404, r.text
+
+    r = b.delete(f"/api/orders/{order_b}/entries/{entry_a}")
+    assert r.status_code == 404, r.text
+
+
+def test_match_entry_foreign_part_id_is_404():
+    """match_entry previously used db.get(Part, id) which skipped the
+    workspace check. Confirm assert_in_workspace closes the gap: passing
+    another workspace's part_id in the match payload must 404."""
+    a, b = _two_workspaces()
+    part_a = _create_part(a, "A-Part")
+
+    # B creates a project + unmatched entry, then tries to match A's part.
+    proj_b = b.post("/api/projects", json={"name": "PB"}).json()["data"]["id"]
+    entry_b = b.post(
+        f"/api/projects/{proj_b}/entries",
+        json={"entry_type": "unmatched", "name": "mystery", "quantity": 1},
+    ).json()["data"]["id"]
+
+    r = b.post(
+        f"/api/projects/{proj_b}/entries/{entry_b}/match",
+        json={"part_id": part_a},
+    )
+    assert r.status_code == 404, r.text


### PR DESCRIPTION
Closes #66

## Summary
- Add `assert_child_in_parent()` to `_helpers.py` — single query enforces workspace_id + parent FK, so a foreign entry_id can't silently pass through (BE2-021)
- Refactor `patch_entry`, `del_entry`, `match_entry` in `projects.py` and `patch_entry`, `del_entry` in `orders.py` to use the new helper
- In `match_entry`, replace `db.get(Part, payload.part_id)` + manual workspace check with `assert_in_workspace(...)` for the Part lookup
- Add regression tests in `test_workspace_isolation.py`: foreign entry_id on project PATCH/DELETE/match → 404; foreign entry_id on order PATCH/DELETE → 404; foreign part_id on match_entry → 404

## Tests
Backend: 480 passed, 1 skipped, 3 xfailed
Frontend build: N/A (backend-only change)