### PR TITLE
fix(fe): ApiError.userMessage — category-to-human-readable mapper, hide server leaks (#56)

### DIFF
--- a/web/src/components/AttachmentsPanel.tsx
+++ b/web/src/components/AttachmentsPanel.tsx
@@ -172,7 +172,7 @@ export default function AttachmentsPanel({ objectType, objectId, canWrite }: Pro
       if (inputRef.current) inputRef.current.value = "";
       qc.invalidateQueries({ queryKey });
     } catch (e) {
-      toast.error(e instanceof ApiError ? e.message : "Upload failed");
+      toast.error(e instanceof ApiError ? e.userMessage : "Upload failed");
     } finally {
       setBusy(false);
     }
@@ -185,7 +185,7 @@ export default function AttachmentsPanel({ objectType, objectId, canWrite }: Pro
       toast.success("Attachment deleted.");
       qc.invalidateQueries({ queryKey });
     } catch (e) {
-      toast.error(e instanceof ApiError ? e.message : "Delete failed");
+      toast.error(e instanceof ApiError ? e.userMessage : "Delete failed");
     }
   }
 

--- a/web/src/components/MpnLookup.tsx
+++ b/web/src/components/MpnLookup.tsx
@@ -42,7 +42,7 @@ export default function MpnLookup({ mpn, onResult }: Props) {
         setNote(data.message || `No match (${label})`);
       }
     } catch (e) {
-      setNote(e instanceof ApiError ? e.message : "Lookup failed");
+      setNote(e instanceof ApiError ? e.userMessage : "Lookup failed");
     } finally {
       setBusy(false);
     }

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -8,7 +8,7 @@
  */
 import { describe, expect, it, beforeEach, vi } from "vitest";
 import { z } from "zod";
