### PR TITLE
fix(infra): uvicorn graceful shutdown + lifespan timeout docs (#88)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,11 @@ them, that's the bug.
   first.
 - **`web/vite.config.js`** is auto-emitted by the composite TypeScript
   project — gitignored. Don't commit it.
+- **`--timeout-graceful-shutdown` must be less than `stop_grace_period`.**
+  The backend uvicorn command uses `--timeout-graceful-shutdown 25` and the
+  service has `stop_grace_period: 30s`. Keep the uvicorn value at least 5s
+  below the compose value so Compose's SIGKILL never fires during a clean
+  drain (INFRA2-014).
 - The repo has had transient `review-*` directories and stray venvs
   appear at the root in past sessions. They're gitignored; don't
   unignore them.

--- a/deploy/maintenance.html
+++ b/deploy/maintenance.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Maintenance — Parts Inventory</title>
+  <style>
+    /* Mirrors the brand palette from web/src/index.css */
+    :root {
+      --bg:      #f8fafc;
+      --surface: #ffffff;
+      --border:  #e2e8f0;
+      --text:    #1e293b;
+      --muted:   #64748b;
+      --accent:  #3b82f6;
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 2rem;
+    }
+    .card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 0.75rem;
+      padding: 2.5rem 3rem;
+      max-width: 480px;
+      width: 100%;
+      text-align: center;
+      box-shadow: 0 1px 3px rgba(0,0,0,.08);
+    }
+    .icon {
+      font-size: 2.5rem;
+      margin-bottom: 1rem;
+    }
+    h1 {
+      font-size: 1.5rem;
+      font-weight: 600;
+      margin-bottom: 0.75rem;
+    }
+    p {
+      color: var(--muted);
+      line-height: 1.6;
+      font-size: 0.95rem;
+    }
+    .badge {
+      display: inline-block;
+      margin-top: 1.5rem;
+      padding: 0.35rem 0.9rem;
+      border-radius: 9999px;
+      background: #eff6ff;
+      color: var(--accent);
+      font-size: 0.8rem;
+      font-weight: 500;
+      border: 1px solid #bfdbfe;
+    }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <div class="icon">&#128295;</div>
+    <h1>Scheduled Maintenance</h1>
+    <p>
+      Parts Inventory is temporarily offline for a planned update.
+      We'll be back in a few minutes — no data has been lost.
+    </p>
+    <span class="badge">Back shortly</span>
+  </div>
+</body>
+</html>

--- a/deploy/parts.matescb.cz-le-ssl.conf
+++ b/deploy/parts.matescb.cz-le-ssl.conf
@@ -27,8 +27,16 @@
 
     ProxyPreserveHost On
     ProxyPass /.well-known !
-    ProxyPass / http://127.0.0.1:8091/
+    # retry=2 / timeout=30 / connectiontimeout=5 — same as :80 vhost;
+    # keeps behaviour consistent across TLS and plain connections.
+    # NOTE: if certbot ever deletes and re-issues this file, re-apply these
+    # flags (certbot only edits the SSLCertificateFile / SSLCertificateKeyFile
+    # lines during renewal — it does not rewrite the ProxyPass block).
+    ProxyPass / http://127.0.0.1:8091/ retry=2 timeout=30 connectiontimeout=5
     ProxyPassReverse / http://127.0.0.1:8091/
+
+    # Tell clients to retry in ~10s on any 5xx.
+    Header always set Retry-After "10" "expr=%{REQUEST_STATUS} == 502 || %{REQUEST_STATUS} == 503 || %{REQUEST_STATUS} == 504"
 
     # Datasheet + lot photo uploads can run a few MB each.
     LimitRequestBody 26214400

--- a/deploy/parts.matescb.cz.conf
+++ b/deploy/parts.matescb.cz.conf
@@ -20,8 +20,15 @@
     # Let certbot serve HTTP-01 challenges from the filesystem rather than
     # trying to proxy them to the app.
     ProxyPass /.well-known !
-    ProxyPass / http://127.0.0.1:8091/
+    # retry=2: on a 502 Apache retries the backend up to 2 more times before
+    # giving up, bridging short container-restart windows.
+    # timeout=30: upstream read timeout (matches uvicorn's drain window).
+    # connectiontimeout=5: fast-fail if the backend hasn't bound the port yet.
+    ProxyPass / http://127.0.0.1:8091/ retry=2 timeout=30 connectiontimeout=5
     ProxyPassReverse / http://127.0.0.1:8091/
+
+    # Tell clients (especially mobile webviews) to retry in ~10s on any 5xx.
+    Header always set Retry-After "10" "expr=%{REQUEST_STATUS} == 502 || %{REQUEST_STATUS} == 503 || %{REQUEST_STATUS} == 504"
 
     # Datasheet + lot photo uploads can run a few MB each.
     LimitRequestBody 26214400

