### PR TITLE
fix(projects): reject zero/negative BOM entry quantities (#36)

### DIFF
--- a/backend/app/domain/projects/bom_import.py
+++ b/backend/app/domain/projects/bom_import.py
@@ -145,9 +145,15 @@ def _parse_quantity(s: str) -> float:
     if not s:
         return 1.0
     try:
-        return float(s)
+        v = float(s)
     except ValueError:
         return 1.0
+    # Defensive clamp: zero/negative quantities are invalid in a BOM row.
+    # Return 1.0 as a safe default so the import continues rather than
+    # aborting the whole batch over a single bad cell.
+    if v <= 0:
+        return 1.0
+    return v
 
 
 def _parse_dnp(s: str) -> bool:

--- a/backend/app/domain/projects/schemas.py
+++ b/backend/app/domain/projects/schemas.py
@@ -42,7 +42,7 @@ class BomEntryIn(BaseModel):
     part_id: UUID | None = None
     meta_part_id: UUID | None = None
     name: str | None = None
-    quantity: float = 1
+    quantity: float = Field(default=1, gt=0)
     comments: str | None = None
     designators: list[str] = []
     cad_footprint: str | None = None
@@ -57,7 +57,7 @@ class BomEntryPatch(BaseModel):
     part_id: UUID | None = None
     meta_part_id: UUID | None = None
     name: str | None = None
-    quantity: float | None = None
+    quantity: float | None = Field(default=None, gt=0)
     comments: str | None = None
     designators: list[str] | None = None
     cad_footprint: str | None = None

--- a/backend/tests/test_builds.py
+++ b/backend/tests/test_builds.py
@@ -295,3 +295,77 @@ def test_non_substitute_rejected(authed):
     )
     assert r.status_code == 400
     assert "not a substitute" in r.json()["status"]["message"]
+
+
+# BE-007: BOM entry quantity validation tests --------------------------------
+
+
+def test_bom_entry_rejects_zero_quantity(authed):
+    c = authed
+    r = c.post("/api/projects", json={"name": "QV-Zero"})
+    pid = r.json()["data"]["id"]
+    part_id = _create_part(c, "R1k-QV")
+
+    r = c.post(f"/api/projects/{pid}/entries", json={"part_id": part_id, "quantity": 0})
+    assert r.status_code == 422
+    assert r.json()["status"]["category"] == "validation_error"
+
+
+def test_bom_entry_rejects_negative_quantity(authed):
+    c = authed
+    r = c.post("/api/projects", json={"name": "QV-Neg"})
+    pid = r.json()["data"]["id"]
+    part_id = _create_part(c, "R1k-QVN")
+
+    r = c.post(f"/api/projects/{pid}/entries", json={"part_id": part_id, "quantity": -3})
+    assert r.status_code == 422
+    assert r.json()["status"]["category"] == "validation_error"
+
+
+def test_bom_entry_accepts_fractional_quantity(authed):
+    c = authed
+    r = c.post("/api/projects", json={"name": "QV-Frac"})
+    pid = r.json()["data"]["id"]
+    part_id = _create_part(c, "R1k-QVF")
+
+    r = c.post(f"/api/projects/{pid}/entries", json={"part_id": part_id, "quantity": 0.5})
+    assert r.status_code in (200, 201)
+
+
+def test_bom_entry_patch_rejects_zero_quantity(authed):
+    c = authed
+    proj_id = _create_project_with_bom(
+        c, "QV-PatchZero",
+        [{"part_id": _create_part(c, "R1k-PZ"), "quantity": 1}],
+    )
+    entry_id = c.get(f"/api/projects/{proj_id}/entries").json()["data"][0]["id"]
+
+    r = c.patch(f"/api/projects/{proj_id}/entries/{entry_id}", json={"quantity": 0})
+    assert r.status_code == 422
+    assert r.json()["status"]["category"] == "validation_error"
+
+
+def test_bom_entry_patch_rejects_negative_quantity(authed):
+    c = authed
+    proj_id = _create_project_with_bom(
+        c, "QV-PatchNeg",
+        [{"part_id": _create_part(c, "R1k-PN"), "quantity": 1}],
+    )
+    entry_id = c.get(f"/api/projects/{proj_id}/entries").json()["data"][0]["id"]
+
+    r = c.patch(f"/api/projects/{proj_id}/entries/{entry_id}", json={"quantity": -1})
+    assert r.status_code == 422
+    assert r.json()["status"]["category"] == "validation_error"
+
+
+def test_bom_entry_patch_omitting_quantity_still_works(authed):
+    c = authed
+    proj_id = _create_project_with_bom(
+        c, "QV-PatchOmit",
+        [{"part_id": _create_part(c, "R1k-PO"), "quantity": 5}],
+    )
+    entry_id = c.get(f"/api/projects/{proj_id}/entries").json()["data"][0]["id"]
+
+    # Patch only the comments field — quantity omitted → should succeed
+    r = c.patch(f"/api/projects/{proj_id}/entries/{entry_id}", json={"comments": "updated"})
+    assert r.status_code == 200


### PR DESCRIPTION
Closes #36

## Summary
- Add `Field(gt=0)` to `BomEntryIn.quantity` (preserves default=1) and `BomEntryPatch.quantity` in `backend/app/domain/projects/schemas.py`
- Defensive clamp in `bom_import.py::_parse_quantity` — returns 1.0 for zero/negative CSV values rather than aborting the whole batch
- Fix `conftest.py::_alembic_upgrade_head` to use `"heads"` (plural) to handle the existing two-head migration chain (0025 + 0029 both descend from 0023)
- 6 new tests covering zero/negative/fractional/patch/omit cases

## Tests
Backend: 543 passed, 1 skipped, 3 xfailed
Frontend: N/A