### PR TITLE
fix(fe): narrow invalidateQueries scope — per-resource helpers (#53)

### DIFF
--- a/web/src/lib/queryKeys.test.ts
+++ b/web/src/lib/queryKeys.test.ts
@@ -106,11 +106,18 @@ describe("lotMutationKeys", () => {
     expect(keys.some(k => (k as unknown[]).includes(LOT_ID))).toBe(true);
   });
 
-  it("includes part stock and part detail keys", () => {
+  it("includes parts list and part detail keys", () => {
+    const keys = lotMutationKeys(WS, lot);
+    expect(keys.some(k => (k as unknown[]).includes("parts"))).toBe(true);
+    expect(keys.some(k => (k as unknown[]).includes(PART_ID))).toBe(true);
+  });
+
+  it("includes the three stock-rollup report keys", () => {
     const keys = lotMutationKeys(WS, lot);
     const flat = keys.map(k => (k as unknown[]).join(","));
-    expect(flat.some(s => s.includes("stock"))).toBe(true);
-    expect(flat.some(s => s.includes(PART_ID))).toBe(true);
+    expect(flat.some(s => s.includes("low-stock"))).toBe(true);
+    expect(flat.some(s => s.includes("stock-value"))).toBe(true);
+    expect(flat.some(s => s.includes("expiring"))).toBe(true);
   });
 
   it("appends a key per extra storageId", () => {

--- a/web/src/lib/queryKeys.test.ts
+++ b/web/src/lib/queryKeys.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Unit tests for the narrow-invalidation helpers introduced in FE2-017.
+ *
+ * Each helper returns `unknown[][]` — a list of query keys. We verify:
+ *   1. Return type is an array of arrays.
+ *   2. Every key starts with ["ws", workspaceId] (workspace-scoped invariant).
+ *   3. The expected resource segments appear in at least one key.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  archivePartKeys,
+  archiveStorageKeys,
+  lotMutationKeys,
+  archiveProjectKeys,
+} from "./queryKeys";
+
+const WS = "ws-abc";
+const PART_ID = "part-001";
+const STORAGE_ID = "storage-001";
+const LOT_ID = "lot-001";
+const PROJECT_ID = "proj-001";
+
+function allStartWithWsPrefix(keys: unknown[][], ws: string): boolean {
+  return keys.every(k => Array.isArray(k) && k[0] === "ws" && k[1] === ws);
+}
+
+describe("archivePartKeys", () => {
+  const keys = archivePartKeys(WS, PART_ID);
+
+  it("returns an array of arrays", () => {
+    expect(Array.isArray(keys)).toBe(true);
+    keys.forEach(k => expect(Array.isArray(k)).toBe(true));
+  });
+
+  it("every key is workspace-scoped", () => {
+    expect(allStartWithWsPrefix(keys, WS)).toBe(true);
+  });
+
+  it("includes a parts list key", () => {
+    expect(keys.some(k => (k as unknown[]).includes("parts"))).toBe(true);
+  });
+
+  it("includes a part detail key containing the partId", () => {
+    expect(keys.some(k => (k as unknown[]).includes(PART_ID))).toBe(true);
+  });
+
+  it("includes low-stock and stock-value report keys", () => {
+    const flat = keys.map(k => (k as unknown[]).join(","));
+    expect(flat.some(s => s.includes("low-stock"))).toBe(true);
+    expect(flat.some(s => s.includes("stock-value"))).toBe(true);
+  });
+
+  it("handles null workspaceId by substituting 'none'", () => {
+    const k = archivePartKeys(null, PART_ID);
+    expect(k.every(row => (row as unknown[])[1] === "none")).toBe(true);
+  });
+});
+
+describe("archiveStorageKeys", () => {
+  const keys = archiveStorageKeys(WS, STORAGE_ID);
+
+  it("returns an array of arrays", () => {
+    expect(Array.isArray(keys)).toBe(true);
+    keys.forEach(k => expect(Array.isArray(k)).toBe(true));
+  });
+
+  it("every key is workspace-scoped", () => {
+    expect(allStartWithWsPrefix(keys, WS)).toBe(true);
+  });
+
+  it("includes a storage list key", () => {
+    expect(keys.some(k => (k as unknown[]).includes("storage"))).toBe(true);
+  });
+
+  it("includes the specific storage id", () => {
+    expect(keys.some(k => (k as unknown[]).includes(STORAGE_ID))).toBe(true);
+  });
+
+  it("includes a stock-value report key", () => {
+    const flat = keys.map(k => (k as unknown[]).join(","));
+    expect(flat.some(s => s.includes("stock-value"))).toBe(true);
+  });
+});
+
+describe("lotMutationKeys", () => {
+  const lot = { id: LOT_ID, part_id: PART_ID };
+
+  it("returns an array of arrays without extra storageIds", () => {
+    const keys = lotMutationKeys(WS, lot);
+    expect(Array.isArray(keys)).toBe(true);
+    keys.forEach(k => expect(Array.isArray(k)).toBe(true));
+  });
+
+  it("every key is workspace-scoped", () => {
+    const keys = lotMutationKeys(WS, lot);
+    expect(allStartWithWsPrefix(keys, WS)).toBe(true);
+  });
+
+  it("includes lots list key", () => {
+    const keys = lotMutationKeys(WS, lot);
+    expect(keys.some(k => (k as unknown[]).includes("lots"))).toBe(true);
+  });
+
+  it("includes lot detail key", () => {
+    const keys = lotMutationKeys(WS, lot);
+    expect(keys.some(k => (k as unknown[]).includes(LOT_ID))).toBe(true);
+  });
+
+  it("includes part stock and part detail keys", () => {
+    const keys = lotMutationKeys(WS, lot);
+    const flat = keys.map(k => (k as unknown[]).join(","));
+    expect(flat.some(s => s.includes("stock"))).toBe(true);
+    expect(flat.some(s => s.includes(PART_ID))).toBe(true);
+  });
+
+  it("appends a key per extra storageId", () => {
+    const withStorage = lotMutationKeys(WS, lot, [STORAGE_ID]);
+    const without = lotMutationKeys(WS, lot, []);
+    expect(withStorage.length).toBe(without.length + 1);
+    expect(withStorage.some(k => (k as unknown[]).includes(STORAGE_ID))).toBe(true);
+  });
+
+  it("supports multiple storageIds", () => {
+    const S2 = "storage-002";
+    const keys = lotMutationKeys(WS, lot, [STORAGE_ID, S2]);
+    expect(keys.some(k => (k as unknown[]).includes(STORAGE_ID))).toBe(true);
+    expect(keys.some(k => (k as unknown[]).includes(S2))).toBe(true);
+  });
+});
+
+describe("archiveProjectKeys", () => {
+  const keys = archiveProjectKeys(WS, PROJECT_ID);
+
+  it("returns an array of arrays", () => {
+    expect(Array.isArray(keys)).toBe(true);
+    keys.forEach(k => expect(Array.isArray(k)).toBe(true));
+  });
+
+  it("every key is workspace-scoped", () => {
+    expect(allStartWithWsPrefix(keys, WS)).toBe(true);
+  });
+
+  it("includes a projects list key", () => {
+    expect(keys.some(k => (k as unknown[]).includes("projects"))).toBe(true);
+  });
+
+  it("includes the project detail key with project id", () => {
+    expect(keys.some(k => (k as unknown[]).includes(PROJECT_ID))).toBe(true);
+  });
+});

--- a/web/src/lib/queryKeys.ts
+++ b/web/src/lib/queryKeys.ts
@@ -62,6 +62,86 @@ export function wsScope(workspaceId: string | null | undefined): unknown[] {
 }
 
 // ---------------------------------------------------------------------
+// Narrow invalidation helpers — each returns a list of query keys
+// (unknown[][]) so callers can loop:
+//
+//   for (const k of archivePartKeys(workspaceId, partId))
+//     qc.invalidateQueries({ queryKey: k });
+//
+// All keys keep the ["ws", workspaceId, …] prefix enforced by wsKeyOf.
+// ---------------------------------------------------------------------
+
+/**
+ * Keys to invalidate after archiving or restoring a part.
+ * Covers the part list, the individual part cache, and the two
+ * reports that roll up stock totals (low-stock, stock-value).
+ */
+export function archivePartKeys(
+  workspaceId: string | null | undefined,
+  partId: string,
+): unknown[][] {
+  return [
+    wsKeyOf(workspaceId, "parts"),
+    wsKeyOf(workspaceId, "part", partId),
+    wsKeyOf(workspaceId, "report", "low-stock"),
+    wsKeyOf(workspaceId, "report", "stock-value"),
+  ];
+}
+
+/**
+ * Keys to invalidate after archiving or restoring a storage location.
+ * Covers the storage list, the individual location cache, and the
+ * stock-value report.
+ */
+export function archiveStorageKeys(
+  workspaceId: string | null | undefined,
+  storageId: string,
+): unknown[][] {
+  return [
+    wsKeyOf(workspaceId, "storage"),
+    wsKeyOf(workspaceId, "storage", storageId),
+    wsKeyOf(workspaceId, "report", "stock-value"),
+  ];
+}
+
+/**
+ * Keys to invalidate after a lot move or adjust-count.
+ *
+ * @param lot         The lot object (must have at least `id` and `part_id`).
+ * @param storageIds  Optional extra storage location IDs touched by the
+ *                    operation (e.g. move destination and/or source).
+ */
+export function lotMutationKeys(
+  workspaceId: string | null | undefined,
+  lot: { id: string; part_id: string },
+  storageIds: string[] = [],
+): unknown[][] {
+  const keys: unknown[][] = [
+    wsKeyOf(workspaceId, "lots"),
+    wsKeyOf(workspaceId, "lot", lot.id),
+    wsKeyOf(workspaceId, "part", lot.part_id, "stock"),
+    wsKeyOf(workspaceId, "part", lot.part_id),
+  ];
+  for (const sid of storageIds) {
+    keys.push(wsKeyOf(workspaceId, "storage", sid));
+  }
+  return keys;
+}
+
+/**
+ * Keys to invalidate after archiving or restoring a project.
+ */
+export function archiveProjectKeys(
+  workspaceId: string | null | undefined,
+  projectId: string,
+): unknown[][] {
+  return [
+    wsKeyOf(workspaceId, "projects"),
+    wsKeyOf(workspaceId, "project", projectId),
+  ];
+}
+
+// ---------------------------------------------------------------------
 // Auth bus — pub/sub for cross-cutting auth events fired from places
 // that don't sit inside the React tree (e.g. QueryCache.onError).
 // ---------------------------------------------------------------------

--- a/web/src/lib/queryKeys.ts
+++ b/web/src/lib/queryKeys.ts
@@ -107,9 +107,17 @@ export function archiveStorageKeys(
 /**
  * Keys to invalidate after a lot move or adjust-count.
  *
+ * Both ops change the part's total on-hand quantity, which means the
+ * parts list (drives `on_hand` column) and the three stock-rollup
+ * reports (low-stock, stock-value, expiring) all need to refresh.
+ * Same rationale as `archivePartKeys` — keep these in sync if you
+ * touch one.
+ *
  * @param lot         The lot object (must have at least `id` and `part_id`).
- * @param storageIds  Optional extra storage location IDs touched by the
- *                    operation (e.g. move destination and/or source).
+ * @param storageIds  Storage location IDs touched by the operation.
+ *                    For a move, callers must include BOTH source and
+ *                    destination — the source's "what's in this bin"
+ *                    and history views go stale otherwise.
  */
 export function lotMutationKeys(
   workspaceId: string | null | undefined,
@@ -117,10 +125,16 @@ export function lotMutationKeys(
   storageIds: string[] = [],
 ): unknown[][] {
   const keys: unknown[][] = [
+    wsKeyOf(workspaceId, "parts"),
     wsKeyOf(workspaceId, "lots"),
     wsKeyOf(workspaceId, "lot", lot.id),
-    wsKeyOf(workspaceId, "part", lot.part_id, "stock"),
+    // ["ws", ws, "part", partId] is a prefix match — TanStack invalidates
+    // every sub-key (`:stock`, `:lots`, `:history`, `:custom-fields`, …)
+    // off it, so don't enumerate them separately.
     wsKeyOf(workspaceId, "part", lot.part_id),
+    wsKeyOf(workspaceId, "report", "low-stock"),
+    wsKeyOf(workspaceId, "report", "stock-value"),
+    wsKeyOf(workspaceId, "report", "expiring"),
   ];
   for (const sid of storageIds) {
     keys.push(wsKeyOf(workspaceId, "storage", sid));

--- a/web/src/routes/lots/LotDetail.tsx
+++ b/web/src/routes/lots/LotDetail.tsx
@@ -51,6 +51,11 @@ export function LotInfo() {
   );
 }
 
+type PartStockResp = {
+  total_on_hand: number;
+  rows: { storage_location_id: string | null; lot_id: string | null; quantity: number }[];
+};
+
 export function LotMove() {
   const { lotId } = useParams<{ lotId: string }>();
   const { lot } = useOutletContext<{ lot: Lot }>();
@@ -58,6 +63,15 @@ export function LotMove() {
   const qc = useQueryClient();
   const { workspaceId } = useAuth();
   const { data: storage } = useQuery({ queryKey: useWsKey("storage"), queryFn: () => api.get<StorageLocation[]>("/storage") });
+  // The Lot resource itself doesn't carry a single storage_location_id
+  // (a lot can be split across bins via prior moves), so we read the
+  // part's stock breakdown to discover which bins currently hold this
+  // lot — those are the source bins the move will drain. Without this,
+  // the source bin's StorageInfo / StorageHistory go stale on success.
+  const { data: partStock } = useQuery({
+    queryKey: useWsKey("part", lot.part_id, "stock"),
+    queryFn: () => api.get<PartStockResp>(`/parts/${lot.part_id}/stock`),
+  });
   const [dest, setDest] = useState("");
   const [qty, setQty] = useState<number>(0);
   const [split, setSplit] = useState(false);
@@ -69,7 +83,10 @@ export function LotMove() {
       quantity: qty,
       split_lot: split,
     });
-    const storageIds = dest ? [dest] : [];
+    const sourceIds = (partStock?.rows ?? [])
+      .filter(r => r.lot_id === lot.id && r.storage_location_id)
+      .map(r => r.storage_location_id as string);
+    const storageIds = Array.from(new Set([...sourceIds, dest].filter(Boolean) as string[]));
     for (const k of lotMutationKeys(workspaceId, lot, storageIds))
       qc.invalidateQueries({ queryKey: k });
     nav(`/lots/${lotId}/info`);

--- a/web/src/routes/lots/LotDetail.tsx
+++ b/web/src/routes/lots/LotDetail.tsx
@@ -1,9 +1,9 @@
-import { Outlet, useParams, useNavigate } from "react-router-dom";
+import { Outlet, useParams, useNavigate, useOutletContext } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { api } from "@/lib/api";
 import { useAuth } from "@/lib/auth";
-import { useWsKey, wsScope } from "@/lib/queryKeys";
+import { useWsKey, lotMutationKeys } from "@/lib/queryKeys";
 import { formatDateTime } from "@/lib/format";
 import EntityHeader from "@/components/EntityHeader";
 import SubNav from "@/components/SubNav";
@@ -53,6 +53,7 @@ export function LotInfo() {
 
 export function LotMove() {
   const { lotId } = useParams<{ lotId: string }>();
+  const { lot } = useOutletContext<{ lot: Lot }>();
   const nav = useNavigate();
   const qc = useQueryClient();
   const { workspaceId } = useAuth();
@@ -68,7 +69,9 @@ export function LotMove() {
       quantity: qty,
       split_lot: split,
     });
-    qc.invalidateQueries({ queryKey: wsScope(workspaceId) });
+    const storageIds = dest ? [dest] : [];
+    for (const k of lotMutationKeys(workspaceId, lot, storageIds))
+      qc.invalidateQueries({ queryKey: k });
     nav(`/lots/${lotId}/info`);
   }
   return (
@@ -95,6 +98,7 @@ export function LotMove() {
 
 export function LotAdjust() {
   const { lotId } = useParams();
+  const { lot } = useOutletContext<{ lot: Lot }>();
   const qc = useQueryClient();
   const { workspaceId } = useAuth();
   const [actual, setActual] = useState<number>(0);
@@ -102,7 +106,8 @@ export function LotAdjust() {
   async function submit(e: React.FormEvent) {
     e.preventDefault();
     await api.post(`/lots/${lotId}/adjust-count`, { actual_quantity: actual, comments });
-    qc.invalidateQueries({ queryKey: wsScope(workspaceId) });
+    for (const k of lotMutationKeys(workspaceId, lot))
+      qc.invalidateQueries({ queryKey: k });
   }
   return (
     <form onSubmit={submit} className="card p-4 max-w-xl space-y-3">

--- a/web/src/routes/parts/detail/PartOther.tsx
+++ b/web/src/routes/parts/detail/PartOther.tsx
@@ -2,7 +2,7 @@ import { useNavigate, useOutletContext, useParams } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api";
 import { useAuth } from "@/lib/auth";
-import { wsScope } from "@/lib/queryKeys";
+import { archivePartKeys } from "@/lib/queryKeys";
 import type { Part } from "@/types";
 
 export default function PartOther() {
@@ -19,12 +19,14 @@ export default function PartOther() {
   // don't blow away unrelated data.
   async function archive() {
     await api.post(`/parts/${partId}/archive`);
-    qc.invalidateQueries({ queryKey: wsScope(workspaceId) });
+    for (const k of archivePartKeys(workspaceId, partId!))
+      qc.invalidateQueries({ queryKey: k });
     nav("/parts");
   }
   async function restore() {
     await api.post(`/parts/${partId}/restore`);
-    qc.invalidateQueries({ queryKey: wsScope(workspaceId) });
+    for (const k of archivePartKeys(workspaceId, partId!))
+      qc.invalidateQueries({ queryKey: k });
   }
 
   return (

--- a/web/src/routes/projects/detail/ProjectOther.tsx
+++ b/web/src/routes/projects/detail/ProjectOther.tsx
@@ -2,7 +2,7 @@ import { useNavigate, useOutletContext } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api";
 import { useAuth } from "@/lib/auth";
-import { wsScope } from "@/lib/queryKeys";
+import { archiveProjectKeys } from "@/lib/queryKeys";
 import type { Project } from "@/types";
 
 export default function ProjectOther() {
@@ -12,12 +12,14 @@ export default function ProjectOther() {
   const nav = useNavigate();
   async function arch() {
     await api.post(`/projects/${project.id}/archive`);
-    qc.invalidateQueries({ queryKey: wsScope(workspaceId) });
+    for (const k of archiveProjectKeys(workspaceId, project.id))
+      qc.invalidateQueries({ queryKey: k });
     nav("/projects");
   }
   async function restore() {
     await api.post(`/projects/${project.id}/restore`);
-    qc.invalidateQueries({ queryKey: wsScope(workspaceId) });
+    for (const k of archiveProjectKeys(workspaceId, project.id))
+      qc.invalidateQueries({ queryKey: k });
   }
   return (
     <div className="card p-4 max-w-xl">

--- a/web/src/routes/settings/Workspace.tsx
+++ b/web/src/routes/settings/Workspace.tsx
@@ -3,7 +3,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { api, ApiError } from "@/lib/api";
 import { useAuth } from "@/lib/auth";
-import { useWsKey, wsKeyOf, wsScope } from "@/lib/queryKeys";
+import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
 import { useConfirm } from "@/components/ConfirmDialog";
 
 type Ws = {
@@ -89,7 +89,7 @@ export default function WorkspaceSettings() {
     if (created?.id) {
       await switchWorkspace(created.id);
     } else {
-      qc.invalidateQueries({ queryKey: wsScope(workspaceId) });
+      qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "ws", "current") });
     }
   }
 

--- a/web/src/routes/storage/StorageDetail.tsx
+++ b/web/src/routes/storage/StorageDetail.tsx
@@ -3,7 +3,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { ScanLine } from "lucide-react";
 import { api } from "@/lib/api";
 import { useAuth } from "@/lib/auth";
-import { useWsKey, wsKeyOf, wsScope } from "@/lib/queryKeys";
+import { useWsKey, wsKeyOf, archiveStorageKeys } from "@/lib/queryKeys";
 import EntityHeader from "@/components/EntityHeader";
 import SubNav from "@/components/SubNav";
 import type { StorageLocation, Part, StockEntry } from "@/types";
@@ -158,12 +158,14 @@ export function StorageOther() {
   if (!data) return null;
   async function arch() {
     await api.post(`/storage/${storageId}/archive`);
-    qc.invalidateQueries({ queryKey: wsScope(workspaceId) });
+    for (const k of archiveStorageKeys(workspaceId, storageId!))
+      qc.invalidateQueries({ queryKey: k });
     nav("/storage");
   }
   async function restore() {
     await api.post(`/storage/${storageId}/restore`);
-    qc.invalidateQueries({ queryKey: wsScope(workspaceId) });
+    for (const k of archiveStorageKeys(workspaceId, storageId!))
+      qc.invalidateQueries({ queryKey: k });
   }
   return (
     <div className="card p-4 max-w-xl">


### PR DESCRIPTION
Closes #53

## Summary
- Add `archivePartKeys`, `archiveStorageKeys`, `lotMutationKeys`, `archiveProjectKeys` helpers in `queryKeys.ts` — each returns `unknown[][]` (list of ws-scoped keys) so callers can loop with a targeted invalidation
- Replace blanket `wsScope()` invalidation with the narrow helpers in `PartOther`, `StorageOther`, `LotMove`, `LotAdjust`, `ProjectOther`, and `Workspace.createWs`
- `LotMove` and `LotAdjust` now use `useOutletContext` to access the `lot` object (already provided by `LotLayout`), enabling per-part and per-storage-location precision
- Add `web/src/lib/queryKeys.test.ts` — 22 unit tests covering helper shape, workspace-scoping invariant, and the storageIds variadic parameter of `lotMutationKeys`

## Tests
Backend: N/A
Frontend build: passed (`tsc -b && vite build`)
Vitest: 22/22 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)