### PR TITLE
fix(infra): fix psql doc snippets expand inside container (#43)

### DIFF
--- a/backend/tests/test_deploy_doc_snippets.py
+++ b/backend/tests/test_deploy_doc_snippets.py
@@ -1,0 +1,41 @@
+"""Regression test: psql snippets in docs/deployment.md must expand
+$POSTGRES_USER / $POSTGRES_DB inside the container, not the host shell.
+
+Any line in deployment.md that contains `psql -U "$POSTGRES_USER"` must be
+wrapped in a `sh -c '...'` invocation so the variable references are
+evaluated by the shell running inside the container, where those variables
+are actually set by the postgres image.
+"""
+
+import pathlib
+import re
+
+DOCS_ROOT = pathlib.Path(__file__).parents[2] / "docs"
+DEPLOYMENT_MD = DOCS_ROOT / "deployment.md"
+
+# Pattern that would be WRONG: psql -U "$POSTGRES_USER" NOT wrapped in sh -c
+# We detect lines that contain the bare, un-wrapped form.
+BARE_PSQL_RE = re.compile(r'psql\s+-U\s+"\$POSTGRES_USER"')
+SH_C_PSQL_RE = re.compile(r"""sh\s+-c\s+['"].*psql\s+-U\s+"\$POSTGRES_USER""")
+
+
+def test_psql_snippets_wrapped_in_sh_c() -> None:
+    """Every psql -U "$POSTGRES_USER" occurrence must be inside sh -c '...'."""
+    assert DEPLOYMENT_MD.exists(), f"{DEPLOYMENT_MD} not found"
+
+    lines = DEPLOYMENT_MD.read_text().splitlines()
+    violations: list[str] = []
+
+    for lineno, line in enumerate(lines, start=1):
+        if not BARE_PSQL_RE.search(line):
+            continue
+        # This line contains the pattern — verify it is part of a sh -c form.
+        if not SH_C_PSQL_RE.search(line):
+            violations.append(f"  line {lineno}: {line.strip()}")
+
+    assert not violations, (
+        "The following lines in docs/deployment.md use psql -U \"$POSTGRES_USER\" "
+        "outside of a sh -c wrapper. Variables expand on the host shell, not inside "
+        "the container.\n"
+        + "\n".join(violations)
+    )

--- a/deploy/db-restore.sh
+++ b/deploy/db-restore.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# Decrypt and restore a pg_dump backup into the running db container.
+#
+# Usage (run as root on the VPS):
+#   sudo /srv/stockmanager/deploy/db-restore.sh \
+#       /path/to/backup-key.txt \
+#       /srv/backups/stockmanager/db-YYYY-MM-DD.sql.gz.age
+#
+# This is DESTRUCTIVE: it pipes the SQL directly into psql which overwrites
+# the existing database. An explicit confirmation prompt guards against
+# accidental runs.
+#
+# Credentials are read from .env.prod so they expand inside the container,
+# not in the operator's host shell where $POSTGRES_USER / $POSTGRES_DB are
+# almost certainly unset (mirrors the pattern in deploy/backup.sh).
+
+set -euo pipefail
+
+REPO_DIR="/srv/stockmanager"
+COMPOSE_FILE="${REPO_DIR}/docker-compose.prod.yml"
+ENV_FILE="${REPO_DIR}/.env.prod"
+
+# ---- Argument validation ----
+if [[ $# -ne 2 ]]; then
+    echo "Usage: $0 <age-key-file> <backup-file.sql.gz.age>" >&2
+    exit 1
+fi
+
+KEY_FILE="$1"
+BACKUP_FILE="$2"
+
+if [[ ! -f "${KEY_FILE}" ]]; then
+    echo "ERROR: key file not found: ${KEY_FILE}" >&2
+    exit 1
+fi
+
+if [[ ! -f "${BACKUP_FILE}" ]]; then
+    echo "ERROR: backup file not found: ${BACKUP_FILE}" >&2
+    exit 1
+fi
+
+if [[ ! -f "${ENV_FILE}" ]]; then
+    echo "ERROR: ${ENV_FILE} not found" >&2
+    exit 1
+fi
+
+# ---- Confirmation prompt ----
+echo "WARNING: This will OVERWRITE the production database."
+echo "  Backup : ${BACKUP_FILE}"
+echo "  Target : db container in ${COMPOSE_FILE}"
+echo ""
+read -r -p "Type YES to continue: " CONFIRM
+if [[ "${CONFIRM}" != "YES" ]]; then
+    echo "Aborted." >&2
+    exit 1
+fi
+
+# ---- Restore ----
+echo "Restoring..."
+age -d -i "${KEY_FILE}" "${BACKUP_FILE}" \
+    | gunzip -c \
+    | sudo -u deploy \
+        docker compose -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" \
+        exec -T db sh -c 'exec psql -U "$POSTGRES_USER" "$POSTGRES_DB"'
+
+echo "Restore complete."

--- a/deploy/db-shell.sh
+++ b/deploy/db-shell.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Open an interactive psql session inside the running db container.
+#
+# Usage (run as root on the VPS):
+#   sudo /srv/stockmanager/deploy/db-shell.sh
+#
+# Credentials are read from .env.prod so they expand inside the container,
+# not in the operator's host shell where $POSTGRES_USER / $POSTGRES_DB are
+# almost certainly unset.
+
+set -euo pipefail
+
+REPO_DIR="/srv/stockmanager"
+COMPOSE_FILE="${REPO_DIR}/docker-compose.prod.yml"
+ENV_FILE="${REPO_DIR}/.env.prod"
+
+if [[ ! -f "${ENV_FILE}" ]]; then
+    echo "ERROR: ${ENV_FILE} not found" >&2
+    exit 1
+fi
+
+# Run as the deploy user (same as CI) to avoid stray root-owned volume files.
+exec sudo -u deploy \
+    docker compose -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" \
+    exec db sh -c 'exec psql -U "$POSTGRES_USER" "$POSTGRES_DB"'

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -352,10 +352,23 @@ sudo -u deploy docker compose -f docker-compose.prod.yml logs -f web
 
 ### psql shell
 
+The `$POSTGRES_USER` / `$POSTGRES_DB` variables must expand **inside the
+container**, not in your host shell (where they are almost certainly unset).
+Use `sh -c '...'` with single quotes so the shell that receives the command
+is the one inside the container, where those variables are already set by
+the postgres image:
+
 ```bash
 cd /srv/stockmanager
 sudo -u deploy docker compose -f docker-compose.prod.yml --env-file .env.prod \
-    exec db psql -U "$POSTGRES_USER" "$POSTGRES_DB"
+    exec db sh -c 'exec psql -U "$POSTGRES_USER" "$POSTGRES_DB"'
+```
+
+Or use the helper script (handles the single-quoting and `sudo -u deploy`
+for you):
+
+```bash
+sudo /srv/stockmanager/deploy/db-shell.sh
 ```
 
 ### Ad-hoc alembic command
@@ -443,6 +456,23 @@ Always use `docker compose -f docker-compose.prod.yml` explicitly on the VPS —
 the repo no longer has a bare `docker-compose.yml` default, so muscle-memory
 `docker compose up -d` without a `-f` flag will error rather than silently
 start the dev stack.
+
+### Wrapper scripts in deploy/
+
+Two helper scripts live in `deploy/` to make the common ops tasks
+less error-prone:
+
+| Script | Purpose |
+|--------|---------|
+| `deploy/db-shell.sh` | Open an interactive `psql` session inside the running `db` container. Reads credentials from `.env.prod` so they never expand in the host shell. |
+| `deploy/db-restore.sh` | Decrypt and restore a `pg_dump` backup. Prompts for confirmation before overwriting. |
+
+Both scripts are designed to be run as root from anywhere on the VPS:
+
+```bash
+sudo /srv/stockmanager/deploy/db-shell.sh
+sudo /srv/stockmanager/deploy/db-restore.sh /path/to/key.txt /path/to/db-YYYY-MM-DD.sql.gz.age
+```
 
 ### Apache vhost edits
 
@@ -632,13 +662,26 @@ All restore commands assume the private key file is available at
 
 Restore the DB (DESTRUCTIVE — overwrites the existing one):
 
+Use the helper script — it prompts for confirmation, reads credentials from
+`.env.prod` directly so the variables never expand in the host shell, and
+handles the `sudo -u deploy` and single-quoting correctly:
+
+```bash
+sudo /srv/stockmanager/deploy/db-restore.sh \
+    /path/to/backup-key.txt \
+    /srv/backups/stockmanager/db-2026-04-30.sql.gz.age
+```
+
+If you need the raw pipeline instead (e.g. piping from stdin), use `sh -c`
+so the variable references expand **inside** the container:
+
 ```bash
 age -d -i /path/to/backup-key.txt \
     /srv/backups/stockmanager/db-2026-04-30.sql.gz.age \
     | gunzip -c \
     | sudo -u deploy docker compose -f /srv/stockmanager/docker-compose.prod.yml \
         --env-file /srv/stockmanager/.env.prod exec -T db \
-        psql -U "$POSTGRES_USER" "$POSTGRES_DB"
+        sh -c 'exec psql -U "$POSTGRES_USER" "$POSTGRES_DB"'
 ```
 
 Restore the uploads volume (DESTRUCTIVE — replaces existing files):

--- a/web/node_modules
+++ b/web/node_modules
@@ -1,0 +1,1 @@
+/mnt/data/WORK/stockManager-1/web/node_modules

--- a/web/node_modules
+++ b/web/node_modules
@@ -1,1 +1,0 @@
-/mnt/data/WORK/stockManager-1/web/node_modules


### PR DESCRIPTION
Closes #43

## Summary
- Rewrite psql shell/restore snippets in `docs/deployment.md` to use `sh -c '...'` so `$POSTGRES_USER`/`$POSTGRES_DB` expand **inside the container** (where the postgres image sets them), not in the operator's host shell where they are typically unset
- Add `deploy/db-shell.sh`: thin wrapper that opens an interactive psql session, reads credentials from `.env.prod`, mirrors the pattern in `deploy/backup.sh`
- Add `deploy/db-restore.sh`: restore wrapper with an explicit confirmation prompt before overwriting the DB
- Add `backend/tests/test_deploy_doc_snippets.py` to assert every `psql -U "$POSTGRES_USER"` line in `docs/deployment.md` is wrapped in `sh -c '...'`

## Tests
Backend: 501 passed, 1 skipped — all green
Frontend: N/A (docs + deploy scripts only)