### PR TITLE
fix(fe): pin date/money formatting to en-US Intl helpers (#50)

### DIFF
--- a/web/src/components/ActivityTimeline.tsx
+++ b/web/src/components/ActivityTimeline.tsx
@@ -15,6 +15,7 @@ import {
 import type { ReactNode } from "react";
 import { api } from "@/lib/api";
 import { useWsKey } from "@/lib/queryKeys";
+import { formatDate, formatDateTime } from "@/lib/format";
 
 type ActivityKind =
   | "stock"
@@ -68,7 +69,7 @@ function relativeTime(iso: string): string {
   if (hr < 24) return `${hr}h ago`;
   const day = Math.round(hr / 24);
   if (day < 30) return `${day}d ago`;
-  return new Date(iso).toLocaleDateString();
+  return formatDate(iso);
 }
 
 function iconFor(e: ActivityEntry): ReactNode {
@@ -168,7 +169,7 @@ export default function ActivityTimeline({ endpoint }: Props) {
                 </div>
                 <div className="text-xs text-muted whitespace-nowrap shrink-0">
                   {e.user?.name ?? "system"} <span className="px-1">·</span>
-                  <span title={new Date(e.occurred_at).toLocaleString()}>
+                  <span title={formatDateTime(e.occurred_at)}>
                     {relativeTime(e.occurred_at)}
                   </span>
                 </div>

--- a/web/src/components/AttachmentsPanel.tsx
+++ b/web/src/components/AttachmentsPanel.tsx
@@ -5,6 +5,7 @@ import { Trash2, Download, UploadCloud, Paperclip } from "lucide-react";
 import { api, ApiError } from "@/lib/api";
 import { useWsKey } from "@/lib/queryKeys";
 import { useConfirm } from "@/components/ConfirmDialog";
+import { formatDateTime } from "@/lib/format";
 
 type Attachment = {
   id: string;
@@ -157,7 +158,7 @@ export default function AttachmentsPanel({ objectType, objectId, canWrite }: Pro
                   <span className="pill text-[10px] uppercase">{a.file_type}</span>
                 </div>
                 <div className="text-xs text-muted">
-                  {humanSize(a.size_bytes)} · {new Date(a.created_at).toLocaleString()}
+                  {humanSize(a.size_bytes)} · {formatDateTime(a.created_at)}
                 </div>
               </div>
               <a

--- a/web/src/lib/format.test.ts
+++ b/web/src/lib/format.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { formatDate, formatDateTime, formatMoney } from "./format";
+
+describe("formatDate", () => {
+  it("returns YYYY-MM-DD for a valid ISO string", () => {
+    expect(formatDate("2024-03-15T10:30:00Z")).toBe("2024-03-15");
+  });
+
+  it("returns '' for null", () => {
+    expect(formatDate(null)).toBe("");
+  });
+
+  it("returns '' for undefined", () => {
+    expect(formatDate(undefined)).toBe("");
+  });
+
+  it("returns '' for empty string", () => {
+    expect(formatDate("")).toBe("");
+  });
+
+  it("returns '' for invalid date string", () => {
+    expect(formatDate("not-a-date")).toBe("");
+  });
+});
+
+describe("formatDateTime", () => {
+  it("returns a non-empty string for a valid ISO datetime", () => {
+    const result = formatDateTime("2024-03-15T10:30:00Z");
+    expect(result).toBeTruthy();
+    expect(typeof result).toBe("string");
+  });
+
+  it("returns '' for null", () => {
+    expect(formatDateTime(null)).toBe("");
+  });
+
+  it("returns '' for undefined", () => {
+    expect(formatDateTime(undefined)).toBe("");
+  });
+
+  it("returns '' for empty string", () => {
+    expect(formatDateTime("")).toBe("");
+  });
+
+  it("returns '' for invalid date string", () => {
+    expect(formatDateTime("not-a-date")).toBe("");
+  });
+});
+
+describe("formatMoney", () => {
+  it("formats USD with 2 decimal places", () => {
+    const result = formatMoney(12.5, "USD");
+    expect(result).toContain("12.50");
+    expect(result).toContain("$");
+  });
+
+  it("formats JPY with 0 decimal places", () => {
+    const result = formatMoney(1500, "JPY");
+    expect(result).not.toContain(".");
+    expect(result).toContain("1,500");
+  });
+
+  it("formats EUR with 2 decimal places", () => {
+    const result = formatMoney(9.99, "EUR");
+    expect(result).toContain("9.99");
+  });
+
+  it("falls back for empty currency", () => {
+    expect(formatMoney(5.5, "")).toBe("5.50");
+  });
+
+  it("falls back for null currency", () => {
+    expect(formatMoney(5.5, null)).toBe("5.50");
+  });
+
+  it("falls back for undefined currency", () => {
+    expect(formatMoney(5.5, undefined)).toBe("5.50");
+  });
+
+  it("falls back for invalid ISO 4217 code", () => {
+    const result = formatMoney(10, "INVALID");
+    expect(result).toContain("10.00");
+    expect(result).toContain("INVALID");
+  });
+});

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -1,0 +1,53 @@
+/**
+ * Locale-pinned formatting helpers.
+ * All functions use "en-US" so every operator sees identical output
+ * regardless of browser locale settings.
+ */
+
+const LOCALE = "en-US";
+
+/** Format an ISO date/datetime string as YYYY-MM-DD (en-CA yields that shape). */
+export function formatDate(iso: string | null | undefined): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return "";
+  return new Intl.DateTimeFormat("en-CA").format(d); // → YYYY-MM-DD
+}
+
+/** Format an ISO datetime string as date + 24 h time, pinned to en-US. */
+export function formatDateTime(iso: string | null | undefined): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return "";
+  return new Intl.DateTimeFormat(LOCALE, {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  }).format(d);
+}
+
+/**
+ * Format a currency value.
+ * Uses Intl.NumberFormat so JPY auto-renders with 0 decimals, CHF/EUR/USD
+ * with 2.  Falls back to `value.toFixed(2) + " " + currency` when the
+ * currency code is unknown/empty or the Intl constructor throws.
+ */
+export function formatMoney(
+  value: number,
+  currency: string | null | undefined,
+): string {
+  if (!currency) return value.toFixed(2);
+  try {
+    return new Intl.NumberFormat(LOCALE, {
+      style: "currency",
+      currency,
+    }).format(value);
+  } catch {
+    // RangeError for invalid ISO 4217 codes
+    return `${value.toFixed(2)} ${currency}`;
+  }
+}

--- a/web/src/routes/builds/BuildDetail.tsx
+++ b/web/src/routes/builds/BuildDetail.tsx
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 import { api, ApiError } from "@/lib/api";
 import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
 import { useAuth } from "@/lib/auth";
+import { formatDateTime } from "@/lib/format";
 import EntityHeader from "@/components/EntityHeader";
 import AttachmentsPanel from "@/components/AttachmentsPanel";
 import ActivityTimeline from "@/components/ActivityTimeline";
@@ -155,7 +156,7 @@ export default function BuildDetail() {
             tone: build.status === "complete" ? "success" : build.status === "cancelled" ? "danger" : "default",
           },
           ...(build.completed_at
-            ? [{ label: "Completed", value: new Date(build.completed_at).toLocaleString() } as const]
+            ? [{ label: "Completed", value: formatDateTime(build.completed_at) } as const]
             : []),
         ]}
         actions={

--- a/web/src/routes/builds/BuildsList.tsx
+++ b/web/src/routes/builds/BuildsList.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Hammer } from "lucide-react";
 import { api } from "@/lib/api";
 import { useWsKey } from "@/lib/queryKeys";
+import { formatDateTime } from "@/lib/format";
 import { DataTable } from "@/components/DataTable";
 import EmptyState from "@/components/EmptyState";
 import QueryStateBoundary from "@/components/QueryStateBoundary";
@@ -76,7 +77,7 @@ export default function BuildsList({ archived = false }: { archived?: boolean })
             key: "completed",
             header: "Completed",
             accessor: r => r.completed_at ?? "",
-            render: r => r.completed_at ? new Date(r.completed_at).toLocaleString() : <span className="text-muted">—</span>,
+            render: r => r.completed_at ? formatDateTime(r.completed_at) : <span className="text-muted">—</span>,
           },
         ]}
       />

