### PR TITLE
fix(fe): remove TypeScript any escape hatches — typed payloads + ambient types (#57)

### DIFF
--- a/web/src/browser-ambient.d.ts
+++ b/web/src/browser-ambient.d.ts
@@ -1,0 +1,25 @@
+/**
+ * Ambient type extensions for browser APIs not yet reflected in TypeScript's
+ * DOM lib. These are real, shipped browser APIs; we declare them here rather
+ * than using `as any` at every call site.
+ */
+
+// --- WebAudio: webkit-prefixed AudioContext (Safari / older browsers) ------
+interface Window {
+  /** Safari / older Chrome fallback for the standard `AudioContext`. */
+  webkitAudioContext?: typeof AudioContext;
+}
+
+// --- MediaTrack: `zoom` capability (Chrome on Android, some desktop) -------
+// TypeScript's DOM lib ships `MediaTrackSettings.zoom?: number` (read-back)
+// but omits `MediaTrackCapabilities.zoom` (capability range query).
+// The MDN-documented shape is a `DoubleRange` with min/max/step.
+interface MediaTrackCapabilities {
+  zoom?: DoubleRange & { step?: number };
+}
+
+// `MediaTrackConstraintSet` also doesn't include zoom, so `applyConstraints`
+// rejects `{ zoom }` values without a cast.  Extend it here.
+interface MediaTrackConstraintSet {
+  zoom?: ConstrainDouble;
+}

--- a/web/src/components/DataTable.tsx
+++ b/web/src/components/DataTable.tsx
@@ -177,7 +177,9 @@ export function DataTable<T>({
     if (!q) return rows;
     return rows.filter(r =>
       columns.some(c => {
-        const v = c.accessor ? c.accessor(r) : (r as any)[c.key];
+        // FIXME: typed row-access requires a generic constraint refactor
+        // (e.g. `T extends Record<string, unknown>`). Deferred — see issue #57.
+        const v = c.accessor ? c.accessor(r) : (r as Record<string, unknown>)[c.key];
         return v != null && String(v).toLowerCase().includes(q);
       })
     );
@@ -187,7 +189,8 @@ export function DataTable<T>({
     if (!sort) return filtered;
     const col = columns.find(c => c.key === sort.key);
     if (!col) return filtered;
-    const acc = col.accessor || ((r: T) => (r as any)[col.key]);
+    // FIXME: typed row-access requires a generic constraint refactor — see issue #57.
+    const acc = col.accessor || ((r: T) => (r as Record<string, unknown>)[col.key]);
     return [...filtered].sort((a, b) => {
       const av = acc(a);
       const bv = acc(b);
@@ -215,7 +218,8 @@ export function DataTable<T>({
     // table cell). Avoid `[object Object]` for non-scalars by checking
     // the type before stringifying.
     if (!c.render) {
-      const v = (r as any)[c.key];
+      // FIXME: typed row-access requires a generic constraint refactor — see issue #57.
+      const v = (r as Record<string, unknown>)[c.key];
       if (v == null) return "";
       const t = typeof v;
       if (t === "string" || t === "number" || t === "boolean") return String(v);
@@ -395,7 +399,8 @@ export function DataTable<T>({
                         align === "center" && "text-center",
                       )}
                     >
-                      {c.render ? c.render(r) : String((c.accessor ? c.accessor(r) : (r as any)[c.key]) ?? "")}
+                      {/* FIXME: typed row-access requires a generic constraint refactor — see issue #57. */}
+                      {c.render ? c.render(r) : String((c.accessor ? c.accessor(r) : (r as Record<string, unknown>)[c.key]) ?? "")}
                     </td>
                   );
                 })}

--- a/web/src/components/scanner/ScanditScanner.tsx
+++ b/web/src/components/scanner/ScanditScanner.tsx
@@ -87,14 +87,20 @@ export default function ScanditScanner({ licenseKey, onScan, className, symbolog
         // but no caller does that today.
         const enabled = symbologiesRef.current ?? LICENSED_SYMBOLOGIES;
         for (const key of enabled) {
-          if ((Symbology as any)[key] !== undefined) {
-            settings.enableSymbology((Symbology as any)[key], true);
+          // `key` is a string matching a Symbology enum key (e.g. "Code128",
+          // "QR"). Cast to `keyof typeof Symbology` after confirming the key
+          // exists — the SDK's enum is not directly indexable without the cast
+          // because TypeScript sees enums as closed types.
+          if (key in Symbology) {
+            settings.enableSymbology(Symbology[key as keyof typeof Symbology], true);
           }
         }
         const capture = await BarcodeCapture.forContext(ctx, settings);
         capture.addListener({
           didScan: (_m, session) => {
-            const b = (session as any).newlyRecognizedBarcode;
+            // `newlyRecognizedBarcode` is a public getter on BarcodeCaptureSession;
+            // no cast needed once the import resolves the SDK's own type.
+            const b = session.newlyRecognizedBarcode;
             if (b) onScanRef.current({ data: b.data ?? "", symbology: b.symbology ?? "?" });
           },
         });

--- a/web/src/components/scanner/ZxingScanner.tsx
+++ b/web/src/components/scanner/ZxingScanner.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { readBarcodes, prepareZXingModule } from "zxing-wasm/reader";
+import { readBarcodes, prepareZXingModule, type ReadInputBarcodeFormat } from "zxing-wasm/reader";
 
 /**
  * Open-source ZXing-C++ wasm decoder. Default scanner backend so workspaces
@@ -69,7 +69,7 @@ let _audioCtx: AudioContext | null = null;
 function scanFeedback(): void {
   try {
     const Ctx: typeof AudioContext | undefined =
-      (window as any).AudioContext ?? (window as any).webkitAudioContext;
+      window.AudioContext ?? window.webkitAudioContext;
     if (Ctx) {
       // Reuse a single AudioContext — Chrome caps the count per tab and
       // every new context is left running until GC.
@@ -228,7 +228,7 @@ export default function ZxingScanner({ onScan, className, symbologies }: Props) 
 
         // Decide hardware vs digital zoom for THIS track. Switching cameras
         // can flip the mode (rear may have hw zoom, front may not).
-        const caps = (track && (track as any).getCapabilities?.()) || {};
+        const caps = (track && track.getCapabilities()) || {};
         if (typeof caps.zoom?.min === "number" && typeof caps.zoom?.max === "number") {
           const cap = {
             min: caps.zoom.min,
@@ -237,7 +237,7 @@ export default function ZxingScanner({ onScan, className, symbologies }: Props) 
           };
           setZoomCap(cap);
           setZoomMode("hardware");
-          const settings = ((track as any)?.getSettings?.() || {}) as any;
+          const settings: MediaTrackSettings = track?.getSettings() ?? {};
           setZoom(typeof settings.zoom === "number" ? settings.zoom : cap.min);
         } else {
           setZoomCap(DIGITAL_ZOOM);
@@ -292,7 +292,10 @@ export default function ZxingScanner({ onScan, className, symbologies }: Props) 
           const imageData = ctx.getImageData(0, 0, sw, sh);
           try {
             const results = await readBarcodes(imageData, {
-              formats: enabled as any,
+              // `enabled` is built from ZXING_FORMAT_BY_PUBLIC values which are
+              // all valid ReadInputBarcodeFormat strings (Code128, QRCode, …).
+              // The filter(Boolean) narrows to string[] so a cast is needed.
+              formats: enabled as ReadInputBarcodeFormat[],
               tryHarder: true,
               tryRotate: true,
               tryInvert: true,
@@ -377,7 +380,7 @@ export default function ZxingScanner({ onScan, className, symbologies }: Props) 
     if (zoomMode !== "hardware") return;
     const track = trackRef.current;
     if (!track) return;
-    (track as any)
+    track
       .applyConstraints({ advanced: [{ zoom }] })
       .catch(() => {
         // Some Android Chromes silently reject mid-stream constraint changes

--- a/web/src/lib/auth.tsx
+++ b/web/src/lib/auth.tsx
@@ -25,7 +25,7 @@ type Ctx = {
   switchWorkspace: (id: string) => Promise<void>;
 };
 
-const AuthCtx = createContext<Ctx>({} as any);
+const AuthCtx = createContext<Ctx | undefined>(undefined);
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [me, setMe] = useState<Me | null>(null);
@@ -167,6 +167,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   );
 }
 
-export function useAuth() {
-  return useContext(AuthCtx);
+export function useAuth(): Ctx {
+  const ctx = useContext(AuthCtx);
+  if (!ctx) throw new Error("useAuth must be used inside <AuthProvider>");
+  return ctx;
 }

--- a/web/src/lib/theme.tsx
+++ b/web/src/lib/theme.tsx
@@ -11,7 +11,7 @@ type Ctx = {
 
 const STORAGE_KEY = "theme";
 
-const ThemeCtx = createContext<Ctx>({} as any);
+const ThemeCtx = createContext<Ctx | undefined>(undefined);
 
 function readPref(): ThemePreference {
   const v = localStorage.getItem(STORAGE_KEY);
@@ -79,6 +79,8 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   );
 }
 
-export function useTheme() {
-  return useContext(ThemeCtx);
+export function useTheme(): Ctx {
+  const ctx = useContext(ThemeCtx);
+  if (!ctx) throw new Error("useTheme must be used inside <ThemeProvider>");
+  return ctx;
 }

--- a/web/src/routes/parts/PartCreate.tsx
+++ b/web/src/routes/parts/PartCreate.tsx
@@ -146,7 +146,7 @@ export default function PartCreate() {
       <div className="grid grid-cols-2 gap-3">
         <div>
           <label className="label">Type</label>
-          <select className="input" value={form.part_type} onChange={e => set("part_type", e.target.value as any)}>
+          <select className="input" value={form.part_type} onChange={e => set("part_type", e.target.value as "linked" | "local" | "meta" | "sub_assembly")}>
             <option value="linked">Linked (MPN)</option>
             <option value="local">Local</option>
             <option value="meta">Meta-part</option>

--- a/web/src/routes/parts/detail/PartAddStock.tsx
+++ b/web/src/routes/parts/detail/PartAddStock.tsx
@@ -103,7 +103,7 @@ export default function PartAddStock() {
       <div className="grid grid-cols-3 gap-3">
         <div>
           <label className="label">Price mode</label>
-          <select className="input" value={priceMode} onChange={e => setPriceMode(e.target.value as any)}>
+          <select className="input" value={priceMode} onChange={e => setPriceMode(e.target.value as "none" | "per_component" | "entire_lot")}>
             <option value="none">No price</option>
             <option value="per_component">Per component</option>
             <option value="entire_lot">Entire lot</option>

--- a/web/src/routes/projects/detail/ProjectImport.tsx
+++ b/web/src/routes/projects/detail/ProjectImport.tsx
@@ -298,7 +298,7 @@ export default function ProjectImport() {
                         className="input"
                         value={m.target}
                         onChange={(e) =>
-                          setMapping(map => map.map(x => x.column_index === m.column_index ? { ...x, target: e.target.value as any } : x))
+                          setMapping(map => map.map(x => x.column_index === m.column_index ? { ...x, target: e.target.value as Mapping["target"] } : x))
                         }
                       >
                         {TARGETS.map(t => <option key={t} value={t}>{t}</option>)}

--- a/web/src/routes/settings/Workspace.tsx
+++ b/web/src/routes/settings/Workspace.tsx
@@ -524,7 +524,7 @@ export default function WorkspaceSettings() {
           </div>
           <div>
             <label className="label">Role</label>
-            <select className="input" value={inviteRole} onChange={e => setInviteRole(e.target.value as any)}>
+            <select className="input" value={inviteRole} onChange={e => setInviteRole(e.target.value as "admin" | "member" | "viewer")}>
               <option value="admin">admin</option>
               <option value="member">member</option>
               <option value="viewer">viewer</option>


### PR DESCRIPTION
Closes #57

## Summary
- Add `web/src/browser-ambient.d.ts` for `window.webkitAudioContext` (Safari WebAudio) and `MediaTrackCapabilities.zoom` / `MediaTrackConstraintSet.zoom` (camera zoom API not yet in TS DOM lib)
- **ScanditScanner**: replace `(Symbology as any)[key]` with `Symbology[key as keyof typeof Symbology]` after a `key in Symbology` guard; drop `(session as any).newlyRecognizedBarcode` — it's a public getter on the SDK's `BarcodeCaptureSession`
- **ZxingScanner**: use `window.webkitAudioContext` directly (ambient decl); call `track.getCapabilities()` / `track.getSettings()` / `track.applyConstraints()` without casts (all in DOM lib); cast `formats` to `ReadInputBarcodeFormat[]` (imported from `zxing-wasm/reader`)
- **auth.tsx / theme.tsx**: `createContext<T | undefined>(undefined)` + non-null asserting `useAuth()` / `useTheme()` hooks (throws if used outside provider)
- **Form selects** (PartCreate, PartAddStock, Workspace, ProjectImport): `e.target.value as any` → explicit union cast matching the state type
- **DataTable**: `(r as any)[c.key]` → `(r as Record<string, unknown>)[c.key]` with `// FIXME` notes — full generic-constraint refactor is out of scope per issue plan

## Tests
- Frontend build: passed (`tsc -b` + `vite build` clean)
- Frontend tests: 63 passed, 3 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)