### PR TITLE
fix(api): request_id in all error responses + validation failure logging (#61)

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -14,7 +14,12 @@ config = context.config
 config.set_main_option("sqlalchemy.url", os.environ.get("DATABASE_URL", settings().DATABASE_URL))
 
 if config.config_file_name is not None:
-    fileConfig(config.config_file_name)
+    # disable_existing_loggers=False preserves app loggers that were
+    # already configured by configure_logging() — without this the alembic
+    # fileConfig() call silently sets logger.disabled=True on every app
+    # logger, causing http_exception_handler and validation_exception_handler
+    # to emit no records during tests (BE2-012 / issue #61).
+    fileConfig(config.config_file_name, disable_existing_loggers=False)
 
 target_metadata = Base.metadata
 

--- a/backend/app/core/logging.py
+++ b/backend/app/core/logging.py
@@ -31,6 +31,25 @@ from typing import Any
 _CONFIGURED = False
 
 
+class RequestIdFilter(logging.Filter):
+    """Inject the current request-id (from the contextvar set by
+    `RequestIdMiddleware`) into every log record while a request is
+    being handled.  Records emitted outside a request context get
+    ``request_id=None`` so downstream log shippers can filter on it."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        # Local import to avoid a circular import at module load time
+        # (request_id.py → logging.py on configure_logging, but
+        # logging.py would need request_id.py only at call time).
+        try:
+            from app.core.request_id import request_id_var  # noqa: PLC0415
+
+            record.request_id = request_id_var.get()
+        except Exception:  # noqa: BLE001
+            record.request_id = None
+        return True
+
+
 class _JsonFormatter(logging.Formatter):
     """Compact JSON-per-line formatter. No multi-line stack traces in
     the body; tracebacks land in `traceback` as a single string."""
@@ -90,6 +109,7 @@ def configure_logging() -> None:
     # — rip them out and replace with ours so format is consistent.
     for h in list(root.handlers):
         root.removeHandler(h)
+    handler.addFilter(RequestIdFilter())
     root.addHandler(handler)
 
     # Quiet down noisy stdlib / lib loggers — these are too chatty at

--- a/backend/app/core/request_id.py
+++ b/backend/app/core/request_id.py
@@ -1,0 +1,75 @@
+"""Request-ID middleware and context-variable helpers.
+
+BE2-012 / issue #61. Every inbound request gets a `request_id` (hex UUID)
+minted and stored on `request.state.request_id`.  The same value is
+propagated via:
+
+- `X-Request-Id` response header (so the browser / curl caller can copy it)
+- a `ContextVar` that `LogFilter` (see `core/logging.py`) injects into every
+  log record emitted during that request's stack, so operators can grep the
+  journal for a single id.
+- `core/responses` error envelopes so the frontend can surface it on error
+  modals.
+
+If the caller sends an `X-Request-Id` header it is reused *if and only if*
+it matches the allowed shape (1–64 hexadecimal characters, case-insensitive).
+A malformed inbound value is silently replaced with a fresh one — never
+rejected, never logged as an error.
+"""
+from __future__ import annotations
+
+import re
+import uuid
+from contextvars import ContextVar
+from typing import Awaitable, Callable
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+# Exported so logging.py can import it.
+request_id_var: ContextVar[str | None] = ContextVar("request_id_var", default=None)
+
+_VALID_REQUEST_ID = re.compile(r"^[0-9a-fA-F]{1,64}$")
+
+
+def _mint_request_id(inbound: str | None) -> str:
+    """Return the inbound id if it's a valid hex string (1–64 chars),
+    otherwise mint a fresh one."""
+    if inbound and _VALID_REQUEST_ID.match(inbound):
+        return inbound[:64]
+    return uuid.uuid4().hex
+
+
+class RequestIdMiddleware(BaseHTTPMiddleware):
+    """Mint / reuse a request-id on every request.
+
+    Must be registered *before* CORS / CSRF so the id is available even
+    when those middlewares short-circuit the request.
+    """
+
+    async def dispatch(
+        self, request: Request, call_next: Callable[[Request], Awaitable[Response]]
+    ) -> Response:
+        rid = _mint_request_id(request.headers.get("x-request-id"))
+        request.state.request_id = rid
+
+        # Set contextvar so the log filter can inject it into every record
+        # emitted while this coroutine / any sub-task is on the stack.
+        token = request_id_var.set(rid)
+
+        # Tag the Sentry event with the same id — free when DSN is unset.
+        try:
+            import sentry_sdk
+
+            sentry_sdk.set_tag("request_id", rid)
+        except Exception:  # noqa: BLE001 — never let Sentry break routing
+            pass
+
+        try:
+            response = await call_next(request)
+        finally:
+            request_id_var.reset(token)
+
+        response.headers["X-Request-Id"] = rid
+        return response

--- a/backend/app/core/request_id.py
+++ b/backend/app/core/request_id.py
@@ -44,8 +44,10 @@ def _mint_request_id(inbound: str | None) -> str:
 class RequestIdMiddleware(BaseHTTPMiddleware):
     """Mint / reuse a request-id on every request.
 
-    Must be registered *before* CORS / CSRF so the id is available even
-    when those middlewares short-circuit the request.
+    Must wrap CORS / CSRF so the id is available even when those
+    middlewares short-circuit the request. Starlette stacks middleware
+    LIFO, so this means `app.add_middleware(RequestIdMiddleware)` must
+    be the LAST add_middleware() call (outermost wrapper).
     """
 
     async def dispatch(

--- a/backend/app/core/responses.py
+++ b/backend/app/core/responses.py
@@ -69,13 +69,26 @@ def ok(data: T | None = None, message: str = "OK") -> Envelope[T]:
     )
 
 
-def err(category: str, message: str, errors: list[dict] | None = None) -> ErrorEnvelope:
+def err(
+    category: str,
+    message: str,
+    errors: list[dict] | None = None,
+    *,
+    request_id: str | None = None,
+) -> ErrorEnvelope:
     """Build an error envelope. Mirrors :func:`ok` but allows arbitrary
     extra keys (the FastAPI exception handler spreads structured
-    ``detail`` dicts onto the top level)."""
+    ``detail`` dicts onto the top level).
+
+    Pass ``request_id`` (from ``request.state.request_id``) to surface the
+    correlation id in the response body alongside the ``X-Request-Id`` header
+    (BE2-012 / issue #61).
+    """
     body: ErrorEnvelope = {"data": None, "status": {"category": category, "message": message}}
     if errors is not None:
         body["errors"] = errors
+    if request_id is not None:
+        body["request_id"] = request_id
     return body
 
 
@@ -85,28 +98,30 @@ async def http_exception_handler(request: Request, exc: HTTPException):
     # The "message" key (or stringified detail) goes into status.message;
     # any remaining dict keys are spread onto the top-level response so
     # the frontend can act on them (e.g. existing_id from a 409 conflict).
+    rid: str | None = getattr(request.state, "request_id", None)
     if isinstance(exc.detail, dict):
         message = exc.detail.get("message") or str(exc.detail)
-        body = err(_category_for_status(exc.status_code), message)
+        body = err(_category_for_status(exc.status_code), message, request_id=rid)
         for k, v in exc.detail.items():
             if k != "message":
                 body[k] = v
     else:
-        body = err(_category_for_status(exc.status_code), str(exc.detail))
-    # Log every 5xx as an error so the local journal has a full record
-    # of server-side failures (matched by Sentry but not contingent on
-    # it). 4xx is too noisy at INFO; route-level logging fires when a
-    # 4xx is actionable (login failures, etc.).
+        body = err(_category_for_status(exc.status_code), str(exc.detail), request_id=rid)
+    # Log 4xx at INFO (useful "did the FE just regress?" signal) and 5xx at
+    # ERROR (matched by Sentry but preserved independently of it).
+    # BE2-012 / issue #61: request_id is injected by RequestIdFilter via the
+    # contextvar, so it appears in the log record automatically.
+    log_extra = {
+        "status": exc.status_code,
+        "path": request.url.path,
+        "method": request.method,
+        "detail": str(exc.detail)[:500],
+        "request_id": rid,
+    }
     if exc.status_code >= 500:
-        _log.error(
-            "http error",
-            extra={
-                "status": exc.status_code,
-                "path": request.url.path,
-                "method": request.method,
-                "message": str(exc.detail)[:500],
-            },
-        )
+        _log.error("http error", extra=log_extra)
+    else:
+        _log.info("http %d", exc.status_code, extra=log_extra)
     return JSONResponse(status_code=exc.status_code, content=body)
 
 
@@ -126,14 +141,26 @@ def _category_for_status(code: int) -> str:
     return "ok"
 
 
-async def validation_exception_handler(_: Request, exc):  # pydantic ValidationError
+async def validation_exception_handler(request: Request, exc):  # pydantic ValidationError
+    rid: str | None = getattr(request.state, "request_id", None)
     fields = []
     try:
         for e in exc.errors():
             fields.append({"field": ".".join(str(p) for p in e.get("loc", [])), "message": e.get("msg", "")})
     except Exception:
         pass
+    # Log validation failures at INFO so the journal captures "did the
+    # frontend send a malformed body?" signals without requiring Sentry.
+    # BE2-012 / issue #61.
+    _log.info(
+        "validation error",
+        extra={
+            "path": request.url.path,
+            "fields": fields,
+            "request_id": rid,
+        },
+    )
     return JSONResponse(
         status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-        content=err("validation_error", "validation failed", fields),
+        content=err("validation_error", "validation failed", fields, request_id=rid),
     )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -121,6 +121,7 @@ from app.api.routes import (
 )
 from app.core.config import settings
 from app.core.deps import require_member_for_writes
+from app.core.request_id import RequestIdMiddleware
 from app.core.responses import http_exception_handler, validation_exception_handler
 
 _is_prod = settings().APP_ENV == "prod"
@@ -313,6 +314,11 @@ class CsrfOriginMiddleware(BaseHTTPMiddleware):
             )
         return await call_next(request)
 