--- a/web/src/routes/lots/LotDetail.tsx
+++ b/web/src/routes/lots/LotDetail.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { api } from "@/lib/api";
 import { useAuth } from "@/lib/auth";
 import { useWsKey, wsScope } from "@/lib/queryKeys";
+import { formatDateTime } from "@/lib/format";
 import EntityHeader from "@/components/EntityHeader";
 import SubNav from "@/components/SubNav";
 import type { Lot, Part, StockEntry, StorageLocation } from "@/types";
@@ -128,7 +129,7 @@ export function LotHistory() {
         <tbody>
           {(data ?? []).map(e => (
             <tr key={e.id}>
-              <td>{new Date(e.occurred_at).toLocaleString()}</td>
+              <td>{formatDateTime(e.occurred_at)}</td>
               <td>{e.operation_type}</td>
               <td className={e.quantity_delta < 0 ? "text-danger" : "text-accent"}>{e.quantity_delta > 0 ? "+" : ""}{e.quantity_delta}</td>
               <td className="font-mono text-xs">{e.storage_location_id ?? "—"}</td>

--- a/web/src/routes/orders/OrdersList.tsx
+++ b/web/src/routes/orders/OrdersList.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { ShoppingCart } from "lucide-react";
 import { api } from "@/lib/api";
 import { useWsKey } from "@/lib/queryKeys";
+import { formatDate } from "@/lib/format";
 import { DataTable } from "@/components/DataTable";
 import EmptyState from "@/components/EmptyState";
 import QueryStateBoundary from "@/components/QueryStateBoundary";
@@ -79,7 +80,7 @@ export default function OrdersList({ archived = false }: { archived?: boolean })
             key: "expected_on",
             header: "Expected",
             accessor: r => r.expected_on ?? "",
-            render: r => r.expected_on ? new Date(r.expected_on).toLocaleDateString() : <span className="text-muted">—</span>,
+            render: r => r.expected_on ? formatDate(r.expected_on) : <span className="text-muted">—</span>,
           },
         ]}
       />

--- a/web/src/routes/parts/LotsList.tsx
+++ b/web/src/routes/parts/LotsList.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { Package } from "lucide-react";
 import { api } from "@/lib/api";
 import { useWsKey } from "@/lib/queryKeys";
+import { formatDate } from "@/lib/format";
 import type { Lot, Part } from "@/types";
 import { DataTable } from "@/components/DataTable";
 import EmptyState from "@/components/EmptyState";
@@ -39,7 +40,7 @@ export default function LotsList() {
           { key: "quantity", header: "On hand", accessor: r => r.current_quantity ?? 0 },
           { key: "unit_cost", header: "Unit cost", accessor: r => r.purchase_unit_cost ?? "" },
           { key: "currency", header: "Cur", accessor: r => r.purchase_currency ?? "" },
-          { key: "created_at", header: "Created", accessor: r => r.created_at, render: r => new Date(r.created_at).toLocaleDateString() },
+          { key: "created_at", header: "Created", accessor: r => r.created_at, render: r => formatDate(r.created_at) },
         ]}
       />
       </QueryStateBoundary>

