### PR TITLE
fix(fe): persist ScanImport draft queue to sessionStorage (#54)

### DIFF
--- a/web/src/routes/parts/ScanImport.tsx
+++ b/web/src/routes/parts/ScanImport.tsx
@@ -124,6 +124,16 @@ export default function ScanImport() {
   const restoredCount = useRef<number>(rows.length);
   // Whether the "restored N drafts" banner has been shown this session.
   const restoredBannerShown = useRef(false);
+  // Capture the workspaceId at mount so the persist effect (and the
+  // restored-banner Discard action) cannot write/clear under a *different*
+  // workspace's storage key if a workspace switch fires before this route
+  // unmounts (workspace switcher is global; switchWorkspace flips
+  // workspaceId before the nav("/parts") tears the route down — see
+  // web/src/lib/auth.tsx). Without this guard we'd briefly leak the
+  // previous workspace's rows into workspace B's draft. Cross-workspace
+  // isolation is enforced in code, not the DB (see CLAUDE.md), so this
+  // needs an explicit guard rather than relying on render-ordering.
+  const mountWsId = useRef<string | undefined>(workspaceId);
 
   // Pre-select the storage when arriving via /storage/<id> "Scan into here"
   // — the destination is whichever bin the user opened.
@@ -152,7 +162,11 @@ export default function ScanImport() {
               setRows([]);
               seenSigs.current.clear();
               seenMpns.current.clear();
-              if (workspaceId) clearDraft(workspaceId);
+              // Use the wsId captured at mount, not the live `workspaceId`
+              // closure, so a workspace switch between mount and click
+              // can't cause us to clearDraft() against the wrong key.
+              const wsId = mountWsId.current;
+              if (wsId) clearDraft(wsId);
               setShowRestoredBanner(false);
             },
           },
@@ -164,9 +178,15 @@ export default function ScanImport() {
   }, []);
 
   // Persist rows to sessionStorage whenever they change.
+  // Bail if the live workspaceId no longer matches the one captured at
+  // mount — a workspace switch flips workspaceId before the route
+  // unmounts, and we mustn't write workspace A's rows under workspace
+  // B's storage key.
   useEffect(() => {
-    if (!workspaceId) return;
-    saveDraft(workspaceId, rows);
+    const wsId = mountWsId.current;
+    if (!wsId) return;
+    if (workspaceId !== wsId) return;
+    saveDraft(wsId, rows);
   }, [rows, workspaceId]);
 
   // Warn before unload when there are unsaved importable rows.
