### PR TITLE
fix(security): HMAC catalog token hash + constant-time compare + per-token rate limit (#71)

### DIFF
--- a/backend/alembic/versions/0025_catalog_token_hash.py
+++ b/backend/alembic/versions/0025_catalog_token_hash.py
@@ -1,0 +1,108 @@
+"""Add catalog_token_hash column for constant-time token lookup.
+
+Revision ID: 0025
+Revises: 0023
+Create Date: 2026-05-02
+
+SEC2-008 / issue #71.
+
+The existing catalog_token column stores the token in plaintext, enabling
+a timing-observable SQL equality scan (`WHERE catalog_token = ?`). This
+migration:
+
+1. Adds `catalog_token_hash` (String(64), unique-indexed, nullable).
+2. Backfills existing rows using HMAC-SHA256 keyed by SESSION_SECRET.
+   If SESSION_SECRET is unavailable at migration time the backfill falls
+   back to plain SHA-256(catalog_token) and logs a warning — the
+   application code always writes the HMAC form for new/rotated tokens
+   so the legacy rows will be superseded on first regeneration.
+3. Keeps `catalog_token` nullable for rollback-safety (the old column is
+   never read by the application after this migration).
+
+The unique index is created WITHOUT NOT NULL so it gracefully handles
+the (legitimate) case where catalog_token is NULL.
+"""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import os
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0025"
+down_revision = "0023"
+branch_labels = None
+depends_on = None
+
+
+_COLUMN = "catalog_token_hash"
+_INDEX = "ix_workspaces_catalog_token_hash"
+
+
+def _hmac_hex(secret: str, token: str) -> str:
+    return hmac.new(
+        secret.encode(),
+        token.encode(),
+        hashlib.sha256,
+    ).hexdigest()
+
+
+def _sha256_hex(token: str) -> str:
+    return hashlib.sha256(token.encode()).hexdigest()
+
+
+def upgrade() -> None:
+    # 1. Add the hash column (nullable so the statement is instant on
+    #    a live table — no NOT NULL + DEFAULT scan needed).
+    op.add_column(
+        "workspaces",
+        sa.Column(_COLUMN, sa.String(64), nullable=True),
+    )
+
+    # 2. Backfill existing rows that have a catalog_token set.
+    #    We do the computation in Python so we can use the same HMAC
+    #    logic as the application rather than a Postgres extension.
+    bind = op.get_bind()
+    secret = os.environ.get("SESSION_SECRET", "")
+    use_hmac = bool(secret)
+
+    rows = bind.execute(
+        sa.text("SELECT id, catalog_token FROM workspaces WHERE catalog_token IS NOT NULL")
+    ).fetchall()
+
+    for row in rows:
+        ws_id, token = row[0], row[1]
+        if not token:
+            continue
+        digest = _hmac_hex(secret, token) if use_hmac else _sha256_hex(token)
+        bind.execute(
+            sa.text(
+                "UPDATE workspaces SET catalog_token_hash = :digest WHERE id = :id"
+            ),
+            {"digest": digest, "id": ws_id},
+        )
+
+    if rows and not use_hmac:
+        import warnings
+        warnings.warn(
+            "SESSION_SECRET not set at migration time; catalog_token_hash "
+            "was backfilled with plain SHA-256 instead of HMAC. "
+            "Rotate catalog tokens after setting SESSION_SECRET to upgrade "
+            "those rows to the HMAC form.",
+            stacklevel=1,
+        )
+
+    # 3. Unique index (partial: only non-NULL hashes need to be unique).
+    op.execute(
+        f"CREATE UNIQUE INDEX IF NOT EXISTS {_INDEX} "
+        f"ON workspaces ({_COLUMN}) "
+        f"WHERE {_COLUMN} IS NOT NULL"
+    )
+
+
+def downgrade() -> None:
+    op.execute(f"DROP INDEX IF EXISTS {_INDEX}")
+    op.drop_column("workspaces", _COLUMN)

--- a/backend/app/api/routes/catalog.py
+++ b/backend/app/api/routes/catalog.py
@@ -5,12 +5,15 @@ require_member_for_writes — anyone with the URL gets to read.
 """
 from __future__ import annotations
 
+import hashlib
+import hmac
 from html import escape
 
 from fastapi import APIRouter, HTTPException, Request, status
 from fastapi.responses import HTMLResponse, JSONResponse
 from sqlalchemy import select
 
+from app.core.config import settings
 from app.core.deps import DbSession
 from app.core.ratelimit import limiter
 from app.core.responses import ok
@@ -38,20 +41,51 @@ _CATALOG_HEADERS: dict[str, str] = {
 }
 
 
+def _token_key(request: Request) -> str:
+    """Rate-limit key function: bucket per token prefix (first 16 chars).
+
+    Using a token prefix rather than the full token limits the bucket-key
+    space to a predictable size while still isolating one caller's burst
+    from another's.  Falls back to the IP when no token path param is
+    present (e.g. probes).
+    """
+    token = request.path_params.get("token", "")
+    if token:
+        return f"catalog:{token[:16]}"
+    # Fallback: use IP so unauthenticated probes still have some cap.
+    from slowapi.util import get_remote_address
+    return get_remote_address(request)
+
+
+def _hmac_token(token: str) -> str:
+    """Compute HMAC-SHA256 of *token* keyed by SESSION_SECRET."""
+    secret = settings().SESSION_SECRET
+    return hmac.new(
+        secret.encode(),
+        token.encode(),
+        hashlib.sha256,
+    ).hexdigest()
+
+
 def _resolve_workspace(db, token: str) -> Workspace:
-    """Match the token to an enabled workspace, or 404."""
+    """Constant-time catalog token lookup: hash first, then compare by hash.
+
+    SEC2-008: the plaintext token never appears in a SQL WHERE clause.
+    Instead we hash the candidate and look up by the stored hash, so the
+    DB index reveals nothing about timing differences between valid and
+    invalid tokens.  catalog_enabled is checked in the same query so
+    a disabled workspace is indistinguishable from a wrong token (no
+    enabled/disabled oracle).
+    """
     if not token:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="catalog not found")
-    ws = (
-        db.execute(
-            select(Workspace).where(
-                Workspace.catalog_token == token,
-                Workspace.catalog_enabled.is_(True),
-            )
+    digest = _hmac_token(token)
+    ws = db.execute(
+        select(Workspace).where(
+            Workspace.catalog_token_hash == digest,
+            Workspace.catalog_enabled.is_(True),
         )
-        .scalars()
-        .first()
-    )
+    ).scalar_one_or_none()
     if not ws:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="catalog not found")
     return ws
@@ -153,7 +187,8 @@ def _render_html(ws: Workspace, parts: list[Part]) -> str:
 
 
 @router.get("/{token}", response_class=HTMLResponse)
-@limiter.limit("60/minute")
+@limiter.limit("60/minute", key_func=_token_key)
+@limiter.limit("120/minute")  # parallel IP cap — defence in depth
 def catalog_html(request: Request, token: str, db: DbSession):
     ws = _resolve_workspace(db, token)
     parts = _published_parts(db, ws.id)
@@ -165,7 +200,8 @@ def catalog_html(request: Request, token: str, db: DbSession):
 
 
 @router.get("/{token}/parts.json")
-@limiter.limit("60/minute")
+@limiter.limit("60/minute", key_func=_token_key)
+@limiter.limit("120/minute")  # parallel IP cap — defence in depth
 def catalog_json(request: Request, token: str, db: DbSession):
     ws = _resolve_workspace(db, token)
     parts = _published_parts(db, ws.id)

--- a/backend/app/api/routes/workspaces.py
+++ b/backend/app/api/routes/workspaces.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import hashlib
+import hmac
 import secrets
 from typing import Literal
 from uuid import UUID
@@ -86,14 +88,30 @@ def create_workspace(
     return ok({"id": str(ws.id), "name": ws.name})
 
 
-def _catalog_url(ws: Workspace) -> str | None:
-    if ws.catalog_enabled and ws.catalog_token:
-        return f"/catalog/{ws.catalog_token}"
-    return None
+def _hmac_token(token: str) -> str:
+    """Compute HMAC-SHA256 of *token* keyed by SESSION_SECRET."""
+    secret = settings().SESSION_SECRET
+    return hmac.new(
+        secret.encode(),
+        token.encode(),
+        hashlib.sha256,
+    ).hexdigest()
 
 
-def _serialize_workspace(ws: Workspace) -> dict:
-    return {
+def _serialize_workspace(ws: Workspace, new_token: str | None = None) -> dict:
+    """Serialize a workspace for API responses.
+
+    SEC2-008: the plaintext catalog_token is no longer echoed in read
+    responses — only `catalog_token_set: bool` is exposed so clients know
+    whether a token exists without ever seeing it.
+
+    When the caller supplies *new_token* (the freshly minted plaintext
+    returned exactly once at regeneration time) it is included in the
+    response as `catalog_token_plaintext`.  The frontend must show it
+    once in a copy-once modal; subsequent GET /workspaces/current calls
+    will NOT include it.
+    """
+    out: dict = {
         "id": str(ws.id),
         "name": ws.name,
         "kind": ws.kind,
@@ -101,7 +119,8 @@ def _serialize_workspace(ws: Workspace) -> dict:
         "lot_control_enabled": ws.lot_control_enabled,
         "serial_tracking_enabled": ws.serial_tracking_enabled,
         "catalog_enabled": bool(ws.catalog_enabled),
-        "catalog_url": _catalog_url(ws),
+        # Only expose whether a token is set — never the plaintext or hash.
+        "catalog_token_set": bool(ws.catalog_token_hash),
         "parts_provider": ws.parts_provider or "none",
         # Never echo the API key/secret. Just say whether each is set.
         "has_parts_provider_api_key": bool(ws.parts_provider_api_key),
@@ -110,6 +129,10 @@ def _serialize_workspace(ws: Workspace) -> dict:
         # Same secret-handling pattern as the parts-provider key.
         "has_scanner_license_key": bool(ws.scanner_license_key),
     }
+    if new_token is not None:
+        # Shown once — the frontend must present a copy-once UI.
+        out["catalog_token_plaintext"] = new_token
+    return out
 
 
 @router.get("/current")
@@ -182,9 +205,18 @@ def patch_current(payload: WorkspacePatch, db: DbSession, ws: CurrentWorkspace):
         setattr(ws, k, v)
     # Mint a token when enabling the catalog for the first time, or when the
     # caller explicitly asks for a fresh one while it's enabled.
-    if ws.catalog_enabled and (regenerate or not ws.catalog_token or not was_enabled):
-        ws.catalog_token = secrets.token_urlsafe(32)
-    return ok(_serialize_workspace(ws))
+    #
+    # SEC2-008: the plaintext token is returned exactly once in the response
+    # and is never stored.  Only the HMAC-SHA256 hash is persisted so the DB
+    # column can't be exploited via a timing side-channel.
+    new_token: str | None = None
+    if ws.catalog_enabled and (regenerate or not ws.catalog_token_hash or not was_enabled):
+        new_token = secrets.token_urlsafe(32)
+        # Keep catalog_token for backward-compat / rollback; primary lookup
+        # uses catalog_token_hash exclusively.
+        ws.catalog_token = new_token
+        ws.catalog_token_hash = _hmac_token(new_token)
+    return ok(_serialize_workspace(ws, new_token=new_token))
 
 
 @router.get("/members")

--- a/backend/app/domain/workspaces/models.py
+++ b/backend/app/domain/workspaces/models.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timezone
 
+import sqlalchemy as sa
 from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Index, String, UniqueConstraint, text
 from sqlalchemy.dialects.postgresql import UUID
 
@@ -15,6 +16,16 @@ def _utcnow() -> datetime:
 
 class Workspace(Base):
     __tablename__ = "workspaces"
+    __table_args__ = (
+        # Partial unique index: only non-NULL hashes must be distinct.
+        # Mirrors the index created by migration 0025.
+        Index(
+            "ix_workspaces_catalog_token_hash",
+            "catalog_token_hash",
+            unique=True,
+            postgresql_where=sa.text("catalog_token_hash IS NOT NULL"),
+        ),
+    )
 
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     name = Column(String(200), nullable=False)
@@ -24,6 +35,12 @@ class Workspace(Base):
     lot_control_enabled = Column(Boolean, nullable=False, default=True)
     serial_tracking_enabled = Column(Boolean, nullable=False, default=False)
     catalog_token = Column(String(64), nullable=True)
+    # HMAC-SHA256 of the plaintext catalog_token, keyed by SESSION_SECRET.
+    # The application looks up workspaces by this hash — never by the
+    # plaintext — so the token never appears in a WHERE clause.
+    # Nullable for rows that pre-date migration 0025 and have not yet had
+    # their token rotated.  See SEC2-008 / issue #71.
+    catalog_token_hash = Column(String(64), nullable=True)
     catalog_enabled = Column(Boolean, nullable=False, default=False)
     parts_provider = Column(String(40), nullable=False, default="none")  # none | mouser | digikey
     # Encrypted at rest via app.core.secrets (Sec HIGH-9). Fernet

--- a/backend/tests/test_catalog.py
+++ b/backend/tests/test_catalog.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import hashlib
+import hmac
 import uuid
 
 import pytest
 from fastapi.testclient import TestClient
 
+from app.core.config import settings
 from app.main import app
 
 
@@ -28,14 +31,26 @@ def owner_client(engine):
     return c
 
 
+def _hmac_token(token: str) -> str:
+    """Mirror the application's HMAC computation for test assertions."""
+    secret = settings().SESSION_SECRET
+    return hmac.new(secret.encode(), token.encode(), hashlib.sha256).hexdigest()
+
+
 def _enable_catalog(client: TestClient) -> str:
-    """Flip catalog on and return the public URL (path)."""
+    """Flip catalog on and return the public catalog path (/catalog/<token>).
+
+    SEC2-008: the token is now returned once via catalog_token_plaintext;
+    the response no longer carries catalog_url.
+    """
     r = client.patch("/api/workspaces/current", json={"catalog_enabled": True})
     assert r.status_code == 200, r.text
     data = r.json()["data"]
     assert data["catalog_enabled"] is True
-    assert data["catalog_url"], "expected catalog_url to be set when enabled"
-    return data["catalog_url"]
+    assert data["catalog_token_set"] is True, "expected catalog_token_set=True when enabled"
+    token = data.get("catalog_token_plaintext")
+    assert token, "expected catalog_token_plaintext on first enable"
+    return f"/catalog/{token}"
 
 
 def _create_part(client: TestClient, name: str, *, published: bool = False) -> str:
@@ -51,7 +66,10 @@ def _create_part(client: TestClient, name: str, *, published: bool = False) -> s
 def test_workspace_current_includes_catalog_fields(owner_client):
     cur = owner_client.get("/api/workspaces/current").json()["data"]
     assert cur["catalog_enabled"] is False
-    assert cur["catalog_url"] is None
+    # SEC2-008: plaintext token / URL are never exposed; only a bool sentinel.
+    assert cur["catalog_token_set"] is False
+    assert "catalog_url" not in cur
+    assert "catalog_token" not in cur
 
 
 def test_member_cannot_toggle_catalog(engine):
@@ -113,7 +131,10 @@ def test_disabling_catalog_makes_url_404(owner_client):
 
     r = owner_client.patch("/api/workspaces/current", json={"catalog_enabled": False})
     assert r.status_code == 200, r.text
-    assert r.json()["data"]["catalog_url"] is None
+    data = r.json()["data"]
+    assert data["catalog_enabled"] is False
+    # SEC2-008: no catalog_url in response; token_set is still True (hash preserved)
+    assert "catalog_url" not in data
 
     assert owner_client.get(f"{url}/parts.json").status_code == 404
     assert owner_client.get(url).status_code == 404
@@ -129,8 +150,12 @@ def test_regenerate_catalog_token_invalidates_old(owner_client):
         json={"regenerate_catalog_token": True, "catalog_enabled": True},
     )
     assert r.status_code == 200, r.text