+
+# RequestIdMiddleware must run BEFORE CORS / CSRF so request.state.request_id
+# is set even when those middlewares short-circuit the request.
+# BE2-012 / issue #61.
+app.add_middleware(RequestIdMiddleware)
 
 app.add_middleware(
     CsrfOriginMiddleware,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -307,24 +307,34 @@ class CsrfOriginMiddleware(BaseHTTPMiddleware):
             request.headers.get("referer")
         )
         if origin is None or origin not in self._allowed:
+            # RequestIdMiddleware runs outside us (added last → outermost),
+            # so request.state.request_id is set by the time we get here.
+            # Surface it in the body and as a response header so the rejected
+            # call is still correlatable in logs/Sentry.
+            rid = getattr(request.state, "request_id", None)
+            content: dict[str, object] = {
+                "data": None,
+                "status": {
+                    "category": "forbidden",
+                    "message": "cross-origin request blocked",
+                },
+            }
+            headers: dict[str, str] = {}
+            if rid:
+                content["request_id"] = rid
+                headers["X-Request-Id"] = rid
             return JSONResponse(
                 status_code=403,
-                content={
-                    "data": None,
-                    "status": {
-                        "category": "forbidden",
-                        "message": "cross-origin request blocked",
-                    },
-                },
+                content=content,
+                headers=headers or None,
             )
         return await call_next(request)
 
 
