### PR TITLE
fix(infra): 5m nginx/Apache timeout for BOM+scan-import routes (#92)

### DIFF
--- a/deploy/nginx-web.conf
+++ b/deploy/nginx-web.conf
@@ -38,6 +38,24 @@ server {
     # everything else explicitly off to neuter the rest of the surface.
     add_header Permissions-Policy "camera=(self), microphone=(), geolocation=(), payment=(), usb=()" always;
 
+    # ---- Long-running import routes (BOM + scan) → extended timeouts ----
+    # Must appear BEFORE the generic /api/ block so nginx's more-specific
+    # regex match wins.  BOM imports and scan-to-import can write hundreds
+    # of rows on a small VPS and routinely exceed the 60s default, causing
+    # nginx to return 504 while the backend is still working (INFRA2-019).
+    location ~ ^/api/(projects/[^/]+/bom/import|parts/bulk-import-from-scan) {
+        proxy_pass http://backend:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host  $host;
+        proxy_read_timeout 5m;
+        proxy_send_timeout 5m;
+        proxy_hide_header Server;
+    }
+
     # ---- /api/* → FastAPI (uvicorn) on the docker network ----
     location /api/ {
         proxy_pass http://backend:8000;

--- a/deploy/parts.matescb.cz-le-ssl.conf
+++ b/deploy/parts.matescb.cz-le-ssl.conf
@@ -27,12 +27,17 @@
 
     ProxyPreserveHost On
     ProxyPass /.well-known !
-    # retry=2 / timeout=30 / connectiontimeout=5 — same as :80 vhost;
-    # keeps behaviour consistent across TLS and plain connections.
+    # retry=2 / timeout=300 / connectiontimeout=5 — keeps behaviour consistent
+    # with the :80 vhost. Production HTTPS traffic terminates here, so the
+    # 5 m upstream read timeout is required to cover BOM + scan-import
+    # routes (INFRA2-019); the in-container nginx sets the matching
+    # proxy_read_timeout on the same routes. A shorter timeout here would
+    # surface a 504 from Apache while the backend was still happily writing
+    # rows.
     # NOTE: if certbot ever deletes and re-issues this file, re-apply these
     # flags (certbot only edits the SSLCertificateFile / SSLCertificateKeyFile
     # lines during renewal — it does not rewrite the ProxyPass block).
-    ProxyPass / http://127.0.0.1:8091/ retry=2 timeout=30 connectiontimeout=5
+    ProxyPass / http://127.0.0.1:8091/ retry=2 timeout=300 connectiontimeout=5
     ProxyPassReverse / http://127.0.0.1:8091/
 
     # Tell clients to retry in ~10s on any 5xx.

--- a/deploy/parts.matescb.cz.conf
+++ b/deploy/parts.matescb.cz.conf
@@ -22,9 +22,10 @@
     ProxyPass /.well-known !
     # retry=2: on a 502 Apache retries the backend up to 2 more times before
     # giving up, bridging short container-restart windows.
-    # timeout=30: upstream read timeout (matches uvicorn's drain window).
+    # timeout=300: upstream read timeout raised to 5 m to cover BOM + scan-import
+    #   routes (INFRA2-019). Matches the in-container nginx proxy_read_timeout.
     # connectiontimeout=5: fast-fail if the backend hasn't bound the port yet.
-    ProxyPass / http://127.0.0.1:8091/ retry=2 timeout=30 connectiontimeout=5
+    ProxyPass / http://127.0.0.1:8091/ retry=2 timeout=300 connectiontimeout=5
     ProxyPassReverse / http://127.0.0.1:8091/
 
     # Tell clients (especially mobile webviews) to retry in ~10s on any 5xx.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -555,10 +555,15 @@ container would serve the expired cert until the next `docker compose up`.
 **BOM / scan-import timeouts (INFRA2-019).** Both proxy layers must agree:
 the in-container nginx sets `proxy_read_timeout 5m` / `proxy_send_timeout 5m`
 for `POST /api/projects/*/bom/import` and `POST /api/parts/bulk-import-from-scan`
-(see `deploy/nginx-web.conf`), and the Apache vhost sets `timeout=300` on its
-`ProxyPass` directive (see `deploy/parts.matescb.cz.conf`). If you change one,
-keep the other in sync. **The Apache vhost change is not auto-deployed** — after
-merging, run the `cp` + `systemctl reload apache2` commands above on the VPS.
+(see `deploy/nginx-web.conf`), and **both** Apache vhosts (`:80` and `:443`)
+set `timeout=300` on their `ProxyPass` directives (see
+`deploy/parts.matescb.cz.conf` and `deploy/parts.matescb.cz-le-ssl.conf`).
+Production HTTPS traffic terminates on the `:443` vhost, so the SSL file is
+the load-bearing one for live BOM/scan-import calls; the `:80` vhost mainly
+serves the HTTP→HTTPS redirect plus `/.well-known` for cert renewal. If you
+change one, keep the other in sync. **The Apache vhost change is not
+auto-deployed** — after merging, run the `cp` + `systemctl reload apache2`
+commands above on the VPS for **both** files.
 
 ## Backups
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -552,6 +552,14 @@ container would serve the expired cert until the next `docker compose up`.
 - **Validate** with
   `certbot renew --dry-run --deploy-hook /etc/letsencrypt/renewal-hooks/deploy/stockmanager-reload.sh`.
 
+**BOM / scan-import timeouts (INFRA2-019).** Both proxy layers must agree:
+the in-container nginx sets `proxy_read_timeout 5m` / `proxy_send_timeout 5m`
+for `POST /api/projects/*/bom/import` and `POST /api/parts/bulk-import-from-scan`
+(see `deploy/nginx-web.conf`), and the Apache vhost sets `timeout=300` on its
+`ProxyPass` directive (see `deploy/parts.matescb.cz.conf`). If you change one,
+keep the other in sync. **The Apache vhost change is not auto-deployed** — after
+merging, run the `cp` + `systemctl reload apache2` commands above on the VPS.
+
 ## Backups
 
 Two volumes need covering:


### PR DESCRIPTION
Closes #92

## Summary
- Add nginx regex `location ~ ^/api/(projects/[^/]+/bom/import|parts/bulk-import-from-scan)` block **before** the generic `/api/` location, with `proxy_read_timeout 5m` and `proxy_send_timeout 5m` — prevents 504s when BOM or scan imports take longer than the previous 60s default on a small VPS
- Add `timeout=300` to the Apache `ProxyPass` directive in `deploy/parts.matescb.cz.conf` so the outer proxy layer also allows 5 minutes
- Document the two-layer timeout requirement in `docs/deployment.md` and note that the Apache vhost change requires a manual operator action on the VPS

## Tests
Backend: N/A (config-only change)
Frontend: N/A

## Operator action required
After merging, sync the Apache vhost on the VPS:
```bash
cp /srv/stockmanager/deploy/parts.matescb.cz.conf \
   /etc/apache2/sites-available/parts.matescb.cz.conf
apache2ctl configtest && systemctl reload apache2
```
The nginx change takes effect automatically on the next `docker compose up --build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)