### PR TITLE
fix(infra): move sentry sourcemap token to CI secrets (#44)

### DIFF
--- a/backend/tests/test_ci_workflow.py
+++ b/backend/tests/test_ci_workflow.py
@@ -10,6 +10,10 @@ would let backend regressions ship to prod via the `main` push trigger).
 INFRA-004: also asserts that the backend-tests job uses `uv sync` (not
 bare `pip install -e`) and that a `uv lock --check` freshness step is
 present.
+
+Also covers INFRA-003 / issue #44: asserts that the Sentry auth token is
+never exposed as a Docker build arg and that sourcemap upload happens
+in CI only.
 """
 from __future__ import annotations
 
@@ -21,6 +25,8 @@ import yaml
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _CI_PATH = _REPO_ROOT / ".github" / "workflows" / "ci.yml"
 _UV_LOCK_PATH = _REPO_ROOT / "backend" / "uv.lock"
+_COMPOSE_PROD_PATH = _REPO_ROOT / "docker-compose.prod.yml"
+_DOCKERFILE_PROD_PATH = _REPO_ROOT / "web" / "Dockerfile.prod"
 
 
 def _load() -> dict:
@@ -99,4 +105,85 @@ def test_ci_has_uv_lock_check_step():
     assert any("uv lock --check" in r for r in runs), (
         "no `uv lock --check` step found in backend-tests job; "
         "add it so CI fails when uv.lock is stale"
+    )
+
+
+# ---------------------------------------------------------------------------
+# INFRA-003 / issue #44: Sentry auth token must never enter the Docker build
+# ---------------------------------------------------------------------------
+
+
+def test_compose_prod_web_build_args_no_sentry_token():
+    """docker-compose.prod.yml must NOT pass SENTRY_AUTH_TOKEN as a build arg.
+
+    The token must only live in GitHub Actions secrets so it never enters
+    the Docker layer cache (INFRA2-010).
+    """
+    assert _COMPOSE_PROD_PATH.exists(), (
+        f"missing compose file at {_COMPOSE_PROD_PATH}"
+    )
+    data = yaml.safe_load(_COMPOSE_PROD_PATH.read_text())
+    web_build = data["services"]["web"]["build"]
+    args = web_build.get("args", {})
+    # args may be a dict or a list of "KEY=value" strings; normalise to names.
+    if isinstance(args, list):
+        arg_names = {a.split("=")[0] for a in args}
+    else:
+        arg_names = set(args.keys())
+    sensitive = {"SENTRY_AUTH_TOKEN", "SENTRY_ORG", "SENTRY_PROJECT"}
+    leaked = sensitive & arg_names
+    assert not leaked, (
+        f"docker-compose.prod.yml web build.args contains sensitive Sentry "
+        f"vars that must live only in GitHub Actions secrets: {leaked}"
+    )
+
+
+def test_dockerfile_prod_no_sentry_token_arg():
+    """web/Dockerfile.prod must NOT declare ARG SENTRY_AUTH_TOKEN.
+
+    Declaring the ARG (even without a default) would allow the token to be
+    passed in via `docker build --build-arg` and baked into a layer.
+    """
+    assert _DOCKERFILE_PROD_PATH.exists(), (
+        f"missing Dockerfile at {_DOCKERFILE_PROD_PATH}"
+    )
+    content = _DOCKERFILE_PROD_PATH.read_text()
+    for line in content.splitlines():
+        stripped = line.strip()
+        # Allow commented-out lines (e.g. documentation notes about why it
+        # was removed) but reject any live ARG declaration.
+        if stripped.startswith("#"):
+            continue
+        assert "ARG SENTRY_AUTH_TOKEN" not in stripped, (
+            "web/Dockerfile.prod has a live `ARG SENTRY_AUTH_TOKEN` line; "
+            "the token must not enter the Docker build context (INFRA2-010)"
+        )
+
+
+def test_ci_web_build_has_sourcemap_upload_step():
+    """The web-build CI job must contain a sourcemap-upload step for Sentry.
+
+    The step must be gated on push-to-main and must use the auth token from
+    GitHub Actions secrets, not from build args.
+    """
+    data = _load()
+    web_build_steps = data["jobs"]["web-build"]["steps"]
+    upload_steps = [
+        s for s in web_build_steps
+        if "sourcemap" in s.get("name", "").lower()
+        or "sentry" in s.get("name", "").lower()
+    ]
+    assert upload_steps, (
+        "web-build job has no sourcemap/sentry upload step; "
+        "add one gated on push to main (INFRA2-010)"
+    )
+    # At least one upload step must be gated on push to main.
+    main_gated = [
+        s for s in upload_steps
+        if "refs/heads/main" in s.get("if", "")
+    ]
+    assert main_gated, (
+        "sourcemap upload step is not gated on `refs/heads/main`; "
+        "PRs must not upload sourcemaps (they'd pin maps to a SHA that "
+        "never ships)"
     )

--- a/deploy/.env.prod.example
+++ b/deploy/.env.prod.example
@@ -102,3 +102,13 @@ SENTRY_TRACES_SAMPLE_RATE=0.0
 # initialised, same trade-off as the backend.
 VITE_SENTRY_DSN=
 VITE_SENTRY_TRACES_SAMPLE_RATE=0.0
+
+# ---- Sentry source-map upload (INFRA2-010) ----
+# SENTRY_AUTH_TOKEN, SENTRY_ORG, and SENTRY_PROJECT must NOT go here.
+# Source-map upload runs in the CI web-build job (push to main only) using
+# GitHub Actions secrets, so the auth token never enters the Docker build
+# context or layer cache.  Add/rotate these values in the GitHub repository
+# Settings → Secrets and variables → Actions:
+#   SENTRY_AUTH_TOKEN  — project auth token (Settings → Auth Tokens in Sentry)
+#   SENTRY_ORG         — Sentry organisation slug
+#   SENTRY_PROJECT     — Sentry project slug


### PR DESCRIPTION
Closes #44

## Summary
- `docker-compose.prod.yml` and `web/Dockerfile.prod` already had `SENTRY_AUTH_TOKEN`/`SENTRY_ORG`/`SENTRY_PROJECT` removed (INFRA2-010). This PR adds the missing companion pieces to complete the fix.
- `deploy/.env.prod.example`: explicit note that Sentry auth vars belong in GitHub Actions secrets, not `.env.prod`, with instructions on where to add them
- `backend/tests/test_ci_workflow.py`: three new INFRA-003 assertions that enforce the constraint in CI going forward:
  - `test_compose_prod_web_build_args_no_sentry_token` — docker-compose.prod.yml web build.args must not contain SENTRY_AUTH_TOKEN/ORG/PROJECT
  - `test_dockerfile_prod_no_sentry_token_arg` — web/Dockerfile.prod must not have a live `ARG SENTRY_AUTH_TOKEN` line
  - `test_ci_web_build_has_sourcemap_upload_step` — ci.yml web-build job must have a sourcemap upload step gated on push-to-main

## Tests
- Backend: 502 passed, 1 pre-existing failure (test_workspace_isolation — unrelated), 1 skipped
- Frontend build: passed (hidden sourcemaps emitted, tsc clean)
- New INFRA-003 tests: 3/3 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)