--- a/deploy/parts.matescb.cz.maintenance.conf
+++ b/deploy/parts.matescb.cz.maintenance.conf
@@ -1,0 +1,41 @@
+# Apache 2.4 "drain mode" drop-in for parts.matescb.cz.
+#
+# PURPOSE: serve a static maintenance page while a destructive migration
+# runs, keeping users away from the backend so requests don't pile up
+# or see confusing 500s. The /api/health endpoint is intentionally
+# exempted so the deploy-gate healthcheck still passes.
+#
+# INSTALL (enter drain mode):
+#   sudo cp /srv/stockmanager/deploy/parts.matescb.cz.maintenance.conf \
+#            /etc/apache2/conf-available/parts-maintenance.conf
+#   sudo cp /srv/stockmanager/deploy/maintenance.html \
+#            /var/www/html/maintenance.html
+#   sudo a2enconf parts-maintenance
+#   sudo apache2ctl configtest && sudo systemctl reload apache2
+#
+# REMOVE (exit drain mode):
+#   sudo a2disconf parts-maintenance
+#   sudo apache2ctl configtest && sudo systemctl reload apache2
+#
+# See docs/deployment.md#drain-mode-for-destructive-migrations for the
+# full procedure including a pre-migration pg_dump step.
+#
+# REQUIRED Apache modules: mod_rewrite (already enabled for other vhosts).
+
+<IfModule mod_rewrite.c>
+  RewriteEngine On
+
+  # Pass /api/health through so the deploy-gate healthcheck stays green.
+  RewriteCond %{REQUEST_URI} ^/api/health [NC]
+  RewriteRule ^ - [L]
+
+  # Return the static maintenance page for everything else with a 503
+  # so load balancers / monitoring treat it as "temporarily down".
+  RewriteRule ^ /maintenance.html [R=503,L]
+</IfModule>
+
+# Suppress caching of the maintenance page so browsers don't serve the
+# stale "down" page after the site comes back.
+<LocationMatch "^/maintenance\.html$">
+  Header always set Cache-Control "no-store, no-cache, must-revalidate"
+</LocationMatch>

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -122,7 +122,11 @@ services:
     #      for the rest of the process tree. From this point uvicorn and
     #      alembic both run unprivileged.
     #   3. alembic upgrade head, then exec uvicorn. Identical to before.
-    command: ["sh", "-c", "chown -R appuser:appuser /data 2>/dev/null || true; exec gosu appuser sh -c 'alembic upgrade head && exec uvicorn app.main:app --host 0.0.0.0 --port 8000 --workers 1 --proxy-headers --forwarded-allow-ips=*'"]
+    # stop_grace_period: give Compose 30s before SIGKILL, matching
+    # --timeout-graceful-shutdown 25 below (5s headroom so SIGKILL
+    # never fires on a clean drain — see CLAUDE.md "Things that have bitten us").
+    stop_grace_period: 30s
+    command: ["sh", "-c", "chown -R appuser:appuser /data 2>/dev/null || true; exec gosu appuser sh -c 'alembic upgrade head && exec uvicorn app.main:app --host 0.0.0.0 --port 8000 --workers 1 --proxy-headers --forwarded-allow-ips=* --timeout-graceful-shutdown 25'"]
 
   web:
     build:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -52,9 +52,16 @@ Practical consequences:
   `alembic upgrade head` before uvicorn boots, so by the time the new
   workers serve traffic, the schema is at the new revision.
 - **Restart window**: `docker compose up --build` recreates containers in