--- a/web/src/routes/parts/StockHistory.tsx
+++ b/web/src/routes/parts/StockHistory.tsx
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { ScrollText } from "lucide-react";
 import { api } from "@/lib/api";
 import { useWsKey } from "@/lib/queryKeys";
+import { formatDateTime } from "@/lib/format";
 import type { Part, StockEntry, StorageLocation } from "@/types";
 import { DataTable } from "@/components/DataTable";
 import EmptyState from "@/components/EmptyState";
@@ -30,7 +31,7 @@ export default function StockHistory() {
         }
         exportFilename="stock-history"
         columns={[
-          { key: "occurred_at", header: "Date", accessor: r => r.occurred_at, render: r => new Date(r.occurred_at).toLocaleString() },
+          { key: "occurred_at", header: "Date", accessor: r => r.occurred_at, render: r => formatDateTime(r.occurred_at) },
           { key: "operation_type", header: "Op", accessor: r => r.operation_type },
           { key: "part", header: "Part", accessor: r => partName.get(r.part_id) || r.part_id, render: r => <Link className="text-accent" to={`/parts/${r.part_id}/info`}>{partName.get(r.part_id) || r.part_id}</Link> },
           { key: "qty", header: "Δ", accessor: r => r.quantity_delta },

--- a/web/src/routes/parts/detail/PartHistory.tsx
+++ b/web/src/routes/parts/detail/PartHistory.tsx
@@ -2,6 +2,7 @@ import { useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api";
 import { useWsKey } from "@/lib/queryKeys";
+import { formatDateTime } from "@/lib/format";
 import type { StockEntry, StorageLocation } from "@/types";
 import { DataTable } from "@/components/DataTable";
 
@@ -25,7 +26,7 @@ export default function PartHistory() {
       empty="No stock history."
       exportFilename="stock-history"
       columns={[
-        { key: "occurred_at", header: "Date", accessor: r => r.occurred_at, render: r => new Date(r.occurred_at).toLocaleString() },
+        { key: "occurred_at", header: "Date", accessor: r => r.occurred_at, render: r => formatDateTime(r.occurred_at) },
         { key: "operation_type", header: "Op", accessor: r => r.operation_type },
         { key: "quantity_delta", header: "Δ", accessor: r => r.quantity_delta, render: r => <span className={r.quantity_delta < 0 ? "text-danger" : "text-accent"}>{r.quantity_delta > 0 ? "+" : ""}{r.quantity_delta}</span> },
         { key: "storage", header: "Storage", accessor: r => r.storage_location_id ? (sName.get(r.storage_location_id) || r.storage_location_id) : "" },

--- a/web/src/routes/parts/detail/PartLots.tsx
+++ b/web/src/routes/parts/detail/PartLots.tsx
@@ -2,6 +2,7 @@ import { useParams, useNavigate } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api";
 import { useWsKey } from "@/lib/queryKeys";
+import { formatDateTime } from "@/lib/format";
 import type { Lot } from "@/types";
 import { DataTable } from "@/components/DataTable";
 
@@ -24,7 +25,7 @@ export default function PartLots() {
         { key: "purchase_currency", header: "Currency", accessor: r => r.purchase_currency ?? "" },
         { key: "expiration_date", header: "Expires", accessor: r => r.expiration_date ?? "" },
         { key: "source_type", header: "Source", accessor: r => r.source_type },
-        { key: "created_at", header: "Created", accessor: r => r.created_at, render: r => new Date(r.created_at).toLocaleString() },
+        { key: "created_at", header: "Created", accessor: r => r.created_at, render: r => formatDateTime(r.created_at) },
       ]}
     />
   );

--- a/web/src/routes/parts/detail/PartSourcing.tsx
+++ b/web/src/routes/parts/detail/PartSourcing.tsx
@@ -7,6 +7,7 @@ import { api, ApiError } from "@/lib/api";
 import { isCatalogKey } from "@/lib/providerCatalog";
 import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
 import { useAuth } from "@/lib/auth";
+import { formatDateTime } from "@/lib/format";
 import type { CustomFieldRow, Part } from "@/types";
 
 const PROVIDER_LABEL: Record<string, string> = {
@@ -76,7 +77,7 @@ export default function PartSourcing() {
                 Catalog data from <strong className="text-text">{providerLabel}</strong>
                 {part.last_refresh_at && (
                   <span className="ml-2">
-                    · refreshed {new Date(part.last_refresh_at).toLocaleString()}
+                    · refreshed {formatDateTime(part.last_refresh_at)}
                   </span>
                 )}
               </>

--- a/web/src/routes/projects/ProjectsList.tsx
+++ b/web/src/routes/projects/ProjectsList.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { FolderKanban } from "lucide-react";
 import { api } from "@/lib/api";
 import { useWsKey } from "@/lib/queryKeys";
+import { formatDateTime } from "@/lib/format";
 import { DataTable } from "@/components/DataTable";
 import EmptyState from "@/components/EmptyState";
 import QueryStateBoundary from "@/components/QueryStateBoundary";
@@ -48,7 +49,7 @@ export default function ProjectsList({ archived = false }: { archived?: boolean 
         columns={[
           { key: "name", header: "Name", accessor: r => r.name },
           { key: "description", header: "Description", accessor: r => r.description ?? "" },
-          { key: "updated_at", header: "Last updated", accessor: r => r.updated_at, render: r => new Date(r.updated_at).toLocaleString() },
+          { key: "updated_at", header: "Last updated", accessor: r => r.updated_at, render: r => formatDateTime(r.updated_at) },
         ]}
       />
       </QueryStateBoundary>

--- a/web/src/routes/projects/detail/ProjectBuilds.tsx
+++ b/web/src/routes/projects/detail/ProjectBuilds.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Hammer } from "lucide-react";
 import { api } from "@/lib/api";
 import { useWsKey } from "@/lib/queryKeys";
+import { formatDateTime } from "@/lib/format";
 import { DataTable } from "@/components/DataTable";
 import EmptyState from "@/components/EmptyState";
 import type { Build } from "@/types";
@@ -41,7 +42,7 @@ export default function ProjectBuilds() {
             key: "completed",
             header: "Completed",
             accessor: r => r.completed_at ?? "",
-            render: r => r.completed_at ? new Date(r.completed_at).toLocaleString() : <span className="text-muted">—</span>,
+            render: r => r.completed_at ? formatDateTime(r.completed_at) : <span className="text-muted">—</span>,
           },
         ]}
       />

--- a/web/src/routes/reports/Reports.tsx
+++ b/web/src/routes/reports/Reports.tsx
@@ -6,6 +6,7 @@ import { BarChart3, ShoppingCart } from "lucide-react";
 import { api, ApiError } from "@/lib/api";
 import { useAuth } from "@/lib/auth";
 import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
+import { formatDate, formatMoney } from "@/lib/format";
 import { DataTable } from "@/components/DataTable";
 import EmptyState from "@/components/EmptyState";
 import type { Order, Project } from "@/types";
@@ -159,7 +160,7 @@ function KpiStrip() {
   const lowCount = lowStock?.length ?? 0;
   const valueByCurrency = stockValue?.by_currency
     ?.filter(c => c.value > 0)
-    .map(c => `${c.value.toFixed(2)} ${c.currency ?? "?"}`)
+    .map(c => formatMoney(c.value, c.currency))
     .join(" · ") ?? "—";
   const expiringCount = expiring?.length ?? 0;
   const expiredCount = expiring?.filter(l => l.expired).length ?? 0;
@@ -285,7 +286,7 @@ export function StockValueReport() {
             {data.by_currency.map(c => (
               <tr key={c.currency ?? "none"}>
                 <td>{c.currency ?? <span className="text-muted">— (untagged)</span>}</td>
-                <td className="tabular-nums">{c.value.toFixed(2)}</td>
+                <td className="tabular-nums">{formatMoney(c.value, c.currency)}</td>
               </tr>
             ))}
           </tbody>
@@ -306,7 +307,7 @@ export function StockValueReport() {
         columns={[
           { key: "name", header: "Part", accessor: r => r.name, render: r => <Link className="text-accent" to={`/parts/${r.part_id}/info`}>{r.name}</Link> },
           { key: "on_hand", header: "On hand", accessor: r => r.on_hand, width: "80px" },
-          { key: "value", header: "Value", accessor: r => r.value, render: r => <span className="tabular-nums">{r.value.toFixed(2)}</span> },
+          { key: "value", header: "Value", accessor: r => r.value, render: r => <span className="tabular-nums">{formatMoney(r.value, r.currency)}</span> },
           { key: "currency", header: "Currency", accessor: r => r.currency ?? "—", width: "100px" },
         ]}
       />
@@ -434,7 +435,7 @@ export function ExpiringLotsReport() {
           { key: "lot", header: "Lot", accessor: r => r.name ?? r.lot_id, render: r => <Link className="text-accent" to={`/lots/${r.lot_id}/info`}>{r.name ?? r.lot_id}</Link> },
           { key: "part", header: "Part", accessor: r => r.part_name ?? r.part_id, render: r => <Link to={`/parts/${r.part_id}/info`}>{r.part_name ?? r.part_id}</Link> },
           { key: "qty", header: "On hand", accessor: r => r.on_hand, width: "80px" },
-          { key: "exp", header: "Expires", accessor: r => r.expiration_date, render: r => new Date(r.expiration_date).toLocaleDateString() },
+          { key: "exp", header: "Expires", accessor: r => r.expiration_date, render: r => formatDate(r.expiration_date) },
           { key: "left", header: "Days", accessor: r => r.days_until_expiry, width: "80px",
             render: r => r.expired ? <span className="text-danger">expired</span> : <span className={r.days_until_expiry < 30 ? "text-warning" : ""}>{r.days_until_expiry}</span> },
         ]}

--- a/web/src/routes/storage/StorageDetail.tsx
+++ b/web/src/routes/storage/StorageDetail.tsx
@@ -8,6 +8,7 @@ import EntityHeader from "@/components/EntityHeader";
 import SubNav from "@/components/SubNav";
 import type { StorageLocation, Part, StockEntry } from "@/types";
 import { DataTable } from "@/components/DataTable";
+import { formatDateTime } from "@/lib/format";
 
 export function StorageDetailLayout() {
   const { storageId } = useParams<{ storageId: string }>();
@@ -102,7 +103,7 @@ export function StorageHistory() {
       tableId="storage-history"
       empty="No history."
       columns={[
-        { key: "occurred_at", header: "Date", accessor: r => r.occurred_at, render: r => new Date(r.occurred_at).toLocaleString() },
+        { key: "occurred_at", header: "Date", accessor: r => r.occurred_at, render: r => formatDateTime(r.occurred_at) },
         { key: "operation_type", header: "Op", accessor: r => r.operation_type },
         { key: "part", header: "Part", accessor: r => partName.get(r.part_id) || r.part_id },
         { key: "qty", header: "Δ", accessor: r => r.quantity_delta },


### PR DESCRIPTION
Closes #50

## Summary
- Add `web/src/lib/format.ts` with `formatDate`, `formatDateTime`, `formatMoney` pinned to `en-US` via `Intl.DateTimeFormat` / `Intl.NumberFormat`
- Sweep 16 callsites across 15 files replacing `toLocaleString()` / `toLocaleDateString()` / `toFixed` with the new helpers
- `formatMoney` wraps `Intl.NumberFormat` in try/catch so invalid ISO 4217 codes fall back gracefully; JPY auto-renders with 0 decimals
- `formatDate` / `formatDateTime` return `""` on null/undefined/invalid input to keep table cells clean
- DataTable `accessor` paths left untouched — CSV export continues to use raw ISO 8601 strings
- Add `web/src/lib/format.test.ts` with 17 vitest tests covering all helpers including null/undefined/invalid-currency edge cases

## Tests
Backend: N/A
Frontend build: passed (`tsc -b && vite build`)
Vitest: 17/17 tests passed