### PR TITLE
fix(infra): pin base images by digest + gate sourcemaps on CI token (INFRA2-015, #89)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+
+updates:
+  # ── GitHub Actions ───────────────────────────────────────────────────────
+  # SHA-pinned actions in ci.yml; Dependabot opens PRs to bump them.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+
+  # ── Docker base images ───────────────────────────────────────────────────
+  # All three base images are digest-pinned (INFRA2-015). Dependabot opens
+  # weekly PRs to rotate digests so we stay on patched base layers.
+  # CI's backend-tests + web-build jobs exercise the images so regressions
+  # surface before merge.
+  - package-ecosystem: "docker"
+    directory: "/web"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+
+  - package-ecosystem: "docker"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+      day: "monday"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,8 +153,22 @@ jobs:
           if-no-files-found: warn
           retention-days: 14
 
+      # INFRA2-015: expose SENTRY_AUTH_TOKEN to `vite build` only on
+      # push to main (matching the upload step's gate below). The
+      # `vite.config.ts` `emitSourcemaps` gate keys off `SENTRY_AUTH_TOKEN`
+      # presence, so without this env block the build emits zero `.map`
+      # files and the subsequent upload step ships nothing — regressing
+      # INFRA2-010. PRs / feature branches still build with no token, so
+      # no `.map` files are emitted off-main. The token never enters any
+      # Docker build context — it only exists in the GitHub Actions runner
+      # env for these two CI steps.
       - name: Type-check + bundle
         working-directory: web
+        env:
+          SENTRY_AUTH_TOKEN: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && secrets.SENTRY_AUTH_TOKEN || '' }}
+          SENTRY_ORG: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && secrets.SENTRY_ORG || '' }}
+          SENTRY_PROJECT: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && secrets.SENTRY_PROJECT || '' }}
+          VITE_APP_VERSION: ${{ github.sha }}
         run: npm run build
 
       # INFRA2-010: upload sourcemaps to Sentry from CI so the auth token

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,6 +153,17 @@ them, that's the bug.
   / `SENTRY_ORG` / `SENTRY_PROJECT` are GitHub Actions secrets — do **not**
   add them back to `web/Dockerfile.prod` ARG/ENV or `docker-compose.prod.yml`
   build args (INFRA2-010).
+- **Base images are digest-pinned (INFRA2-015).** `backend/Dockerfile` and
+  `web/Dockerfile.prod` use `FROM image@sha256:<digest>` — do **not** loosen
+  to a bare tag. Digests are rotated by Dependabot weekly (`.github/dependabot.yml`).
+  To bump manually: `curl -s https://registry.hub.docker.com/v2/repositories/library/<image>/tags/<tag>
+  | python3 -c "import sys,json; print(json.load(sys.stdin)['digest'])"`,
+  then update the `@sha256:` line and the `# Digest pinned on` comment.
+- **Sourcemaps are only emitted in CI.** `web/vite.config.ts` gates
+  `build.sourcemap` on `SENTRY_AUTH_TOKEN` presence (INFRA2-015). VPS builds
+  without the token produce no `.map` files, so the Docker build cache is
+  clean. The `find -name '*.map' -delete` in `web/Dockerfile.prod` remains
+  as belt-and-braces for edge-case local builds.
 
 ## Frontend conventions worth preserving
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,6 +1,7 @@
 # ── Stage 1: builder ────────────────────────────────────────────────────────
 # Full Debian image so we can compile C extensions (psycopg, cryptography, …).
-FROM python:3.12 AS builder
+# Digest pinned on 2026-05-02; bump via Dependabot (docker ecosystem).
+FROM python:3.12@sha256:29cdc34ede8cd9716d1f40a8200447355ae210c05a539c1b0262ccc5fcaf183c AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential libpq-dev \
@@ -19,7 +20,8 @@ RUN pip install --upgrade pip pip-tools \
 
 # ── Stage 2: runtime ────────────────────────────────────────────────────────
 # Slim image — only the runtime libs, no compiler toolchain.
-FROM python:3.12-slim
+# Digest pinned on 2026-05-02; bump via Dependabot (docker ecosystem).
+FROM python:3.12-slim@sha256:46cb7cc2877e60fbd5e21a9ae6115c30ace7a077b9f8772da879e4590c18c2e3
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -690,6 +690,54 @@ before triggering a deploy that causes a longer-than-usual restart (e.g.
 a heavy migration). Resume it once `curl -fsS https://parts.matescb.cz/api/health`
 returns 200.
 
