### PR TITLE
fix(core): add raise_http() wrapper, migrate PR1 routes (#125)

### DIFF
--- a/backend/app/api/_helpers.py
+++ b/backend/app/api/_helpers.py
@@ -4,7 +4,7 @@ from functools import lru_cache
 from typing import TypeVar
 from uuid import UUID
 
-from fastapi import HTTPException, status
+from fastapi import status
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
@@ -127,9 +127,11 @@ def assert_child_in_parent(
         )
     ).scalar_one_or_none()
     if row is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"{label} not found",
+        raise_http(
+            status.HTTP_404_NOT_FOUND,
+            ErrorCodes.RESOURCE_NOT_FOUND,
+            f"{label} not found",
+            resource=label,
         )
     return row
 


### PR DESCRIPTION
Closes #125

## Summary
- `backend/app/core/errors.py` — `raise_http(status, code, message=None, **fields)` always builds `detail={"code": ..., "message": ..., **fields}`; `ErrorCodes` class holds all stable machine-readable string constants for PR1 scope (auth, workspaces, invitations, sentry_tunnel, deps, helpers)
- Migrated PR1 callsites: `auth.py`, `workspaces.py`, `invitations.py`, `sentry_tunnel.py`, `core/deps.py`, `api/_helpers.py` — all `raise HTTPException(detail="string")` replaced with `raise_http(...)`
- Fixed last raw `raise HTTPException` in `_helpers.assert_child_in_parent` (missed in initial pass)
- All cross-workspace responses stay 404; MPN 409 keeps `existing_id`+`existing_name`; API envelope `{data, status}` unchanged
- `tests/test_error_envelope.py` pins the contract for auth/workspace/invitation error shapes

## Tests
Backend: 28/28 passed (test_error_envelope, test_invitations, test_workspaces)
Full suite: 508 passed, 2 flaky pre-existing failures (pass when run alone), 1 pre-existing migration CONCURRENTLY error on fresh DB setup

## Frontend
N/A — no frontend changes; `code` field is additive to existing error shape