### PR TITLE
docs(infra): TLS renewal hook example for future docker-stack TLS (#93)

### DIFF
--- a/deploy/letsencrypt-deploy-hook.sh.example
+++ b/deploy/letsencrypt-deploy-hook.sh.example
@@ -1,0 +1,28 @@
+#!/bin/sh
+# letsencrypt-deploy-hook.sh.example
+#
+# PURPOSE
+#   Tell the in-container web server to reload its TLS certificate after
+#   certbot renews it successfully.
+#
+# STATUS: NO-OP TODAY
+#   TLS currently terminates at the host Apache 2.4 vhost.  Certbot's
+#   Debian package already reloads Apache automatically via
+#   /etc/letsencrypt/renewal-hooks/deploy/apache.  This script is only
+#   needed if TLS ever moves into the Docker stack (i.e. nginx inside
+#   the "web" container holds the cert).
+#
+# HOW TO INSTALL (only when TLS lives in the Docker stack)
+#   sudo cp /srv/stockmanager/deploy/letsencrypt-deploy-hook.sh.example \
+#           /etc/letsencrypt/renewal-hooks/deploy/stockmanager-reload.sh
+#   sudo chmod +x /etc/letsencrypt/renewal-hooks/deploy/stockmanager-reload.sh
+#   sudo chown root:root /etc/letsencrypt/renewal-hooks/deploy/stockmanager-reload.sh
+#
+# VALIDATE
+#   sudo certbot renew --dry-run \
+#     --deploy-hook /etc/letsencrypt/renewal-hooks/deploy/stockmanager-reload.sh
+
+set -e
+
+docker compose -f /srv/stockmanager/docker-compose.prod.yml \
+    exec web nginx -s reload

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -411,6 +411,25 @@ apache2ctl configtest && systemctl reload apache2
 The `…-le-ssl.conf` companion file is owned by certbot — don't edit it
 unless you mean to.
 
+### If you ever move TLS into the docker stack
+
+Today certbot's Debian package reloads Apache automatically after renewal
+(via `/etc/letsencrypt/renewal-hooks/deploy/apache`).  If TLS ever
+terminates inside the docker stack instead (nginx in the `web` container
+holds the cert), that hook no longer reloads the right thing and the
+container would serve the expired cert until the next `docker compose up`.
+
+- **Apache reload-on-renewal goes away** because there is no Apache in
+  that scenario; the certbot package hook becomes a no-op.
+- **Install the dormant hook** at
+  `deploy/letsencrypt-deploy-hook.sh.example` as
+  `/etc/letsencrypt/renewal-hooks/deploy/stockmanager-reload.sh`
+  (executable, owned by root).  The script runs
+  `docker compose … exec web nginx -s reload` so nginx picks up the fresh
+  cert without a full container restart.
+- **Validate** with
+  `certbot renew --dry-run --deploy-hook /etc/letsencrypt/renewal-hooks/deploy/stockmanager-reload.sh`.
+
 ## Backups
 
 Two volumes need covering:


### PR DESCRIPTION
Closes #93

## Summary
- Add `deploy/letsencrypt-deploy-hook.sh.example` (non-executable, no-op today): a `docker compose exec web nginx -s reload` script with comments explaining it is dormant until TLS moves into the docker stack
- Add `docs/deployment.md` subsection "If you ever move TLS into the docker stack" with 3 bullets: Apache reload goes away, how to install the hook, how to validate with `certbot renew --dry-run`

## Tests
Backend: N/A
Frontend: N/A
No operator action required today — the hook only matters if TLS moves into the docker stack.