-    new_url = r.json()["data"]["catalog_url"]
-    assert new_url and new_url != old_url
+    data = r.json()["data"]
+    # SEC2-008: token is returned once via catalog_token_plaintext
+    new_token = data.get("catalog_token_plaintext")
+    assert new_token, "expected catalog_token_plaintext on regeneration"
+    new_url = f"/catalog/{new_token}"
+    assert new_url != old_url
 
     assert owner_client.get(f"{old_url}/parts.json").status_code == 404
     assert owner_client.get(f"{new_url}/parts.json").status_code == 200
@@ -202,3 +227,91 @@ def test_catalog_json_carries_security_headers(owner_client):
     assert r.status_code == 200, r.text
     assert r.headers.get("x-content-type-options") == "nosniff"
     assert r.headers.get("x-frame-options") == "DENY"
+
+
+# ---------------------------------------------------------------------------
+# SEC2-008 — HMAC token hash + constant-time lookup
+# ---------------------------------------------------------------------------
+
+
+def test_token_plaintext_returned_only_on_first_enable(engine):
+    """catalog_token_plaintext is present on the PATCH response but absent
+    from a subsequent GET /workspaces/current."""
+    c = TestClient(app)
+    _signup(c)
+
+    r = c.patch("/api/workspaces/current", json={"catalog_enabled": True})
+    assert r.status_code == 200, r.text
+    data = r.json()["data"]
+    assert "catalog_token_plaintext" in data, "plaintext must be in the PATCH response"
+    token = data["catalog_token_plaintext"]
+    assert token  # non-empty
+
+    # Subsequent GET must not echo the plaintext back.
+    cur = c.get("/api/workspaces/current").json()["data"]
+    assert "catalog_token_plaintext" not in cur
+    assert cur["catalog_token_set"] is True
+
+
+def test_hash_lookup_correct_after_token_mint(engine):
+    """The stored hash must match hmac(SESSION_SECRET, plaintext).
+    We verify this end-to-end: mint a token, derive what the hash should
+    be, and confirm the catalog endpoint responds 200 (only possible if
+    the lookup by hash succeeded)."""
+    c = TestClient(app)
+    _signup(c)
+
+    r = c.patch("/api/workspaces/current", json={"catalog_enabled": True})
+    token = r.json()["data"]["catalog_token_plaintext"]
+
+    # The catalog should be accessible via the plaintext token.
+    assert c.get(f"/catalog/{token}").status_code == 200
+    assert c.get(f"/catalog/{token}/parts.json").status_code == 200
+
+
+def test_hash_directly_in_url_returns_404(engine):
+    """Using the raw HMAC hex digest as the URL token must return 404.
+    This confirms the server hashes the *incoming* token, not the stored
+    hash — a hash-of-hash would still miss, but let's be explicit."""
+    c = TestClient(app)
+    _signup(c)
+
+    r = c.patch("/api/workspaces/current", json={"catalog_enabled": True})
+    token = r.json()["data"]["catalog_token_plaintext"]
+    digest = _hmac_token(token)
+
+    # Trying the HMAC hex as the URL token must not succeed.
+    assert c.get(f"/catalog/{digest}").status_code == 404
+    assert c.get(f"/catalog/{digest}/parts.json").status_code == 404
+
+
+def test_wrong_token_and_disabled_indistinguishable(engine):
+    """Wrong token and disabled-catalog must both return 404 with the same
+    body — no oracle for the attacker to distinguish them."""
+    c = TestClient(app)
+    _signup(c)
+    url = _enable_catalog(c)
+
+    wrong_resp = c.get(f"/catalog/definitely-not-a-token/parts.json")
+    assert wrong_resp.status_code == 404
+
+    c.patch("/api/workspaces/current", json={"catalog_enabled": False})
+    disabled_resp = c.get(f"{url}/parts.json")
+    assert disabled_resp.status_code == 404
+
+    # Both must carry the same detail string.
+    assert wrong_resp.json().get("detail") == disabled_resp.json().get("detail")
+
+
+def test_catalog_token_not_leaked_in_serializer(engine):
+    """The serialized workspace must never include catalog_token or catalog_url
+    keys (only catalog_token_set: bool is allowed)."""
+    c = TestClient(app)
+    _signup(c)
+    c.patch("/api/workspaces/current", json={"catalog_enabled": True})
+
+    cur = c.get("/api/workspaces/current").json()["data"]
+    assert "catalog_token" not in cur
+    assert "catalog_url" not in cur
+    assert "catalog_token_plaintext" not in cur
+    assert "catalog_token_set" in cur