+## Base image pinning (INFRA2-015)
+
+All three Docker base images are pinned by digest, not tag, so a compromised
+or republished `node:20-alpine` / `nginx:alpine` / `python:3.12-slim` tag can
+never silently change what we build:
+
+| File | Stage | Image |
+|------|-------|-------|
+| `backend/Dockerfile` | builder | `python:3.12@sha256:…` |
+| `backend/Dockerfile` | runtime | `python:3.12-slim@sha256:…` |
+| `web/Dockerfile.prod` | build | `node:20-alpine@sha256:…` |
+| `web/Dockerfile.prod` | runtime | `nginx:alpine@sha256:…` |
+
+### Bumping a digest
+
+Resolve the current manifest-list digest (multi-arch index):
+
+```bash
+curl -s "https://registry.hub.docker.com/v2/repositories/library/<image>/tags/<tag>" \
+    | python3 -c "import sys,json; print(json.load(sys.stdin)['digest'])"
+```
+
+Then update the `@sha256:` line in the Dockerfile and the `# Digest pinned on`
+comment. Open as a normal PR — CI's `backend-tests` and `web-build` jobs will
+exercise the new image.
+
+### Dependabot
+
+`.github/dependabot.yml` configures weekly Dependabot PRs for the `docker`
+ecosystem targeting `backend/` and `web/` directories. Dependabot will open
+PRs automatically when newer digests are available. Review and merge them like
+any dependency-bump PR; CI gates protect against regressions.
+
+### Buildkit cache hygiene
+
+The VPS build cache accumulates layers from previous builds. If you need to
+evict stale layers (e.g. after a security incident or after rotating secrets
+from build args), run on the VPS:
+
+```bash
+docker buildx prune -af
+```
+
+This forces a full cold rebuild on the next deploy. After INFRA2-015 landed,
+sourcemaps are no longer emitted during VPS builds (only in CI where
+`SENTRY_AUTH_TOKEN` is set), so the build cache no longer accumulates `.map`
+files.
+
 ## Header hardening (SEC2-018)
 
 Two surfaces were tightened to avoid advertising the stack identity:

--- a/web/Dockerfile.prod
+++ b/web/Dockerfile.prod
@@ -7,7 +7,8 @@
 # so this file can copy both `web/` (sources) and `deploy/nginx-web.conf`.
 
 # ---- build stage ----
-FROM node:20-alpine AS build
+# Digest pinned on 2026-05-02; bump via Dependabot (docker ecosystem).
+FROM node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293 AS build
 
 WORKDIR /app
 
@@ -38,7 +39,8 @@ RUN npm run build
 
 
 # ---- runtime stage ----
-FROM nginx:alpine AS runtime
+# Digest pinned on 2026-05-02; bump via Dependabot (docker ecosystem).
+FROM nginx:alpine@sha256:5616878291a2eed594aee8db4dade5878cf7edcb475e59193904b198d9b830de AS runtime
 
 # Replace the default site with our SPA-aware config (try_files → index.html).
 COPY deploy/nginx-web.conf /etc/nginx/conf.d/default.conf

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -23,6 +23,13 @@ const sentryOrg = process.env.SENTRY_ORG;
 const sentryProject = process.env.SENTRY_PROJECT;
 const enableSentryUpload = Boolean(sentryToken && sentryOrg && sentryProject);
 
+// INFRA2-015: Only emit sourcemaps when SENTRY_AUTH_TOKEN is present
+// (i.e. in CI, where they're uploaded to Sentry immediately after build).
+// VPS builds run without the token, so no .map files ever reach the
+// Docker build cache. Dockerfile.prod's `find -name '*.map' -delete` step
+// remains as belt-and-braces for any edge-case local builds.
+const emitSourcemaps = Boolean(sentryToken);
+
 export default defineConfig({
   // @ts-expect-error vitest config lives next to vite's; types come from vitest/config
   test: {
@@ -58,11 +65,12 @@ export default defineConfig({
     },
   },
   build: {
-    // Always produce hidden sourcemaps so the CI job can upload them to
-    // Sentry. "hidden" omits the //# sourceMappingURL= footer so browsers
-    // don't fetch them; Dockerfile.prod strips the .map files before the
-    // nginx image is assembled (Infra CRIT-5).
-    sourcemap: "hidden",
+    // Emit hidden sourcemaps only when SENTRY_AUTH_TOKEN is set (CI).
+    // "hidden" omits the //# sourceMappingURL= footer so browsers don't
+    // fetch them; the CI job uploads them to Sentry immediately after
+    // `npm run build`. VPS builds run without the token so no .map files
+    // ever reach the Docker build-cache (INFRA2-015 / Infra CRIT-5).
+    sourcemap: emitSourcemaps ? "hidden" : false,
     rollupOptions: {
       output: {
         // Carve heavy third-party deps into their own cached chunks so


### PR DESCRIPTION
Closes #89

## Summary

- **Base image digest pinning** (`backend/Dockerfile` and `web/Dockerfile.prod`): all four `FROM` lines now use `@sha256:` manifest-list digests (pinned 2026-05-02) so a tag rewrite can never silently change what we build.
- **Dependabot for Docker ecosystem** (`.github/dependabot.yml`): weekly PRs targeting `backend/` and `web/` directories so digests rotate automatically. Includes existing github-actions entries for completeness.
- **Gate sourcemap emission on `SENTRY_AUTH_TOKEN`** (`web/vite.config.ts`): VPS builds run without the token so `vite build` emits no `.map` files at all, eliminating the build-cache sourcemap leak surface. CI builds (token present) still emit hidden maps, uploaded to Sentry immediately after build. The `find -name '*.map' -delete` in `Dockerfile.prod` is retained as belt-and-braces.
- **Documentation** (`docs/deployment.md`, `CLAUDE.md`): new "Base image pinning" section with bump procedure and buildkit cache hygiene note.

> Note: security headers were already shipped in `deploy/nginx-web.conf` (SEC2-009/SEC2-010) — the original gap cited in the issue was already fixed. This PR addresses the remaining items from the implementation plan: digest pinning, sourcemap cache hygiene, and Dependabot setup.

## Tests

- Frontend build: `npm run build` passed — zero `.map` files emitted (no `SENTRY_AUTH_TOKEN` present).
- TypeScript: `tsc -b` passed (part of build step).
- Backend: no Python changes, N/A.

## Post-merge VPS note

After merging, run `docker buildx prune -af` on the VPS once to evict any build-cache layers that still contain old sourcemaps. The next deploy will cold-rebuild from the pinned digests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)