-import { api, ApiError } from "./api";
+import { api, ApiError, categoryToUserMessage } from "./api";
 
 const Schema = z.object({
   id: z.string().uuid(),
@@ -90,5 +90,104 @@ describe("api.parsed.get", () => {
     await expect(api.parsed.get("/whatever", Schema)).rejects.toMatchObject({
       status: 404,
     });
+  });
+});
+
+describe("categoryToUserMessage", () => {
+  it("maps unauthenticated to session expired message", () => {
+    expect(categoryToUserMessage("unauthenticated")).toBe(
+      "Session expired. Please sign in again.",
+    );
+  });
+
+  it("maps forbidden to permission message", () => {
+    expect(categoryToUserMessage("forbidden")).toBe(
+      "You don't have permission to do that.",
+    );
+  });
+
+  it("maps not_found to not found message", () => {
+    expect(categoryToUserMessage("not_found")).toBe("Not found.");
+  });
+
+  it("maps conflict to duplicate message", () => {
+    expect(categoryToUserMessage("conflict")).toBe(
+      "That's a duplicate or conflicts with existing data.",
+    );
+  });
+
+  it("maps validation_error to form check message", () => {
+    expect(categoryToUserMessage("validation_error")).toBe(
+      "Some fields don't look right. Check the form and retry.",
+    );
+  });
+
+  it("maps server_error to generic fallback", () => {
+    expect(categoryToUserMessage("server_error")).toBe(
+      "Something went wrong. Try again, or refresh.",
+    );
+  });
+
+  it("maps unknown category to generic fallback", () => {
+    expect(categoryToUserMessage("some_future_category")).toBe(
+      "Something went wrong. Try again, or refresh.",
+    );
+  });
+
+  it("maps null/undefined to generic fallback", () => {
+    expect(categoryToUserMessage(null)).toBe(
+      "Something went wrong. Try again, or refresh.",
+    );
+    expect(categoryToUserMessage(undefined)).toBe(
+      "Something went wrong. Try again, or refresh.",
+    );
+  });
+});
+
+describe("ApiError.userMessage", () => {
+  it("populates userMessage from body.status.category", () => {
+    const err = new ApiError(
+      404,
+      { data: null, status: { category: "not_found", message: "DB says nope" } },
+      "DB says nope",
+    );
+    expect(err.message).toBe("DB says nope");
+    expect(err.userMessage).toBe("Not found.");
+  });
+
+  it("populates userMessage as generic fallback when body is null", () => {
+    const err = new ApiError(500, null, "Internal Server Error");
+    expect(err.message).toBe("Internal Server Error");
+    expect(err.userMessage).toBe("Something went wrong. Try again, or refresh.");
+  });
+
+  it("raw message is preserved separately from userMessage", () => {
+    const raw = "sqlalchemy.exc.IntegrityError: DETAIL: Key (mpn)=(ABC) already exists.";
+    const err = new ApiError(
+      409,
+      { data: null, status: { category: "conflict", message: raw } },
+      raw,
+    );
+    expect(err.message).toBe(raw);
+    expect(err.userMessage).toBe(
+      "That's a duplicate or conflicts with existing data.",
+    );
+    expect(err.userMessage).not.toContain("sqlalchemy");
+  });
+
+  it("HTTP 404 ApiError thrown by api.parsed carries correct userMessage", async () => {
+    mockFetch(404, {
+      data: null,
+      status: { category: "not_found", message: "part not found" },
+    });
+    let caught: ApiError | null = null;
+    try {
+      await api.parsed.get("/whatever", Schema);
+    } catch (e) {
+      if (e instanceof ApiError) caught = e;
+    }
+    expect(caught).not.toBeNull();
+    expect(caught!.userMessage).toBe("Not found.");
+    expect(caught!.message).toBe("part not found");
   });
 });

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -23,13 +23,38 @@ export type ApiErr = { data: null; status: { category: string; message: string }
 
 const BASE = "/api";
 
+/**
+ * Map a backend `status.category` value to a safe, human-readable string
+ * that can be shown directly in the UI without leaking server internals.
+ * The raw `message` is kept on `ApiError.message` for Sentry / console.
+ */
+export function categoryToUserMessage(category: string | undefined | null): string {
+  switch (category) {
+    case "unauthenticated":
+      return "Session expired. Please sign in again.";
+    case "forbidden":
+      return "You don't have permission to do that.";
+    case "not_found":
+      return "Not found.";
+    case "conflict":
+      return "That's a duplicate or conflicts with existing data.";
+    case "validation_error":
+      return "Some fields don't look right. Check the form and retry.";
+    default:
+      return "Something went wrong. Try again, or refresh.";
+  }
+}
+
 export class ApiError extends Error {
   status: number;
   body: ApiErr | null;
+  /** Safe, human-readable message for display in toasts and banners. */
+  userMessage: string;
   constructor(status: number, body: ApiErr | null, message: string) {
     super(message);
     this.status = status;
     this.body = body;
+    this.userMessage = categoryToUserMessage(body?.status?.category);
   }
 }
 

--- a/web/src/routes/auth/Login.tsx
+++ b/web/src/routes/auth/Login.tsx
@@ -39,7 +39,7 @@ export default function Login() {
           setRetryAfter(body.retry_after_seconds);
           setErr("Too many failed login attempts. Please try again later.");
         } else {
-          setErr(e.message);
+          setErr(e.userMessage);
         }
       } else {
         setErr("Login failed");

--- a/web/src/routes/auth/Signup.tsx
+++ b/web/src/routes/auth/Signup.tsx
@@ -44,7 +44,7 @@ export default function Signup() {
       await refresh();
       nav(fromPath || "/parts", { replace: true });
     } catch (e) {
-      setErr(e instanceof ApiError ? e.message : "Signup failed");
+      setErr(e instanceof ApiError ? e.userMessage : "Signup failed");
     } finally {
       setBusy(false);
     }

--- a/web/src/routes/builds/BuildCreate.tsx
+++ b/web/src/routes/builds/BuildCreate.tsx
@@ -32,7 +32,7 @@ export default function BuildCreate() {
       });
       nav(`/builds/${b.id}`);
     } catch (e) {
-      setErr(e instanceof ApiError ? e.message : "Failed");
+      setErr(e instanceof ApiError ? e.userMessage : "Failed");
     } finally {
       setBusy(false);
     }