-  place. There's a ~5–10 s window where Apache returns 502 while uvicorn
-  comes back up. Fine for this app's traffic level; tighten with
-  healthchecks if it ever stops being fine.
+  place. There's a brief window where Apache returns 502 while uvicorn comes
+  back up. Three mitigations reduce the impact (INFRA2-014):
+  1. `stop_grace_period: 30s` + `--timeout-graceful-shutdown 25` on the
+     backend: in-flight requests get up to 25 s to drain before uvicorn
+     exits; Compose's 30 s SIGKILL deadline gives a 5 s safety margin.
+  2. `ProxyPass … retry=2 timeout=30 connectiontimeout=5` on the Apache
+     vhost: Apache retries the backend twice before surfacing the 502, and
+     `Retry-After: 10` tells clients to back off rather than hammering.
+  3. For long migrations use [Drain mode](#drain-mode-for-destructive-migrations)
+     to show users a static maintenance page while the schema changes run.
 - **Red CI** keeps prod on the previous version: the deploy job is gated
   on `needs: [backend-tests, web-build]` and won't start if either failed.
   GitHub emails on red.
@@ -414,8 +421,82 @@ cp /srv/stockmanager/deploy/parts.matescb.cz.conf \
 apache2ctl configtest && systemctl reload apache2
 ```
 
-The `…-le-ssl.conf` companion file is owned by certbot — don't edit it
-unless you mean to.
+The `…-le-ssl.conf` companion file (`deploy/parts.matescb.cz-le-ssl.conf`)
+is canonical in this repo and must also be copied to
+`/etc/apache2/sites-available/` after any edit:
+
+```bash
+cp /srv/stockmanager/deploy/parts.matescb.cz-le-ssl.conf \
+   /etc/apache2/sites-available/parts.matescb.cz-le-ssl.conf
+apache2ctl configtest && systemctl reload apache2
+```
+
+**After a certbot re-issue:** `certbot renew` only rotates the cert files
+(`SSLCertificateFile` / `SSLCertificateKeyFile`) — it does **not** rewrite
+the `ProxyPass` block. However, if you ever run `certbot --apache` again
+from scratch, it regenerates the ssl conf and overwrites any manual edits.
+Re-copy the canonical file from the repo immediately afterwards.
+
+### Drain mode for destructive migrations
+
+Use this procedure when a migration is expected to take more than a few
+seconds (e.g. table rewrites, large backfills) so users see a clean
+"maintenance" page instead of 500/503 errors.
+
+**Enter drain mode**
+
+```bash
+# 1. Copy the maintenance assets onto the host.
+sudo cp /srv/stockmanager/deploy/maintenance.html /var/www/html/maintenance.html
+sudo cp /srv/stockmanager/deploy/parts.matescb.cz.maintenance.conf \
+        /etc/apache2/conf-available/parts-maintenance.conf
+
+# 2. Enable the drop-in (serves 503 + maintenance page for all non-health requests).
+sudo a2enconf parts-maintenance
+sudo apache2ctl configtest && sudo systemctl reload apache2
+
+# 3. Verify: browsing the site shows the maintenance page;
+#    /api/health still returns 200.
+curl -s https://parts.matescb.cz/api/health
+```
+
+**Take a pre-migration snapshot**
+
+```bash
+/srv/stockmanager/deploy/backup.sh
+```
+
+**Run the migration**
+
+```bash
+# In the currently-running backend container (before the new image is built).
+cd /srv/stockmanager
+sudo -u deploy docker compose -f docker-compose.prod.yml --env-file .env.prod \
+    exec backend alembic upgrade head
+```
+
+**Deploy the new image**
+
+```bash
+cd /srv/stockmanager
+sudo -u deploy git fetch --quiet origin main
+sudo -u deploy git reset --hard origin/main
+sudo -u deploy docker compose -f docker-compose.prod.yml --env-file .env.prod \
+    up -d --build
+```
+
+**Exit drain mode**
+
+```bash
+sudo a2disconf parts-maintenance
+sudo apache2ctl configtest && sudo systemctl reload apache2
+```
+
+**Verify**
+
+```bash
+curl -s https://parts.matescb.cz/api/health
+```
 
 ### If you ever move TLS into the docker stack
 


### PR DESCRIPTION
Closes #88

## Summary

- **`stop_grace_period: 30s`** added to the backend service in `docker-compose.prod.yml`; uvicorn now gets `--timeout-graceful-shutdown 25` (5 s under the SIGKILL deadline) so in-flight requests fully drain on every redeploy.
- **Apache `ProxyPass` hardened** (`retry=2 timeout=30 connectiontimeout=5`) on both `:80` and `:443` vhosts — Apache retries the backend twice before surfacing a 502, bridging the short container-restart window. A `Retry-After: 10` header is set on any 502/503/504 so mobile webviews back off rather than showing an error.
- **Drain mode** for destructive migrations: new `deploy/maintenance.html` static page + `deploy/parts.matescb.cz.maintenance.conf` Apache drop-in (`a2enconf parts-maintenance`) serve a branded 503 to users while the schema changes run; `/api/health` is exempted so the deploy gate still passes.
- **`docs/deployment.md`** updated: restart-window caveat replaced with the three mitigations; new "Drain mode for destructive migrations" subsection with full operator runbook.
- **`CLAUDE.md`** gains a bullet reminding future agents to keep `--timeout-graceful-shutdown < stop_grace_period`.

## Tests

No Python backend files changed — pytest N/A. Changes are infra/config/docs only.

Operational verification steps per the implementation plan:
1. `docker inspect … | jq '.[0].HostConfig.StopTimeout'` should return 30 after deploy.
2. `apache2ctl configtest` clean after copying vhost files.
3. Drain-mode dry run: `a2enconf parts-maintenance && systemctl reload apache2`; browse site → maintenance page; flip back → site returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)