-# RequestIdMiddleware must run BEFORE CORS / CSRF so request.state.request_id
-# is set even when those middlewares short-circuit the request.
-# BE2-012 / issue #61.
-app.add_middleware(RequestIdMiddleware)
-
+# Starlette stacks middleware LIFO: the LAST add_middleware() call becomes
+# the OUTERMOST wrapper. RequestIdMiddleware must wrap CORS / CSRF so that
+# request.state.request_id is set even when those middlewares short-circuit
+# the request (CSRF 403, CORS preflight). BE2-012 / issue #61.
 app.add_middleware(
     CsrfOriginMiddleware,
     allowed_origins=settings().cors_origin_list,
@@ -338,6 +348,9 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+# Added last → outermost. Sees every request before CORS/CSRF run.
+app.add_middleware(RequestIdMiddleware)
 
 app.add_exception_handler(HTTPException, http_exception_handler)
 app.add_exception_handler(RequestValidationError, validation_exception_handler)

--- a/backend/tests/test_4xx_logging.py
+++ b/backend/tests/test_4xx_logging.py
@@ -1,0 +1,98 @@
+"""Tests that http_exception_handler logs 4xx at INFO (BE2-012 / #61).
+
+A 404 / 401 response must produce an INFO log record with `status`,
+`path`, `method`, and a non-empty `request_id`.
+
+Note on log capture: we attach a temporary handler directly to
+`app.core.responses` rather than relying on pytest's `caplog` fixture,
+which does not reliably capture records emitted in the TestClient's
+thread after `configure_logging()` has replaced the root handlers.
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+from contextlib import contextmanager
+from typing import Generator
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+class _ListHandler(logging.Handler):
+    """Simple accumulating handler for test assertions."""
+
+    def __init__(self) -> None:
+        super().__init__(logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+
+@contextmanager
+def _capture_logger(name: str) -> Generator[_ListHandler, None, None]:
+    """Temporarily attach a list handler to *name*, yield it, then clean up."""
+    handler = _ListHandler()
+    logger = logging.getLogger(name)
+    orig_level = logger.level
+    logger.setLevel(logging.DEBUG)
+    logger.addHandler(handler)
+    try:
+        yield handler
+    finally:
+        logger.removeHandler(handler)
+        logger.setLevel(orig_level)
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def test_404_produces_info_log(client):
+    """GET on a non-existent part UUID triggers a 401 (unauthenticated) or
+    404 (not found).  Either way, http_exception_handler should log at INFO."""
+    with _capture_logger("app.core.responses") as handler:
+        r = client.get(f"/api/parts/{uuid.uuid4()}")
+
+    assert r.status_code in (401, 404)
+    records = [rec for rec in handler.records if rec.levelno == logging.INFO]
+    assert records, (
+        "expected an INFO log record from app.core.responses; got: "
+        + str([(r.name, r.levelname, r.getMessage()) for r in handler.records])
+    )
+    rec = records[0]
+    assert getattr(rec, "status", None) in (401, 404), f"unexpected status: {rec.__dict__}"
+    assert getattr(rec, "method", None) == "GET", rec.__dict__
+    rid = getattr(rec, "request_id", None)
+    assert rid, f"request_id missing or empty in log record: {rec.__dict__}"
+
+
+def test_4xx_log_request_id_matches_header(client):
+    """The `request_id` in the log record must equal the `X-Request-Id`
+    response header so operators can correlate client reports to journal
+    entries."""
+    with _capture_logger("app.core.responses") as handler:
+        r = client.get(f"/api/parts/{uuid.uuid4()}")
+
+    header_rid = r.headers.get("x-request-id")
+    assert header_rid, "X-Request-Id header missing"
+    records = [rec for rec in handler.records if rec.levelno == logging.INFO]
+    assert records
+    log_rid = getattr(records[0], "request_id", None)
+    assert log_rid == header_rid, (
+        f"log request_id={log_rid!r} != header {header_rid!r}"
+    )
+
+
+def test_4xx_body_contains_request_id(client):
+    """The JSON error body must include a top-level `request_id`."""
+    r = client.get(f"/api/parts/{uuid.uuid4()}")
+    body = r.json()
+    header_rid = r.headers.get("x-request-id")
+    assert body.get("request_id") == header_rid, (
+        f"body request_id={body.get('request_id')!r} != header {header_rid!r}"
+    )

--- a/backend/tests/test_request_id_middleware.py
+++ b/backend/tests/test_request_id_middleware.py
@@ -78,3 +78,32 @@ def test_validation_error_body_has_request_id(client):
     header_rid = r.headers.get("x-request-id")
     assert header_rid, "X-Request-Id header missing on 422"
     assert body.get("request_id") == header_rid, body
+
+
+def test_csrf_rejection_carries_request_id(client):
+    """A POST to a CSRF-protected path with a hostile Origin gets a 403 from
+    CsrfOriginMiddleware. The id middleware wraps CSRF, so the rejection must
+    still carry an `X-Request-Id` header and a top-level `request_id` body key
+    that match. Locks down the LIFO ordering invariant: regressing the
+    add_middleware() order would break this assertion."""
+    # POST /api/parts is CSRF-protected (state-changing, not exempt). A bogus
+    # Origin (not in cors_origin_list) makes CsrfOriginMiddleware short-circuit
+    # with 403 before the route handler runs.
+    caller_id = uuid.uuid4().hex
+    r = client.post(
+        "/api/parts",
+        json={"name": "x"},
+        headers={
+            "origin": "https://evil.example.com",
+            "x-request-id": caller_id,
+        },
+    )
+    assert r.status_code == 403, r.text
+    body = r.json()
+    # The CSRF rejection envelope is `{ data, status }`; we add request_id.
+    assert body.get("status", {}).get("category") == "forbidden", body
+    header_rid = r.headers.get("x-request-id")
+    assert header_rid == caller_id, (
+        f"valid inbound id was not propagated through CSRF rejection: {header_rid!r}"
+    )
+    assert body.get("request_id") == caller_id, body

--- a/backend/tests/test_request_id_middleware.py
+++ b/backend/tests/test_request_id_middleware.py
@@ -1,0 +1,80 @@
+"""Tests for RequestIdMiddleware (BE2-012 / issue #61).
+
+Assertions:
+- Every response carries an `X-Request-Id` header.
+- The header value matches the `request_id` key in the JSON body on error
+  responses.
+- A well-formed inbound `X-Request-Id` header is reused verbatim.
+- A malformed inbound value is silently replaced with a fresh id.
+"""
+from __future__ import annotations
+
+import re
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+_HEX_RE = re.compile(r"^[0-9a-f]{1,64}$")
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def test_response_carries_x_request_id_header(client):
+    r = client.get("/api/health")
+    assert "x-request-id" in {k.lower() for k in r.headers}
+    rid = r.headers["x-request-id"]
+    assert _HEX_RE.match(rid), f"unexpected request_id format: {rid!r}"
+
+
+def test_error_body_contains_request_id_matching_header(client):
+    """A 404 error body must have a top-level `request_id` that equals the
+    `X-Request-Id` response header."""
+    r = client.get(f"/api/parts/{uuid.uuid4()}")
+    # Unauthenticated access → 401 (but we still get a request_id)
+    assert r.status_code in (401, 404)
+    body = r.json()
+    header_rid = r.headers.get("x-request-id")
+    assert header_rid, "X-Request-Id header missing"
+    assert body.get("request_id") == header_rid, (
+        f"body request_id={body.get('request_id')!r} != header {header_rid!r}"
+    )
+
+
+def test_inbound_valid_request_id_is_reused(client):
+    """A valid hex `X-Request-Id` sent by the caller must be echoed back."""
+    caller_id = uuid.uuid4().hex
+    r = client.get("/api/health", headers={"x-request-id": caller_id})
+    assert r.headers.get("x-request-id") == caller_id
+
+
+def test_inbound_invalid_request_id_is_replaced(client):
+    """A malformed inbound id (spaces, slashes, too long) must be silently
+    replaced with a fresh hex id."""
+    bad_ids = [
+        "not-hex-at-all",
+        "../../../etc/passwd",
+        "a" * 65,  # exceeds 64 chars
+        "",
+    ]
+    for bad in bad_ids:
+        r = client.get("/api/health", headers={"x-request-id": bad})
+        rid = r.headers.get("x-request-id", "")
+        assert _HEX_RE.match(rid), f"bad id {bad!r} produced non-hex response: {rid!r}"
+        assert rid != bad, f"bad id {bad!r} was reused without replacement"
+
+
+def test_validation_error_body_has_request_id(client):
+    """A 422 Pydantic validation error must surface request_id in the body."""
+    # POST /api/auth/login with missing fields → 422
+    r = client.post("/api/auth/login", json={})
+    assert r.status_code == 422
+    body = r.json()
+    header_rid = r.headers.get("x-request-id")
+    assert header_rid, "X-Request-Id header missing on 422"
+    assert body.get("request_id") == header_rid, body

--- a/backend/tests/test_validation_logging.py
+++ b/backend/tests/test_validation_logging.py
@@ -1,0 +1,98 @@
+"""Tests that validation_exception_handler logs at INFO (BE2-012 / #61).
+
+A deliberately invalid request body must produce exactly one INFO record
+with a `fields` extra containing the failed field names.
+
+Note on log capture: pytest's `caplog` fixture does not reliably capture
+records emitted in the TestClient's thread when the root logger has been
+reconfigured by `configure_logging()` (which replaces the root handlers on
+first import).  We therefore attach a temporary handler directly to the
+`app.core.responses` logger for the duration of each test.
+"""
+from __future__ import annotations
+
+import logging
+from contextlib import contextmanager
+from typing import Generator
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+class _ListHandler(logging.Handler):
+    """Simple accumulating handler for test assertions."""
+
+    def __init__(self) -> None:
+        super().__init__(logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+
+@contextmanager
+def _capture_logger(name: str) -> Generator[_ListHandler, None, None]:
+    """Temporarily attach a list handler to *name*, yield it, then clean up."""
+    handler = _ListHandler()
+    logger = logging.getLogger(name)
+    orig_level = logger.level
+    logger.setLevel(logging.DEBUG)
+    logger.addHandler(handler)
+    try:
+        yield handler
+    finally:
+        logger.removeHandler(handler)
+        logger.setLevel(orig_level)
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def test_validation_failure_is_logged_at_info(client):
+    """POST /api/auth/login with an empty body triggers a 422.  We expect
+    exactly one INFO log record whose `fields` extra contains the missing
+    fields and whose `path` extra matches the endpoint."""
+    with _capture_logger("app.core.responses") as handler:
+        r = client.post("/api/auth/login", json={})
+
+    assert r.status_code == 422
+    records = [rec for rec in handler.records if "validation" in rec.getMessage().lower()]
+    assert records, (
+        "expected at least one validation log record from app.core.responses; "
+        f"got: {[r.getMessage() for r in handler.records]}"
+    )
+    rec = records[0]
+    assert rec.levelno == logging.INFO, f"expected INFO, got {rec.levelname}"
+    fields = getattr(rec, "fields", None)
+    assert isinstance(fields, list) and fields, (
+        f"expected non-empty 'fields' extra, got {fields!r}"
+    )
+    # The field names should mention the missing body parameters.
+    assert fields, f"fields list is empty: {fields!r}"
+    path = getattr(rec, "path", None)
+    assert path == "/api/auth/login", f"unexpected path: {path!r}"
+
+
+def test_validation_log_record_has_request_id(client):
+    """The validation log record must carry a request_id that matches the
+    `X-Request-Id` response header."""
+    with _capture_logger("app.core.responses") as handler:
+        r = client.post("/api/auth/login", json={})
+
+    assert r.status_code == 422
+    header_rid = r.headers.get("x-request-id")
+    assert header_rid, "X-Request-Id header missing"
+    records = [
+        rec for rec in handler.records
+        if "validation" in rec.getMessage().lower()
+    ]
+    assert records
+    rec = records[0]
+    log_rid = getattr(rec, "request_id", None)
+    assert log_rid == header_rid, (
+        f"log request_id={log_rid!r} != header {header_rid!r}"
+    )


### PR DESCRIPTION
Closes #61

## Summary
- Add `RequestIdMiddleware` that mints/reuses a hex request_id on every request, sets it on `request.state.request_id`, and echoes it as `X-Request-Id` response header
- Add `RequestIdFilter` to `core/logging.py`; attaches to root handler so every log record emitted during a request carries `request_id` automatically via ContextVar
- Extend `err()` with optional `request_id` kwarg; inject into error envelopes so the JSON body always carries the correlation key
- Update `http_exception_handler` to log all 4xx at INFO (was: only 5xx) and inject `request_id` into body
- Update `validation_exception_handler` to log at INFO with field list and inject `request_id`
- Rename `0021_invitation_lookup_index.py` → `0022` to resolve duplicate revision conflict introduced by two PRs both landing as `0021` on main
- Fix `alembic/env.py` `fileConfig` call to pass `disable_existing_loggers=False` so app loggers are not silently disabled during test migrations

## Tests
Backend: **496 passed**, 1 skipped, 3 deselected, 3 xfailed
- 10 new tests added: `test_request_id_middleware`, `test_validation_logging`, `test_4xx_logging`

Frontend build: N/A (backend-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)