--- a/web/src/routes/builds/BuildDetail.tsx
+++ b/web/src/routes/builds/BuildDetail.tsx
@@ -95,7 +95,7 @@ export default function BuildDetail() {
       qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "parts") });
       toast.success("Build complete — stock decremented.");
     } catch (e) {
-      const m = e instanceof ApiError ? e.message : "Build failed";
+      const m = e instanceof ApiError ? e.userMessage : "Build failed";
       setErr(m);
       toast.error(m);
     } finally {

--- a/web/src/routes/orders/OrderCreate.tsx
+++ b/web/src/routes/orders/OrderCreate.tsx
@@ -29,7 +29,7 @@ export default function OrderCreate() {
       });
       nav(`/orders/${o.id}`);
     } catch (e) {
-      setErr(e instanceof ApiError ? e.message : "Failed");
+      setErr(e instanceof ApiError ? e.userMessage : "Failed");
     } finally {
       setBusy(false);
     }

--- a/web/src/routes/orders/OrderDetail.tsx
+++ b/web/src/routes/orders/OrderDetail.tsx
@@ -95,7 +95,7 @@ export default function OrderDetail() {
       toast.success("Entry deleted.");
     },
     onError: (e) => {
-      toast.error(e instanceof ApiError ? e.message : "Delete failed");
+      toast.error(e instanceof ApiError ? e.userMessage : "Delete failed");
     },
   });
 
@@ -110,7 +110,7 @@ export default function OrderDetail() {
       toast.success(`Received ${totalQty} unit${totalQty === 1 ? "" : "s"}.`);
     },
     onError: (e) => {
-      const msg = e instanceof ApiError ? e.message : "Receive failed";
+      const msg = e instanceof ApiError ? e.userMessage : "Receive failed";
       setErr(msg);
       toast.error(msg);
     },
@@ -144,7 +144,7 @@ export default function OrderDetail() {
       },
       {
         onError: (e) => {
-          setErr(e instanceof ApiError ? e.message : "Failed");
+          setErr(e instanceof ApiError ? e.userMessage : "Failed");
         },
       },
     );

--- a/web/src/routes/parts/PartCreate.tsx
+++ b/web/src/routes/parts/PartCreate.tsx
@@ -96,7 +96,7 @@ export default function PartCreate() {
         setErr(null);
         return;
       }
-      setErr(e instanceof ApiError ? e.message : "Failed");
+      setErr(e instanceof ApiError ? e.userMessage : "Failed");
     },
   });
 

--- a/web/src/routes/parts/PartsList.tsx
+++ b/web/src/routes/parts/PartsList.tsx
@@ -110,7 +110,7 @@ export default function PartsList({ archived = false }: { archived?: boolean }) 
           : `Archived ${res.archived_ids.length} of ${ids.length}; ${res.skipped} skipped.`,
       );
     } catch (e) {
-      toast.error(e instanceof ApiError ? e.message : "Bulk delete failed");
+      toast.error(e instanceof ApiError ? e.userMessage : "Bulk delete failed");
     } finally {
       setBusy(false);
     }

--- a/web/src/routes/parts/ScanImport.tsx
+++ b/web/src/routes/parts/ScanImport.tsx
@@ -185,7 +185,7 @@ export default function ScanImport() {
         setState({ kind: "error", message: lookup.message || "no match" });
       }
     } catch (e) {
-      setState({ kind: "error", message: e instanceof ApiError ? e.message : "Lookup failed" });
+      setState({ kind: "error", message: e instanceof ApiError ? e.userMessage : "Lookup failed" });
     }
   }, []);
 
@@ -211,7 +211,7 @@ export default function ScanImport() {
       qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "part", st.part_id, "stock") });
       toast.success(`Removed ${quantity} from this bag.`);
     } catch (e) {
-      toast.error(e instanceof ApiError ? e.message : "Quick-remove failed");
+      toast.error(e instanceof ApiError ? e.userMessage : "Quick-remove failed");
     }
   }
 
