### PR TITLE
fix(ci): alembic single-head check — fail on divergent migration chain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,14 @@ jobs:
             exit 1
           fi
 
+      - name: alembic single-head check
+        working-directory: backend
+        env:
+          DATABASE_URL: postgresql+psycopg://stockmgr:stockmgr@localhost:5432/stockmgr_test
+        run: |
+          test "$(python -m alembic heads --resolve-dependencies 2>/dev/null | wc -l)" -eq 1 || \
+            { echo "Multiple Alembic heads — two PRs claim the same down_revision. Rebase and renumber."; exit 1; }
+
       - name: pytest
         working-directory: backend
         env:


### PR DESCRIPTION
## Summary

Adds a CI step to the `backend-tests` job that checks the Alembic migration chain has exactly one head. If two PRs both claim the same `down_revision`, one of them will create a fork — this check catches it before `pytest` runs.

```
alembic heads --resolve-dependencies | wc -l == 1
```

Failure message: "Multiple Alembic heads — two PRs claim the same down_revision. Rebase and renumber."

## Why

Parallel automated agents have been opening PRs with colliding migration numbers. Pre-assigning numbers helps, but this CI gate is the authoritative safety net.

## Tests

Backend: N/A (CI config change)
Frontend: N/A