### PR TITLE
fix(security): login lockout + HIBP k-anon + email verification on signup (#73)

### DIFF
--- a/backend/alembic/versions/0028_login_lockout.py
+++ b/backend/alembic/versions/0028_login_lockout.py
@@ -1,0 +1,69 @@
+"""Add user_login_failures table for per-account login lockout (SEC2-014).
+
+Revision ID: 0028
+Revises: 0023
+Create Date: 2026-05-02
+
+Per-account lockout:
+- New table `user_login_failures`: tracks failed login attempts per
+  user/email-hash.  The lockout check counts rows within the last
+  LOCKOUT_WINDOW_MINUTES; a successful login deletes all rows for that user.
+- `user_id` is SET NULL on user deletion so audit rows are retained as
+  orphaned tombstones without a dangling FK.
+- `email_hash` (SHA-256 of the lowercased email) allows capping failed
+  attempts for unknown-email stuffing without leaking user existence or
+  storing PII.
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = "0028"
+down_revision = "0023"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user_login_failures",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("email_hash", sa.String(length=64), nullable=False),
+        sa.Column(
+            "occurred_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column("client_ip", sa.String(length=45), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["users.id"],
+            ondelete="SET NULL",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_user_login_failures_user_id",
+        "user_login_failures",
+        ["user_id"],
+    )
+    op.create_index(
+        "ix_user_login_failures_email_hash",
+        "user_login_failures",
+        ["email_hash"],
+    )
+    op.create_index(
+        "ix_user_login_failures_occurred_at",
+        "user_login_failures",
+        ["occurred_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_user_login_failures_occurred_at", table_name="user_login_failures")
+    op.drop_index("ix_user_login_failures_email_hash", table_name="user_login_failures")
+    op.drop_index("ix_user_login_failures_user_id", table_name="user_login_failures")
+    op.drop_table("user_login_failures")

--- a/backend/alembic/versions/0029_pending_users.py
+++ b/backend/alembic/versions/0029_pending_users.py
@@ -1,0 +1,64 @@
+"""Add pending_users table for email-verified signup (SEC2-014).
+
+Revision ID: 0029
+Revises: 0028
+Create Date: 2026-05-02
+
+Email-verification flow:
+- New table `pending_users`: holds a signup record between the initial
+  POST /auth/signup and the email-link POST /auth/verify.
+- On verify, the row is promoted atomically to User + Workspace +
+  WorkspaceMember; `verified_at` is set before the transaction commits.
+- Rows older than 24 h are reaped (no explicit DB-side TTL — the
+  reap is application-driven on the verify endpoint).
+
+NOTE: this table has no workspace_id FK — signup precedes workspace
+creation.  This is intentional; see CLAUDE.md "workspace isolation" note.
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = "0029"
+down_revision = "0028"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "pending_users",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("email", sa.String(length=320), nullable=False),
+        sa.Column("name", sa.String(length=200), nullable=False),
+        sa.Column("password_hash", sa.String(length=500), nullable=False),
+        sa.Column("workspace_name", sa.String(length=200), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column("verification_token_hmac", sa.String(length=64), nullable=False),
+        sa.Column("verified_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("ip", sa.String(length=45), nullable=True),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_pending_users_email",
+        "pending_users",
+        ["email"],
+    )
+    op.create_index(
+        "ix_pending_users_created_at",
+        "pending_users",
+        ["created_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_pending_users_created_at", table_name="pending_users")
+    op.drop_index("ix_pending_users_email", table_name="pending_users")
+    op.drop_table("pending_users")

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -1,14 +1,20 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+import hmac as _hmac
+import secrets
+from datetime import datetime, timedelta, timezone
+from uuid import UUID
 
 from fastapi import APIRouter, Request, Response, status
 from pydantic import BaseModel, ConfigDict, EmailStr, Field
 
 from app.core.auth import (
     WeakPasswordError,
+    check_login_lockout,
+    clear_login_failures,
     create_session_row,
     hash_password,
+    record_login_failure,
     revoke_all_user_sessions,
     revoke_session,
     validate_password_strength,
@@ -18,13 +24,49 @@ from app.core.config import settings
 from app.core.deps import CurrentUser, DbSession
 from app.core.errors import ErrorCodes, raise_http
 from app.core.logging import get_logger
+from app.core.mail import send_verification_email
 from app.core.ratelimit import limiter
 from app.core.responses import Envelope, ok
-from app.domain.users.models import User
+from app.domain.users.models import PendingUser, User
 from app.domain.workspaces.models import Workspace, WorkspaceMember
 
 router = APIRouter()
 log = get_logger(__name__)
+
+# How long a pending signup verification is valid (in hours).
+_VERIFY_TTL_HOURS = 24
+
+
+def _set_session_cookie(response: Response, token: str) -> None:
+    response.set_cookie(
+        key=settings().SESSION_COOKIE_NAME,
+        value=token,
+        httponly=True,
+        # Mark Secure in prod where the proxy terminates TLS, so browsers
+        # never re-send the cookie over plaintext. Stays off in dev where
+        # we serve plain HTTP on localhost.
+        secure=settings().APP_ENV == "prod",
+        samesite="lax",
+        max_age=settings().SESSION_LIFETIME_DAYS * 24 * 3600,
+        path="/",
+    )
+
+
+def _hmac_token(plaintext: str) -> str:
+    """HMAC-SHA-256 (keyed on SESSION_SECRET) hex digest of the plaintext.
+
+    Used for the email-verification token stored in `pending_users.
+    verification_token_hmac`.  The accept flow compares via
+    `hmac.compare_digest(_hmac_token(supplied), row.verification_token_hmac)`
+    for constant-time comparison (SEC2-013 pattern).
+    """
+    key = settings().SESSION_SECRET.encode("utf-8")
+    return _hmac.new(key, plaintext.encode("utf-8"), "sha256").hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
 
 
 class SignupIn(BaseModel):
@@ -43,20 +85,16 @@ class LoginIn(BaseModel):
     password: str
 
 
-def _set_session_cookie(response: Response, token: str) -> None:
-    response.set_cookie(
-        key=settings().SESSION_COOKIE_NAME,
-        value=token,
-        httponly=True,
-        # Mark Secure in prod where the proxy terminates TLS, so browsers
-        # never re-send the cookie over plaintext. Stays off in dev where
-        # we serve plain HTTP on localhost.
-        secure=settings().APP_ENV == "prod",
-        samesite="lax",
-        max_age=settings().SESSION_LIFETIME_DAYS * 24 * 3600,
-        path="/",
-    )
+class VerifyIn(BaseModel):
+    model_config = ConfigDict(extra="forbid")
 
+    id: str
+    token: str
+
+
+# ---------------------------------------------------------------------------
+# Sign-up — creates a PendingUser and sends verification email
+# ---------------------------------------------------------------------------
 
 # Sign-up rate limit: legitimate humans rarely create more than one account
 # per IP per hour. Tighter than login because failed signups are a stronger
@@ -66,6 +104,19 @@ def _set_session_cookie(response: Response, token: str) -> None:
 def signup(
     request: Request, payload: SignupIn, response: Response, db: DbSession
 ) -> Envelope[dict]:
+    """Handle account signup.
+
+    Behaviour depends on SIGNUP_REQUIRE_EMAIL_VERIFICATION (SEC2-014):
+
+    * True (prod default): create a PendingUser row, send verification email,
+      return 202 Accepted. No User/Workspace is created yet.
+    * False (dev/test default): create User + Workspace immediately and issue
+      a session cookie — same as the original behaviour. Returns 200 OK.
+
+    The flag is forced to True when APP_ENV == "prod" by the Settings
+    model_validator, so the email-verification path is always active in
+    production even if the env var is omitted.
+    """
     try:
         validate_password_strength(payload.password)
     except WeakPasswordError as exc:
@@ -74,6 +125,8 @@ def signup(
             ErrorCodes.AUTH_WEAK_PASSWORD,
             str(exc),
         )
+
+    # Reject if there is already a verified User with this email.
     existing = db.query(User).filter(User.email == payload.email).first()
     if existing:
         log.warning("signup conflict", extra={"email": payload.email})
@@ -82,52 +135,266 @@ def signup(
             ErrorCodes.AUTH_EMAIL_TAKEN,
             "email already registered",
         )
-    user = User(email=payload.email, name=payload.name, password_hash=hash_password(payload.password))
+
+    if not settings().SIGNUP_REQUIRE_EMAIL_VERIFICATION:
+        # --- Dev / legacy path: immediate signup (no email verification) ---
+        user = User(
+            email=payload.email,
+            name=payload.name,
+            password_hash=hash_password(payload.password),
+        )
+        db.add(user)
+        db.flush()
+
+        ws = Workspace(
+            name=payload.workspace_name or f"{payload.name}'s workspace",
+            kind="personal",
+            owner_user_id=user.id,
+        )
+        db.add(ws)
+        db.flush()
+        db.add(WorkspaceMember(workspace_id=ws.id, user_id=user.id, role="owner", status="active"))
+
+        sess = create_session_row(db, user.id)
+        user.last_login_at = datetime.now(timezone.utc)
+
+        _set_session_cookie(response, sess.token)
+        log.info("signup (immediate)", extra={"user_id": str(user.id), "workspace_id": str(ws.id)})
+        return ok(
+            {"user": {"id": str(user.id), "email": user.email, "name": user.name}, "workspace_id": str(ws.id)},
+        )
+
+    # --- Prod path: email-verification two-step flow ---
+
+    # Reap expired pending rows for this email before checking for an
+    # active pending one, so old unverified attempts don't block a retry.
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=_VERIFY_TTL_HOURS)
+    db.query(PendingUser).filter(
+        PendingUser.email == payload.email,
+        PendingUser.created_at < cutoff,
+        PendingUser.verified_at.is_(None),
+    ).delete(synchronize_session=False)
+
+    # If there's already a non-expired pending row, return 202 again
+    # without creating a duplicate row. The user may click the first
+    # link or wait for it to expire and re-sign-up.
+    existing_pending = (
+        db.query(PendingUser)
+        .filter(
+            PendingUser.email == payload.email,
+            PendingUser.verified_at.is_(None),
+        )
+        .first()
+    )
+    if existing_pending:
+        log.info("signup resent existing pending", extra={"email": payload.email})
+        response.status_code = status.HTTP_202_ACCEPTED
+        return ok(
+            {"status": "verification_sent"},
+            "verification email sent",
+        )
+
+    # Mint a verification token, store its HMAC, send the link.
+    plaintext_token = secrets.token_urlsafe(32)
+    pending = PendingUser(
+        email=payload.email,
+        name=payload.name,
+        password_hash=hash_password(payload.password),
+        workspace_name=payload.workspace_name,
+        verification_token_hmac=_hmac_token(plaintext_token),
+        ip=request.client.host if request.client else None,
+    )
+    db.add(pending)
+    db.flush()  # populate pending.id
+
+    # Build verification link and send the email.
+    link = f"{settings().APP_BASE_URL}/verify?id={pending.id}&token={plaintext_token}"
+    try:
+        send_verification_email(to=payload.email, verification_link=link)
+    except Exception as exc:
+        log.error("failed to send verification email to %s: %s", payload.email, exc)
+        raise_http(
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            "mail.send_failed",
+            "could not send verification email — please try again later",
+        )
+
+    log.info("signup pending", extra={"pending_id": str(pending.id)})
+    response.status_code = status.HTTP_202_ACCEPTED
+    return ok(
+        {"status": "verification_sent"},
+        "verification email sent",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Verify — consumes PendingUser, creates User + Workspace + session
+# ---------------------------------------------------------------------------
+
+# Verification rate limit: protect against token brute-force.
+@router.post("/verify")
+@limiter.limit("10/minute")
+def verify(
+    request: Request, payload: VerifyIn, response: Response, db: DbSession
+) -> Envelope[dict]:
+    # Look up by id (PK) — no timing oracle on the SQL lookup.
+    try:
+        pending_id = UUID(payload.id)
+    except ValueError:
+        raise_http(
+            status.HTTP_400_BAD_REQUEST,
+            ErrorCodes.AUTH_VERIFICATION_INVALID,
+            "invalid verification link",
+        )
+
+    pending = db.get(PendingUser, pending_id)
+
+    # Constant-time HMAC comparison regardless of whether the row exists.
+    supplied_hmac = _hmac_token(payload.token)
+    dummy_hmac = "0" * 64  # same length as a SHA-256 hex digest
+    stored_hmac = pending.verification_token_hmac if pending is not None else dummy_hmac
+
+    token_ok = _hmac.compare_digest(supplied_hmac, stored_hmac) and pending is not None
+
+    if not token_ok:
+        raise_http(
+            status.HTTP_400_BAD_REQUEST,
+            ErrorCodes.AUTH_VERIFICATION_INVALID,
+            "invalid or expired verification link",
+        )
+
+    # At this point pending is not None (token_ok implies it).
+    assert pending is not None  # noqa: S101 — mypy / type narrowing
+
+    if pending.verified_at is not None:
+        raise_http(
+            status.HTTP_400_BAD_REQUEST,
+            ErrorCodes.AUTH_VERIFICATION_INVALID,
+            "verification link already used",
+        )
+
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=_VERIFY_TTL_HOURS)
+    if pending.created_at < cutoff:
+        raise_http(
+            status.HTTP_400_BAD_REQUEST,
+            ErrorCodes.AUTH_VERIFICATION_EXPIRED,
+            "verification link expired — please sign up again",
+        )
+
+    # Check the email isn't already taken (race-condition guard).
+    if db.query(User).filter(User.email == pending.email).first():
+        raise_http(
+            status.HTTP_409_CONFLICT,
+            ErrorCodes.AUTH_EMAIL_TAKEN,
+            "email already registered",
+        )
+
+    # Promote: create User + Workspace + WorkspaceMember in one transaction.
+    pending.verified_at = datetime.now(timezone.utc)
+
+    user = User(
+        email=pending.email,
+        name=pending.name,
+        password_hash=pending.password_hash,
+    )
     db.add(user)
     db.flush()
 
-    # Personal workspace + membership
-    ws = Workspace(name=payload.workspace_name or f"{payload.name}'s workspace", kind="personal", owner_user_id=user.id)
+    ws = Workspace(
+        name=pending.workspace_name or f"{pending.name}'s workspace",
+        kind="personal",
+        owner_user_id=user.id,
+    )
     db.add(ws)
     db.flush()
-    db.add(WorkspaceMember(workspace_id=ws.id, user_id=user.id, role="owner", status="active"))
+    db.add(
+        WorkspaceMember(
+            workspace_id=ws.id,
+            user_id=user.id,
+            role="owner",
+            status="active",
+        )
+    )
 
     sess = create_session_row(db, user.id)
     user.last_login_at = datetime.now(timezone.utc)
 
     _set_session_cookie(response, sess.token)
-    log.info("signup", extra={"user_id": str(user.id), "workspace_id": str(ws.id)})
-    return ok({"user": {"id": str(user.id), "email": user.email, "name": user.name}, "workspace_id": str(ws.id)})
+    log.info(
+        "signup verified",
+        extra={"user_id": str(user.id), "workspace_id": str(ws.id)},
+    )
+    return ok(
+        {"user": {"id": str(user.id), "email": user.email, "name": user.name}, "workspace_id": str(ws.id)},
+        "email verified",
+    )
 
+
+# ---------------------------------------------------------------------------
+# Login — with per-account lockout
+# ---------------------------------------------------------------------------
 
 # Login rate limit: 10 / minute per IP is enough for a human fat-fingering
-# their password, far short of viable for online password stuffing.
+# their password, far short of viable for online password stuffing.  The
+# per-account lockout below provides an additional layer.
 @router.post("/login")
 @limiter.limit("10/minute")
 def login(
     request: Request, payload: LoginIn, response: Response, db: DbSession
 ) -> Envelope[dict]:
+    client_ip = request.client.host if request.client else None
+
+    # Per-account lockout check (SEC2-014).
+    # We check BEFORE the credential comparison so a locked account
+    # always gets the lockout response, not a generic "invalid credentials".
+    # The check is constant-time on the DB side regardless of email existence.
+    if check_login_lockout(db, email=payload.email):
+        raise_http(
+            status.HTTP_429_TOO_MANY_REQUESTS,
+            ErrorCodes.AUTH_ACCOUNT_LOCKED,
+            "too many failed login attempts — try again later",
+            retry_after_seconds=LOCKOUT_WINDOW_SECONDS,
+        )
+
     user = db.query(User).filter(User.email == payload.email).first()
     if not user or not verify_password(user.password_hash, payload.password):
-        # Log failures (without the password). Useful for spotting
-        # brute-force patterns alongside the slowapi rate-limit.
+        # Record the failure before raising so the row is committed even
+        # though the route exits via HTTPException.  The DB session is
+        # committed by the dep on clean exit; on exception we must flush
+        # manually and let the DB dep roll back (but we've already added
+        # the row — the dep rolls the whole tx including this row, so we
+        # commit explicitly here via a nested flush → the session
+        # auto-commits when the dep closes it without an exception).
+        #
+        # Implementation: record_login_failure adds the row; the dep
+        # commits on 200 but rolls back on exception.  To ensure the
+        # failure row is persisted even when we're about to raise, we
+        # flush and commit here before raising.
+        record_login_failure(db, email=payload.email, client_ip=client_ip)
+        try:
+            db.commit()
+        except Exception:
+            db.rollback()
         log.warning("login failed", extra={"email": payload.email})
         raise_http(
             status.HTTP_401_UNAUTHORIZED,
             ErrorCodes.AUTH_INVALID_CREDENTIALS,
             "invalid credentials",
         )
-    # SEC2-015 — session rotation on login. Drop every previously-issued
-    # session for this user before minting the new one so a stolen
-    # cookie cannot survive a password change / re-login on a fresh
-    # device. Cheap (single DELETE by user_id index) and stops session
-    # fixation cleanly.
+
+    # Success: clear the failure counter, rotate session.
+    clear_login_failures(db, email=payload.email)
+    # SEC2-015 — session rotation on login.
     revoke_all_user_sessions(db, user.id)
     sess = create_session_row(db, user.id)
     user.last_login_at = datetime.now(timezone.utc)
     _set_session_cookie(response, sess.token)
     log.info("login", extra={"user_id": str(user.id)})
     return ok({"user": {"id": str(user.id), "email": user.email, "name": user.name}})
+
+
+# Expose the lockout window in seconds for the 429 retry_after_seconds field.
+LOCKOUT_WINDOW_SECONDS: int = 15 * 60
 
 
 @router.post("/logout")

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -1,15 +1,19 @@
 from __future__ import annotations
 
 import hashlib
+import logging
 import secrets
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 
+import httpx
 from argon2 import PasswordHasher
 from argon2.exceptions import VerifyMismatchError
 from sqlalchemy.orm import Session
 
 from app.core.config import settings
+
+_log = logging.getLogger(__name__)
 
 _hasher = PasswordHasher()
 
@@ -38,13 +42,68 @@ class WeakPasswordError(ValueError):
     """Raised when a candidate password fails the strength check."""
 
 
+def _hibp_check(password: str) -> None:
+    """Query the HIBP k-anonymity range API for ``password``.
+
+    Computes SHA-1(password), sends the first 5 hex chars to
+    https://api.pwnedpasswords.com/range/{prefix}, then scans the
+    response for the remaining 35-char suffix.
+
+    Raises WeakPasswordError if the password appears in the breach list.
+
+    FAIL-OPEN: any HTTP error, timeout, or unexpected response is logged
+    as a warning and the function returns without raising.  Blocking ALL
+    signups when HIBP is unreachable is worse than the modest signal lost
+    on a brief outage.  Sentry will capture the warning so ops can see
+    the rate of fall-throughs.
+    """
+    sha1 = hashlib.sha1(password.encode("utf-8")).hexdigest().upper()  # noqa: S324
+    prefix, suffix = sha1[:5], sha1[5:]
+    try:
+        resp = httpx.get(
+            f"https://api.pwnedpasswords.com/range/{prefix}",
+            timeout=2.0,
+            headers={"Add-Padding": "true"},
+        )
+        resp.raise_for_status()
+    except Exception as exc:
+        # Fail-open: HIBP down / timeout / network error.  Document the
+        # event for ops via Sentry breadcrumb (if Sentry is configured)
+        # and a log warning.  The caller proceeds without raising.
+        _log.warning("HIBP check failed (fail-open): %s", exc)
+        try:
+            import sentry_sdk
+            sentry_sdk.add_breadcrumb(
+                category="hibp",
+                message=f"HIBP range API unavailable — fail-open: {exc}",
+                level="warning",
+            )
+        except ImportError:
+            pass
+        return
+    for line in resp.text.splitlines():
+        parts = line.strip().split(":")
+        if len(parts) == 2 and parts[0].upper() == suffix:
+            count = int(parts[1]) if parts[1].isdigit() else 1
+            if count > 0:
+                raise WeakPasswordError(
+                    f"password has appeared in {count:,} known data breaches — "
+                    "choose a unique password"
+                )
+
+
 def validate_password_strength(password: str) -> None:
     """Reject obvious weak passwords. Caller maps to HTTPException 400.
 
     Stricter than the schema's `min_length=8` but kept loose by
-    design — argon2 + slowapi rate-limit + the per-IP login cap are
-    the load-bearing defences. This filter just stops "password123"
-    from being committed to the DB.
+    design — argon2 + slowapi rate-limit + the per-account lockout are
+    the load-bearing defences. This filter stops "password123" from
+    being committed to the DB and also checks against the HIBP k-anonymity
+    breach corpus.
+
+    HIBP check is fail-open (see _hibp_check docstring): a network
+    failure falls back to the local blocklist + entropy heuristic so
+    signups aren't blocked when HIBP is unreachable.
     """
     if len(password) < 8:
         raise WeakPasswordError("password must be at least 8 characters")
@@ -58,6 +117,8 @@ def validate_password_strength(password: str) -> None:
         raise WeakPasswordError(
             "password is too repetitive (use a longer / more varied passphrase)"
         )
+    # HIBP k-anonymity check — fail-open on network error.
+    _hibp_check(password)
 
 
 def verify_password(hash_: str, password: str) -> bool:
@@ -130,6 +191,101 @@ def revoke_all_user_sessions(db: Session, user_id) -> int:
     for r in rows:
         db.delete(r)
     return len(rows)
+
+
+# ---------------------------------------------------------------------------
+# Per-account login lockout (SEC2-014).
+#
+# Thresholds are hardcoded — no config knob yet.  Change here if the ops
+# team decides to tune them; no migration is needed (these are pure code
+# constants, not DB-stored parameters).
+# ---------------------------------------------------------------------------
+
+LOCKOUT_MAX_FAILURES: int = 10
+LOCKOUT_WINDOW_MINUTES: int = 15
+
+
+def _hash_email_for_lockout(email: str) -> str:
+    """SHA-256 hex digest of the lowercased email address.
+
+    Used as `email_hash` on `user_login_failures` rows for unknown-email
+    stuffing attempts.  Storing the hash (not the plaintext) means the
+    lockout table doesn't accumulate PII for non-existent addresses.
+    """
+    return hashlib.sha256(email.lower().encode("utf-8")).hexdigest()
+
+
+def record_login_failure(db: Session, *, email: str, client_ip: str | None) -> None:
+    """Insert a UserLoginFailure row.
+
+    Accepts any email; `user_id` is filled when a matching User exists.
+    Always records the `email_hash` so phantom-account stuffing is also
+    rate-limited.
+
+    Called BEFORE the response is returned so the row is committed even
+    when the route raises HTTPException.  The caller must commit.
+    """
+    from app.domain.users.models import User, UserLoginFailure
+
+    user = db.query(User).filter(User.email == email).first()
+    db.add(
+        UserLoginFailure(
+            user_id=user.id if user else None,
+            email_hash=_hash_email_for_lockout(email),
+            client_ip=client_ip,
+        )
+    )
+
+
+def check_login_lockout(db: Session, *, email: str) -> bool:
+    """Return True if the account for ``email`` is locked out.
+
+    Counts failure rows within the last LOCKOUT_WINDOW_MINUTES for
+    either the user's id (if they exist) or the email hash (for
+    unknown-email stuffing).
+
+    Constant-time on the DB side: we always do the hash and always
+    query — no short-circuit on "user not found" — so the response
+    time doesn't reveal whether the email exists.
+    """
+    from datetime import timedelta
+
+    from sqlalchemy import or_
+
+    from app.domain.users.models import User, UserLoginFailure
+
+    cutoff = datetime.now(timezone.utc) - timedelta(minutes=LOCKOUT_WINDOW_MINUTES)
+    email_hash = _hash_email_for_lockout(email)
+    user = db.query(User).filter(User.email == email).first()
+    user_id = user.id if user else None
+
+    q = db.query(UserLoginFailure).filter(
+        UserLoginFailure.occurred_at >= cutoff
+    )
+    if user_id is not None:
+        q = q.filter(
+            or_(
+                UserLoginFailure.user_id == user_id,
+                UserLoginFailure.email_hash == email_hash,
+            )
+        )
+    else:
+        q = q.filter(UserLoginFailure.email_hash == email_hash)
+
+    count = q.count()
+    return count >= LOCKOUT_MAX_FAILURES
+
+
+def clear_login_failures(db: Session, *, email: str) -> None:
+    """Delete all login failure rows for ``email`` after a successful login."""
+    from app.domain.users.models import User, UserLoginFailure
+
+    user = db.query(User).filter(User.email == email).first()
+    if not user:
+        return
+    db.query(UserLoginFailure).filter(
+        UserLoginFailure.user_id == user.id
+    ).delete(synchronize_session=False)
 
 
 def purge_expired_sessions(db: Session, *, now: datetime | None = None) -> int:

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -70,6 +70,23 @@ class Settings(BaseSettings):
     # only — leaving it unset in dev keeps local error stacks clean.
     SENTRY_DSN: str = ""
     SENTRY_TRACES_SAMPLE_RATE: float = 0.0
+    # Email / SMTP for the email-verification flow (SEC2-014).
+    # In dev (APP_ENV != "prod") the mail backend writes to stdout so the
+    # verification link surfaces in container logs without an SMTP server.
+    # In prod all four SMTP_* vars must be set.
+    SMTP_HOST: str = ""
+    SMTP_PORT: int = 587
+    SMTP_USER: str = ""
+    SMTP_PASSWORD: str = ""
+    MAIL_FROM: str = "noreply@stockmanager.local"
+    # Public-facing base URL for generating verification links.
+    # In dev the default mirrors the Vite dev server.
+    APP_BASE_URL: str = "http://localhost:5173"
+    # Enable the two-step email-verification flow on signup (SEC2-014).
+    # Defaults to True in prod, False elsewhere so the test suite can
+    # use the old immediate-signup path without mocking mail.
+    # Set SIGNUP_REQUIRE_EMAIL_VERIFICATION=true in .env.dev to opt in.
+    SIGNUP_REQUIRE_EMAIL_VERIFICATION: bool = False
     # Release identifier — set to the git SHA at deploy time by compose.
     # Sentry groups issues per release and auto-resolves when a fixed
     # release ships.
@@ -110,6 +127,15 @@ class Settings(BaseSettings):
                     f"postgresql+psycopg://{self.POSTGRES_USER}:{encoded_pw}"
                     f"@{self.POSTGRES_HOST}:{self.POSTGRES_PORT}/{self.POSTGRES_DB}"
                 )
+        return self
+
+    @model_validator(mode="after")
+    def _default_email_verification_in_prod(self) -> "Settings":
+        """Force SIGNUP_REQUIRE_EMAIL_VERIFICATION=True in prod even if the
+        operator forgets to set it, so the security feature is always on
+        in production (SEC2-014)."""
+        if self.APP_ENV == "prod":
+            self.SIGNUP_REQUIRE_EMAIL_VERIFICATION = True
         return self
 
     @model_validator(mode="after")

--- a/backend/app/core/errors.py
+++ b/backend/app/core/errors.py
@@ -100,6 +100,10 @@ class ErrorCodes:
     AUTH_INVALID_CREDENTIALS = "auth.invalid_credentials"
     AUTH_EMAIL_TAKEN = "auth.email_taken"
     AUTH_WEAK_PASSWORD = "auth.weak_password"
+    AUTH_ACCOUNT_LOCKED = "auth.account_locked"
+    AUTH_VERIFICATION_PENDING = "auth.verification_pending"
+    AUTH_VERIFICATION_INVALID = "auth.verification_invalid"
+    AUTH_VERIFICATION_EXPIRED = "auth.verification_expired"
 
     # Workspace / membership
     WORKSPACE_NOT_FOUND = "workspace.not_found"

--- a/backend/app/core/mail.py
+++ b/backend/app/core/mail.py
@@ -1,0 +1,107 @@
+"""Pluggable email backend for transactional mail (SEC2-014).
+
+Two backends are available:
+
+* **StdoutBackend** (default in dev): writes the full email body to
+  stdout / the container log so the developer can copy-paste the
+  verification link without needing a real SMTP server.
+
+* **SmtpBackend**: sends via SMTP with STARTTLS.  Used when
+  ``APP_ENV == "prod"`` and ``SMTP_HOST`` is non-empty.
+
+Call :func:`send_verification_email` from route code — it picks the
+right backend automatically based on the current settings.
+
+Design notes:
+- All functions are synchronous; FastAPI routes calling them must use
+  ``run_in_executor`` if they need async (not required today — the
+  signup flow is already a sync def).
+- No retry logic here.  A failure surfaces as a 500; the caller should
+  not mint a ``PendingUser`` row before a successful send so no orphaned
+  rows are left behind.
+"""
+from __future__ import annotations
+
+import logging
+import smtplib
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+
+from app.core.config import settings
+
+_log = logging.getLogger(__name__)
+
+
+def _build_verification_email(to: str, verification_link: str) -> MIMEMultipart:
+    """Build a MIME multipart message with plain-text and HTML parts."""
+    cfg = settings()
+    msg = MIMEMultipart("alternative")
+    msg["Subject"] = "Verify your Stock Manager account"
+    msg["From"] = cfg.MAIL_FROM
+    msg["To"] = to
+
+    plain = (
+        f"Welcome to Stock Manager!\n\n"
+        f"Please verify your email address by visiting:\n{verification_link}\n\n"
+        f"This link expires in 24 hours.\n\n"
+        f"If you did not sign up, you can safely ignore this email."
+    )
+    html = (
+        f"<p>Welcome to <strong>Stock Manager</strong>!</p>"
+        f"<p>Please verify your email address by clicking the link below:</p>"
+        f'<p><a href="{verification_link}">Verify my email</a></p>'
+        f"<p>Or copy and paste this URL: {verification_link}</p>"
+        f"<p><small>This link expires in 24 hours. If you did not sign up, "
+        f"ignore this email.</small></p>"
+    )
+    msg.attach(MIMEText(plain, "plain"))
+    msg.attach(MIMEText(html, "html"))
+    return msg
+
+
+def send_verification_email(*, to: str, verification_link: str) -> None:
+    """Send an email-verification message to ``to``.
+
+    Picks the stdout backend in dev and the SMTP backend in prod.
+    Raises on failure so the caller can abort the signup transaction.
+    """
+    cfg = settings()
+    if cfg.APP_ENV == "prod" and cfg.SMTP_HOST:
+        _send_smtp(to=to, verification_link=verification_link)
+    else:
+        _send_stdout(to=to, verification_link=verification_link)
+
+
+def _send_stdout(*, to: str, verification_link: str) -> None:
+    """Dev backend: write the email to stdout / container logs."""
+    _log.info(
+        "MAIL (stdout backend) To: %s\nVerification link: %s",
+        to,
+        verification_link,
+    )
+    # Also print directly so it appears even when log level is WARNING.
+    print(
+        f"\n{'='*60}\n"
+        f"[DEV MAIL] Verification email\n"
+        f"To: {to}\n"
+        f"Link: {verification_link}\n"
+        f"{'='*60}\n",
+        flush=True,
+    )
+
+
+def _send_smtp(*, to: str, verification_link: str) -> None:
+    """Prod backend: send via SMTP with STARTTLS."""
+    cfg = settings()
+    msg = _build_verification_email(to=to, verification_link=verification_link)
+    try:
+        with smtplib.SMTP(cfg.SMTP_HOST, cfg.SMTP_PORT, timeout=10) as smtp:
+            smtp.ehlo()
+            smtp.starttls()
+            smtp.ehlo()
+            if cfg.SMTP_USER:
+                smtp.login(cfg.SMTP_USER, cfg.SMTP_PASSWORD)
+            smtp.sendmail(cfg.MAIL_FROM, [to], msg.as_string())
+    except Exception as exc:
+        _log.error("SMTP send failed to %s: %s", to, exc)
+        raise

--- a/backend/app/domain/all_models.py
+++ b/backend/app/domain/all_models.py
@@ -42,7 +42,7 @@ from app.domain.projects.models import (  # noqa: F401
 from app.domain.stock.models import StockEntry  # noqa: F401
 from app.domain.storage.models import StorageLocation  # noqa: F401
 from app.domain.tags.models import Tag, TagLink  # noqa: F401
-from app.domain.users.models import User, UserSession  # noqa: F401
+from app.domain.users.models import PendingUser, User, UserLoginFailure, UserSession  # noqa: F401
 from app.domain.workspaces.models import (  # noqa: F401
     Workspace,
     WorkspaceInvitation,

--- a/backend/app/domain/users/models.py
+++ b/backend/app/domain/users/models.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timezone
 
-from sqlalchemy import Column, DateTime, ForeignKey, String
+from sqlalchemy import Column, DateTime, ForeignKey, String, Text
 from sqlalchemy.dialects.postgresql import UUID
 
 from app.infra.db import Base
@@ -48,3 +48,71 @@ class UserSession(Base):
     # SQLAlchemy would emit a redundant CREATE INDEX in a future
     # autogenerate run.
     expires_at = Column(DateTime(timezone=True), nullable=False)
+
+
+class UserLoginFailure(Base):
+    """Per-account login failure record for the account-lockout mechanism.
+
+    Each failed login attempt appends one row.  The lockout check counts
+    rows within the last LOCKOUT_WINDOW_MINUTES minutes; a successful login
+    deletes all rows for the user.
+
+    `user_id` is SET NULL on user deletion so we retain the IP-based audit
+    trail without a dangling FK.  Rows with `user_id IS NULL` are orphaned
+    tombstones — they are still counted for the phantom-account cap (see
+    `auth.py::_check_login_lockout`) while not leaking user existence.
+
+    NOTE: the account-lockout rows are intentionally NOT workspace-scoped.
+    Login is a pre-workspace operation and the lockout table protects the
+    user credential, not any particular workspace resource.
+    """
+
+    __tablename__ = "user_login_failures"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    # SET NULL on delete preserves the audit trail for orphaned sessions.
+    user_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    # The email is stored as a SHA-256 hex digest (normalised to lowercase)
+    # so we can count failures for unknown-email attempts without storing
+    # PII and without revealing whether the address exists in the DB.
+    email_hash = Column(String(64), nullable=False, index=True)
+    occurred_at = Column(DateTime(timezone=True), nullable=False, default=_utcnow, index=True)
+    client_ip = Column(String(45), nullable=True)  # IPv4 or IPv6
+
+
+class PendingUser(Base):
+    """Transient signup record held until the user verifies their email.
+
+    Created by POST /auth/signup; consumed (and promoted to User +
+    Workspace + WorkspaceMember) by POST /auth/verify in a single
+    transaction.  Rows older than 24 h are treated as expired.
+
+    NOTE: this table is intentionally NOT workspace-scoped.  Signup
+    precedes workspace creation — there is no workspace to scope against.
+    This is one of the few tables in the app that lacks a workspace_id FK.
+    Do NOT add workspace_id here; see the workspace-isolation hard
+    invariant in CLAUDE.md.
+    """
+
+    __tablename__ = "pending_users"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    email = Column(String(320), nullable=False, index=True)
+    name = Column(String(200), nullable=False)
+    password_hash = Column(String(500), nullable=False)
+    workspace_name = Column(String(200), nullable=True)
+    created_at = Column(DateTime(timezone=True), nullable=False, default=_utcnow)
+    # HMAC-SHA-256 (keyed on SESSION_SECRET) of the plaintext verification
+    # token.  The plaintext is sent to the user's email and never stored.
+    # Verification compares hmac.compare_digest(hmac_of_supplied, this col)
+    # for constant-time comparison.
+    verification_token_hmac = Column(String(64), nullable=False)
+    verified_at = Column(DateTime(timezone=True), nullable=True)
+    ip = Column(String(45), nullable=True)
+    # Optional free-form notes — not used by the core flow.
+    notes = Column(Text, nullable=True)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -260,6 +260,10 @@ _CSRF_EXEMPT_PATHS = frozenset({
     "/api/sentry-tunnel",
     "/api/auth/login",
     "/api/auth/signup",
+    # /auth/verify is a pre-auth endpoint: the user follows a link from
+    # their email client, which carries no Origin header (or a mail-client
+    # origin). Exempt so the CSRF middleware doesn't block the verify call.
+    "/api/auth/verify",
 })
 
 

--- a/backend/tests/_factories.py
+++ b/backend/tests/_factories.py
@@ -13,6 +13,14 @@ functions keep the dependency surface small and the call sites obvious.
 If a test needs richer data (extra fields, non-default flags), pass them
 as ``**extra`` — every factory forwards unknown kwargs to the request
 body so call sites stay one line.
+
+Email-verification (SEC2-014): in dev/test mode
+(SIGNUP_REQUIRE_EMAIL_VERIFICATION=False, which is the default when
+APP_ENV != "prod") the signup endpoint immediately creates the User +
+Workspace and returns 200 — the same behaviour as before this feature
+landed. Tests that specifically exercise the email-verification round-trip
+should set SIGNUP_REQUIRE_EMAIL_VERIFICATION=true (via override in their
+own patching) and call the /auth/signup + /auth/verify endpoints directly.
 """
 from __future__ import annotations
 
@@ -45,7 +53,14 @@ def signup_user(
     password: str = DEFAULT_PASSWORD,
 ) -> Any:
     """Sign up a fresh user. Returns the raw response so call sites can
-    pull whatever they need (``workspace_id``, ``user_id``, etc)."""
+    pull whatever they need (``workspace_id``, ``user_id``, etc).
+
+    In tests (APP_ENV=dev, SIGNUP_REQUIRE_EMAIL_VERIFICATION=False) the
+    endpoint creates the User + Workspace immediately and returns 200 —
+    same shape as before SEC2-014.  The HIBP network call is stubbed via
+    the ``hibp_mock`` autouse fixture in conftest.py so no real network
+    calls occur.
+    """
     email = email or f"u-{uuid.uuid4().hex[:8]}@example.com"
     r = client.post(
         "/api/auth/signup",

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -123,3 +123,17 @@ def authed_client():
     c = TestClient(app)
     _signup(c)
     return c
+
+
+@pytest.fixture(autouse=True)
+def _mock_hibp(monkeypatch):
+    """Stub the HIBP k-anonymity check for all tests so no outbound HTTP
+    calls are made during the test suite run (SEC2-014).
+
+    Tests that specifically exercise the HIBP path (test_hibp.py) override
+    this fixture locally using their own httpx_mock / monkeypatch.
+    """
+    import unittest.mock as _mock
+
+    with _mock.patch("app.core.auth._hibp_check"):
+        yield

--- a/backend/tests/test_auth_lockout.py
+++ b/backend/tests/test_auth_lockout.py
@@ -1,0 +1,143 @@
+"""Per-account login lockout tests (SEC2-014).
+
+Covers:
+- 10 consecutive failed logins lock the account for 15 min.
+- Successful login resets the failure counter.
+- Lockout response is 429 with retry_after_seconds.
+- Lockout does NOT reveal whether the email exists.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+from tests._factories import DEFAULT_PASSWORD, signup_user
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture
+def user_email_and_client():
+    """Return (email, authed TestClient) for a freshly signed-up user."""
+    c = TestClient(app)
+    email = f"lockout-{uuid.uuid4().hex[:8]}@x.com"
+    signup_user(c, email=email)
+    return email, c
+
+
+def _fail_login(c: TestClient, email: str, n: int = 1) -> list:
+    """Attempt n failed logins for email. Returns list of responses."""
+    resps = []
+    for _ in range(n):
+        r = c.post("/api/auth/login", json={"email": email, "password": "WrongPass!!X"})
+        resps.append(r)
+    return resps
+
+
+def test_ten_failures_lock_account(user_email_and_client):
+    """After LOCKOUT_MAX_FAILURES (10) recorded failures, the next attempt returns 429.
+
+    The lockout check runs BEFORE credential validation.  Recording a
+    failure happens only on a 401 response, so:
+    - Attempts 1–10: check passes (< 10 prior failures), wrong cred → 401 +
+      one failure recorded.
+    - Attempt 11: check finds 10 prior failures → 429 without touching creds.
+
+    This means 11 total failed attempts are needed to see the lockout 429.
+    """
+    email, _ = user_email_and_client
+    c = TestClient(app)
+
+    from app.core.auth import LOCKOUT_MAX_FAILURES
+
+    # First LOCKOUT_MAX_FAILURES attempts should all return 401.
+    resps = _fail_login(c, email, n=LOCKOUT_MAX_FAILURES)
+    for r in resps:
+        assert r.status_code == 401, r.text
+
+    # Next attempt: check fires before creds → 429.
+    r = _fail_login(c, email, n=1)[0]
+    assert r.status_code == 429, r.text
+    body = r.json()
+    assert body["code"] == "auth.account_locked"
+    assert "retry_after_seconds" in body
+    assert body["retry_after_seconds"] > 0
+
+
+def test_lockout_blocks_correct_password(user_email_and_client):
+    """After the lockout threshold is reached, even the correct password returns 429."""
+    email, _ = user_email_and_client
+    c = TestClient(app)
+
+    from app.core.auth import LOCKOUT_MAX_FAILURES
+
+    # Exhaust failures to trigger the lockout on the next attempt.
+    _fail_login(c, email, n=LOCKOUT_MAX_FAILURES)
+
+    # Correct credentials — should be locked by the pre-check.
+    r = c.post("/api/auth/login", json={"email": email, "password": DEFAULT_PASSWORD})
+    assert r.status_code == 429, r.text
+    assert r.json()["code"] == "auth.account_locked"
+
+
+def test_successful_login_resets_counter(user_email_and_client):
+    """Fewer-than-threshold failures followed by a successful login resets the counter."""
+    email, _ = user_email_and_client
+    c = TestClient(app)
+
+    from app.core.auth import LOCKOUT_MAX_FAILURES
+
+    # Fail fewer than the threshold.
+    _fail_login(c, email, n=LOCKOUT_MAX_FAILURES - 1)
+
+    # Successful login.
+    r = c.post("/api/auth/login", json={"email": email, "password": DEFAULT_PASSWORD})
+    assert r.status_code == 200, r.text
+
+    # Counter is reset — threshold-1 more failures should still return 401.
+    resps = _fail_login(c, email, n=LOCKOUT_MAX_FAILURES - 1)
+    for r in resps:
+        assert r.status_code == 401, r.text
+
+
+def test_unknown_email_also_gets_locked():
+    """Stuffing attempts against a non-existent email are also rate-limited.
+
+    The lockout does not reveal whether the email exists:
+    - Before lockout threshold: returns 401 (same as wrong password on a real account).
+    - After threshold: returns 429 (same as a real account lockout).
+    """
+    from app.core.auth import LOCKOUT_MAX_FAILURES
+
+    c = TestClient(app)
+    ghost = f"ghost-{uuid.uuid4().hex[:8]}@nowhere.com"
+
+    resps = _fail_login(c, ghost, n=LOCKOUT_MAX_FAILURES)
+    for r in resps:
+        assert r.status_code == 401, r.text
+
+    r = _fail_login(c, ghost, n=1)[0]
+    assert r.status_code == 429, r.text
+    assert r.json()["code"] == "auth.account_locked"
+
+
+def test_lockout_response_envelope():
+    """The 429 lockout response must be in the standard {data, status} envelope."""
+    c = TestClient(app)
+    email = f"env-{uuid.uuid4().hex[:8]}@x.com"
+    signup_user(c, email=email)
+
+    _fail_login(c, email, n=10)
+
+    r = c.post("/api/auth/login", json={"email": email, "password": "WrongPass!!X"})
+    assert r.status_code == 429
+    body = r.json()
+    # Must have the envelope shape.
+    assert "data" in body
+    assert "status" in body or "code" in body  # http_exception_handler spreads the detail

--- a/backend/tests/test_hibp.py
+++ b/backend/tests/test_hibp.py
@@ -1,0 +1,90 @@
+"""HIBP k-anonymity password check tests (SEC2-014).
+
+Covers:
+- A suffix found in the HIBP response rejects the password.
+- A network error / timeout causes the check to fail-open (not reject).
+- The breach-count logic (any suffix match with count > 0 rejects).
+"""
+from __future__ import annotations
+
+import hashlib
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.core.auth import WeakPasswordError, _hibp_check
+
+
+_PASSWORD = "SecureButInBreachList!99"
+
+
+def _sha1_parts(password: str) -> tuple[str, str]:
+    """Return (prefix, suffix) of the SHA-1 hex digest (uppercase)."""
+    digest = hashlib.sha1(password.encode()).hexdigest().upper()  # noqa: S324
+    return digest[:5], digest[5:]
+
+
+def test_hibp_rejects_breached_password():
+    """When the HIBP range response contains the password suffix with count > 0,
+    WeakPasswordError is raised."""
+    prefix, suffix = _sha1_parts(_PASSWORD)
+    # Build a fake response body containing the suffix with a nonzero count.
+    fake_body = f"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA:1\n{suffix}:42\nBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB:100\n"
+
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.text = fake_body
+
+    with patch("httpx.get", return_value=mock_resp):
+        with pytest.raises(WeakPasswordError, match="known data breaches"):
+            _hibp_check(_PASSWORD)
+
+
+def test_hibp_accepts_clean_password():
+    """When the HIBP range response does NOT contain the password suffix,
+    no exception is raised."""
+    prefix, suffix = _sha1_parts(_PASSWORD)
+    # Response does not include our suffix.
+    fake_body = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA:1\nBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB:100\n"
+
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.text = fake_body
+
+    with patch("httpx.get", return_value=mock_resp):
+        _hibp_check(_PASSWORD)  # Should not raise.
+
+
+def test_hibp_fail_open_on_network_error():
+    """A network error / timeout causes the check to fail-open.
+
+    HIBP fail-open is intentional (see implementation plan): blocking ALL
+    signups when HIBP is down is worse than the brief signal loss.
+    """
+    with patch("httpx.get", side_effect=TimeoutError("simulated timeout")):
+        _hibp_check(_PASSWORD)  # Should NOT raise.
+
+
+def test_hibp_fail_open_on_http_error():
+    """A non-2xx HTTP response from HIBP also fails-open."""
+    import httpx
+
+    with patch("httpx.get", side_effect=httpx.HTTPStatusError("500", request=MagicMock(), response=MagicMock())):
+        _hibp_check(_PASSWORD)  # Should NOT raise.
+
+
+def test_hibp_suffix_match_zero_count_accepts():
+    """A suffix in the HIBP response with count = 0 should NOT reject the password.
+
+    HIBP's padding feature (Add-Padding=true) includes random fictitious
+    suffixes with count 0. These must be ignored.
+    """
+    prefix, suffix = _sha1_parts(_PASSWORD)
+    fake_body = f"{suffix}:0\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA:5\n"
+
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.text = fake_body
+
+    with patch("httpx.get", return_value=mock_resp):
+        _hibp_check(_PASSWORD)  # Should NOT raise — count is 0.

--- a/backend/tests/test_invitations.py
+++ b/backend/tests/test_invitations.py
@@ -6,16 +6,22 @@ import pytest
 from fastapi.testclient import TestClient
 
 from app.main import app
+from tests._factories import signup_user
 
 
-def _signup(c, email=None):
+def _signup(c: TestClient, email: str | None = None, name: str = "u") -> tuple[str, str]:
+    """Sign up a fresh user and return (email, workspace_id).
+
+    Delegates to the canonical ``signup_user`` factory which handles the
+    HIBP stub and uses the immediate-create path (dev/test mode).
+    """
     email = email or f"u-{uuid.uuid4().hex[:8]}@x.com"
-    r = c.post(
-        "/api/auth/signup",
-        json={"email": email, "name": "u", "password": "TestPass-2026-Stronk"},
-    )
-    assert r.status_code == 200, r.text
+    r = signup_user(c, email=email, name=name)
     return email, r.json()["data"]["workspace_id"]
+
+
+# Also expose a direct-call alias for tests that need the full Client.
+_do_signup_verify = _signup
 
 
 @pytest.fixture
@@ -40,12 +46,9 @@ def test_admin_creates_invitation_user_accepts(admin):
     token = inv["token"]
     assert token
 
-    # Sign up the invitee in their own client
+    # Sign up + verify the invitee in their own client
     invitee = TestClient(app)
-    invitee.post(
-        "/api/auth/signup",
-        json={"email": invitee_email, "name": "Newbie", "password": "TestPass-2026-Stronk"},
-    )
+    _do_signup_verify(invitee, email=invitee_email, name="Newbie")
 
     # Accept
     r = invitee.post("/api/invitations/accept", json={"token": token})
@@ -72,10 +75,7 @@ def test_non_admin_cannot_invite():
     inv = owner.post("/api/invitations", json={"email": invitee_email, "role": "member"}).json()["data"]
 
     invitee = TestClient(app)
-    invitee.post(
-        "/api/auth/signup",
-        json={"email": invitee_email, "name": "M", "password": "TestPass-2026-Stronk"},
-    )
+    _do_signup_verify(invitee, email=invitee_email, name="M")
     invitee.post("/api/invitations/accept", json={"token": inv["token"]})
     # Switch to the shared workspace
     members_in_admin = owner.get("/api/workspaces/members").json()["data"]
@@ -96,10 +96,7 @@ def test_invitation_email_must_match(admin):
     inv_for = f"forA-{uuid.uuid4().hex[:6]}@x.com"
     inv = admin.post("/api/invitations", json={"email": inv_for, "role": "member"}).json()["data"]
     other = TestClient(app)
-    other.post(
-        "/api/auth/signup",
-        json={"email": f"someone-else-{uuid.uuid4().hex[:6]}@x.com", "name": "Other", "password": "TestPass-2026-Stronk"},
-    )
+    _do_signup_verify(other, email=f"someone-else-{uuid.uuid4().hex[:6]}@x.com", name="Other")
     r = other.post("/api/invitations/accept", json={"token": inv["token"]})
     assert r.status_code == 403
 
@@ -111,10 +108,7 @@ def test_revoke_invitation_blocks_acceptance(admin):
     assert r.status_code == 200
 
     invitee = TestClient(app)
-    invitee.post(
-        "/api/auth/signup",
-        json={"email": invitee_email, "name": "x", "password": "TestPass-2026-Stronk"},
-    )
+    _do_signup_verify(invitee, email=invitee_email, name="x")
     r = invitee.post("/api/invitations/accept", json={"token": inv["token"]})
     assert r.status_code == 400
 
@@ -130,10 +124,7 @@ def test_cannot_already_member(admin):
     invitee_email = f"dup-{uuid.uuid4().hex[:6]}@x.com"
     inv = admin.post("/api/invitations", json={"email": invitee_email, "role": "member"}).json()["data"]
     invitee = TestClient(app)
-    invitee.post(
-        "/api/auth/signup",
-        json={"email": invitee_email, "name": "x", "password": "TestPass-2026-Stronk"},
-    )
+    _do_signup_verify(invitee, email=invitee_email, name="x")
     invitee.post("/api/invitations/accept", json={"token": inv["token"]})
     # Now try to invite the same email again — should 409
     r = admin.post("/api/invitations", json={"email": invitee_email, "role": "member"})
@@ -217,10 +208,7 @@ def test_accept_with_wrong_token_returns_404(admin):
     inv_id = inv_data["id"]
 
     invitee = TestClient(app)
-    invitee.post(
-        "/api/auth/signup",
-        json={"email": invitee_email, "name": "x", "password": "TestPass-2026-Stronk"},
-    )
+    _do_signup_verify(invitee, email=invitee_email, name="x")
 
     # a) Correct id, wrong plaintext — HMAC compare_digest must fail → 404.
     r = invitee.post(

--- a/backend/tests/test_parts_mpn_unique.py
+++ b/backend/tests/test_parts_mpn_unique.py
@@ -17,14 +17,11 @@ import pytest
 from fastapi.testclient import TestClient
 
 from app.main import app
+from tests._factories import signup_user as _signup_factory
 
 
 def _signup(c: TestClient) -> None:
-    r = c.post(
-        "/api/auth/signup",
-        json={"email": f"u-{uuid.uuid4().hex[:8]}@x.com", "name": "u", "password": "TestPass-2026-Stronk"},
-    )
-    assert r.status_code == 200, r.text
+    _signup_factory(c)
 
 
 @pytest.fixture

--- a/backend/tests/test_password_strength.py
+++ b/backend/tests/test_password_strength.py
@@ -29,6 +29,13 @@ from app.main import app
 
 
 def _signup(c: TestClient, *, email: str | None = None, password: str) -> int:
+    """Call /auth/signup and return the status code.
+
+    HIBP is already patched for the whole suite by the ``_mock_hibp``
+    autouse fixture in conftest.py — no per-call patch needed here.
+    In dev/test mode (SIGNUP_REQUIRE_EMAIL_VERIFICATION=False) a valid
+    signup returns 200 immediately.
+    """
     email = email or f"u-{uuid.uuid4().hex[:8]}@x.com"
     r = c.post(
         "/api/auth/signup",
@@ -70,6 +77,10 @@ WEAK_PASSWORD_CASES = [
     ("too_short", "abc12", (400, 422)),
 ]
 
+# In test mode (SIGNUP_REQUIRE_EMAIL_VERIFICATION=False) signup returns 200.
+# In prod mode (or with the flag explicitly set) it returns 202.
+_SIGNUP_OK_CODES = (200, 202)
+
 
 @pytest.mark.parametrize(
     ("method", "route", "make_payload"),
@@ -82,6 +93,7 @@ WEAK_PASSWORD_CASES = [
     ids=[c[0] for c in WEAK_PASSWORD_CASES],
 )
 def test_weak_password_rejected(method, route, make_payload, case_id, password, ok_codes):
+    """HIBP is stubbed globally by conftest._mock_hibp; no per-test patch needed."""
     c = TestClient(app)
     payload = make_payload(password)
     r = c.request(method, route, json=payload)
@@ -92,9 +104,10 @@ def test_weak_password_rejected(method, route, make_payload, case_id, password, 
 
 
 def test_strong_password_succeeds_on_signup():
+    """A strong password returns 200 (dev mode) or 202 (prod mode, SEC2-014)."""
     c = TestClient(app)
     code = _signup(c, password="VeryStrong-2026-Stockmgr!")
-    assert code == 200, code
+    assert code in _SIGNUP_OK_CODES, code
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_signup_verification.py
+++ b/backend/tests/test_signup_verification.py
@@ -1,0 +1,244 @@
+"""Email-verification signup flow tests (SEC2-014).
+
+Covers:
+- Signup with SIGNUP_REQUIRE_EMAIL_VERIFICATION=True returns 202.
+- No User / Workspace exists after the 202.
+- Verify creates User + Workspace in one transaction.
+- A PendingUser row older than 24 h is treated as expired.
+- A duplicate signup (same email, non-expired pending) returns 202 without
+  creating a second row.
+- Incorrect verification token returns 400.
+"""
+from __future__ import annotations
+
+import re
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.core.config import settings
+from app.domain.users.models import PendingUser, User
+from app.domain.workspaces.models import Workspace, WorkspaceMember
+from app.infra.db import SessionLocal
+from app.main import app
+
+
+PASSWORD = "StrongVerify-2026!!"
+
+
+def _full_signup_verify(
+    *,
+    email: str | None = None,
+    name: str = "Verifier",
+    workspace_name: str | None = None,
+) -> tuple[TestClient, str, str]:
+    """Perform the full signup + verify flow with email-verification enabled.
+
+    Returns (client, email, pending_id).  The client has a session cookie
+    set after the verify step.
+    """
+    email = email or f"v-{uuid.uuid4().hex[:8]}@x.com"
+    c = TestClient(app)
+    captured: dict[str, str] = {}
+
+    def _cap(*, to: str, verification_link: str) -> None:
+        captured["link"] = verification_link
+
+    # Force the email-verification code path regardless of APP_ENV.
+    with (
+        patch.object(settings(), "SIGNUP_REQUIRE_EMAIL_VERIFICATION", True),
+        patch("app.api.routes.auth.send_verification_email", side_effect=_cap),
+    ):
+        r = c.post(
+            "/api/auth/signup",
+            json={"email": email, "name": name, "password": PASSWORD,
+                  **({"workspace_name": workspace_name} if workspace_name else {})},
+        )
+    assert r.status_code == 202, r.text
+    assert "link" in captured, "send_verification_email was not called"
+
+    m_id = re.search(r"[?&]id=([^&]+)", captured["link"])
+    assert m_id
+    pending_id = m_id.group(1)
+
+    m_tok = re.search(r"[?&]token=([^&]+)", captured["link"])
+    assert m_tok
+    token = m_tok.group(1)
+
+    verify_r = c.post("/api/auth/verify", json={"id": pending_id, "token": token})
+    assert verify_r.status_code == 200, verify_r.text
+
+    return c, email, pending_id
+
+
+def test_signup_returns_202_when_verification_enabled():
+    """With SIGNUP_REQUIRE_EMAIL_VERIFICATION=True, signup returns 202."""
+    email = f"v-{uuid.uuid4().hex[:8]}@x.com"
+    c = TestClient(app)
+
+    with (
+        patch.object(settings(), "SIGNUP_REQUIRE_EMAIL_VERIFICATION", True),
+        patch("app.api.routes.auth.send_verification_email"),
+    ):
+        r = c.post(
+            "/api/auth/signup",
+            json={"email": email, "name": "T", "password": PASSWORD},
+        )
+    assert r.status_code == 202, r.text
+    assert r.json()["data"]["status"] == "verification_sent"
+
+
+def test_no_user_workspace_before_verify():
+    """After a 202 signup, no User or Workspace row should exist yet."""
+    email = f"v-{uuid.uuid4().hex[:8]}@x.com"
+    c = TestClient(app)
+
+    with (
+        patch.object(settings(), "SIGNUP_REQUIRE_EMAIL_VERIFICATION", True),
+        patch("app.api.routes.auth.send_verification_email"),
+    ):
+        c.post(
+            "/api/auth/signup",
+            json={"email": email, "name": "T", "password": PASSWORD},
+        )
+
+    with SessionLocal() as db:
+        user = db.query(User).filter(User.email == email).first()
+        assert user is None, "User row must not exist before verify"
+
+
+def test_verify_creates_user_workspace():
+    """POST /auth/verify promotes PendingUser → User + Workspace atomically."""
+    client, email, _ = _full_signup_verify()
+
+    with SessionLocal() as db:
+        user = db.query(User).filter(User.email == email).first()
+        assert user is not None, "User must exist after verify"
+
+        memberships = db.query(WorkspaceMember).filter(WorkspaceMember.user_id == user.id).all()
+        assert len(memberships) == 1
+        assert memberships[0].role == "owner"
+
+        ws = db.get(Workspace, memberships[0].workspace_id)
+        assert ws is not None
+        assert ws.kind == "personal"
+
+    # Client should have a session cookie.
+    cookie = client.cookies.get(settings().SESSION_COOKIE_NAME)
+    assert cookie, "session cookie must be set after verify"
+
+
+def test_verify_returns_user_and_workspace_id():
+    """The verify response body should contain user and workspace_id."""
+    client, email, _ = _full_signup_verify()
+
+    # Re-call verify via a fresh call to check response shape — we already
+    # consumed the verification in _full_signup_verify. Instead, let's
+    # check the final state via /auth/me.
+    me_r = client.get("/api/auth/me")
+    assert me_r.status_code == 200, me_r.text
+    me = me_r.json()["data"]
+    assert me["user"]["email"] == email
+    assert len(me["workspaces"]) == 1
+
+
+def test_verify_wrong_token_returns_400():
+    """An incorrect verification token returns 400 (not 200)."""
+    email = f"v-{uuid.uuid4().hex[:8]}@x.com"
+    c = TestClient(app)
+    captured: dict[str, str] = {}
+
+    def _cap(*, to: str, verification_link: str) -> None:
+        captured["link"] = verification_link
+
+    with (
+        patch.object(settings(), "SIGNUP_REQUIRE_EMAIL_VERIFICATION", True),
+        patch("app.api.routes.auth.send_verification_email", side_effect=_cap),
+    ):
+        c.post("/api/auth/signup", json={"email": email, "name": "T", "password": PASSWORD})
+
+    m_id = re.search(r"[?&]id=([^&]+)", captured["link"])
+    assert m_id
+    pending_id = m_id.group(1)
+
+    r = c.post("/api/auth/verify", json={"id": pending_id, "token": "wrong-token-value"})
+    assert r.status_code == 400, r.text
+    assert r.json()["code"] == "auth.verification_invalid"
+
+
+def test_verify_expired_row_returns_400(db):
+    """A PendingUser created more than 24 h ago is expired."""
+    email = f"v-{uuid.uuid4().hex[:8]}@x.com"
+    c = TestClient(app)
+    captured: dict[str, str] = {}
+
+    def _cap(*, to: str, verification_link: str) -> None:
+        captured["link"] = verification_link
+
+    with (
+        patch.object(settings(), "SIGNUP_REQUIRE_EMAIL_VERIFICATION", True),
+        patch("app.api.routes.auth.send_verification_email", side_effect=_cap),
+    ):
+        c.post("/api/auth/signup", json={"email": email, "name": "T", "password": PASSWORD})
+
+    m_id = re.search(r"[?&]id=([^&]+)", captured["link"])
+    m_tok = re.search(r"[?&]token=([^&]+)", captured["link"])
+    assert m_id and m_tok
+
+    # Backdate the created_at to > 24 h ago.
+    pending = db.query(PendingUser).filter(PendingUser.email == email).first()
+    assert pending is not None
+    pending.created_at = datetime.now(timezone.utc) - timedelta(hours=25)
+    db.commit()
+
+    r = c.post("/api/auth/verify", json={"id": m_id.group(1), "token": m_tok.group(1)})
+    assert r.status_code == 400, r.text
+    assert r.json()["code"] == "auth.verification_expired"
+
+
+def test_duplicate_signup_same_email_returns_202_without_new_row(db):
+    """A second signup for the same (non-expired) email returns 202 without
+    creating a duplicate PendingUser row."""
+    email = f"v-{uuid.uuid4().hex[:8]}@x.com"
+    c = TestClient(app)
+
+    def _noop(*, to, verification_link):
+        pass
+
+    with (
+        patch.object(settings(), "SIGNUP_REQUIRE_EMAIL_VERIFICATION", True),
+        patch("app.api.routes.auth.send_verification_email", side_effect=_noop),
+    ):
+        r1 = c.post("/api/auth/signup", json={"email": email, "name": "T", "password": PASSWORD})
+        assert r1.status_code == 202
+
+        # Count rows after first signup.
+        count_after_first = db.query(PendingUser).filter(PendingUser.email == email).count()
+
+        r2 = c.post("/api/auth/signup", json={"email": email, "name": "T2", "password": PASSWORD})
+        assert r2.status_code == 202
+
+    count_after_second = db.query(PendingUser).filter(PendingUser.email == email).count()
+    assert count_after_second == count_after_first, (
+        "second signup for same email must NOT create a new PendingUser row"
+    )
+
+
+def test_signup_rejects_already_verified_email():
+    """Signing up with an email that already has a verified User returns 409."""
+    email = f"v-{uuid.uuid4().hex[:8]}@x.com"
+    # First: complete the full verification flow to create a User.
+    _full_signup_verify(email=email)
+
+    # Second attempt should 409.
+    c2 = TestClient(app)
+    with (
+        patch.object(settings(), "SIGNUP_REQUIRE_EMAIL_VERIFICATION", True),
+        patch("app.api.routes.auth.send_verification_email"),
+    ):
+        r = c2.post("/api/auth/signup", json={"email": email, "name": "T2", "password": PASSWORD})
+    assert r.status_code == 409, r.text
+    assert r.json()["code"] == "auth.email_taken"

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8,6 +8,8 @@ import { ConfirmDialogProvider } from "@/components/ConfirmDialog";
 // a fallback flash on first paint.
 import Login from "@/routes/auth/Login";
 import Signup from "@/routes/auth/Signup";
+// SEC2-014: email-verification landing page.
+import Verify from "@/routes/auth/Verify";
 
 // Parts area — the home of the app. Eagerly loaded because every authed
 // session lands on /parts and the alternative is a Suspense flash on
@@ -136,6 +138,8 @@ export default function App() {
         <Routes>
           <Route path="/login" element={<Login />} />
           <Route path="/signup" element={<Signup />} />
+          {/* SEC2-014: email verification landing — pre-auth, no Gate wrapper */}
+          <Route path="/verify" element={<Verify />} />
 
           {/* Single layout route — Gate stays mounted across every
               authed navigation, so AppShell + its state survive. */}

--- a/web/src/routes/auth/Login.tsx
+++ b/web/src/routes/auth/Login.tsx
@@ -11,6 +11,9 @@ export default function Login() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [err, setErr] = useState<string | null>(null);
+  // SEC2-014: the server returns retry_after_seconds on a 429 lockout
+  // response. Show a countdown so the user knows how long to wait.
+  const [retryAfter, setRetryAfter] = useState<number | null>(null);
   const [busy, setBusy] = useState(false);
 
   // `from` is set by `<Gate>` (and by the 401 handler in auth.tsx) when
@@ -22,13 +25,25 @@ export default function Login() {
   async function submit(e: React.FormEvent) {
     e.preventDefault();
     setErr(null);
+    setRetryAfter(null);
     setBusy(true);
     try {
       await api.post("/auth/login", { email, password });
       await refresh();
       nav(fromPath || "/parts", { replace: true });
     } catch (e) {
-      setErr(e instanceof ApiError ? e.message : "Login failed");
+      if (e instanceof ApiError) {
+        // SEC2-014: per-account lockout returns 429 with retry_after_seconds.
+        const body = e.body as Record<string, unknown> | null;
+        if (e.status === 429 && body && typeof body.retry_after_seconds === "number") {
+          setRetryAfter(body.retry_after_seconds);
+          setErr("Too many failed login attempts. Please try again later.");
+        } else {
+          setErr(e.message);
+        }
+      } else {
+        setErr("Login failed");
+      }
     } finally {
       setBusy(false);
     }
@@ -40,6 +55,11 @@ export default function Login() {
         {err && (
           <div className="rounded-md border border-danger/40 bg-danger/10 px-3 py-2 text-danger text-sm">
             {err}
+            {retryAfter !== null && (
+              <span className="block mt-1 text-xs">
+                Try again in {Math.ceil(retryAfter / 60)} minute{retryAfter > 60 ? "s" : ""}.
+              </span>
+            )}
           </div>
         )}
         <div>

--- a/web/src/routes/auth/Signup.tsx
+++ b/web/src/routes/auth/Signup.tsx
@@ -14,6 +14,10 @@ export default function Signup() {
   const [workspaceName, setWorkspaceName] = useState("");
   const [err, setErr] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
+  // SEC2-014: when the server enables email-verification the signup
+  // returns 202 with status="verification_sent" instead of 200 with
+  // a session cookie. We show a "check your inbox" view in that case.
+  const [verificationSent, setVerificationSent] = useState(false);
 
   // Mirror the Login deep-link replay so a user who hit a protected
   // route, signed up instead of in, still lands on the original target.
@@ -25,12 +29,18 @@ export default function Signup() {
     setErr(null);
     setBusy(true);
     try {
-      await api.post("/auth/signup", {
+      const data = await api.post("/auth/signup", {
         name,
         email,
         password,
         workspace_name: workspaceName || undefined,
       });
+      // SEC2-014: email-verification path returns {status: "verification_sent"}.
+      if ((data as { status?: string }).status === "verification_sent") {
+        setVerificationSent(true);
+        return;
+      }
+      // Legacy / dev path: immediate session — refresh and navigate.
       await refresh();
       nav(fromPath || "/parts", { replace: true });
     } catch (e) {
@@ -38,6 +48,35 @@ export default function Signup() {
     } finally {
       setBusy(false);
     }
+  }
+
+  // "Check your inbox" view shown after a 202 verification_sent response.
+  if (verificationSent) {
+    return (
+      <AuthShell title="Check your inbox">
+        <div className="space-y-4">
+          <p className="text-sm">
+            We've sent a verification link to <strong>{email}</strong>.
+            Click the link in the email to complete your account setup.
+          </p>
+          <p className="text-sm text-muted">
+            Didn't receive it? Check your spam folder, or{" "}
+            <button
+              type="button"
+              className="text-accent hover:underline"
+              onClick={() => setVerificationSent(false)}
+            >
+              try again
+            </button>
+            .
+          </p>
+          <p className="text-sm text-muted">
+            Already verified?{" "}
+            <Link to="/login" className="text-accent hover:underline">Sign in</Link>
+          </p>
+        </div>
+      </AuthShell>
+    );
   }
 
   return (

--- a/web/src/routes/auth/Verify.tsx
+++ b/web/src/routes/auth/Verify.tsx
@@ -1,0 +1,93 @@
+/**
+ * Email-verification landing page (SEC2-014).
+ *
+ * The user arrives here by clicking the link in their verification email:
+ *   /verify?id=<pending_id>&token=<plaintext_token>
+ *
+ * We POST to /auth/verify with the id + token.  On success the server
+ * issues a session cookie and we refresh the auth context, then navigate
+ * to the app.  On failure we show an error with a link back to signup.
+ */
+import { useEffect, useState } from "react";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
+import { api, ApiError } from "@/lib/api";
+import { useAuth } from "@/lib/auth";
+import AuthShell from "./AuthShell";
+
+type State = "verifying" | "success" | "error";
+
+export default function Verify() {
+  const [params] = useSearchParams();
+  const nav = useNavigate();
+  const { refresh } = useAuth();
+  const [state, setState] = useState<State>("verifying");
+  const [errMsg, setErrMsg] = useState<string | null>(null);
+
+  const id = params.get("id");
+  const token = params.get("token");
+
+  useEffect(() => {
+    if (!id || !token) {
+      setState("error");
+      setErrMsg("Invalid verification link — the id or token is missing.");
+      return;
+    }
+
+    let cancelled = false;
+
+    api
+      .post("/auth/verify", { id, token })
+      .then(async () => {
+        if (cancelled) return;
+        await refresh();
+        setState("success");
+        nav("/parts", { replace: true });
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        setState("error");
+        setErrMsg(
+          e instanceof ApiError
+            ? e.message
+            : "Verification failed — please try again.",
+        );
+      });
+
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id, token]);
+
+  if (state === "verifying") {
+    return (
+      <AuthShell title="Verifying your email…">
+        <p className="text-sm text-muted">Please wait…</p>
+      </AuthShell>
+    );
+  }
+
+  if (state === "error") {
+    return (
+      <AuthShell title="Verification failed">
+        <div className="space-y-4">
+          <div className="rounded-md border border-danger/40 bg-danger/10 px-3 py-2 text-danger text-sm">
+            {errMsg}
+          </div>
+          <p className="text-sm text-muted">
+            The link may have expired (links are valid for 24 hours).{" "}
+            <Link to="/signup" className="text-accent hover:underline">Sign up again</Link>
+            {" "}to receive a fresh link.
+          </p>
+        </div>
+      </AuthShell>
+    );
+  }
+
+  // success — navigation already triggered in useEffect
+  return (
+    <AuthShell title="Email verified!">
+      <p className="text-sm">Redirecting to your workspace…</p>
+    </AuthShell>
+  );
+}


### PR DESCRIPTION
Closes #73

## Summary
- **Per-account login lockout**: `user_login_failures` table tracks failed attempts per user/email-hash; after `LOCKOUT_MAX_FAILURES` (10) attempts in 15 min, the next login returns 429 with `retry_after_seconds`. Also rate-limits unknown-email credential stuffing via `email_hash`.
- **HIBP k-anonymity check**: `validate_password_strength` now queries `api.pwnedpasswords.com/range/{prefix}` before allowing signup. Fail-open on network error (documented in code with Sentry breadcrumb) — blocking all signups when HIBP is down is worse than the brief signal loss.
- **Email verification on signup**: New `pending_users` table + `POST /auth/verify` endpoint. Controlled by `SIGNUP_REQUIRE_EMAIL_VERIFICATION` (auto-True in prod via model_validator, False in dev/test for backward compatibility). New `core/mail.py` with stdout backend (dev) and SMTP backend (prod).
- **Migrations 0026/0027**: `user_login_failures` and `pending_users` tables.
- **Frontend**: Signup shows "check your inbox" view on 202, new `Verify.tsx` page at `/verify`, Login surfaces 429 lockout with retry-after hint.

## Hard invariants preserved
- Session cookie `secure` gated on `APP_ENV == "prod"` — unchanged
- API envelope `{data, status}` on all responses
- HIBP fail-open intentional and documented
- `pending_users` is NOT workspace-scoped (signup precedes any workspace) — documented in model docstring
- No changes to merged migrations

## Tests
- `test_auth_lockout.py`: lockout fires after threshold; correct password blocked; counter reset on success; unknown-email also locked
- `test_hibp.py`: breach suffix rejects; network error fail-open; zero-count suffix accepted
- `test_signup_verification.py`: 202 returned when enabled; no User/Workspace before verify; promote atomic; expired row rejected; duplicate pending handled; rate-limit preserved
- Full suite: **512 passed**, 1 skipped, 3 deselected (slow), 3 xfailed
- Frontend build: **passed**