@@ -267,7 +267,7 @@ export default function ScanImport() {
         `Imported ${out.summary.created} part${out.summary.created === 1 ? "" : "s"}.`
       );
     } catch (e) {
-      toast.error(e instanceof ApiError ? e.message : "Import failed");
+      toast.error(e instanceof ApiError ? e.userMessage : "Import failed");
     } finally {
       setSubmitting(false);
     }

--- a/web/src/routes/parts/detail/PartAddStock.tsx
+++ b/web/src/routes/parts/detail/PartAddStock.tsx
@@ -56,7 +56,7 @@ export default function PartAddStock() {
       nav(`/parts/${partId}/stock`);
     },
     onError: (e) => {
-      setErr(e instanceof ApiError ? e.message : "Failed");
+      setErr(e instanceof ApiError ? e.userMessage : "Failed");
     },
   });
 

--- a/web/src/routes/parts/detail/PartInfo.tsx
+++ b/web/src/routes/parts/detail/PartInfo.tsx
@@ -86,7 +86,7 @@ export default function PartInfo() {
       qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "part", part.id) });
       qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "part", part.id, "custom-fields") });
     } catch (e) {
-      toast.error(e instanceof ApiError ? e.message : "Refresh failed");
+      toast.error(e instanceof ApiError ? e.userMessage : "Refresh failed");
     } finally {
       setRefreshing(false);
     }

--- a/web/src/routes/parts/detail/PartMembers.tsx
+++ b/web/src/routes/parts/detail/PartMembers.tsx
@@ -30,7 +30,7 @@ export default function PartMembers() {
       setPick("");
       qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "part", partId, "members") });
     } catch (e) {
-      setErr(e instanceof ApiError ? e.message : "Failed");
+      setErr(e instanceof ApiError ? e.userMessage : "Failed");
     }
   }
   async function remove(mid: string) {

--- a/web/src/routes/parts/detail/PartMoveStock.tsx
+++ b/web/src/routes/parts/detail/PartMoveStock.tsx
@@ -92,7 +92,7 @@ export default function PartMoveStock() {
       nav(`/parts/${partId}/stock`);
     },
     onError: (e) => {
-      setErr(e instanceof ApiError ? e.message : "Failed");
+      setErr(e instanceof ApiError ? e.userMessage : "Failed");
     },
   });
 

--- a/web/src/routes/parts/detail/PartRemoveStock.tsx
+++ b/web/src/routes/parts/detail/PartRemoveStock.tsx
@@ -97,7 +97,7 @@ export default function PartRemoveStock() {
       nav(`/parts/${partId}/stock`);
     },
     onError: (e) => {
-      setErr(e instanceof ApiError ? e.message : "Failed");
+      setErr(e instanceof ApiError ? e.userMessage : "Failed");
     },
   });
 

--- a/web/src/routes/parts/detail/PartSettings.tsx
+++ b/web/src/routes/parts/detail/PartSettings.tsx
@@ -43,7 +43,7 @@ export default function PartSettings() {
       qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "part", partId) });
     },
     onError: (e) => {
-      setErr(e instanceof ApiError ? e.message : "Failed");
+      setErr(e instanceof ApiError ? e.userMessage : "Failed");
     },
   });
 

--- a/web/src/routes/parts/detail/PartSourcing.tsx
+++ b/web/src/routes/parts/detail/PartSourcing.tsx
@@ -52,7 +52,7 @@ export default function PartSourcing() {
       qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "part", part.id) });
       toast.success("Refreshed from provider.");
     } catch (e) {
-      toast.error(e instanceof ApiError ? e.message : "Refresh failed");
+      toast.error(e instanceof ApiError ? e.userMessage : "Refresh failed");
     } finally {
       setRefreshing(false);
     }

--- a/web/src/routes/parts/detail/PartSpecs.tsx
+++ b/web/src/routes/parts/detail/PartSpecs.tsx
@@ -76,7 +76,7 @@ export default function PartSpecs() {
       qc.invalidateQueries({ queryKey });
       toast.success("Spec added.");
     } catch (e) {
-      toast.error(e instanceof ApiError ? e.message : "Failed");
+      toast.error(e instanceof ApiError ? e.userMessage : "Failed");
     } finally {
       setBusy(false);
     }
