### PR TITLE
fix(infra): add dead-man's switch pings to backup script (#47)

### DIFF
--- a/backend/tests/test_backup_script.py
+++ b/backend/tests/test_backup_script.py
@@ -1,0 +1,61 @@
+"""Assert deploy/backup.sh and deploy/.env.prod.example contain the
+dead-man's-switch env vars introduced in INFRA-006 (issue #47).
+
+These are static-file checks — no database required.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_BACKUP_SH = _REPO_ROOT / "deploy" / "backup.sh"
+_ENV_EXAMPLE = _REPO_ROOT / "deploy" / ".env.prod.example"
+
+
+def _read(path: Path) -> str:
+    assert path.exists(), f"missing file: {path}"
+    return path.read_text()
+
+
+def test_backup_sh_declares_ok_url_var():
+    assert "BACKUP_HEALTHCHECK_OK_URL" in _read(_BACKUP_SH), (
+        "deploy/backup.sh must declare BACKUP_HEALTHCHECK_OK_URL"
+    )
+
+
+def test_backup_sh_declares_fail_url_var():
+    assert "BACKUP_HEALTHCHECK_FAIL_URL" in _read(_BACKUP_SH), (
+        "deploy/backup.sh must declare BACKUP_HEALTHCHECK_FAIL_URL"
+    )
+
+
+def test_backup_sh_has_trap_err():
+    content = _read(_BACKUP_SH)
+    assert "trap" in content and "ERR" in content, (
+        "deploy/backup.sh must contain 'trap ... ERR' for failure alerting"
+    )
+
+
+def test_backup_sh_pings_ok_url_on_success():
+    content = _read(_BACKUP_SH)
+    # The success ping must reference the OK URL variable after the last echo.
+    assert "BACKUP_HEALTHCHECK_OK_URL" in content, (
+        "deploy/backup.sh must ping BACKUP_HEALTHCHECK_OK_URL on success"
+    )
+    # curl must be used to perform the ping.
+    assert "curl" in content, (
+        "deploy/backup.sh must use curl to send healthcheck pings"
+    )
+
+
+def test_env_example_documents_ok_url():
+    assert "BACKUP_HEALTHCHECK_OK_URL" in _read(_ENV_EXAMPLE), (
+        "deploy/.env.prod.example must document BACKUP_HEALTHCHECK_OK_URL"
+    )
+
+
+def test_env_example_documents_fail_url():
+    assert "BACKUP_HEALTHCHECK_FAIL_URL" in _read(_ENV_EXAMPLE), (
+        "deploy/.env.prod.example must document BACKUP_HEALTHCHECK_FAIL_URL"
+    )

--- a/deploy/.env.prod.example
+++ b/deploy/.env.prod.example
@@ -76,6 +76,21 @@ WORKSPACE_SECRETS_KEY=
 #   5. To restore from an encrypted backup, see docs/deployment.md#backups.
 BACKUP_AGE_RECIPIENT=age1...
 
+# Dead-man's-switch alerting for the nightly backup (optional).
+#
+# When set, deploy/backup.sh pings these URLs via curl:
+#   OK_URL  — called at the very end of a successful run.
+#   FAIL_URL — called immediately when any command exits non-zero (trap ERR).
+#
+# Recommended service: https://healthchecks.io (free tier covers this use-case).
+# Create one check, then copy the ping URL into OK_URL. Enable the /fail
+# endpoint on the same check and copy that URL into FAIL_URL. This gives
+# both "went silent" (missed ping) and "explicit failure" alerting.
+#
+# Leave both empty to rely solely on cron mail (the behaviour before INFRA-006).
+BACKUP_HEALTHCHECK_OK_URL=
+BACKUP_HEALTHCHECK_FAIL_URL=
+
 # ---- Sentry (optional) ----
 # Leave both empty to disable error tracking entirely (no SDK init, no
 # events, no network egress). Populate the DSN once a Sentry project

--- a/deploy/backup.sh
+++ b/deploy/backup.sh
@@ -14,6 +14,13 @@
 # Errors are surfaced via the cron log + the script's non-zero exit code.
 # The cron daemon emails root on failure if MTA is configured.
 #
+# Dead-man's-switch alerting (optional, but strongly recommended):
+#   Set BACKUP_HEALTHCHECK_OK_URL and BACKUP_HEALTHCHECK_FAIL_URL in .env.prod
+#   to ping a monitoring service (e.g. healthchecks.io) on success/failure.
+#   If only OK_URL is set the service alerts you when pings stop arriving.
+#   If FAIL_URL is also set the service alerts immediately on each failure.
+#   Leave both empty to rely solely on cron mail (the previous behaviour).
+#
 # Prerequisites:
 #   - age must be installed on the VPS (https://github.com/FiloSottile/age)
 #     Install: https://github.com/FiloSottile/age/releases — pick the static
@@ -22,6 +29,20 @@
 #   - The corresponding age private key must be escrowed off-VPS
 
 set -euo pipefail
+
+# ---- Dead-man's-switch URLs (optional) ----
+# Read from .env.prod if present; fall back to empty (no-op).
+BACKUP_HEALTHCHECK_OK_URL="${BACKUP_HEALTHCHECK_OK_URL:-}"
+BACKUP_HEALTHCHECK_FAIL_URL="${BACKUP_HEALTHCHECK_FAIL_URL:-}"
+
+on_failure() {
+    local rc=$?
+    if [ -n "$BACKUP_HEALTHCHECK_FAIL_URL" ]; then
+        curl -fsS --max-time 10 "$BACKUP_HEALTHCHECK_FAIL_URL" >/dev/null 2>&1 || true
+    fi
+    exit $rc
+}
+trap on_failure ERR
 
 REPO_DIR="/srv/stockmanager"
 BACKUP_DIR="/srv/backups/stockmanager"
@@ -128,3 +149,8 @@ find "${BACKUP_DIR}" -maxdepth 1 -type f -name 'db-*.sql.gz.age' -mtime "+${RETA
 find "${BACKUP_DIR}" -maxdepth 1 -type f -name 'uploads-*.tar.gz.age' -mtime "+${RETAIN_DAYS}" -delete
 
 echo "$(date -Iseconds)  backup OK"
+
+# ---- Dead-man's-switch: ping success URL ----
+if [ -n "$BACKUP_HEALTHCHECK_OK_URL" ]; then
+    curl -fsS --max-time 10 "$BACKUP_HEALTHCHECK_OK_URL" >/dev/null || echo "warning: backup OK ping failed"
+fi

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -578,6 +578,29 @@ Each artifact is `age`-encrypted with the recipient public key stored in
 idempotent and fail-loud — non-zero exit → cron emails root if MTA is
 configured.
 
+### Dead-man's-switch alerting (INFRA-006)
+
+Cron mail is unreliable because it requires a working MTA and is often
+silently lost. `backup.sh` now supports explicit ping-on-success /
+ping-on-failure via two optional env vars in `.env.prod`:
+
+| Variable | Purpose |
+|---|---|
+| `BACKUP_HEALTHCHECK_OK_URL` | Pinged at the end of a successful run |
+| `BACKUP_HEALTHCHECK_FAIL_URL` | Pinged immediately via `trap ERR` on any non-zero exit |
+
+Recommended service: [healthchecks.io](https://healthchecks.io) (free tier is
+sufficient). Create one check, copy its ping URL into `BACKUP_HEALTHCHECK_OK_URL`,
+and copy the `/fail` endpoint URL into `BACKUP_HEALTHCHECK_FAIL_URL`. This gives
+two alert modes:
+
+- **Missed-ping alert** — the check goes "Late" if the backup didn't run at all
+  (cron failed, host was down, etc.).
+- **Explicit failure alert** — immediate notification when the script itself errors.
+
+Both vars default to empty; leaving them unset preserves the previous cron-mail-only
+behaviour.
+
 ### Recipient key + private-key escrow
 
 **Operator action required before first backup run:**


### PR DESCRIPTION
Closes #47

## Summary
- Add `BACKUP_HEALTHCHECK_OK_URL` / `BACKUP_HEALTHCHECK_FAIL_URL` env vars to `deploy/backup.sh`; both default to empty (no-op), preserving the previous cron-mail-only behaviour
- Ping the FAIL URL immediately via `trap on_failure ERR` on any non-zero exit; ping the OK URL at the very end of a successful run
- Document both vars in `deploy/.env.prod.example` with healthchecks.io as a recommended service
- Add a "Dead-man's-switch alerting (INFRA-006)" sub-section to the Backups chapter in `docs/deployment.md`
- Add `backend/tests/test_backup_script.py` (6 static-file assertions) to pin the new contract

## Tests
Backend: 514 passed, 6 new tests pass; 2 pre-existing failures + 1 error on `origin/main` are unrelated to this change (workspace_isolation / workspace_scanner).
Frontend: N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)