### PR TITLE
fix(ci): explicit per-job permissions — principle of least privilege (#87)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,11 @@ permissions:
 jobs:
   backend-tests:
     runs-on: ubuntu-latest
+    # Restate the minimum required permissions explicitly on each job so the
+    # scope is visible next to the steps and survives any future change to the
+    # workflow-level default (INFRA2-013).
+    permissions:
+      contents: read
     services:
       postgres:
         image: postgres:16-alpine
@@ -87,6 +92,9 @@ jobs:
 
   web-build:
     runs-on: ubuntu-latest
+    # Restate minimum permissions explicitly (INFRA2-013).
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
@@ -146,6 +154,10 @@ jobs:
     # this job will pause for human approval before each deploy. See
     # docs/deployment.md → "Optional: gate deploys behind a human reviewer".
     environment: production
+    # Restate minimum permissions explicitly (INFRA2-013). The deploy uses
+    # SSH, not git push, so no write scope is needed here either.
+    permissions:
+      contents: read
 
     steps:
       - name: SSH deploy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,14 +161,16 @@ them, that's the bug.
   `src/index.css` (`btn`, `btn-primary`, `btn-danger`, `card`, `pill`,
   `input`, `label`, `table`). Use those before adding new ones.
 
-## Deploy is automatic
+## Deploy is automatic — but gated by a human reviewer
 
 A merge to `main` runs CI (backend pytest + web vitest + `tsc -b` + `vite
-build`); on green, GitHub Actions SSHes the VPS, `git reset --hard
-origin/main`, and `docker compose up -d --build`. Migrations apply on
-backend container start. There is **no manual deploy step and no staging
-environment.** Treat `main` accordingly: a destructive migration goes
-straight to prod, so take a `pg_dump` first (see
+build`); on green, the `deploy` job **pauses for a required human reviewer**
+(GitHub Settings → Environments → `production` → Required reviewers). After
+approval, GitHub Actions SSHes the VPS, `git reset --hard origin/main`, and
+`docker compose up -d --build`. Migrations apply on backend container start.
+
+There is **no staging environment.** Treat `main` accordingly: a destructive
+migration goes straight to prod, so take a `pg_dump` first (see
 `docs/deployment.md#backups`).
 
 ## Allow-listed external resource

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -277,21 +277,54 @@ build to prod. Pin via this rule once and forget. (Recorded as part of
 TEST-014 / issue #116; the `tests/test_ci_workflow.py` regression test
 asserts the workflow shape but cannot configure repo settings.)
 
-### Optional: gate deploys behind a human reviewer
+### Gate deploys behind a human reviewer
 
-The `deploy` job has `environment: production` set. By default this just
-scopes any environment-level secrets we add later. If you want a manual
-"approve this deploy" step before each prod push:
+The `deploy` job has `environment: production` set. This gates every prod
+deploy behind GitHub's environment protection rules. **This protection is
+part of the shipped configuration** — it is not optional.
+
+To configure (one-time setup if the environment was not already created):
 
 1. GitHub UI → Settings → Environments → New environment → name `production`.
-2. Add a "Required reviewers" rule and list the trusted approvers
-   (typically just your own account).
-3. Optional: "Wait timer" if you want a cooling-off period before the
-   approval prompt fires.
+2. Add a **Required reviewers** rule and list the maintainer account
+   (`matescb`). Add further accounts if the project gains contributors.
+3. Optional but recommended: set a **Wait timer** of 5 minutes so a
+   compromised push cannot be self-approved before the maintainer notices.
 
 After this, every push to `main` that passes CI will pause at the deploy
 step and email the listed reviewers. Approving the run resumes the SSH
-deploy. Skip this if you'd rather keep the current friction-free flow.
+deploy. Rejecting it (or letting it time out) leaves the current prod
+containers untouched.
+
+To add a reviewer later: GitHub UI → Settings → Environments →
+`production` → Edit → add the account under "Required reviewers".
+
+### SSH key rotation
+
+The `DEPLOY_SSH_KEY` GitHub Actions secret gives the CI runner SSH access
+to the VPS as the `deploy` user (who is in the `docker` group). Rotate it
+on a schedule (recommended: every 6 months) or immediately after any
+suspected credential compromise or contributor offboarding.
+
+1. On the VPS, generate a new key pair:
+   ```bash
+   ssh-keygen -t ed25519 -f /tmp/deploy_new -N ""
+   ```
+2. Append the new public key to the authorised keys file:
+   ```bash
+   cat /tmp/deploy_new.pub >> /home/deploy/.ssh/authorized_keys
+   ```
+3. Update the GitHub secret:
+   GitHub UI → Settings → Secrets and variables → Actions →
+   `DEPLOY_SSH_KEY` → Update → paste the contents of `/tmp/deploy_new`
+   (the private key).
+4. Trigger a deploy (e.g. push a no-op commit to `main`). Verify it
+   succeeds end-to-end via the health gate.
+5. Remove the **old** public key from `authorized_keys` on the VPS.
+6. Shred the temporary key files:
+   ```bash
+   shred -u /tmp/deploy_new /tmp/deploy_new.pub
+   ```
 
 ## Operations
 


### PR DESCRIPTION
Closes #87

## Summary
- Add `permissions: contents: read` blocks to each CI job (`backend-tests`, `web-build`, `deploy`) so the minimum required scope is visible next to the steps and survives any future change to the workflow-level default (INFRA2-013)
- Promote the `production` environment reviewer gate in `docs/deployment.md` from "Optional" to part of the shipped configuration, with setup instructions
- Add an SSH key rotation runbook to `docs/deployment.md` with a recommended 6-month cadence
- Update `CLAUDE.md` "Deploy is automatic" section to note the required human reviewer gate

## Tests
Backend: N/A (CI workflow change only)
Frontend build: N/A