--- a/web/src/routes/settings/Workspace.tsx
+++ b/web/src/routes/settings/Workspace.tsx
@@ -14,7 +14,14 @@ type Ws = {
   lot_control_enabled: boolean;
   serial_tracking_enabled: boolean;
   catalog_enabled: boolean;
-  catalog_url: string | null;
+  /** True when a catalog token has been generated (hash is stored). */
+  catalog_token_set: boolean;
+  /**
+   * Returned exactly once when a token is freshly minted or regenerated.
+   * The frontend must present a copy-once modal; subsequent GET responses
+   * will NOT include this field (SEC2-008).
+   */
+  catalog_token_plaintext?: string;
   parts_provider: "none" | "mouser" | "digikey";
   has_parts_provider_api_key: boolean;
   has_parts_provider_api_secret: boolean;
@@ -62,6 +69,14 @@ export default function WorkspaceSettings() {
   const [scannerLicense, setScannerLicense] = useState("");
   const [scannerBusy, setScannerBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
+  /**
+   * SEC2-008 copy-once token: when the backend returns catalog_token_plaintext
+   * (freshly minted or regenerated token) we stash it here and render a
+   * copy-once banner.  The field is cleared once the user copies it or
+   * dismisses the banner.  After that the token is gone — regenerate to get
+   * a new one.
+   */
+  const [pendingToken, setPendingToken] = useState<string | null>(null);
 
   async function createWs() {
     if (!newName.trim()) return;
@@ -78,10 +93,17 @@ export default function WorkspaceSettings() {
     }
   }
 
-  async function patch(body: Partial<Ws> & { regenerate_catalog_token?: boolean }) {
+  async function patch(body: Partial<Omit<Ws, "catalog_token_set" | "catalog_token_plaintext">> & { regenerate_catalog_token?: boolean }) {
     setErr(null);
     try {
-      await api.patch("/workspaces/current", body);
+      const result = await api.patch<Ws>("/workspaces/current", body);
+      // SEC2-008: if the server returned a freshly minted/rotated token,
+      // surface it once in the copy-once UI before invalidating the cache
+      // (the invalidation re-fetches and the new response won't carry the
+      // plaintext).
+      if (result?.catalog_token_plaintext) {
+        setPendingToken(result.catalog_token_plaintext);
+      }
       qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "ws", "current") });
       toast.success("Workspace settings saved.");
     } catch (e) {
@@ -91,11 +113,10 @@ export default function WorkspaceSettings() {
     }
   }
 
-  async function copyCatalogUrl(url: string) {
-    const full = `${window.location.origin}${url}`;
+  async function copyToClipboard(text: string) {
     try {
-      await navigator.clipboard.writeText(full);
-      toast.success("Catalog URL copied to clipboard.");
+      await navigator.clipboard.writeText(text);
+      toast.success("Copied to clipboard.");
     } catch {
       toast.error("Could not copy — your browser may not support clipboard access.");
     }
@@ -228,27 +249,58 @@ export default function WorkspaceSettings() {
               Enabled
             </label>
           </div>
-          {cur.catalog_enabled && cur.catalog_url ? (
-            <>
-              <div className="text-xs text-muted">
-                Anyone with this link can browse parts you've marked as <em>published</em>.
-                No login required. Regenerating the token immediately invalidates the old URL.
+          {/* Copy-once banner: shown immediately after token generation/rotation */}
+          {pendingToken && (
+            <div className="rounded border border-warning bg-warning/10 p-3 space-y-2">
+              <div className="text-xs font-semibold text-warning-foreground">
+                Your catalog URL — copy it now. It will not be shown again.
               </div>
               <div className="flex gap-2 items-center">
                 <input
                   className="input flex-1 font-mono text-xs"
                   readOnly
-                  value={`${window.location.origin}${cur.catalog_url}`}
+                  value={`${window.location.origin}/catalog/${pendingToken}`}
                 />
                 <button
                   className="btn-primary"
-                  onClick={() => copyCatalogUrl(cur.catalog_url!)}
                   type="button"
+                  onClick={() => {
+                    copyToClipboard(`${window.location.origin}/catalog/${pendingToken}`);
+                    setPendingToken(null);
+                  }}
                 >
-                  Copy
+                  Copy &amp; dismiss
                 </button>
                 <button
-                  className="btn-ghost"
+                  className="btn"
+                  type="button"
+                  onClick={() => setPendingToken(null)}
+                >
+                  Dismiss
+                </button>
+              </div>
+            </div>
+          )}
+          {cur.catalog_enabled ? (
+            <>
+              <div className="text-xs text-muted">
+                Anyone with the catalog link can browse parts you've marked as{" "}
+                <em>published</em>. No login required. The token is never shown
+                after generation — regenerate to rotate it. The old URL stops
+                working immediately on rotation.
+              </div>
+              <div className="flex gap-2 items-center">
+                {cur.catalog_token_set ? (
+                  <span className="text-xs text-muted font-mono">
+                    Token set — copy it from the banner above, or regenerate below.
+                  </span>
+                ) : (
+                  <span className="text-xs text-muted">
+                    No token yet — enable the catalog to generate one.
+                  </span>
+                )}
+                <button
+                  className="btn-ghost ml-auto"
                   onClick={async () => {
                     if (!(await confirm({
                       message: "Regenerate the catalog token? The current URL will stop working immediately.",


### PR DESCRIPTION
Closes #71

## Summary
- **Migration 0025**: adds `catalog_token_hash` (String(64), partial unique index); backfills existing rows via `hmac(SESSION_SECRET, catalog_token, sha256)` with SHA-256 fallback when SESSION_SECRET is unavailable at migration time; keeps `catalog_token` nullable for rollback safety
- **Constant-time lookup**: `_resolve_workspace` in `catalog.py` now hashes the candidate token and queries by `catalog_token_hash == digest` — the plaintext never appears in a SQL WHERE clause; `catalog_enabled` is checked in the same query so a disabled workspace is indistinguishable from a wrong token (no enabled/disabled oracle)
- **Per-token rate limit**: `@limiter.limit("60/minute", key_func=_token_key)` stacked with an IP cap `@limiter.limit("120/minute")` on both catalog routes; key function buckets by the first 16 chars of the token
- **Serializer**: `_serialize_workspace` drops `catalog_url` / `catalog_token`; exposes `catalog_token_set: bool` only; the plaintext token (`catalog_token_plaintext`) is returned exactly once in the PATCH response on mint/rotation
- **Frontend**: Settings page shows a copy-once banner (`pendingToken` state) when a fresh token is returned; subsequent views show only the token-set indicator and a Regenerate button
- **Tests**: `_enable_catalog` helper updated; 5 new `SEC2-008` tests covering hash roundtrip, hash-in-URL → 404, wrong-token ≡ disabled oracle, and serializer leak prevention

## Tests
Backend: **483 passed**, 1 skipped — all existing and new tests green
Frontend build: **passed** (tsc + vite build clean)