@@ -337,9 +357,12 @@ export default function ScanImport() {
       setRows(prev => {
         const remaining = prev.filter(r => !importedMpns.has(r.bag.mpn));
         // If every row was imported, clear the draft completely; otherwise
-        // the updated (smaller) rows list will be persisted by the rows effect.
-        if (remaining.length === 0 && workspaceId) {
-          clearDraft(workspaceId);
+        // the updated (smaller) rows list will be persisted by the rows
+        // effect. Use the wsId captured at mount so a mid-flight workspace
+        // switch can't redirect this clear to a different key.
+        const wsId = mountWsId.current;
+        if (remaining.length === 0 && wsId) {
+          clearDraft(wsId);
         }
         return remaining;
       });

--- a/web/src/routes/parts/ScanImport.tsx
+++ b/web/src/routes/parts/ScanImport.tsx
@@ -38,6 +38,7 @@ import {
   type LookupState,
   type Row,
 } from "./ScanImport/types";
+import { loadDraft, saveDraft, clearDraft } from "./ScanImport/storage";
 
 // "Service Unavailable", "upstream unavailable (TimeoutException)",
 // "DigiKey rate limit reached", connection-resets — anything that's
@@ -98,18 +99,90 @@ export default function ScanImport() {
   const qc = useQueryClient();
   const { workspaceId } = useAuth();
   const [searchParams] = useSearchParams();
-  const [rows, setRows] = useState<Row[]>([]);
-  // Pre-select the storage when arriving via /storage/<id> "Scan into here"
-  // — the destination is whichever bin the user opened.
-  const [storageId, setStorageId] = useState<string>(() => searchParams.get("storage_id") ?? "");
-  const [submitting, setSubmitting] = useState(false);
-  const [lastSummary, setLastSummary] = useState<ImportResponse | null>(null);
 
   // Dedup against the camera firing didScan continuously while a code is
   // in frame: we key by signature first (catches the same bag re-read from
   // a slightly different angle), and fall back to MPN for non-2D scans.
   const seenSigs = useRef<Set<string>>(new Set());
   const seenMpns = useRef<Set<string>>(new Set());
+
+  // Lazy initialiser: restore draft from sessionStorage on first render so
+  // the rows survive a Back-button, workspace switch, or tab refresh.
+  // seenSigs / seenMpns are rebuilt here so dedup is consistent.
+  const [rows, setRows] = useState<Row[]>(() => {
+    if (!workspaceId) return [];
+    const restored = loadDraft(workspaceId);
+    if (!restored) return [];
+    for (const r of restored) {
+      if (r.bagSig) seenSigs.current.add(r.bagSig);
+      seenMpns.current.add(r.bag.mpn);
+    }
+    return restored;
+  });
+
+  // Track how many rows were restored so we can surface the banner once.
+  const restoredCount = useRef<number>(rows.length);
+  // Whether the "restored N drafts" banner has been shown this session.
+  const restoredBannerShown = useRef(false);
+
+  // Pre-select the storage when arriving via /storage/<id> "Scan into here"
+  // — the destination is whichever bin the user opened.
+  const [storageId, setStorageId] = useState<string>(() => searchParams.get("storage_id") ?? "");
+  const [submitting, setSubmitting] = useState(false);
+  const [lastSummary, setLastSummary] = useState<ImportResponse | null>(null);
+  // Controls the "restored N drafts" banner visibility.
+  const [showRestoredBanner, setShowRestoredBanner] = useState(() => rows.length > 0);
+
+  // Show the restored-draft toast banner once on mount when rows were restored.
+  useEffect(() => {
+    if (
+      !restoredBannerShown.current &&
+      restoredCount.current > 0 &&
+      showRestoredBanner
+    ) {
+      restoredBannerShown.current = true;
+      const n = restoredCount.current;
+      toast.info(
+        `Restored ${n} draft scan${n === 1 ? "" : "s"} from your previous session.`,
+        {
+          duration: 8000,
+          action: {
+            label: "Discard",
+            onClick: () => {
+              setRows([]);
+              seenSigs.current.clear();
+              seenMpns.current.clear();
+              if (workspaceId) clearDraft(workspaceId);
+              setShowRestoredBanner(false);
+            },
+          },
+        },
+      );
+    }
+    // Only run once on mount.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Persist rows to sessionStorage whenever they change.
+  useEffect(() => {
+    if (!workspaceId) return;
+    saveDraft(workspaceId, rows);
+  }, [rows, workspaceId]);
+
+  // Warn before unload when there are unsaved importable rows.
+  useEffect(() => {
+    function handleBeforeUnload(e: BeforeUnloadEvent) {
+      const importable = rows.filter(r => r.state.kind === "found");
+      const hasPending = rows.some(
+        r => r.state.kind === "found" || r.state.kind === "pending",
+      );
+      if (rows.length > 0 && (importable.length > 0 || hasPending)) {
+        e.preventDefault();
+      }
+    }
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => window.removeEventListener("beforeunload", handleBeforeUnload);
+  }, [rows]);
 
   // Honour ?storage_id= even when the URL changes mid-session (e.g. a
   // back-button navigation drops us back here from Storage).
@@ -261,7 +334,15 @@ export default function ScanImport() {
       const importedMpns = new Set(
         out.rows.filter(r => r.status === "created").map(r => r.mpn)
       );
-      setRows(prev => prev.filter(r => !importedMpns.has(r.bag.mpn)));
+      setRows(prev => {
+        const remaining = prev.filter(r => !importedMpns.has(r.bag.mpn));
+        // If every row was imported, clear the draft completely; otherwise
+        // the updated (smaller) rows list will be persisted by the rows effect.
+        if (remaining.length === 0 && workspaceId) {
+          clearDraft(workspaceId);
+        }
+        return remaining;
+      });
       importedMpns.forEach(m => seenMpns.current.delete(m));
       toast.success(
         `Imported ${out.summary.created} part${out.summary.created === 1 ? "" : "s"}.`

--- a/web/src/routes/parts/ScanImport/storage.ts
+++ b/web/src/routes/parts/ScanImport/storage.ts
@@ -1,0 +1,99 @@
+/**
+ * sessionStorage helpers for ScanImport draft queue persistence (FE2-018 / #54).
+ *
+ * Draft is keyed per-workspace so switching workspaces never leaks rows
+ * across different part libraries. sessionStorage is per-tab, so the draft
+ * is automatically cleared when the tab closes — no cross-session leakage.
+ *
+ * The persisted envelope is versioned (`{v: 1, rows: [...]}`).  If a future
+ * Row shape change would crash on rehydrate we detect the mismatch via the
+ * version field and silently discard the stale draft rather than exploding.
+ *
+ * Any row whose `state.kind === "pending"` at save-time was interrupted
+ * mid-lookup.  On rehydrate those rows are coerced to
+ * `{ kind: "error", message: "interrupted, re-scan to retry" }` so the
+ * operator knows they need to re-scan those bags.
+ */
+
+import type { Row, LookupState } from "./types";
+
+// Bump this when the persisted Row shape changes in a breaking way.
+const CURRENT_VERSION = 1;
+const INTERRUPTED_STATE: LookupState = {
+  kind: "error",
+  message: "interrupted, re-scan to retry",
+};
+
+type DraftEnvelope = {
+  v: number;
+  rows: Row[];
+};
+
+function storageKey(wsId: string): string {
+  return `scanImport:draft:${wsId}`;
+}
+
+/**
+ * Persist `rows` to sessionStorage for `wsId`.
+ * Rows with `state.kind === "pending"` are saved as-is; they will be
+ * coerced to "error" on the next loadDraft call (i.e. after a reload).
+ */
+export function saveDraft(wsId: string, rows: Row[]): void {
+  if (!wsId) return;
+  try {
+    const envelope: DraftEnvelope = { v: CURRENT_VERSION, rows };
+    sessionStorage.setItem(storageKey(wsId), JSON.stringify(envelope));
+  } catch {
+    // sessionStorage can throw in private browsing when storage is full.
+    // Silently swallow — losing the draft is better than crashing the UI.
+  }
+}
+
+/**
+ * Load the draft for `wsId` from sessionStorage.
+ *
+ * Returns `null` when there is no draft, the version doesn't match, or the
+ * stored JSON is corrupt.  Any `state.kind === "pending"` rows are coerced
+ * to `{ kind: "error", message: "interrupted, re-scan to retry" }`.
+ */
+export function loadDraft(wsId: string): Row[] | null {
+  if (!wsId) return null;
+  try {
+    const raw = sessionStorage.getItem(storageKey(wsId));
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      (parsed as DraftEnvelope).v !== CURRENT_VERSION ||
+      !Array.isArray((parsed as DraftEnvelope).rows)
+    ) {
+      // Version mismatch or malformed — discard.
+      clearDraft(wsId);
+      return null;
+    }
+    const envelope = parsed as DraftEnvelope;
+    const rows: Row[] = envelope.rows.map(r => ({
+      ...r,
+      state: r.state.kind === "pending" ? INTERRUPTED_STATE : r.state,
+    }));
+    return rows.length > 0 ? rows : null;
+  } catch {
+    // JSON.parse failure — discard silently.
+    clearDraft(wsId);
+    return null;
+  }
+}
+
+/**
+ * Remove the draft for `wsId` from sessionStorage (called after a
+ * successful submitAll so the persisted queue doesn't grow stale).
+ */
+export function clearDraft(wsId: string): void {
+  if (!wsId) return;
+  try {
+    sessionStorage.removeItem(storageKey(wsId));
+  } catch {
+    // ignore
+  }
+}

--- a/web/src/routes/parts/__tests__/ScanImport.draft.dom.test.tsx
+++ b/web/src/routes/parts/__tests__/ScanImport.draft.dom.test.tsx
@@ -1,0 +1,181 @@
+/**
+ * Unit tests for the ScanImport sessionStorage draft-persistence helpers
+ * (FE2-018 / #54).
+ *
+ * These tests exercise `storage.ts` (loadDraft / saveDraft / clearDraft)
+ * in isolation without mounting the full ScanImport component — the component
+ * itself brings in Scanner (camera SDK) and network calls which are not
+ * relevant to persistence correctness.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { loadDraft, saveDraft, clearDraft } from "../ScanImport/storage";
+import type { Row, LookupState } from "../ScanImport/types";
+
+// ---------------------------------------------------------------------------
+// Minimal Row fixtures
+// ---------------------------------------------------------------------------
+
+function makeRow(overrides: Partial<Row> = {}): Row {
+  return {
+    rowId: "row-1",
+    bag: {
+      mpn: "GRM155R71C104KA88D",
+      manufacturer: "Murata",
+      quantity: 10,
+      raw: "raw-bag-code-abc",
+    },
+    bagSig: "deadbeef1234",
+    quantity: 10,
+    state: {
+      kind: "found",
+      result: {
+        mpn: "GRM155R71C104KA88D",
+        manufacturer: "Murata",
+        description: "100nF cap",
+        specs: [],
+        footprint: "0402",
+        category: "Capacitors",
+        datasheet_url: null,
+        source_url: "https://mouser.com/example",
+        image_url: null,
+      },
+      provider: "mouser",
+    },
+    ...overrides,
+  } as Row;
+}
+
+const WS_ID = "ws-abc-123";
+const STORAGE_KEY = `scanImport:draft:${WS_ID}`;
+
+beforeEach(() => {
+  sessionStorage.clear();
+});
+
+afterEach(() => {
+  sessionStorage.clear();
+});
+
+// ---------------------------------------------------------------------------
+// saveDraft / loadDraft round-trip
+// ---------------------------------------------------------------------------
+
+describe("saveDraft + loadDraft", () => {
+  it("persists rows and restores them with correct shape", () => {
+    const row = makeRow();
+    saveDraft(WS_ID, [row]);
+
+    const restored = loadDraft(WS_ID);
+    expect(restored).not.toBeNull();
+    expect(restored).toHaveLength(1);
+    expect(restored![0].rowId).toBe(row.rowId);
+    expect(restored![0].bag.mpn).toBe(row.bag.mpn);
+    expect(restored![0].bagSig).toBe(row.bagSig);
+    expect(restored![0].quantity).toBe(row.quantity);
+    expect(restored![0].state.kind).toBe("found");
+  });
+
+  it("coerces pending rows to error on rehydrate", () => {
+    const pendingRow = makeRow({ rowId: "row-pending", state: { kind: "pending" } });
+    saveDraft(WS_ID, [pendingRow]);
+
+    const restored = loadDraft(WS_ID);
+    expect(restored).not.toBeNull();
+    const firstState = restored![0].state;
+    expect(firstState.kind).toBe("error");
+    expect((firstState as Extract<LookupState, { kind: "error" }>).message).toMatch(/interrupted/i);
+  });
+
+  it("preserves non-pending states (error, found, duplicate) verbatim", () => {
+    const errorRow = makeRow({ rowId: "row-err", state: { kind: "error", message: "no match" } });
+    saveDraft(WS_ID, [errorRow]);
+
+    const restored = loadDraft(WS_ID);
+    expect(restored).not.toBeNull();
+    const s = restored![0].state;
+    expect(s.kind).toBe("error");
+    expect((s as Extract<LookupState, { kind: "error" }>).message).toBe("no match");
+  });
+
+  it("stores under workspace-specific key", () => {
+    saveDraft(WS_ID, [makeRow()]);
+    expect(sessionStorage.getItem(STORAGE_KEY)).not.toBeNull();
+    // Different workspace should find nothing.
+    expect(loadDraft("other-ws")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadDraft edge-cases
+// ---------------------------------------------------------------------------
+
+describe("loadDraft edge-cases", () => {
+  it("returns null when no draft exists", () => {
+    expect(loadDraft(WS_ID)).toBeNull();
+  });
+
+  it("returns null and removes stale entry on version mismatch", () => {
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify({ v: 999, rows: [] }));
+    expect(loadDraft(WS_ID)).toBeNull();
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it("returns null and removes entry on corrupt JSON", () => {
+    sessionStorage.setItem(STORAGE_KEY, "{ not valid json %%");
+    expect(loadDraft(WS_ID)).toBeNull();
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it("returns null for an empty rows array", () => {
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify({ v: 1, rows: [] }));
+    expect(loadDraft(WS_ID)).toBeNull();
+  });
+
+  it("returns null when wsId is empty string", () => {
+    expect(loadDraft("")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// clearDraft
+// ---------------------------------------------------------------------------
+
+describe("clearDraft", () => {
+  it("removes the entry from sessionStorage", () => {
+    saveDraft(WS_ID, [makeRow()]);
+    expect(sessionStorage.getItem(STORAGE_KEY)).not.toBeNull();
+    clearDraft(WS_ID);
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it("is a no-op when no draft exists", () => {
+    expect(() => clearDraft(WS_ID)).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// seenSigs / seenMpns rebuild contract (logic-level, not React)
+// ---------------------------------------------------------------------------
+
+describe("loadDraft — bagSig / mpn coverage for dedup rebuild", () => {
+  it("restored rows carry bagSig so caller can populate seenSigs", () => {
+    const row = makeRow({ bagSig: "sha256abc" });
+    saveDraft(WS_ID, [row]);
+    const restored = loadDraft(WS_ID);
+    expect(restored![0].bagSig).toBe("sha256abc");
+  });
+
+  it("restored rows carry bag.mpn so caller can populate seenMpns", () => {
+    const row = makeRow();
+    saveDraft(WS_ID, [row]);
+    const restored = loadDraft(WS_ID);
+    expect(restored![0].bag.mpn).toBe("GRM155R71C104KA88D");
+  });
+
+  it("null bagSig is preserved (non-crypto browsers)", () => {
+    const row = makeRow({ bagSig: null });
+    saveDraft(WS_ID, [row]);
+    const restored = loadDraft(WS_ID);
+    expect(restored![0].bagSig).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #54

## Summary
- Add `web/src/routes/parts/ScanImport/storage.ts`: `loadDraft` / `saveDraft` / `clearDraft` helpers with versioned JSON envelope (`{v: 1, rows: [...]}`) and silent try/catch on corrupt or version-mismatched data
- Persist `rows` to `sessionStorage` on every change, keyed by workspace id (`scanImport:draft:<wsId>`) — per-tab, no cross-session leakage
- Restore rows on mount via `useState` lazy initialiser; rebuild `seenSigs` / `seenMpns` from restored rows so dedup is consistent; coerce `state.kind === "pending"` rows to `{ kind: "error", message: "interrupted, re-scan to retry" }`
- Surface a `sonner` toast with a **Discard** action on mount when rows are restored
- Add `window.beforeunload` guard that calls `event.preventDefault()` when importable or pending rows are present
- Clear sessionStorage after `submitAll()` completes successfully for the imported rows

## Tests
- New file: `web/src/routes/parts/__tests__/ScanImport.draft.dom.test.tsx` — 14 tests covering round-trip persistence, pending→error coercion, version mismatch discard, corrupt JSON discard, empty-string wsId guard, clearDraft, and bagSig/mpn passthrough for dedup rebuild
- Frontend build: passed (`tsc -b` + `vite build`)
- Frontend tests: 77 passed / 3 skipped (0 failed)
- Backend: N/A (frontend-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)