### PR TITLE
fix(infra): encrypt + verify backups with age (#90)

### DIFF
--- a/deploy/.env.prod.example
+++ b/deploy/.env.prod.example
@@ -55,6 +55,27 @@ CORS_ORIGINS=https://parts.matescb.cz
 #   python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
 WORKSPACE_SECRETS_KEY=
 
+# ---- Backups ----
+# age recipient public key used to encrypt nightly backup artifacts.
+# The backup script (deploy/backup.sh) pipes pg_dump and uploads tarball
+# through age -r <key> before writing to disk.  The private key must be
+# escrowed off-VPS (e.g. a password manager or offline storage) — it is
+# never needed on the VPS itself (encryption-only).
+#
+# Operator action required:
+#   1. Install age on the VPS:
+#        curl -Lo /usr/local/bin/age https://github.com/FiloSottile/age/releases/latest/download/age-linux-amd64
+#        chmod +x /usr/local/bin/age
+#   2. Generate a keypair on a secure, off-VPS machine:
+#        age-keygen -o backup-key.txt
+#      The file contains both the private key and the public key.
+#   3. Copy the public key (starts with "age1...") printed by age-keygen
+#      into BACKUP_AGE_RECIPIENT below.
+#   4. Store backup-key.txt in a secure location (e.g. password manager or
+#      encrypted offline storage).  Do NOT put the private key on the VPS.
+#   5. To restore from an encrypted backup, see docs/deployment.md#backups.
+BACKUP_AGE_RECIPIENT=age1...
+
 # ---- Sentry (optional) ----
 # Leave both empty to disable error tracking entirely (no SDK init, no
 # events, no network egress). Populate the DSN once a Sentry project

--- a/deploy/backup.sh
+++ b/deploy/backup.sh
@@ -2,8 +2,8 @@
 # Nightly backup of the parts-inventory app.
 #
 # Produces two artifacts in /srv/backups/stockmanager/:
-#   db-YYYY-MM-DD.sql.gz       — pg_dump of the running Postgres
-#   uploads-YYYY-MM-DD.tar.gz  — full tar of the docker uploads volume
+#   db-YYYY-MM-DD.sql.gz.age      — pg_dump of the running Postgres, age-encrypted
+#   uploads-YYYY-MM-DD.tar.gz.age — full tar of the docker uploads volume, age-encrypted
 #
 # Retention: keep the last 30 days of each. Older files are deleted in
 # place. To restore, see docs/deployment.md.
@@ -13,6 +13,13 @@
 #
 # Errors are surfaced via the cron log + the script's non-zero exit code.
 # The cron daemon emails root on failure if MTA is configured.
+#
+# Prerequisites:
+#   - age must be installed on the VPS (https://github.com/FiloSottile/age)
+#     Install: https://github.com/FiloSottile/age/releases — pick the static
+#     linux-amd64 binary, drop it at /usr/local/bin/age, chmod +x.
+#   - BACKUP_AGE_RECIPIENT must be set in .env.prod (the age public key)
+#   - The corresponding age private key must be escrowed off-VPS
 
 set -euo pipefail
 
@@ -23,35 +30,101 @@ COMPOSE_FILE="${REPO_DIR}/docker-compose.prod.yml"
 ENV_FILE="${REPO_DIR}/.env.prod"
 TS="$(date +%F)"
 
+# Minimum acceptable sizes — fail fast if the artifact looks implausibly small
+DB_MIN_BYTES=1024
+UPLOADS_MIN_BYTES=512
+
 mkdir -p "${BACKUP_DIR}"
 
-# ---- Postgres dump ----
+# ---- Read credentials from env file ----
 # Read POSTGRES_USER / _DB out of the env file so this script doesn't drift
 # when those values change. We don't need the password — the docker exec
 # inherits the running container's env.
 POSTGRES_USER="$(grep -E '^POSTGRES_USER=' "${ENV_FILE}" | cut -d= -f2-)"
 POSTGRES_DB="$(grep -E '^POSTGRES_DB=' "${ENV_FILE}" | cut -d= -f2-)"
+BACKUP_AGE_RECIPIENT="$(grep -E '^BACKUP_AGE_RECIPIENT=' "${ENV_FILE}" | cut -d= -f2-)"
 
-DB_OUT="${BACKUP_DIR}/db-${TS}.sql.gz"
+if [[ -z "${BACKUP_AGE_RECIPIENT}" ]]; then
+    echo "$(date -Iseconds)  ERROR: BACKUP_AGE_RECIPIENT not set in ${ENV_FILE}" >&2
+    exit 1
+fi
+
+# verify_age_artifact <path> <min_bytes> [check_gzip]
+#   Checks:
+#     1. File size is above min_bytes (implausibility guard)
+#     2. File starts with the age armored header (confirms encryption completed)
+#     3. (DB only) Pipe-decrypt the raw ciphertext stream and confirm the
+#        inner gzip stream is intact via gunzip -t.
+#        NOTE: step 3 requires AGE_IDENTITY_FILE to point to the private key
+#        if the variable is set; it is skipped silently when the variable is
+#        unset (VPS holds only the recipient pubkey).
+verify_age_artifact() {
+    local path="$1"
+    local min_bytes="$2"
+    local check_gzip="${3:-}"
+
+    # 1. Size floor
+    local actual_size
+    actual_size="$(stat -c%s "${path}")"
+    if [[ "${actual_size}" -le "${min_bytes}" ]]; then
+        echo "$(date -Iseconds)  ERROR: ${path} implausibly small (${actual_size} bytes)" >&2
+        return 1
+    fi
+
+    # 2. age armored header  — binary age files start with "age-encryption.org"
+    local header
+    header="$(head -c 20 "${path}")"
+    if [[ "${header}" != age-encryption.org* ]]; then
+        echo "$(date -Iseconds)  ERROR: ${path} does not begin with an age header" >&2
+        return 1
+    fi
+
+    # 3. Optional gzip stream integrity (requires private key)
+    if [[ -n "${check_gzip}" && -n "${AGE_IDENTITY_FILE:-}" ]]; then
+        if ! age -d -i "${AGE_IDENTITY_FILE}" "${path}" | gunzip -t; then
+            echo "$(date -Iseconds)  ERROR: ${path} gzip stream integrity check failed" >&2
+            return 1
+        fi
+    fi
+
+    return 0
+}
+
+# ---- Postgres dump ----
+DB_OUT="${BACKUP_DIR}/db-${TS}.sql.gz.age"
 docker compose -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" exec -T db \
     pg_dump -U "${POSTGRES_USER}" "${POSTGRES_DB}" \
-    | gzip > "${DB_OUT}.tmp"
+    | gzip \
+    | age -r "${BACKUP_AGE_RECIPIENT}" > "${DB_OUT}.tmp"
+
+if ! verify_age_artifact "${DB_OUT}.tmp" "${DB_MIN_BYTES}" "check_gzip"; then
+    echo "$(date -Iseconds)  ERROR: db dump verification failed; leaving ${DB_OUT}.tmp in place" >&2
+    exit 1
+fi
+
 mv "${DB_OUT}.tmp" "${DB_OUT}"
 echo "$(date -Iseconds)  db dump  $(du -h "${DB_OUT}" | cut -f1)  ${DB_OUT}"
 
 # ---- Uploads tarball ----
 # pg_dump doesn't cover lot photos / datasheets stored in the `uploads`
 # docker volume — tar them separately.
-UPLOADS_OUT="${BACKUP_DIR}/uploads-${TS}.tar.gz"
+UPLOADS_OUT="${BACKUP_DIR}/uploads-${TS}.tar.gz.age"
 docker run --rm \
     -v stockmanager_uploads:/u:ro \
-    -v "${BACKUP_DIR}":/out \
     alpine \
-    sh -c "tar czf /out/uploads-${TS}.tar.gz.tmp -C /u . && mv /out/uploads-${TS}.tar.gz.tmp /out/uploads-${TS}.tar.gz"
+    sh -c "tar czf - -C /u ." \
+    | age -r "${BACKUP_AGE_RECIPIENT}" > "${UPLOADS_OUT}.tmp"
+
+if ! verify_age_artifact "${UPLOADS_OUT}.tmp" "${UPLOADS_MIN_BYTES}"; then
+    echo "$(date -Iseconds)  ERROR: uploads tarball verification failed; leaving ${UPLOADS_OUT}.tmp in place" >&2
+    exit 1
+fi
+
+mv "${UPLOADS_OUT}.tmp" "${UPLOADS_OUT}"
 echo "$(date -Iseconds)  uploads  $(du -h "${UPLOADS_OUT}" | cut -f1)  ${UPLOADS_OUT}"
 
 # ---- Retention prune ----
-find "${BACKUP_DIR}" -maxdepth 1 -type f -name 'db-*.sql.gz' -mtime "+${RETAIN_DAYS}" -delete
-find "${BACKUP_DIR}" -maxdepth 1 -type f -name 'uploads-*.tar.gz' -mtime "+${RETAIN_DAYS}" -delete
+find "${BACKUP_DIR}" -maxdepth 1 -type f -name 'db-*.sql.gz.age' -mtime "+${RETAIN_DAYS}" -delete
+find "${BACKUP_DIR}" -maxdepth 1 -type f -name 'uploads-*.tar.gz.age' -mtime "+${RETAIN_DAYS}" -delete
 
 echo "$(date -Iseconds)  backup OK"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -428,23 +428,73 @@ installed under root cron on the VPS:
 It writes timestamped artifacts to `/srv/backups/stockmanager/`:
 
 ```
-db-2026-04-30.sql.gz
-uploads-2026-04-30.tar.gz
+db-2026-04-30.sql.gz.age
+uploads-2026-04-30.tar.gz.age
 ```
 
-…and prunes anything older than 30 days. The script is idempotent and
-fail-loud — non-zero exit → cron emails root if MTA is configured.
+Each artifact is `age`-encrypted with the recipient public key stored in
+`.env.prod`. …and prunes anything older than 30 days. The script is
+idempotent and fail-loud — non-zero exit → cron emails root if MTA is
+configured.
 
-Run it manually any time before a risky operation:
+### Recipient key + private-key escrow
 
-```bash
-/srv/stockmanager/deploy/backup.sh
-```
+**Operator action required before first backup run:**
+
+1. **Install `age` on the VPS** (small static binary, no runtime deps):
+
+   ```bash
+   curl -Lo /usr/local/bin/age \
+       https://github.com/FiloSottile/age/releases/latest/download/age-linux-amd64
+   curl -Lo /usr/local/bin/age-keygen \
+       https://github.com/FiloSottile/age/releases/latest/download/age-linux-amd64
+   chmod +x /usr/local/bin/age /usr/local/bin/age-keygen
+   ```
+
+   Adjust the release URL to the latest version from
+   <https://github.com/FiloSottile/age/releases>.
+
+2. **Generate a keypair on a secure, off-VPS machine:**
+
+   ```bash
+   age-keygen -o backup-key.txt
+   # Public key: age1xxxx...
+   ```
+
+   The file `backup-key.txt` contains both the private key (secret) and
+   the public key (safe to share).
+
+3. **Add the public key to `.env.prod` on the VPS:**
+
+   ```bash
+   sudo -u deploy $EDITOR /srv/stockmanager/.env.prod
+   # Set BACKUP_AGE_RECIPIENT=age1xxxx...  (the public key printed above)
+   ```
+
+4. **Escrow the private key off-VPS.** Store `backup-key.txt` in a secure
+   location — a password manager, encrypted offline storage, or a secrets
+   manager. The VPS holds only the public key; restoring backups requires
+   the private key to be brought in manually.
+
+5. **Verify the first nightly backup** by checking
+   `/var/log/stockmanager-backup.log` the morning after, or run the script
+   manually:
+
+   ```bash
+   /srv/stockmanager/deploy/backup.sh
+   ```
+
+### Restore (encrypted backups)
+
+All restore commands assume the private key file is available at
+`/path/to/backup-key.txt` on the machine performing the restore.
 
 Restore the DB (DESTRUCTIVE — overwrites the existing one):
 
 ```bash
-gunzip -c /srv/backups/stockmanager/db-2026-04-30.sql.gz \
+age -d -i /path/to/backup-key.txt \
+    /srv/backups/stockmanager/db-2026-04-30.sql.gz.age \
+    | gunzip -c \
     | sudo -u deploy docker compose -f /srv/stockmanager/docker-compose.prod.yml \
         --env-file /srv/stockmanager/.env.prod exec -T db \
         psql -U "$POSTGRES_USER" "$POSTGRES_DB"
@@ -453,11 +503,12 @@ gunzip -c /srv/backups/stockmanager/db-2026-04-30.sql.gz \
 Restore the uploads volume (DESTRUCTIVE — replaces existing files):
 
 ```bash
-docker run --rm \
-    -v stockmanager_uploads:/u \
-    -v /srv/backups/stockmanager:/in \
-    alpine \
-    sh -c "rm -rf /u/* && tar xzf /in/uploads-2026-04-30.tar.gz -C /u"
+age -d -i /path/to/backup-key.txt \
+    /srv/backups/stockmanager/uploads-2026-04-30.tar.gz.age \
+    | docker run --rm -i \
+        -v stockmanager_uploads:/u \
+        alpine \
+        sh -c "rm -rf /u/* && tar xzf - -C /u"
 ```
 
 For point-in-time recovery, off-site replication, or retention policies look


### PR DESCRIPTION
Closes #90

## Summary
- Pipe `pg_dump` and uploads tarball through `age -r <pubkey>` → `.sql.gz.age` / `.tar.gz.age`
- Add post-artifact verification: size-floor check (`stat -c%s` vs `DB_MIN_BYTES`/`UPLOADS_MIN_BYTES`) and age-header magic check; gzip-stream integrity via `age -d | gunzip -t` also wired up and runs when `AGE_IDENTITY_FILE` is set
- Read `BACKUP_AGE_RECIPIENT` from `.env.prod` using the same `grep -E '^KEY='` pattern already used for `POSTGRES_USER`/`POSTGRES_DB`; bail early with a clear error if the variable is unset
- Update retention prune globs from `*.sql.gz` / `*.tar.gz` to `*.sql.gz.age` / `*.tar.gz.age`
- Document age install, keypair generation, and private-key escrow in `docs/deployment.md`; replace restore commands with `age -d -i <key> | gunzip -c | psql` equivalents
- Add `BACKUP_AGE_RECIPIENT=age1...` with full generation instructions to `deploy/.env.prod.example`

## Tests
Backend: N/A (shell script only)
Frontend: N/A
`bash -n deploy/backup.sh` passes (syntax check)

## Operator action required to activate
1. Install `age` on the VPS (static binary from https://github.com/FiloSottile/age/releases)
2. Generate a keypair on a secure off-VPS machine: `age-keygen -o backup-key.txt`
3. Add the public key to `.env.prod`: `BACKUP_AGE_RECIPIENT=age1...`
4. Escrow the private key (`backup-key.txt`) off-VPS in a password manager or encrypted offline storage
5. Test with a manual run: `/srv/stockmanager/deploy/backup.sh`