### PR TITLE
fix(activity): cursor pagination (before_occurred_at/id) + user_map caching (#64)

### DIFF
--- a/backend/app/api/routes/_activity.py
+++ b/backend/app/api/routes/_activity.py
@@ -11,6 +11,23 @@ exact JSON. We keep it a single shape (kind discriminator + nullable fields)
 because every consumer just renders a list of entries; carving out separate
 shapes per kind would force the frontend to handle three branches for what
 is fundamentally one timeline.
+
+Cursor pagination
+-----------------
+All three activity routes support `(occurred_at DESC, id DESC)` cursor
+pagination via query params `before_occurred_at` + `before_id`.
+
+  ?before_occurred_at=<isoformat>&before_id=<uuid>&limit=<int>
+
+The response body includes `next_before_occurred_at` / `next_before_id`
+when a subsequent page exists; omitting these keys signals the last page.
+
+User-map caching
+----------------
+`_user_map` accepts an optional ``cache`` dict (typically
+``request.state.user_cache``) and populates it lazily — the user table is
+queried at most once per unique user_id per request across all calls that
+share the same cache dict.
 """
 
 from __future__ import annotations
@@ -24,7 +41,8 @@ from app.domain.stock.models import StockEntry
 from app.domain.users.models import User
 
 
-_LIMIT = 200
+_DEFAULT_LIMIT = 50
+_MAX_LIMIT = 200
 
 
 def _user_dict(user: User | None) -> dict | None:
@@ -33,17 +51,42 @@ def _user_dict(user: User | None) -> dict | None:
     return {"id": str(user.id), "name": user.name}
 
 
-def _user_map(db: Session, user_ids: Iterable[UUID | None]) -> dict[UUID, User]:
+def _user_map(
+    db: Session,
+    user_ids: Iterable[UUID | None],
+    *,
+    cache: dict[UUID, User] | None = None,
+) -> dict[UUID, User]:
+    """Return a mapping of user_id → User for the given ids.
+
+    When ``cache`` is supplied (e.g. ``request.state.user_cache``) it is
+    used as a read-through cache: only ids that are absent from the cache
+    trigger a DB query; results are written back so subsequent calls within
+    the same request share the warm dict.
+    """
     ids = {uid for uid in user_ids if uid is not None}
     if not ids:
         return {}
-    rows = db.query(User).filter(User.id.in_(ids)).all()
-    return {u.id: u for u in rows}
+
+    if cache is None:
+        # No cache — fetch all ids in one shot.
+        rows = db.query(User).filter(User.id.in_(ids)).all()
+        return {u.id: u for u in rows}
+
+    # Cache-aware path: resolve the miss-set, query only those, merge.
+    missing = ids - cache.keys()
+    if missing:
+        rows = db.query(User).filter(User.id.in_(missing)).all()
+        for u in rows:
+            cache[u.id] = u
+
+    return {uid: cache[uid] for uid in ids if uid in cache}
 
 
 def _stock_event(row: StockEntry, user: User | None) -> dict:
     return {
         "kind": "stock",
+        "id": str(row.id),
         "operation_type": row.operation_type,
         "quantity_delta": row.quantity_delta,
         "user": _user_dict(user),
@@ -66,6 +109,7 @@ def _entity_event(
 ) -> dict:
     return {
         "kind": kind,
+        "id": None,
         "operation_type": None,
         "quantity_delta": None,
         "user": _user_dict(user),
@@ -88,32 +132,71 @@ def build_activity(
     updated_by: UUID | None,
     created_kind: str,
     updated_kind: str,
-) -> list[dict]:
-    """Combine entity create/update synthetic events with `stock_rows` and
-    return them sorted by occurred_at DESC, capped at 200."""
+    limit: int = _DEFAULT_LIMIT,
+    include_synthetic: bool = True,
+    user_cache: dict[UUID, User] | None = None,
+) -> dict:
+    """Combine entity create/update synthetic events with ``stock_rows``.
+
+    Returns a dict with:
+      - ``events``               — list of activity dicts, sorted occurred_at DESC
+      - ``next_before_occurred_at`` — isoformat string, present when next page exists
+      - ``next_before_id``          — UUID string, present when next page exists
+
+    Parameters
+    ----------
+    stock_rows:
+        Pre-fetched stock entries for this page (already ordered + cursor-filtered
+        by the caller, length <= limit + 1 to detect next-page existence).
+    limit:
+        Maximum number of events to include in this page (default 50, max 200).
+    include_synthetic:
+        When False the created/updated synthetic events are omitted — callers set
+        this to False on continuation pages so they only appear on the first page.
+    user_cache:
+        Optional per-request dict shared across activity helper calls to avoid
+        re-querying the users table per route invocation.
+    """
+    limit = min(max(1, limit), _MAX_LIMIT)
+
+    # Detect whether there's a next page: callers fetch limit+1 rows.
+    has_next = len(stock_rows) > limit
+    page_rows = stock_rows[:limit]
+
     user_ids: list[UUID | None] = [created_by, updated_by]
-    user_ids.extend(r.created_by for r in stock_rows)
-    users = _user_map(db, user_ids)
+    user_ids.extend(r.created_by for r in page_rows)
+    users = _user_map(db, user_ids, cache=user_cache)
 
     events: list[dict] = []
-    if created_at is not None:
-        events.append(
-            _entity_event(
-                kind=created_kind,
-                occurred_at=created_at,
-                user=users.get(created_by) if created_by else None,
+    if include_synthetic:
+        if created_at is not None:
+            events.append(
+                _entity_event(
+                    kind=created_kind,
+                    occurred_at=created_at,
+                    user=users.get(created_by) if created_by else None,
+                )
             )
-        )
-    if updated_at is not None and updated_at != created_at:
-        events.append(
-            _entity_event(
-                kind=updated_kind,
-                occurred_at=updated_at,
-                user=users.get(updated_by) if updated_by else None,
+        if updated_at is not None and updated_at != created_at:
+            events.append(
+                _entity_event(
+                    kind=updated_kind,
+                    occurred_at=updated_at,
+                    user=users.get(updated_by) if updated_by else None,
+                )
             )
-        )
-    for row in stock_rows:
+
+    for row in page_rows:
         events.append(_stock_event(row, users.get(row.created_by) if row.created_by else None))
 
     events.sort(key=lambda e: e["occurred_at"], reverse=True)
-    return events[:_LIMIT]
+
+    result: dict = {"events": events}
+
+    if has_next and page_rows:
+        # Cursor points at the last stock row returned (oldest on this page).
+        last = page_rows[-1]
+        result["next_before_occurred_at"] = last.occurred_at.isoformat()
+        result["next_before_id"] = str(last.id)
+
+    return result

--- a/backend/app/api/routes/builds.py
+++ b/backend/app/api/routes/builds.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException, Query, status
-from sqlalchemy import select
+from fastapi import APIRouter, HTTPException, Query, Request, status
+from sqlalchemy import and_, or_, select
 
 from app.api._helpers import require_resource_access
-from app.api.routes._activity import build_activity
+from app.api.routes._activity import _DEFAULT_LIMIT, _MAX_LIMIT, build_activity
 from app.core.deps import CurrentUser, CurrentWorkspace, DbSession
 from app.core.responses import ok
 from app.domain.builds.models import Build
@@ -174,18 +174,46 @@ def consume_build(
 
 
 @router.get("/{build_id}/activity")
-def build_activity_route(build_id: UUID, db: DbSession, ws: CurrentWorkspace):
+def build_activity_route(
+    request: Request,
+    build_id: UUID,
+    db: DbSession,
+    ws: CurrentWorkspace,
+    limit: int = Query(default=_DEFAULT_LIMIT, ge=1, le=_MAX_LIMIT),
+    before_occurred_at: str | None = Query(default=None),
+    before_id: UUID | None = Query(default=None),
+):
     b = _get_build(db, ws.id, build_id)
-    stock_rows = list(
-        db.execute(
-            select(StockEntry)
-            .where(StockEntry.workspace_id == ws.id)
-            .where(StockEntry.build_id == b.id)
-            .order_by(StockEntry.occurred_at.desc())
-            .limit(200)
-        ).scalars()
+
+    cursor_at: datetime | None = None
+    if before_occurred_at is not None:
+        try:
+            cursor_at = datetime.fromisoformat(before_occurred_at)
+        except ValueError:
+            raise HTTPException(status_code=422, detail="invalid before_occurred_at")
+
+    stmt = (
+        select(StockEntry)
+        .where(StockEntry.workspace_id == ws.id)
+        .where(StockEntry.build_id == b.id)
     )
-    events = build_activity(
+    if cursor_at is not None and before_id is not None:
+        stmt = stmt.where(
+            or_(
+                StockEntry.occurred_at < cursor_at,
+                and_(
+                    StockEntry.occurred_at == cursor_at,
+                    StockEntry.id < before_id,
+                ),
+            )
+        )
+    stmt = stmt.order_by(StockEntry.occurred_at.desc(), StockEntry.id.desc()).limit(limit + 1)
+    stock_rows = list(db.execute(stmt).scalars())
+
+    if not hasattr(request.state, "user_cache"):
+        request.state.user_cache = {}
+
+    result = build_activity(
         db,
         stock_rows=stock_rows,
         created_at=b.created_at,
@@ -194,5 +222,8 @@ def build_activity_route(build_id: UUID, db: DbSession, ws: CurrentWorkspace):
         updated_by=b.updated_by,
         created_kind="build_created",
         updated_kind="build_updated",
+        limit=limit,
+        include_synthetic=(cursor_at is None),
+        user_cache=request.state.user_cache,
     )
-    return ok(events)
+    return ok(result)

--- a/backend/app/api/routes/orders.py
+++ b/backend/app/api/routes/orders.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException, Query, status
-from sqlalchemy import or_, select
+from fastapi import APIRouter, HTTPException, Query, Request, status
+from sqlalchemy import and_, or_, select
 
 from app.api._helpers import assert_child_in_parent, require_resource_access
-from app.api.routes._activity import build_activity
+from app.api.routes._activity import _DEFAULT_LIMIT, _MAX_LIMIT, build_activity
 from app.core.deps import CurrentUser, CurrentWorkspace, DbSession
 from app.core.responses import ok
 from app.domain.orders.models import Order, OrderEntry
@@ -260,18 +260,46 @@ def receive_order(order_id: UUID, payload: ReceiveIn, db: DbSession, ws: Current
 
 
 @router.get("/{order_id}/activity")
-def order_activity(order_id: UUID, db: DbSession, ws: CurrentWorkspace):
+def order_activity(
+    request: Request,
+    order_id: UUID,
+    db: DbSession,
+    ws: CurrentWorkspace,
+    limit: int = Query(default=_DEFAULT_LIMIT, ge=1, le=_MAX_LIMIT),
+    before_occurred_at: str | None = Query(default=None),
+    before_id: UUID | None = Query(default=None),
+):
     o = _get_order(db, ws.id, order_id)
-    stock_rows = list(
-        db.execute(
-            select(StockEntry)
-            .where(StockEntry.workspace_id == ws.id)
-            .where(StockEntry.order_id == o.id)
-            .order_by(StockEntry.occurred_at.desc())
-            .limit(200)
-        ).scalars()
+
+    cursor_at: datetime | None = None
+    if before_occurred_at is not None:
+        try:
+            cursor_at = datetime.fromisoformat(before_occurred_at)
+        except ValueError:
+            raise HTTPException(status_code=422, detail="invalid before_occurred_at")
+
+    stmt = (
+        select(StockEntry)
+        .where(StockEntry.workspace_id == ws.id)
+        .where(StockEntry.order_id == o.id)
     )
-    events = build_activity(
+    if cursor_at is not None and before_id is not None:
+        stmt = stmt.where(
+            or_(
+                StockEntry.occurred_at < cursor_at,
+                and_(
+                    StockEntry.occurred_at == cursor_at,
+                    StockEntry.id < before_id,
+                ),
+            )
+        )
+    stmt = stmt.order_by(StockEntry.occurred_at.desc(), StockEntry.id.desc()).limit(limit + 1)
+    stock_rows = list(db.execute(stmt).scalars())
+
+    if not hasattr(request.state, "user_cache"):
+        request.state.user_cache = {}
+
+    result = build_activity(
         db,
         stock_rows=stock_rows,
         created_at=o.created_at,
@@ -280,5 +308,8 @@ def order_activity(order_id: UUID, db: DbSession, ws: CurrentWorkspace):
         updated_by=o.updated_by,
         created_kind="order_created",
         updated_kind="order_updated",
+        limit=limit,
+        include_synthetic=(cursor_at is None),
+        user_cache=request.state.user_cache,
     )
-    return ok(events)
+    return ok(result)

--- a/backend/app/api/routes/parts.py
+++ b/backend/app/api/routes/parts.py
@@ -10,7 +10,7 @@ from fastapi.responses import FileResponse
 from sqlalchemy import or_, select
 
 from app.api._helpers import assert_in_workspace, require_resource_access
-from app.api.routes._activity import build_activity
+from app.api.routes._activity import _DEFAULT_LIMIT, _MAX_LIMIT, build_activity
 from app.api.routes._parts_shared import (
     get_part as _get_part,
     image_urls_for_parts as _image_urls_for_parts,
@@ -542,19 +542,50 @@ def del_member(meta_id: UUID, member_id: UUID, db: DbSession, ws: CurrentWorkspa
 
 
 @router.get("/{part_id}/activity")
-def part_activity(part_id: UUID, db: DbSession, ws: CurrentWorkspace):
+def part_activity(
+    request: Request,
+    part_id: UUID,
+    db: DbSession,
+    ws: CurrentWorkspace,
+    limit: int = Query(default=_DEFAULT_LIMIT, ge=1, le=_MAX_LIMIT),
+    before_occurred_at: str | None = Query(default=None),
+    before_id: UUID | None = Query(default=None),
+):
     # Read endpoint — let archived parts surface their history too.
     p = _get_part(db, ws.id, part_id, include_archived=True)
-    stock_rows = list(
-        db.execute(
-            select(StockEntry)
-            .where(StockEntry.workspace_id == ws.id)
-            .where(StockEntry.part_id == p.id)
-            .order_by(StockEntry.occurred_at.desc())
-            .limit(200)
-        ).scalars()
+
+    # Parse cursor
+    cursor_at: datetime | None = None
+    if before_occurred_at is not None:
+        try:
+            cursor_at = datetime.fromisoformat(before_occurred_at)
+        except ValueError:
+            raise HTTPException(status_code=422, detail="invalid before_occurred_at")
+
+    stmt = (
+        select(StockEntry)
+        .where(StockEntry.workspace_id == ws.id)
+        .where(StockEntry.part_id == p.id)
     )
-    events = build_activity(
+    if cursor_at is not None and before_id is not None:
+        from sqlalchemy import or_, and_, tuple_
+        stmt = stmt.where(
+            or_(
+                StockEntry.occurred_at < cursor_at,
+                and_(
+                    StockEntry.occurred_at == cursor_at,
+                    StockEntry.id < before_id,
+                ),
+            )
+        )
+    stmt = stmt.order_by(StockEntry.occurred_at.desc(), StockEntry.id.desc()).limit(limit + 1)
+    stock_rows = list(db.execute(stmt).scalars())
+
+    # Per-request user cache stashed on request.state so it's isolated per request.
+    if not hasattr(request.state, "user_cache"):
+        request.state.user_cache = {}
+
+    result = build_activity(
         db,
         stock_rows=stock_rows,
         created_at=p.created_at,
@@ -563,8 +594,11 @@ def part_activity(part_id: UUID, db: DbSession, ws: CurrentWorkspace):
         updated_by=p.updated_by,
         created_kind="part_created",
         updated_kind="part_updated",
+        limit=limit,
+        include_synthetic=(cursor_at is None),
+        user_cache=request.state.user_cache,
     )
-    return ok(events)
+    return ok(result)
 
 
 # Reserved keys that surface elsewhere on PartInfo (Media card). These

--- a/backend/tests/test_activity.py
+++ b/backend/tests/test_activity.py
@@ -55,7 +55,8 @@ def test_part_activity_orders_desc_and_includes_creation(authed):
 
     r = authed.get(f"/api/parts/{part_id}/activity")
     assert r.status_code == 200, r.text
-    events = r.json()["data"]
+    page = r.json()["data"]
+    events = page["events"]
 
     kinds = [e["kind"] for e in events]
     ops = [e["operation_type"] for e in events]
@@ -107,7 +108,8 @@ def test_order_activity_shows_create_and_receive(authed):
 
     r = authed.get(f"/api/orders/{order['id']}/activity")
     assert r.status_code == 200
-    events = r.json()["data"]
+    page = r.json()["data"]
+    events = page["events"]
     kinds = [e["kind"] for e in events]
     assert "order_created" in kinds
     stock_events = [e for e in events if e["kind"] == "stock"]
@@ -160,7 +162,8 @@ def test_build_activity_includes_reserve_and_consume(authed):
 
     r = authed.get(f"/api/builds/{bid}/activity")
     assert r.status_code == 200
-    events = r.json()["data"]
+    page = r.json()["data"]
+    events = page["events"]
     kinds = [e["kind"] for e in events]
     ops = [e["operation_type"] for e in events]
     assert "build_created" in kinds

--- a/backend/tests/test_activity_pagination.py
+++ b/backend/tests/test_activity_pagination.py
@@ -1,0 +1,219 @@
+"""BE2-019: cursor pagination for activity routes.
+
+Seed 250 stock entries on a part; verify:
+  - First call (no cursor) returns default 50 with next_* cursor.
+  - Second call with cursor returns the next 50, strictly older.
+  - Pagination continues until cursor is absent (last page).
+  - Total events across all pages equals 250 stock + 1 synthetic created.
+  - Limit param is respected (default 50, explicit 10, max capped at 200).
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+def _signup(c: TestClient, name: str = "Alice"):
+    email = f"u-{uuid.uuid4().hex[:8]}@x.com"
+    r = c.post(
+        "/api/auth/signup",
+        json={"email": email, "name": name, "password": "TestPass-2026-Stronk"},
+    )
+    assert r.status_code == 200, r.text
+    return r
+
+
+@pytest.fixture
+def authed():
+    c = TestClient(app)
+    _signup(c)
+    return c
+
+
+def _make_part(c, name="Cap"):
+    r = c.post("/api/parts", json={"name": name, "part_type": "local"})
+    assert r.status_code in (200, 201), r.text
+    return r.json()["data"]["id"]
+
+
+def _make_storage(c, name="Shelf"):
+    r = c.post("/api/storage", json={"name": name})
+    assert r.status_code in (200, 201)
+    return r.json()["data"]["id"]
+
+
+def _add_stock(c, part_id, storage_id, qty=1):
+    r = c.post(
+        "/api/stock/add",
+        json={"part_id": part_id, "quantity": qty, "storage_location_id": storage_id},
+    )
+    assert r.status_code == 200, r.text
+
+
+def _fetch_activity(c, part_id, **params):
+    r = c.get(f"/api/parts/{part_id}/activity", params=params)
+    assert r.status_code == 200, r.text
+    return r.json()["data"]
+
+
+# ---------------------------------------------------------------------------
+# Core pagination tests
+# ---------------------------------------------------------------------------
+
+
+def test_first_page_default_limit(authed):
+    """First page with default limit=50 returns cursor and includes synthetic created event."""
+    part_id = _make_part(authed, "P-pagination")
+    storage_id = _make_storage(authed, "S-pagination")
+
+    for _ in range(60):
+        _add_stock(authed, part_id, storage_id)
+
+    page = _fetch_activity(authed, part_id)
+    events = page["events"]
+    # Stock events = 50 (limit); synthetic events may push total slightly above limit.
+    stock_events = [e for e in events if e["kind"] == "stock"]
+    assert len(stock_events) == 50
+    assert "next_before_occurred_at" in page
+    assert "next_before_id" in page
+
+    # Sorted descending
+    timestamps = [e["occurred_at"] for e in events]
+    assert timestamps == sorted(timestamps, reverse=True)
+
+    # Synthetic created event appears on first page (cursor_at is None)
+    kinds = [e["kind"] for e in events]
+    assert "part_created" in kinds
+
+
+def test_cursor_continuation(authed):
+    """Second page returns events strictly older than the cursor."""
+    part_id = _make_part(authed, "P-cursor")
+    storage_id = _make_storage(authed, "S-cursor")
+
+    for _ in range(120):
+        _add_stock(authed, part_id, storage_id)
+
+    page1 = _fetch_activity(authed, part_id, limit=50)
+    assert "next_before_occurred_at" in page1
+    assert "next_before_id" in page1
+
+    cursor_ts = page1["next_before_occurred_at"]
+
+    page2 = _fetch_activity(
+        authed,
+        part_id,
+        limit=50,
+        before_occurred_at=cursor_ts,
+        before_id=page1["next_before_id"],
+    )
+    events1 = page1["events"]
+    events2 = page2["events"]
+
+    # All page2 stock events must have occurred_at <= cursor (the boundary used for the query)
+    for e in events2:
+        if e["kind"] == "stock":
+            assert e["occurred_at"] <= cursor_ts
+
+    # No overlap of stock event ids between pages
+    ids1 = {e.get("id") for e in events1 if e["kind"] == "stock"}
+    ids2 = {e.get("id") for e in events2 if e["kind"] == "stock"}
+    assert ids1.isdisjoint(ids2)
+
+    # Synthetic events only on first page
+    assert any(e["kind"] == "part_created" for e in events1)
+    assert not any(e["kind"].endswith("_created") or e["kind"].endswith("_updated") for e in events2)
+
+
+def test_full_traversal_250_entries(authed):
+    """Walk all pages of a 250-entry history; total stock events = 250."""
+    part_id = _make_part(authed, "P-big")
+    storage_id = _make_storage(authed, "S-big")
+
+    n = 250
+    for _ in range(n):
+        _add_stock(authed, part_id, storage_id)
+
+    all_events = []
+    params: dict = {"limit": 50}
+    while True:
+        page = _fetch_activity(authed, part_id, **params)
+        all_events.extend(page["events"])
+        if "next_before_occurred_at" not in page:
+            break
+        params = {
+            "limit": 50,
+            "before_occurred_at": page["next_before_occurred_at"],
+            "before_id": page["next_before_id"],
+        }
+
+    stock_events = [e for e in all_events if e["kind"] == "stock"]
+    assert len(stock_events) == n
+
+    # Exactly one synthetic created event (on first page only)
+    created_events = [e for e in all_events if e["kind"] == "part_created"]
+    assert len(created_events) == 1
+
+
+def test_no_next_cursor_on_last_page(authed):
+    """When total events <= limit, no next_* cursor is returned."""
+    part_id = _make_part(authed, "P-small")
+    storage_id = _make_storage(authed, "S-small")
+
+    for _ in range(5):
+        _add_stock(authed, part_id, storage_id)
+
+    page = _fetch_activity(authed, part_id, limit=50)
+    assert "next_before_occurred_at" not in page
+    assert "next_before_id" not in page
+
+
+def test_explicit_limit_respected(authed):
+    """?limit=10 returns at most 10 stock events (plus possible synthetic events)."""
+    part_id = _make_part(authed, "P-limit10")
+    storage_id = _make_storage(authed, "S-limit10")
+
+    for _ in range(30):
+        _add_stock(authed, part_id, storage_id)
+
+    page = _fetch_activity(authed, part_id, limit=10)
+    stock_events = [e for e in page["events"] if e["kind"] == "stock"]
+    assert len(stock_events) <= 10
+    assert "next_before_occurred_at" in page
+
+
+def test_limit_at_max_200(authed):
+    """?limit=200 returns at most 200 stock events; limit=999 is rejected (422)."""
+    part_id = _make_part(authed, "P-cap")
+    storage_id = _make_storage(authed, "S-cap")
+
+    for _ in range(210):
+        _add_stock(authed, part_id, storage_id)
+
+    # limit=200 is the maximum allowed; should succeed.
+    page = _fetch_activity(authed, part_id, limit=200)
+    stock_events = [e for e in page["events"] if e["kind"] == "stock"]
+    assert len(stock_events) <= 200
+
+    # limit=999 exceeds le=200 constraint → FastAPI returns 422.
+    r = authed.get(f"/api/parts/{part_id}/activity", params={"limit": 999})
+    assert r.status_code == 422
+
+
+def test_invalid_cursor_returns_422(authed):
+    """A malformed before_occurred_at returns 422."""
+    part_id = _make_part(authed, "P-bad-cursor")
+    r = authed.get(f"/api/parts/{part_id}/activity", params={"before_occurred_at": "not-a-date"})
+    assert r.status_code == 422
+
+
+def test_response_shape_has_events_key(authed):
+    """Response is {events: [...], ...}, not a bare list."""
+    part_id = _make_part(authed, "P-shape")
+    page = _fetch_activity(authed, part_id)
+    assert "events" in page
+    assert isinstance(page["events"], list)

--- a/backend/tests/test_activity_user_cache.py
+++ b/backend/tests/test_activity_user_cache.py
@@ -1,0 +1,125 @@
+"""BE2-019: user_map caching per request.
+
+Verify that when fetching activity for a part with many stock entries all
+created by the same user, the users table is queried at most once (i.e.
+_user_map with a warm cache does not re-query).
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import patch, MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.api.routes._activity import _user_map
+
+
+def _signup(c: TestClient, name: str = "Alice"):
+    email = f"u-{uuid.uuid4().hex[:8]}@x.com"
+    r = c.post(
+        "/api/auth/signup",
+        json={"email": email, "name": name, "password": "TestPass-2026-Stronk"},
+    )
+    assert r.status_code == 200, r.text
+    return r
+
+
+@pytest.fixture
+def authed():
+    c = TestClient(app)
+    _signup(c)
+    return c
+
+
+def _make_part(c, name="Cap"):
+    r = c.post("/api/parts", json={"name": name, "part_type": "local"})
+    assert r.status_code in (200, 201), r.text
+    return r.json()["data"]["id"]
+
+
+def _make_storage(c, name="Shelf"):
+    r = c.post("/api/storage", json={"name": name})
+    assert r.status_code in (200, 201)
+    return r.json()["data"]["id"]
+
+
+def test_user_map_cache_read_through():
+    """_user_map: when cache is pre-populated, DB is not queried for known ids."""
+    from uuid import uuid4
+    from app.domain.users.models import User
+
+    uid = uuid4()
+    user_obj = MagicMock(spec=User)
+    user_obj.id = uid
+
+    db = MagicMock()
+    cache: dict = {uid: user_obj}
+
+    # Call with a fully-cached user_id — should NOT touch the DB.
+    result = _user_map(db, [uid], cache=cache)
+    db.query.assert_not_called()
+    assert result[uid] is user_obj
+
+
+def test_user_map_cache_miss_fetches_only_missing():
+    """_user_map: only missing ids trigger a DB query; hits come from cache."""
+    from uuid import uuid4
+    from app.domain.users.models import User
+
+    uid_cached = uuid4()
+    uid_missing = uuid4()
+
+    cached_user = MagicMock(spec=User)
+    cached_user.id = uid_cached
+
+    missing_user = MagicMock(spec=User)
+    missing_user.id = uid_missing
+
+    # Fake the DB chain: db.query(User).filter(...).all() → [missing_user]
+    db = MagicMock()
+    db.query.return_value.filter.return_value.all.return_value = [missing_user]
+
+    cache: dict = {uid_cached: cached_user}
+
+    result = _user_map(db, [uid_cached, uid_missing], cache=cache)
+
+    # DB was queried exactly once (for the missing id).
+    db.query.assert_called_once()
+    assert result[uid_cached] is cached_user
+    assert result[uid_missing] is missing_user
+    # Cache is now fully warm.
+    assert uid_missing in cache
+
+
+def test_activity_endpoint_user_cache_single_query(authed):
+    """HTTP-level smoke: 200 stock entries by the same user → single fetch page."""
+    part_id = _make_part(authed, "P-user-cache")
+    storage_id = _make_storage(authed, "S-user-cache")
+
+    for _ in range(20):
+        r = authed.post(
+            "/api/stock/add",
+            json={"part_id": part_id, "quantity": 1, "storage_location_id": storage_id},
+        )
+        assert r.status_code == 200, r.text
+
+    query_calls: list = []
+
+    original_user_map = _user_map
+
+    def counting_user_map(db, user_ids, *, cache=None):
+        # Count how many times the DB query path is entered.
+        result = original_user_map(db, user_ids, cache=cache)
+        return result
+
+    with patch("app.api.routes._activity._user_map", side_effect=counting_user_map) as mock_um:
+        r = authed.get(f"/api/parts/{part_id}/activity")
+        assert r.status_code == 200
+        # _user_map was called once for this page
+        assert mock_um.call_count == 1
+
+    data = r.json()["data"]
+    assert "events" in data
+    assert len(data["events"]) > 0

--- a/web/src/components/ActivityTimeline.tsx
+++ b/web/src/components/ActivityTimeline.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
+import { useInfiniteQuery } from "@tanstack/react-query";
 import {
   Plus,
   Minus,
@@ -49,6 +49,12 @@ export type ActivityEntry = {
   storage_location_id: string | null;
   order_id: string | null;
   build_id: string | null;
+};
+
+type ActivityPage = {
+  events: ActivityEntry[];
+  next_before_occurred_at?: string;
+  next_before_id?: string;
 };
 
 type Props = {
@@ -136,10 +142,44 @@ function summary(e: ActivityEntry): string {
 }
 
 export default function ActivityTimeline({ endpoint }: Props) {
-  const { data, isLoading } = useQuery({
+  const {
+    data,
+    isLoading,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useInfiniteQuery<ActivityPage>({
     queryKey: useWsKey("activity", endpoint),
-    queryFn: () => api.get<ActivityEntry[]>(endpoint),
+    queryFn: ({ pageParam }) => {
+      let url = endpoint;
+      if (
+        pageParam &&
+        typeof pageParam === "object" &&
+        "before_occurred_at" in pageParam &&
+        "before_id" in pageParam
+      ) {
+        const p = pageParam as { before_occurred_at: string; before_id: string };
+        const qs = new URLSearchParams({
+          before_occurred_at: p.before_occurred_at,
+          before_id: p.before_id,
+        });
+        url = `${endpoint}?${qs.toString()}`;
+      }
+      return api.get<ActivityPage>(url);
+    },
+    initialPageParam: null,
+    getNextPageParam: (lastPage) => {
+      if (lastPage.next_before_occurred_at && lastPage.next_before_id) {
+        return {
+          before_occurred_at: lastPage.next_before_occurred_at,
+          before_id: lastPage.next_before_id,
+        };
+      }
+      return undefined;
+    },
   });
+
+  const allEvents = data?.pages.flatMap((p) => p.events) ?? [];
 
   return (
     <div className="card p-4">
@@ -150,12 +190,12 @@ export default function ActivityTimeline({ endpoint }: Props) {
 
       {isLoading ? (
         <div className="text-muted text-sm">Loading…</div>
-      ) : !data || data.length === 0 ? (
+      ) : allEvents.length === 0 ? (
         <div className="text-muted text-sm">No activity yet.</div>
       ) : (
         <>
           <ul className="space-y-2">
-            {data.map((e, i) => (
+            {allEvents.map((e, i) => (
               <li key={i} className="flex items-start gap-3 text-sm">
                 <div className="mt-0.5 shrink-0 w-6 h-6 rounded-full bg-panel2 flex items-center justify-center">
                   {iconFor(e)}
@@ -175,9 +215,15 @@ export default function ActivityTimeline({ endpoint }: Props) {
               </li>
             ))}
           </ul>
-          {data.length >= 200 && (
-            <div className="text-xs text-muted mt-3">
-              Showing the most recent 200 events.
+          {hasNextPage && (
+            <div className="mt-3 flex justify-center">
+              <button
+                className="btn text-xs"
+                onClick={() => fetchNextPage()}
+                disabled={isFetchingNextPage}
+              >
+                {isFetchingNextPage ? "Loading…" : "Load older"}
+              </button>
             </div>
           )}
         </>


### PR DESCRIPTION
Closes #64

## Summary
- Add `(occurred_at DESC, id DESC)` cursor pagination to all three activity routes (`part_activity`, `order_activity`, `build_activity_route`) via `?before_occurred_at=<iso>&before_id=<uuid>&limit=<int>` params
- Default `limit=50`, max `200`; response includes `next_before_occurred_at` + `next_before_id` when a next page exists (omitted on last page)
- Cache `_user_map` per-request via `request.state.user_cache` (lazy read-through dict); users table queried at most once per unique user_id per HTTP request
- Synthetic `created`/`updated` events appear on first page only (`before_occurred_at is None`)
- Response shape changes from bare list to `{events: [...], next_before_occurred_at?, next_before_id?}`
- Frontend `ActivityTimeline` migrated from `useQuery` to `useInfiniteQuery` with "Load older" button

## Tests
- `backend/tests/test_activity_pagination.py` — seeds 250 entries, walks all pages, verifies cursor correctness, no overlap, limit respected
- `backend/tests/test_activity_user_cache.py` — unit-tests `_user_map` cache read-through and miss-fetch; endpoint smoke test
- `backend/tests/test_activity.py` — updated to match `{events}` response shape
- Backend: **488 passed, 1 skipped** (full suite)
- Frontend build: **passed** (`tsc -b && vite build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)