### PR TITLE
fix(providers): rate limit + response caching + upstream timeout cap (#60)

### DIFF
--- a/backend/alembic/versions/0022_invitation_token_hmac.py
+++ b/backend/alembic/versions/0022_invitation_token_hmac.py
@@ -1,7 +1,7 @@
 """Add token_hmac column to workspace_invitations (SEC2-013).
 
-Revision ID: 0021
-Revises: 0020
+Revision ID: 0022
+Revises: 0021
 Create Date: 2026-05-02
 
 SEC2-013 fix: the invitation accept flow previously queried

--- a/backend/app/api/routes/parts.py
+++ b/backend/app/api/routes/parts.py
@@ -26,6 +26,7 @@ from app.core.secrets import decrypt
 from app.domain.custom_fields.models import CustomField
 from app.domain.parts.models import Part, PartMetaMember, PartSubstitute
 from app.domain.parts.providers import make_provider
+from app.domain.parts.services.provider_cache import lookup_fresh, lookup_with_cache
 from app.domain.parts.schemas import (
     BulkDeleteIn,
     MetaMemberIn,
@@ -690,7 +691,10 @@ def refresh_from_provider(
             detail="no parts provider configured (set one in Workspace settings)",
         )
 
-    out = provider.lookup_mpn(p.mpn.strip())
+    # Use lookup_fresh (not lookup_with_cache) — the operator explicitly
+    # triggered a refresh, so we always hit upstream.  The fresh result is
+    # written back to the cache so subsequent lookup_with_cache calls see it.
+    out = lookup_fresh(provider, p.mpn.strip())
     if not out.get("found") or not out.get("result"):
         return ok(
             {
@@ -945,7 +949,7 @@ def bulk_import_from_scan(
         # swallowing — the row still resolves with `lookup_failed` so
         # the operator sees something, but ops aren't blind to the bug.
         try:
-            lookup = provider.lookup_mpn(mpn)
+            lookup = lookup_with_cache(provider, mpn)
         except Exception as exc:
             try:  # local import keeps this path zero-cost when SENTRY_DSN is empty
                 import sentry_sdk

--- a/backend/app/api/routes/parts_provider.py
+++ b/backend/app/api/routes/parts_provider.py
@@ -10,6 +10,7 @@ from app.core.ratelimit import limiter, workspace_key
 from app.core.responses import ok
 from app.core.secrets import decrypt
 from app.domain.parts.providers import make_provider
+from app.domain.parts.services.provider_cache import lookup_with_cache
 
 router = APIRouter()
 
@@ -37,7 +38,7 @@ def lookup_mpn(request: Request, payload: LookupIn, ws: CurrentWorkspace):
             "message": "no provider configured (set one in Workspace settings)",
             "provider": ws.parts_provider or "none",
         })
-    out = provider.lookup_mpn(payload.mpn.strip())
+    out = lookup_with_cache(provider, payload.mpn.strip())
     # Tag the response with the provider name so the UI can label its
     # success/failure note.
     return ok({**out, "provider": provider.name})

--- a/backend/app/domain/parts/providers/digikey.py
+++ b/backend/app/domain/parts/providers/digikey.py
@@ -26,7 +26,7 @@ _API_BASE = "https://api.digikey.com"
 _TOKEN_PATH = "/v1/oauth2/token"
 _PRODUCT_DETAILS_PATH = "/products/v4/search/{mpn}/productdetails"
 _KEYWORD_SEARCH_PATH = "/products/v4/search/keyword"
-_TIMEOUT_SEC = 15.0
+_TIMEOUT_SEC = 8.0  # Cap upstream wall-clock to prevent worker stall (BE2-011).
 
 _LOCALE_SITE = "CZ"
 _LOCALE_LANG = "en"

--- a/backend/app/domain/parts/providers/mouser.py
+++ b/backend/app/domain/parts/providers/mouser.py
@@ -10,7 +10,7 @@ from app.domain.parts.providers.base import MpnLookupResult
 
 
 _ENDPOINT = "https://api.mouser.com/api/v1/search/partnumber"
-_TIMEOUT_SEC = 10.0
+_TIMEOUT_SEC = 8.0  # Cap upstream wall-clock to prevent worker stall (BE2-011).
 
 
 def _post_mouser(url: str, payload: dict[str, Any]) -> dict[str, Any]:

--- a/backend/app/domain/parts/services/provider_cache.py
+++ b/backend/app/domain/parts/services/provider_cache.py
@@ -1,0 +1,260 @@
+"""TTL result cache + circuit breaker for provider MPN lookups.
+
+Goals
+-----
+* Avoid burning upstream API quota on repeated lookups for the same MPN
+  (e.g. scan-to-import batch, operator refreshing the same part repeatedly).
+* Return fast synthetic failures when a provider's upstream is clearly down
+  rather than stalling the only uvicorn worker for 8 s × N consecutive calls.
+
+Design notes
+------------
+Cache keying
+    `(provider.name, mpn.strip().lower())` — two workspaces using the same
+    provider share the same cache hit.  Both DigiKey and Mouser return
+    public catalog data; nothing in the result is tied to the workspace's
+    API key.  Pricing is a snapshot from the upstream catalog, not a
+    workspace-scoped price list.
+
+What is cached
+    Only positive `{"found": True, ...}` results — failure responses are
+    short-lived and re-trying after a minute is acceptable.  Negative hits
+    from a real `{"found": False, "message": "no match for MPN"}` are also
+    cached with a shorter TTL so we don't hammer the API on a typo either.
+
+Circuit breaker
+    Five consecutive failures → breaker opens for 60 s.  While open, calls
+    return `{"found": False, "message": "provider temporarily unavailable"}`
+    without hitting the network.  The counter resets on any success.
+
+    Per-provider, per-process state (in-memory dict).  Not persisted across
+    restarts (CLAUDE.md hard constraint: `--workers 1` in prod).
+
+No new runtime dependencies.  The TTL LRU cache is hand-rolled because
+`cachetools` is not in pyproject.toml and we should not add dependencies for
+a ~20-line data structure.
+"""
+from __future__ import annotations
+
+import time
+from collections import OrderedDict
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from app.domain.parts.providers.base import MpnLookupResult, PartsProvider
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# How long to keep a positive ("found": True) result in memory.
+_HIT_TTL_SEC: float = 86_400.0  # 24 h
+
+# How long to suppress a negative ("found": False) result.  Shorter so that
+# a newly stocked part or a typo fix doesn't take a full day to re-check.
+_MISS_TTL_SEC: float = 300.0  # 5 min
+
+# Maximum number of entries across all providers.
+_MAX_ENTRIES: int = 512
+
+# Circuit-breaker tuning.
+_CB_FAIL_THRESHOLD: int = 5      # consecutive failures before opening
+_CB_OPEN_SEC: float = 60.0       # seconds the breaker stays open
+
+
+# ---------------------------------------------------------------------------
+# Internal: tiny TTL-LRU cache (no external deps)
+# ---------------------------------------------------------------------------
+
+class _TtlLruCache:
+    """Thread-unsafe TTL-capped LRU cache.
+
+    Eviction policy: when max size is reached, the least-recently-used entry
+    is dropped first.  Entries that have exceeded their TTL are lazily evicted
+    on every read.
+
+    This is intentionally minimal — it only needs to work with the GIL and
+    the synchronous (non-async) provider calls.
+    """
+
+    def __init__(self, maxsize: int, default_ttl: float) -> None:
+        self._maxsize = maxsize
+        self._default_ttl = default_ttl
+        # Ordered by insertion/access order (LRU at the left).
+        self._store: OrderedDict[str, tuple[object, float]] = OrderedDict()
+
+    def _make_key(self, provider_name: str, mpn: str) -> str:
+        return f"{provider_name}:{mpn.strip().lower()}"
+
+    def get(self, provider_name: str, mpn: str) -> "MpnLookupResult | None":
+        key = self._make_key(provider_name, mpn)
+        item = self._store.get(key)
+        if item is None:
+            return None
+        value, expires_at = item
+        if time.monotonic() >= expires_at:
+            del self._store[key]
+            return None
+        # Move to end (most-recently-used).
+        self._store.move_to_end(key)
+        return value  # type: ignore[return-value]
+
+    def set(self, provider_name: str, mpn: str, value: "MpnLookupResult", ttl: float) -> None:
+        key = self._make_key(provider_name, mpn)
+        expires_at = time.monotonic() + ttl
+        if key in self._store:
+            self._store.move_to_end(key)
+        self._store[key] = (value, expires_at)
+        # Evict oldest entries when over capacity.
+        while len(self._store) > self._maxsize:
+            self._store.popitem(last=False)
+
+
+# Module-level singleton shared across all requests (same process, --workers 1).
+_cache = _TtlLruCache(maxsize=_MAX_ENTRIES, default_ttl=_HIT_TTL_SEC)
+
+
+# ---------------------------------------------------------------------------
+# Internal: per-provider circuit breakers
+# ---------------------------------------------------------------------------
+
+class _CircuitBreaker:
+    """Consecutive-failure counter with a timed open state."""
+
+    def __init__(self, threshold: int, open_sec: float) -> None:
+        self._threshold = threshold
+        self._open_sec = open_sec
+        self._consecutive_failures: int = 0
+        self._open_until: float = 0.0  # monotonic time
+
+    @property
+    def is_open(self) -> bool:
+        return time.monotonic() < self._open_until
+
+    def record_success(self) -> None:
+        self._consecutive_failures = 0
+
+    def record_failure(self) -> None:
+        self._consecutive_failures += 1
+        if self._consecutive_failures >= self._threshold:
+            self._open_until = time.monotonic() + self._open_sec
+            # Don't reset the counter — the next success after the breaker
+            # closes will reset it; a failure immediately after reopening
+            # re-opens instantly (already at threshold).
+
+
+# One breaker per provider name.  Built lazily.
+_breakers: dict[str, _CircuitBreaker] = {}
+
+
+def _get_breaker(provider_name: str) -> _CircuitBreaker:
+    if provider_name not in _breakers:
+        _breakers[provider_name] = _CircuitBreaker(
+            threshold=_CB_FAIL_THRESHOLD,
+            open_sec=_CB_OPEN_SEC,
+        )
+    return _breakers[provider_name]
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def lookup_with_cache(provider: "PartsProvider", mpn: str) -> "MpnLookupResult":
+    """Call ``provider.lookup_mpn(mpn)`` with TTL caching and circuit-breaking.
+
+    * If a cached positive result exists, return it without hitting the network.
+    * If the circuit breaker is open, return a synthetic unavailable response.
+    * Otherwise, call the provider, update the cache, and update the breaker.
+    """
+    normalized_mpn = mpn.strip()
+    breaker = _get_breaker(provider.name)
+
+    # 1. Check the cache first (before the breaker so cached hits bypass both).
+    cached = _cache.get(provider.name, normalized_mpn)
+    if cached is not None:
+        return cached
+
+    # 2. Circuit breaker — don't call the upstream if it's been consistently
+    #    failing.  This keeps the single uvicorn worker from stalling on a
+    #    misbehaving upstream.
+    if breaker.is_open:
+        return {
+            "found": False,
+            "result": None,
+            "message": "provider temporarily unavailable (circuit breaker open)",
+        }
+
+    # 3. Live call.
+    result = provider.lookup_mpn(normalized_mpn)
+
+    # 4. Update breaker state.
+    if result.get("found"):
+        breaker.record_success()
+    else:
+        # Only count hard failures (network errors, 5xx, auth failures) as
+        # breaker-trips — "no match for MPN" is a clean miss, not a failure.
+        msg = (result.get("message") or "").lower()
+        _is_hard_failure = any(
+            token in msg
+            for token in ("unavailable", "auth failed", "rate limit", "http 5", "http 4")
+        )
+        if _is_hard_failure:
+            breaker.record_failure()
+
+    # 5. Cache the result (different TTLs for hits vs misses).
+    if result.get("found"):
+        _cache.set(provider.name, normalized_mpn, result, ttl=_HIT_TTL_SEC)
+    else:
+        # Cache clean misses ("no match for MPN") only — not hard failures,
+        # so that a transient upstream error doesn't suppress future retries.
+        msg = (result.get("message") or "").lower()
+        if "no match" in msg or "empty mpn" in msg:
+            _cache.set(provider.name, normalized_mpn, result, ttl=_MISS_TTL_SEC)
+
+    return result
+
+
+def lookup_fresh(provider: "PartsProvider", mpn: str) -> "MpnLookupResult":
+    """Like ``lookup_with_cache`` but skips the cache read (always hits upstream).
+
+    Use this for operator-initiated refresh actions where the intent is
+    explicitly "fetch the latest from the upstream provider".  The circuit
+    breaker is still applied so a broken upstream doesn't stall the worker.
+    On a successful result, the cache is updated so subsequent
+    ``lookup_with_cache`` calls see the fresh value.
+    """
+    normalized_mpn = mpn.strip()
+    breaker = _get_breaker(provider.name)
+
+    # Circuit breaker still applies — a manual refresh into a broken upstream
+    # should fail fast, not pin the only uvicorn worker for 8 s.
+    if breaker.is_open:
+        return {
+            "found": False,
+            "result": None,
+            "message": "provider temporarily unavailable (circuit breaker open)",
+        }
+
+    # Live call — deliberately no cache read here.
+    result = provider.lookup_mpn(normalized_mpn)
+
+    # Update breaker state.
+    if result.get("found"):
+        breaker.record_success()
+    else:
+        msg = (result.get("message") or "").lower()
+        _is_hard_failure = any(
+            token in msg
+            for token in ("unavailable", "auth failed", "rate limit", "http 5", "http 4")
+        )
+        if _is_hard_failure:
+            breaker.record_failure()
+
+    # Overwrite the cache so the fresh result is visible to lookup_with_cache.
+    if result.get("found"):
+        _cache.set(provider.name, normalized_mpn, result, ttl=_HIT_TTL_SEC)
+
+    return result

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -241,6 +241,27 @@ def _mock_hibp(monkeypatch):
         yield
 
 
+@pytest.fixture(autouse=True)
+def _reset_provider_cache_and_breakers():
+    """Reset the in-process provider TTL cache and circuit-breaker state
+    between every test so module-level singletons don't bleed across tests.
+
+    The cache and breakers are intentionally module-level (per CLAUDE.md:
+    --workers 1 in prod, single-process, no Redis). This fixture is the
+    test-isolation equivalent of clearing slowapi's in-memory bucket store
+    between rate-limit tests."""
+    import app.domain.parts.services.provider_cache as _cache_mod
+
+    # Clear TTL cache entries.
+    _cache_mod._cache._store.clear()
+    # Reset all circuit breakers.
+    _cache_mod._breakers.clear()
+    yield
+    # Clean up after the test as well (belt-and-suspenders).
+    _cache_mod._cache._store.clear()
+    _cache_mod._breakers.clear()
+
+
 # ---------------------------------------------------------------------------
 # Opt-out for tests that need real cross-connection commits.
 #

--- a/backend/tests/test_provider_circuit_breaker.py
+++ b/backend/tests/test_provider_circuit_breaker.py
@@ -1,0 +1,234 @@
+"""Tests for BE2-011: circuit breaker in provider_cache.lookup_with_cache.
+
+After N consecutive hard failures the breaker opens and subsequent calls
+return a synthetic "temporarily unavailable" response without hitting the
+upstream.  The counter resets on a successful call.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Unit tests against lookup_with_cache directly (no HTTP layer needed)
+# ---------------------------------------------------------------------------
+
+
+def _make_provider(name: str = "test-provider"):
+    """Return a minimal object that satisfies the PartsProvider protocol."""
+
+    class _FakeProvider:
+        pass
+
+    p = _FakeProvider()
+    p.name = name  # type: ignore[attr-defined]
+    return p
+
+
+def _reset_state(provider_name: str) -> None:
+    """Clear cache entry and reset circuit breaker for isolation."""
+    import app.domain.parts.services.provider_cache as _m
+
+    # Clear the TTL cache.
+    _m._cache._store.clear()
+
+    # Remove the breaker entry so each test starts fresh.
+    _m._breakers.pop(provider_name, None)
+
+
+# ---------------------------------------------------------------------------
+# Breaker opens after threshold consecutive failures
+# ---------------------------------------------------------------------------
+
+
+def test_breaker_opens_after_threshold_failures(monkeypatch):
+    """After _CB_FAIL_THRESHOLD hard failures the breaker opens; the next
+    call returns the synthetic unavailable message without hitting the
+    provider."""
+    import app.domain.parts.services.provider_cache as _m
+
+    provider_name = "breaker-test-open"
+    _reset_state(provider_name)
+
+    provider = _make_provider(provider_name)
+    call_count = 0
+
+    def _fail_lookup(mpn: str) -> dict:
+        nonlocal call_count
+        call_count += 1
+        return {"found": False, "result": None, "message": "upstream unavailable (ConnectionError)"}
+
+    provider.lookup_mpn = _fail_lookup  # type: ignore[attr-defined]
+
+    threshold = _m._CB_FAIL_THRESHOLD
+
+    # Fire exactly threshold calls — all should reach the provider.
+    for i in range(threshold):
+        result = _m.lookup_with_cache(provider, f"MPN-{i}")
+        assert result["found"] is False
+
+    assert call_count == threshold, (
+        f"Expected exactly {threshold} upstream calls before breaker opened, "
+        f"got {call_count}."
+    )
+
+    # The (threshold + 1)-th call should be intercepted by the open breaker.
+    result = _m.lookup_with_cache(provider, "MPN-EXTRA")
+    assert result["found"] is False
+    assert "circuit breaker" in (result.get("message") or "").lower(), (
+        f"Expected circuit-breaker message, got: {result.get('message')!r}"
+    )
+    # Provider must NOT have been called again.
+    assert call_count == threshold, (
+        f"Provider should not be called when breaker is open, "
+        f"but call_count is {call_count}."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Breaker counter resets on success
+# ---------------------------------------------------------------------------
+
+
+def test_breaker_counter_resets_on_success(monkeypatch):
+    """A successful lookup resets the consecutive-failure counter so the
+    threshold must be reached again from zero before the breaker reopens."""
+    import app.domain.parts.services.provider_cache as _m
+
+    provider_name = "breaker-test-reset"
+    _reset_state(provider_name)
+
+    provider = _make_provider(provider_name)
+    threshold = _m._CB_FAIL_THRESHOLD
+    fail_count = [0]
+    should_fail = [True]
+
+    def _toggle_lookup(mpn: str) -> dict:
+        if should_fail[0]:
+            fail_count[0] += 1
+            return {
+                "found": False,
+                "result": None,
+                "message": "upstream unavailable (TimeoutError)",
+            }
+        return {"found": True, "result": {"mpn": mpn}, "message": None}
+
+    provider.lookup_mpn = _toggle_lookup  # type: ignore[attr-defined]
+
+    # Accumulate threshold - 1 failures (breaker not yet open).
+    for i in range(threshold - 1):
+        _m.lookup_with_cache(provider, f"FAIL-{i}")
+
+    # Now succeed — counter should reset.
+    should_fail[0] = False
+    result = _m.lookup_with_cache(provider, "SUCCESS-MPN")
+    assert result["found"] is True
+
+    # Now fail again; we need a full threshold of NEW failures to open.
+    should_fail[0] = True
+    breaker = _m._get_breaker(provider_name)
+    # After reset the counter should be 0.
+    assert breaker._consecutive_failures == 0, (
+        f"Expected failure counter to reset to 0 after success, "
+        f"got {breaker._consecutive_failures}."
+    )
+
+
+# ---------------------------------------------------------------------------
+# "No match" results do NOT trip the breaker
+# ---------------------------------------------------------------------------
+
+
+def test_clean_miss_does_not_trip_breaker(monkeypatch):
+    """A 'no match for MPN' response is not a hard failure — calling the
+    endpoint many times for non-existent MPNs must not open the breaker."""
+    import app.domain.parts.services.provider_cache as _m
+
+    provider_name = "breaker-test-miss"
+    _reset_state(provider_name)
+
+    provider = _make_provider(provider_name)
+
+    def _miss_lookup(mpn: str) -> dict:
+        return {"found": False, "result": None, "message": "no match for MPN"}
+
+    provider.lookup_mpn = _miss_lookup  # type: ignore[attr-defined]
+
+    threshold = _m._CB_FAIL_THRESHOLD
+
+    # Fire many more than threshold calls; each is a "clean" miss.
+    for i in range(threshold + 5):
+        result = _m.lookup_with_cache(provider, f"NONEXISTENT-{i}")
+        assert result["found"] is False
+
+    breaker = _m._get_breaker(provider_name)
+    assert not breaker.is_open, (
+        "Breaker must not open on clean 'no match' misses."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Integration: circuit breaker via HTTP route
+# ---------------------------------------------------------------------------
+
+
+def test_circuit_breaker_returns_503_like_message_via_route(monkeypatch):
+    """Exhausting the circuit breaker via the HTTP route returns a found=False
+    result with the unavailability message without a network round-trip."""
+    import uuid
+    import app.domain.parts.services.provider_cache as _m
+    from fastapi.testclient import TestClient
+    from app.main import app
+
+    provider_name = "mouser"
+    _reset_state(provider_name)
+
+    threshold = _m._CB_FAIL_THRESHOLD
+    call_count = [0]
+
+    def _fail_post_mouser(url: str, payload: dict) -> dict:
+        call_count[0] += 1
+        raise RuntimeError("simulated upstream failure")
+
+    monkeypatch.setattr(
+        "app.domain.parts.providers.mouser._post_mouser",
+        _fail_post_mouser,
+    )
+
+    c = TestClient(app)
+    email = f"u-{uuid.uuid4().hex[:8]}@x.com"
+    r = c.post(
+        "/api/auth/signup",
+        json={"email": email, "name": "u", "password": "TestPass-2026-Stronk"},
+    )
+    assert r.status_code == 200, r.text
+
+    r = c.patch(
+        "/api/workspaces/current",
+        json={"parts_provider": "mouser", "parts_provider_api_key": "fake-key"},
+    )
+    assert r.status_code == 200, r.text
+
+    # Trip the breaker with threshold calls using distinct MPNs (so no
+    # cache hit deduplicates them).
+    for i in range(threshold):
+        mpn = f"TRIP-{uuid.uuid4().hex[:6]}"
+        r = c.post("/api/parts/lookup-mpn", json={"mpn": mpn})
+        assert r.status_code == 200, r.text
+
+    assert call_count[0] == threshold
+
+    # The breaker is now open — next call must not hit the network.
+    mpn_after = f"AFTER-{uuid.uuid4().hex[:6]}"
+    r = c.post("/api/parts/lookup-mpn", json={"mpn": mpn_after})
+    assert r.status_code == 200, r.text
+    data = r.json()["data"]
+    assert data["found"] is False
+    assert "circuit breaker" in (data.get("message") or "").lower(), (
+        f"Expected circuit-breaker message in response, got: {data}"
+    )
+    # Provider not called again.
+    assert call_count[0] == threshold, (
+        f"Provider must not be called when breaker is open, "
+        f"but was called {call_count[0]} times total."
+    )

--- a/backend/tests/test_provider_lookup_cache.py
+++ b/backend/tests/test_provider_lookup_cache.py
@@ -1,0 +1,220 @@
+"""Tests for BE2-011: provider result caching in lookup_with_cache.
+
+The cache ensures that identical (provider, mpn) queries within the TTL
+window hit the upstream exactly once, saving API quota and reducing latency.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _signup(email: str | None = None) -> tuple[TestClient, str]:
+    c = TestClient(app)
+    email = email or f"u-{uuid.uuid4().hex[:8]}@x.com"
+    r = c.post(
+        "/api/auth/signup",
+        json={"email": email, "name": "u", "password": "TestPass-2026-Stronk"},
+    )
+    assert r.status_code == 200, r.text
+    ws_id = r.json()["data"]["workspace_id"]
+    return c, ws_id
+
+
+def _enable_mouser(client: TestClient, key: str = "fake-test-key") -> None:
+    r = client.patch(
+        "/api/workspaces/current",
+        json={"parts_provider": "mouser", "parts_provider_api_key": key},
+    )
+    assert r.status_code == 200, r.text
+
+
+# ---------------------------------------------------------------------------
+# Cache hit test — provider called only once for identical MPN
+# ---------------------------------------------------------------------------
+
+
+def test_cache_deduplicates_identical_mpn_lookups(monkeypatch):
+    """Two identical MPN lookups within the TTL should call the upstream
+    exactly once; the second call is served from the in-process cache."""
+    import app.domain.parts.services.provider_cache as _cache_mod
+
+    # Reset module-level cache singleton for isolation.
+    _cache_mod._cache._store.clear()
+
+    call_count = 0
+    found_response = {
+        "Errors": [],
+        "SearchResults": {
+            "NumberOfResult": 1,
+            "Parts": [
+                {
+                    "ManufacturerPartNumber": "GRM188R61A106KE69D",
+                    "Manufacturer": "Murata",
+                    "Description": "MLCC 10uF 10V 0603",
+                    "Category": "Capacitors",
+                    "ProductAttributes": [],
+                    "PriceBreaks": [],
+                    "DataSheetUrl": "",
+                    "ImagePath": "",
+                    "ProductDetailUrl": "",
+                    "MouserPartNumber": "81-GRM188R61A106KE69D",
+                    "LifecycleStatus": "Active",
+                    "ROHSStatus": "RoHS Compliant",
+                    "Availability": "1000 In Stock",
+                    "LeadTime": "",
+                    "ProductCompliance": [],
+                }
+            ],
+        },
+    }
+
+    def _fake_post_mouser(url: str, payload: dict) -> dict:
+        nonlocal call_count
+        call_count += 1
+        return found_response
+
+    monkeypatch.setattr(
+        "app.domain.parts.providers.mouser._post_mouser",
+        _fake_post_mouser,
+    )
+
+    c, _ = _signup()
+    _enable_mouser(c)
+
+    mpn = f"GRM188R61A106KE69D-{uuid.uuid4().hex[:4]}"
+
+    r1 = c.post("/api/parts/lookup-mpn", json={"mpn": mpn})
+    assert r1.status_code == 200, r1.text
+
+    r2 = c.post("/api/parts/lookup-mpn", json={"mpn": mpn})
+    assert r2.status_code == 200, r2.text
+
+    # The underlying provider function must have been called exactly once.
+    assert call_count == 1, (
+        f"Expected upstream to be called once (cache should serve the second "
+        f"request), but it was called {call_count} times."
+    )
+
+    # Both responses should be identical found=True results.
+    assert r1.json()["data"]["found"] is True
+    assert r2.json()["data"]["found"] is True
+
+
+# ---------------------------------------------------------------------------
+# Cache miss for negative results uses a shorter TTL but still deduplicates
+# ---------------------------------------------------------------------------
+
+
+def test_cache_deduplicates_negative_miss(monkeypatch):
+    """Two 'no match' lookups for the same MPN should call the upstream
+    exactly once within the miss TTL window."""
+    import app.domain.parts.services.provider_cache as _cache_mod
+
+    _cache_mod._cache._store.clear()
+
+    call_count = 0
+    no_match_response = {
+        "Errors": [],
+        "SearchResults": {"NumberOfResult": 0, "Parts": []},
+    }
+
+    def _fake_post_mouser(url: str, payload: dict) -> dict:
+        nonlocal call_count
+        call_count += 1
+        return no_match_response
+
+    monkeypatch.setattr(
+        "app.domain.parts.providers.mouser._post_mouser",
+        _fake_post_mouser,
+    )
+
+    c, _ = _signup()
+    _enable_mouser(c)
+
+    mpn = f"NONEXISTENT-MPN-{uuid.uuid4().hex[:4]}"
+
+    r1 = c.post("/api/parts/lookup-mpn", json={"mpn": mpn})
+    assert r1.status_code == 200
+    assert r1.json()["data"]["found"] is False
+
+    r2 = c.post("/api/parts/lookup-mpn", json={"mpn": mpn})
+    assert r2.status_code == 200
+    assert r2.json()["data"]["found"] is False
+
+    assert call_count == 1, (
+        f"Expected upstream called once for negative result, got {call_count}."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cache is keyed on normalised MPN (strip + lower)
+# ---------------------------------------------------------------------------
+
+
+def test_cache_key_normalises_mpn_case_and_whitespace(monkeypatch):
+    """'  GRM188  ' and 'grm188' should hit the same cache entry."""
+    import app.domain.parts.services.provider_cache as _cache_mod
+
+    _cache_mod._cache._store.clear()
+
+    call_count = 0
+    unique_mpn = f"NRM-{uuid.uuid4().hex[:6]}"
+
+    found_response = {
+        "Errors": [],
+        "SearchResults": {
+            "NumberOfResult": 1,
+            "Parts": [
+                {
+                    "ManufacturerPartNumber": unique_mpn,
+                    "Manufacturer": "Test",
+                    "Description": "Test part",
+                    "Category": "Test",
+                    "ProductAttributes": [],
+                    "PriceBreaks": [],
+                    "DataSheetUrl": "",
+                    "ImagePath": "",
+                    "ProductDetailUrl": "",
+                    "MouserPartNumber": f"TEST-{unique_mpn}",
+                    "LifecycleStatus": "Active",
+                    "ROHSStatus": "",
+                    "Availability": "100 In Stock",
+                    "LeadTime": "",
+                    "ProductCompliance": [],
+                }
+            ],
+        },
+    }
+
+    def _fake_post_mouser(url: str, payload: dict) -> dict:
+        nonlocal call_count
+        call_count += 1
+        return found_response
+
+    monkeypatch.setattr(
+        "app.domain.parts.providers.mouser._post_mouser",
+        _fake_post_mouser,
+    )
+
+    c, _ = _signup()
+    _enable_mouser(c)
+
+    r1 = c.post("/api/parts/lookup-mpn", json={"mpn": unique_mpn})
+    assert r1.status_code == 200
+    r2 = c.post("/api/parts/lookup-mpn", json={"mpn": f"  {unique_mpn.lower()}  "})
+    assert r2.status_code == 200
+
+    assert call_count == 1, (
+        f"Same MPN with different case/whitespace should resolve to one cache entry, "
+        f"but upstream was called {call_count} times."
+    )


### PR DESCRIPTION
Closes #60

## Summary
- Add 24h TTL LRU response cache (512 entries, keyed on `(provider.name, mpn.lower())`) in `domain/parts/services/provider_cache.py`; `lookup-mpn` and `bulk-import-from-scan` serve repeated lookups from cache; `refresh-from-provider` uses `lookup_fresh` which always hits upstream but writes back to cache
- Add per-provider consecutive-failure circuit breaker (opens after 5 hard failures, stays open 60s) to prevent the single uvicorn worker from stalling on a misbehaving upstream
- Reduce DigiKey timeout 15s → 8s, Mouser 10s → 8s; two upstream calls worst-case stays under 20s
- Fix duplicate alembic revision `0021` (two PRs landed the same revision ID); renumber `invitation_token_hmac` migration to `0022`
- Add autouse pytest fixture in conftest resetting cache/breaker singletons between tests

**Note on pricing**: Both DigiKey and Mouser return public catalog data; nothing in the cached result is tied to the workspace's API key credentials, so sharing the cache across workspaces is safe.

## Tests
- `tests/test_provider_lookup_cache.py` — 3 new tests: dedup, negative-miss TTL, case+whitespace normalisation
- `tests/test_provider_circuit_breaker.py` — 4 new tests: open-after-threshold, reset-on-success, no-trip-on-clean-miss, integration via HTTP route
- Full backend suite: **493 passed, 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)