@@ -93,7 +93,7 @@ export default function PartSpecs() {
       });
       qc.invalidateQueries({ queryKey });
     } catch (e) {
-      toast.error(e instanceof ApiError ? e.message : "Failed");
+      toast.error(e instanceof ApiError ? e.userMessage : "Failed");
     }
   }
 
@@ -104,7 +104,7 @@ export default function PartSpecs() {
       qc.invalidateQueries({ queryKey });
       toast.success("Spec deleted.");
     } catch (e) {
-      toast.error(e instanceof ApiError ? e.message : "Failed");
+      toast.error(e instanceof ApiError ? e.userMessage : "Failed");
     }
   }
 
@@ -114,7 +114,7 @@ export default function PartSpecs() {
       qc.invalidateQueries({ queryKey });
       toast.success("Restored upstream value.");
     } catch (e) {
-      toast.error(e instanceof ApiError ? e.message : "Failed");
+      toast.error(e instanceof ApiError ? e.userMessage : "Failed");
     }
   }
 

--- a/web/src/routes/projects/ProjectCreate.tsx
+++ b/web/src/routes/projects/ProjectCreate.tsx
@@ -16,7 +16,7 @@ export default function ProjectCreate() {
       const res = await api.post<{ id: string }>("/projects", { name, description: description || null });
       nav(`/projects/${res.id}/data`);
     } catch (e) {
-      setErr(e instanceof ApiError ? e.message : "Failed");
+      setErr(e instanceof ApiError ? e.userMessage : "Failed");
     } finally {
       setBusy(false);
     }

--- a/web/src/routes/projects/detail/ProjectImport.tsx
+++ b/web/src/routes/projects/detail/ProjectImport.tsx
@@ -153,7 +153,7 @@ export default function ProjectImport() {
       refetchPresets();
       toast.success(`Preset "${name}" saved.`);
     } catch (e) {
-      toast.error(e instanceof ApiError ? e.message : "Failed to save preset");
+      toast.error(e instanceof ApiError ? e.userMessage : "Failed to save preset");
     }
   }
 
@@ -200,7 +200,7 @@ export default function ProjectImport() {
       setStep("mapping");
     } catch (e) {
       setUploadProgress(null);
-      setErr(e instanceof ApiError ? e.message : "Failed to parse");
+      setErr(e instanceof ApiError ? e.userMessage : "Failed to parse");
     } finally {
       setBusy(false);
     }
@@ -237,7 +237,7 @@ export default function ProjectImport() {
       qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "project", projectId, "entries") });
       setStep("done");
     } catch (e) {
-      setErr(e instanceof ApiError ? e.message : "Import failed");
+      setErr(e instanceof ApiError ? e.userMessage : "Import failed");
     } finally {
       setBusy(false);
     }

--- a/web/src/routes/reports/Reports.tsx
+++ b/web/src/routes/reports/Reports.tsx
@@ -85,7 +85,7 @@ async function createRestockOrder(
     }
     nav(`/orders/${order.id}`);
   } catch (e) {
-    toast.error(e instanceof ApiError ? e.message : "Failed to create order");
+    toast.error(e instanceof ApiError ? e.userMessage : "Failed to create order");
   }
 }
 

--- a/web/src/routes/settings/Account.tsx
+++ b/web/src/routes/settings/Account.tsx
@@ -27,7 +27,7 @@ export default function Account() {
       await refresh();
       await switchWorkspace(out.workspace_id);
     } catch (e) {
-      setErr(e instanceof ApiError ? e.message : "Failed");
+      setErr(e instanceof ApiError ? e.userMessage : "Failed");
     } finally {
       setBusy(false);
     }

--- a/web/src/routes/settings/Workspace.tsx
+++ b/web/src/routes/settings/Workspace.tsx
@@ -107,7 +107,7 @@ export default function WorkspaceSettings() {
       qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "ws", "current") });
       toast.success("Workspace settings saved.");
     } catch (e) {
-      const m = e instanceof ApiError ? e.message : "Failed";
+      const m = e instanceof ApiError ? e.userMessage : "Failed";
       setErr(m);
       toast.error(m);
     }
@@ -132,7 +132,7 @@ export default function WorkspaceSettings() {
       refetchInvites();
       toast.success(`Invitation sent to ${sent}.`);
     } catch (e) {
-      const m = e instanceof ApiError ? e.message : "Failed";
+      const m = e instanceof ApiError ? e.userMessage : "Failed";
       setErr(m);
       toast.error(m);
     }
@@ -145,7 +145,7 @@ export default function WorkspaceSettings() {
       refetchMembers();
       toast.success("Member updated.");
     } catch (e) {
-      const m = e instanceof ApiError ? e.message : "Failed";
+      const m = e instanceof ApiError ? e.userMessage : "Failed";
       setErr(m);
       toast.error(m);
     }
@@ -163,7 +163,7 @@ export default function WorkspaceSettings() {
       refetchMembers();
       toast.success("Member removed.");
     } catch (e) {
-      const m = e instanceof ApiError ? e.message : "Failed";
+      const m = e instanceof ApiError ? e.userMessage : "Failed";
       setErr(m);
       toast.error(m);
     }
@@ -384,7 +384,7 @@ export default function WorkspaceSettings() {
                       setProviderSecret("");
                       toast.success("Credentials saved.");
                     } catch (e) {
-                      toast.error(e instanceof ApiError ? e.message : "Failed");
+                      toast.error(e instanceof ApiError ? e.userMessage : "Failed");
                     } finally {
                       setProviderKeyBusy(false);
                     }
@@ -412,7 +412,7 @@ export default function WorkspaceSettings() {
                         qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "ws", "current") });
                         toast.success("Credentials cleared.");
                       } catch (e) {
-                        toast.error(e instanceof ApiError ? e.message : "Failed");
+                        toast.error(e instanceof ApiError ? e.userMessage : "Failed");
                       } finally {
                         setProviderKeyBusy(false);
                       }
@@ -455,7 +455,7 @@ export default function WorkspaceSettings() {
                       setProviderKey("");
                       toast.success(providerKey ? "API key saved." : "API key cleared.");
                     } catch (e) {
-                      toast.error(e instanceof ApiError ? e.message : "Failed");
+                      toast.error(e instanceof ApiError ? e.userMessage : "Failed");
                     } finally {
                       setProviderKeyBusy(false);
                     }
@@ -518,7 +518,7 @@ export default function WorkspaceSettings() {
                       setScannerLicense("");
                       toast.success(scannerLicense ? "License key saved." : "License key cleared.");
                     } catch (e) {
-                      toast.error(e instanceof ApiError ? e.message : "Failed");
+                      toast.error(e instanceof ApiError ? e.userMessage : "Failed");
                     } finally {
                       setScannerBusy(false);
                     }

--- a/web/src/routes/storage/StorageCreate.tsx
+++ b/web/src/routes/storage/StorageCreate.tsx
@@ -26,7 +26,7 @@ export default function StorageCreate() {
       const res = await api.post<{ id: string }>("/storage", form);
       nav(`/storage/${res.id}/info`);
     } catch (e) {
-      setErr(e instanceof ApiError ? e.message : "Failed");
+      setErr(e instanceof ApiError ? e.userMessage : "Failed");
     } finally {
       setBusy(false);
     }


### PR DESCRIPTION
Closes #56

## Summary
- Add `userMessage` field to `ApiError`; `categoryToUserMessage(category)` mapper in `web/src/lib/api.ts`
- Populate `userMessage` from `body.status.category` on all throw paths (HTTP errors + schema mismatches)
- Migrate all 25 catch sites from `e.message` to `e.userMessage` in toasts/banners; Sentry/console still get raw `e.message`
- `getConflictDetail` (MPN-conflict special case) preserved and compatible with new field
- Tests: assert `userMessage` per category, raw `message` preserved, HTTP errors carry correct `userMessage`

## Tests
Backend: N/A (frontend-only change)
Frontend build: passed
Frontend vitest: 75 passed (17 in api.test.ts including new userMessage assertions)