### PR TITLE
fix(stock): enforce storage constraints via current stock (#35)

### DIFF
--- a/backend/app/api/routes/stock.py
+++ b/backend/app/api/routes/stock.py
@@ -11,6 +11,7 @@ from app.domain.stock.schemas import (
     RemoveStockIn,
 )
 from app.domain.stock.service import (
+    StockConflictError,
     StockError,
     add_stock,
     adjust_stock,
@@ -50,6 +51,15 @@ def add(
 ) -> Envelope[dict]:
     try:
         e = add_stock(db, workspace_id=ws.id, user_id=user.id, payload=payload)
+    except StockConflictError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "message": str(exc),
+                "constraint": exc.constraint,
+                "storage_location_id": str(exc.storage_location_id),
+            },
+        )
     except StockError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
     return ok(_serialize_entry(e))
@@ -70,6 +80,15 @@ def remove(
 def move(payload: MoveStockIn, db: DbSession, ws: CurrentWorkspace, user: CurrentUser):
     try:
         out_e, in_e = move_stock(db, workspace_id=ws.id, user_id=user.id, payload=payload)
+    except StockConflictError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "message": str(exc),
+                "constraint": exc.constraint,
+                "storage_location_id": str(exc.storage_location_id),
+            },
+        )
     except StockError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
     return ok({"out": _serialize_entry(out_e), "in": _serialize_entry(in_e)})

--- a/backend/app/domain/stock/service.py
+++ b/backend/app/domain/stock/service.py
@@ -104,6 +104,41 @@ def lock_parts_for_stock_write(
         _lock_for_stock_write(db, workspace_id=workspace_id, part_id=pid)
 
 
+def _lock_for_storage_constraint(
+    db: Session, *, workspace_id: UUID, storage_location_id: UUID
+) -> None:
+    """Per-(workspace, storage) advisory lock for storage-constraint reads.
+
+    The per-(workspace, part) lock from ``_lock_for_stock_write`` only
+    serialises writers that touch the *same* part. ``single_part_only``
+    and ``existing_parts_only`` are cross-part invariants on the
+    *destination location*: two concurrent ``add_stock`` / ``move_stock``
+    calls for **different parts** targeting the same single_part_only
+    bin each hold a different per-part lock, both read
+    ``stock_for_storage(loc) == []``, both pass the check, and both
+    insert their StockEntry — leaving the bin holding two parts.
+
+    This second lock closes the cross-part race by serialising every
+    write whose destination is the same location. There is no DB-level
+    CHECK or trigger backing single_part_only / existing_parts_only
+    (the 0013 trigger only enforces non-negative balances), so the
+    application-level lock is the only line of defence.
+
+    **Lock ordering**: callers always acquire the per-part lock first
+    (``_lock_for_stock_write``) and the per-storage lock second. Two
+    concurrent writers targeting the same destination thus contend on
+    the storage lock without circular waits — there is no path that
+    holds the storage lock while waiting for a per-part lock. (The
+    multi-part helpers — ``builds.consume``, ``orders.receive`` — do
+    not pass a destination through ``_enforce_storage_constraints``,
+    so they don't take a storage lock.)
+    """
+    db.execute(
+        text("SELECT pg_advisory_xact_lock(hashtextextended(:k, 0))"),
+        {"k": f"{workspace_id}:storage:{storage_location_id}"},
+    )
+
+
 def current_quantity(
     db: Session,
     *,
@@ -304,11 +339,26 @@ def _enforce_storage_constraints(
     """Enforce single_part_only and existing_parts_only constraints using
     current stock (positive on-hand balances), not historical row counts.
 
-    Must be called inside the advisory lock for (workspace_id, part_id) so
-    the read-check-write sequence is serialised.
+    Must be called inside the advisory lock for (workspace_id, part_id) —
+    every caller acquires that via ``_lock_for_stock_write`` first. We
+    additionally acquire the per-(workspace, storage) lock here so that
+    two concurrent writers targeting the *same destination* with
+    *different parts* can't both pass the single_part_only /
+    existing_parts_only check on a stale read and then both insert
+    (cross-part race). The per-part lock alone only serialises same-part
+    writers; the storage lock closes the cross-part hole. Lock ordering
+    is fixed (part, then storage) to avoid AB/BA deadlocks with
+    ``_lock_for_stock_write``.
+
+    Scope: ``add_stock`` and ``move_stock`` (the storage-constrained
+    paths). ``adjust_stock`` / ``remove_stock`` don't enter constrained
+    locations from outside, and the multi-part helpers don't pass a
+    destination through this function.
 
     Raises StockConflictError on violation.
     """
+    _lock_for_storage_constraint(db, workspace_id=workspace_id, storage_location_id=storage.id)
+
     if storage.single_part_only:
         # Any part other than the one being added/moved-in currently has
         # positive on-hand stock at this location?

--- a/backend/app/domain/stock/service.py
+++ b/backend/app/domain/stock/service.py
@@ -27,6 +27,20 @@ class StockError(Exception):
     pass
 
 
+class StockConflictError(StockError):
+    """Raised when a storage-location constraint blocks a stock mutation.
+
+    Attributes:
+        constraint: "single_part_only" | "existing_parts_only"
+        storage_location_id: the UUID of the conflicting location
+    """
+
+    def __init__(self, message: str, *, constraint: str, storage_location_id: UUID) -> None:
+        super().__init__(message)
+        self.constraint = constraint
+        self.storage_location_id = storage_location_id
+
+
 def _now() -> datetime:
     return datetime.now(timezone.utc)
 
@@ -280,6 +294,52 @@ def stock_for_storage(
     ]
 
 
+def _enforce_storage_constraints(
+    db: Session,
+    *,
+    workspace_id: UUID,
+    storage: StorageLocation,
+    part_id: UUID,
+) -> None:
+    """Enforce single_part_only and existing_parts_only constraints using
+    current stock (positive on-hand balances), not historical row counts.
+
+    Must be called inside the advisory lock for (workspace_id, part_id) so
+    the read-check-write sequence is serialised.
+
+    Raises StockConflictError on violation.
+    """
+    if storage.single_part_only:
+        # Any part other than the one being added/moved-in currently has
+        # positive on-hand stock at this location?
+        current = stock_for_storage(db, workspace_id=workspace_id, storage_location_id=storage.id)
+        other_parts = {row["part_id"] for row in current if row["part_id"] != part_id}
+        if other_parts:
+            raise StockConflictError(
+                "destination is single-part-only and already holds a different part",
+                constraint="single_part_only",
+                storage_location_id=storage.id,
+            )
+
+    if storage.existing_parts_only:
+        # The part must have at least one prior positive stock-entry at this
+        # location (i.e. it was previously stocked here).
+        prior = db.execute(
+            select(func.count())
+            .select_from(StockEntry)
+            .where(StockEntry.workspace_id == workspace_id)
+            .where(StockEntry.storage_location_id == storage.id)
+            .where(StockEntry.part_id == part_id)
+            .where(StockEntry.quantity_delta > 0)
+        ).scalar_one()
+        if not prior:
+            raise StockConflictError(
+                "destination only accepts previously-stocked parts and this part has no prior stock here",
+                constraint="existing_parts_only",
+                storage_location_id=storage.id,
+            )
+
+
 def add_stock(
     db: Session,
     *,
@@ -305,6 +365,7 @@ def add_stock(
             raise StockError("storage location is archived")
         if storage.is_full:
             raise StockError("storage location is marked full")
+        _enforce_storage_constraints(db, workspace_id=workspace_id, storage=storage, part_id=payload.part_id)
 
     # Mandatory default-storage check (spec §19.2). Previously the chain
     # short-circuited when `storage` was None — any row that simply omitted
@@ -477,17 +538,7 @@ def move_stock(
     if payload.quantity > available:
         raise StockError(f"insufficient stock at source (have {available}, want {payload.quantity})")
 
-    if dest.single_part_only:
-        # any other part already in this location?
-        any_other = db.execute(
-            select(func.count())
-            .select_from(StockEntry)
-            .where(StockEntry.workspace_id == workspace_id)
-            .where(StockEntry.storage_location_id == dest.id)
-            .where(StockEntry.part_id != part.id)
-        ).scalar_one()
-        if any_other:
-            raise StockError("destination is single-part-only and holds another part")
+    _enforce_storage_constraints(db, workspace_id=workspace_id, storage=dest, part_id=part.id)
 
     # Pre-assign UUIDs so the two StockEntry rows can reference each
     # other via `related_entry_id`. The actual write strategy is a

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -73,7 +73,7 @@ def _alembic_upgrade_head(database_url: str) -> None:
     cfg = AlembicConfig(str(_BACKEND_ROOT / "alembic.ini"))
     cfg.set_main_option("script_location", str(_BACKEND_ROOT / "alembic"))
     cfg.set_main_option("sqlalchemy.url", database_url)
-    command.upgrade(cfg, "head")
+    command.upgrade(cfg, "heads")
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/backend/tests/test_storage_constraints.py
+++ b/backend/tests/test_storage_constraints.py
@@ -1,0 +1,349 @@
+"""Storage constraint enforcement — BE-004.
+
+Tests that `single_part_only` and `existing_parts_only` flags on
+StorageLocation are enforced via current positive on-hand stock
+(through stock_for_storage), not by historical row counts.
+
+Regression cases (marked "regression") verify the old broken
+behaviour is gone: the old code counted any historical StockEntry
+with a different part_id, so a location that once held part A but is
+now empty would still reject part B. The new code only looks at
+current positive balances.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _signup(c: TestClient) -> None:
+    r = c.post(
+        "/api/auth/signup",
+        json={
+            "email": f"u-{uuid.uuid4().hex[:8]}@example.com",
+            "name": "tester",
+            "password": "TestPass-2026-Stronk",
+        },
+    )
+    assert r.status_code == 200, r.text
+
+
+@pytest.fixture
+def c():
+    client = TestClient(app)
+    _signup(client)
+    return client
+
+
+def _part(c: TestClient, name: str = "P") -> str:
+    r = c.post("/api/parts", json={"name": name, "part_type": "local"})
+    assert r.status_code in (200, 201), r.text
+    return r.json()["data"]["id"]
+
+
+def _storage(c: TestClient, name: str = "Bin", **flags) -> str:
+    body = {"name": name}
+    body.update(flags)
+    r = c.post("/api/storage", json=body)
+    assert r.status_code in (200, 201), r.text
+    return r.json()["data"]["id"]
+
+
+def _add(c: TestClient, part_id: str, qty: int, storage_id: str) -> None:
+    r = c.post(
+        "/api/stock/add",
+        json={"part_id": part_id, "quantity": qty, "storage_location_id": storage_id},
+    )
+    assert r.status_code == 200, r.text
+
+
+def _remove(c: TestClient, part_id: str, qty: int, storage_id: str) -> None:
+    r = c.post(
+        "/api/stock/remove",
+        json={"part_id": part_id, "quantity": qty, "storage_location_id": storage_id},
+    )
+    assert r.status_code == 200, r.text
+
+
+def _move(c: TestClient, part_id: str, qty: int, src: str, dst: str) -> dict:
+    r = c.post(
+        "/api/stock/move",
+        json={
+            "part_id": part_id,
+            "quantity": qty,
+            "source_storage_location_id": src,
+            "destination_storage_location_id": dst,
+        },
+    )
+    return r
+
+
+# ---------------------------------------------------------------------------
+# single_part_only — add_stock
+# ---------------------------------------------------------------------------
+
+
+def test_single_part_only_rejects_different_part_add(c):
+    """single_part_only: add part B when part A has positive stock → 409."""
+    loc = _storage(c, "SPO", single_part_only=True)
+    part_a = _part(c, "A")
+    part_b = _part(c, "B")
+
+    # Stock part A into the location first.
+    _add(c, part_a, 5, loc)
+
+    # Now try to add part B — should be rejected.
+    r = c.post(
+        "/api/stock/add",
+        json={"part_id": part_b, "quantity": 1, "storage_location_id": loc},
+    )
+    assert r.status_code == 409, r.text
+    detail = r.json()
+    assert detail.get("constraint") == "single_part_only"
+    assert detail.get("storage_location_id") == loc
+
+
+def test_single_part_only_allows_same_part_add(c):
+    """single_part_only: re-adding the same part that already occupies the location is fine."""
+    loc = _storage(c, "SPO-same", single_part_only=True)
+    part_a = _part(c, "A2")
+
+    _add(c, part_a, 3, loc)
+
+    r = c.post(
+        "/api/stock/add",
+        json={"part_id": part_a, "quantity": 2, "storage_location_id": loc},
+    )
+    assert r.status_code == 200, r.text
+
+
+def test_single_part_only_allows_add_after_stock_emptied_regression(c):
+    """Regression (old code rejected this): single_part_only should allow
+    part B once all part A stock has been removed (location is now empty).
+
+    Old code counted any historical StockEntry with part_id != part_b, so
+    it always rejected. New code checks current positive balances only.
+    """
+    loc = _storage(c, "SPO-empty", single_part_only=True)
+    part_a = _part(c, "A3")
+    part_b = _part(c, "B3")
+
+    # Add and then fully remove part A.
+    _add(c, part_a, 4, loc)
+    _remove(c, part_a, 4, loc)
+
+    # Location is now empty — part B should be accepted.
+    r = c.post(
+        "/api/stock/add",
+        json={"part_id": part_b, "quantity": 1, "storage_location_id": loc},
+    )
+    assert r.status_code == 200, r.text
+
+
+# ---------------------------------------------------------------------------
+# single_part_only — move_stock
+# ---------------------------------------------------------------------------
+
+
+def test_single_part_only_rejects_move_of_different_part(c):
+    """single_part_only: moving part B into a location that holds part A → 409."""
+    src_a = _storage(c, "Src-A")
+    src_b = _storage(c, "Src-B")
+    dest = _storage(c, "Dest-SPO", single_part_only=True)
+
+    part_a = _part(c, "MA")
+    part_b = _part(c, "MB")
+
+    _add(c, part_a, 5, src_a)
+    _add(c, part_b, 5, src_b)
+
+    # Stock part A in dest first.
+    r = _move(c, part_a, 3, src_a, dest)
+    assert r.status_code == 200, r.text
+
+    # Now try to move part B into the same dest.
+    r = _move(c, part_b, 2, src_b, dest)
+    assert r.status_code == 409, r.text
+    detail = r.json()
+    assert detail.get("constraint") == "single_part_only"
+    assert detail.get("storage_location_id") == dest
+
+
+def test_single_part_only_allows_move_after_location_emptied_regression(c):
+    """Regression (old code rejected this): moving part B into a
+    single_part_only location that held part A but is now empty must succeed.
+
+    Old check used historical row count; new check uses current stock.
+    """
+    src_a = _storage(c, "Src-A2")
+    src_b = _storage(c, "Src-B2")
+    dest = _storage(c, "Dest-SPO2", single_part_only=True)
+    staging = _storage(c, "Staging")
+
+    part_a = _part(c, "MA2")
+    part_b = _part(c, "MB2")
+
+    _add(c, part_a, 5, src_a)
+    _add(c, part_b, 5, src_b)
+
+    # Move A into dest, then move it all back out to staging.
+    r = _move(c, part_a, 5, src_a, dest)
+    assert r.status_code == 200, r.text
+    r = _move(c, part_a, 5, dest, staging)
+    assert r.status_code == 200, r.text
+
+    # dest is now empty — part B should be accepted.
+    r = _move(c, part_b, 3, src_b, dest)
+    assert r.status_code == 200, r.text
+
+
+# ---------------------------------------------------------------------------
+# existing_parts_only
+# ---------------------------------------------------------------------------
+
+
+def test_existing_parts_only_rejects_part_with_no_prior_history(c):
+    """existing_parts_only: part with no prior positive entry at the
+    location → 409."""
+    loc = _storage(c, "EPO", existing_parts_only=True)
+    part = _part(c, "New")
+
+    r = c.post(
+        "/api/stock/add",
+        json={"part_id": part, "quantity": 1, "storage_location_id": loc},
+    )
+    assert r.status_code == 409, r.text
+    detail = r.json()
+    assert detail.get("constraint") == "existing_parts_only"
+    assert detail.get("storage_location_id") == loc
+
+
+def test_existing_parts_only_allows_part_with_prior_positive_history(c):
+    """existing_parts_only: part that was previously stocked here
+    (even if currently zero) is allowed back."""
+    loc = _storage(c, "EPO-prior", existing_parts_only=True)
+    part = _part(c, "OldPart")
+
+    # Bypass the constraint to seed initial stock (turn off flag, add, turn on).
+    # The simplest way: add without the flag, then patch the storage.
+    # Use a second storage to add then move.
+    staging = _storage(c, "Staging-EPO")
+    _add(c, part, 5, staging)
+
+    # Patch storage to enable existing_parts_only.
+    r = c.patch(f"/api/storage/{loc}", json={"existing_parts_only": True})
+    # Some implementations may not expose patch; use a helper via the DB or
+    # create the storage already flagged with a known prior entry.
+    # Instead: seed initial stock directly to the loc while it's NOT flagged,
+    # then remove it to make it empty, then try to add again.
+
+    # Create a fresh location without the flag, add stock, set flag, remove,
+    # verify it still allows re-add.
+    loc2 = _storage(c, "EPO-prior2")  # no flag yet
+    part2 = _part(c, "OldPart2")
+
+    # Add then remove (creates prior positive entry).
+    _add(c, part2, 3, loc2)
+    _remove(c, part2, 3, loc2)
+
+    # Now enable the flag on loc2 via PATCH.
+    r2 = c.patch(f"/api/storage/{loc2}", json={"existing_parts_only": True})
+    # If PATCH is not supported we just re-create with the flag knowing the
+    # prior entries already exist. But the flag needs to be True at query time.
+    if r2.status_code not in (200, 201):
+        # Fallback: the test is not applicable if storage patch isn't wired.
+        pytest.skip("storage PATCH not available")
+
+    # part2 has prior positive history at loc2 — should be accepted.
+    r3 = c.post(
+        "/api/stock/add",
+        json={"part_id": part2, "quantity": 2, "storage_location_id": loc2},
+    )
+    assert r3.status_code == 200, r3.text
+
+
+# ---------------------------------------------------------------------------
+# Combined flags
+# ---------------------------------------------------------------------------
+
+
+def test_combined_flags_single_and_existing(c):
+    """Location with both flags: part B trying to enter a location that has
+    prior history for part A (and currently holds part A) is rejected.
+
+    Setup:
+    - Create loc without flags, seed part A stock in it, remove it (creating
+      prior history), then enable both flags.
+    - Move part A back in (both constraints satisfied: it has prior history,
+      and the location is empty when it enters).
+    - Part B has no prior history → existing_parts_only fires.
+    """
+    # Create loc without flags first so we can seed prior history for part A.
+    loc = _storage(c, "Both")
+    part_a = _part(c, "CombA")
+    part_b = _part(c, "CombB")
+
+    staging = _storage(c, "Staging-Comb")
+    _add(c, part_a, 5, staging)
+    _add(c, part_b, 5, staging)
+
+    # Seed prior positive history for part A at loc (no flags yet).
+    _add(c, part_a, 2, loc)
+    _remove(c, part_a, 2, loc)
+
+    # Enable both flags now that prior history exists.
+    r_patch = c.patch(f"/api/storage/{loc}", json={"single_part_only": True, "existing_parts_only": True})
+    assert r_patch.status_code in (200, 201), r_patch.text
+
+    # Move part A into the now-flagged location (has prior history, location empty → OK).
+    r = _move(c, part_a, 3, staging, loc)
+    assert r.status_code == 200, r.text
+
+    # part B has no prior history AND the location holds part A → 409
+    # (either constraint fires; we only care that it's rejected with 409).
+    r2 = _move(c, part_b, 2, staging, loc)
+    assert r2.status_code == 409, r2.text
+    assert r2.json().get("constraint") in ("single_part_only", "existing_parts_only")
+
+
+# ---------------------------------------------------------------------------
+# Workspace isolation
+# ---------------------------------------------------------------------------
+
+
+def test_workspace_isolation_storage_constraints(c):
+    """stock_for_storage is workspace-filtered; a second workspace's
+    occupant must not interfere with the first workspace's constraint check."""
+    # Workspace 1 (c) has a single_part_only location holding part A.
+    loc = _storage(c, "Isolated-SPO", single_part_only=True)
+    part_a = _part(c, "IsoA")
+    _add(c, part_a, 5, loc)
+
+    # A second independent workspace signs up.
+    c2 = TestClient(app)
+    _signup(c2)
+
+    # Workspace 2 creates its own unrelated part and storage.
+    # These must not influence workspace 1's stock_for_storage query.
+    part_b_ws2 = _part(c2, "IsoB-ws2")
+    loc_ws2 = _storage(c2, "Bin-ws2")
+    _add(c2, part_b_ws2, 10, loc_ws2)
+
+    # Workspace 1: adding a different part to loc should still be rejected
+    # (its own occupant part_a is there — not confused by ws2's data).
+    part_b_ws1 = _part(c, "IsoB-ws1")
+    r = c.post(
+        "/api/stock/add",
+        json={"part_id": part_b_ws1, "quantity": 1, "storage_location_id": loc},
+    )
+    assert r.status_code == 409, r.text
+    assert r.json().get("constraint") == "single_part_only"

--- a/backend/tests/test_storage_constraints.py
+++ b/backend/tests/test_storage_constraints.py
@@ -12,6 +12,7 @@ current positive balances.
 """
 from __future__ import annotations
 
+import threading
 import uuid
 
 import pytest
@@ -229,46 +230,32 @@ def test_existing_parts_only_rejects_part_with_no_prior_history(c):
 
 def test_existing_parts_only_allows_part_with_prior_positive_history(c):
     """existing_parts_only: part that was previously stocked here
-    (even if currently zero) is allowed back."""
-    loc = _storage(c, "EPO-prior", existing_parts_only=True)
+    (even if currently zero) is allowed back.
+
+    Setup: create the location WITHOUT the flag, seed prior positive
+    history (add then remove so the location is currently empty), then
+    PATCH the flag on. Re-adding the same part must now succeed —
+    the helper checks for any prior positive entry, not current stock.
+    """
+    loc = _storage(c, "EPO-prior")  # no flag yet
     part = _part(c, "OldPart")
 
-    # Bypass the constraint to seed initial stock (turn off flag, add, turn on).
-    # The simplest way: add without the flag, then patch the storage.
-    # Use a second storage to add then move.
-    staging = _storage(c, "Staging-EPO")
-    _add(c, part, 5, staging)
+    # Add then remove (creates prior positive entry, zero current balance).
+    _add(c, part, 3, loc)
+    _remove(c, part, 3, loc)
 
-    # Patch storage to enable existing_parts_only.
-    r = c.patch(f"/api/storage/{loc}", json={"existing_parts_only": True})
-    # Some implementations may not expose patch; use a helper via the DB or
-    # create the storage already flagged with a known prior entry.
-    # Instead: seed initial stock directly to the loc while it's NOT flagged,
-    # then remove it to make it empty, then try to add again.
-
-    # Create a fresh location without the flag, add stock, set flag, remove,
-    # verify it still allows re-add.
-    loc2 = _storage(c, "EPO-prior2")  # no flag yet
-    part2 = _part(c, "OldPart2")
-
-    # Add then remove (creates prior positive entry).
-    _add(c, part2, 3, loc2)
-    _remove(c, part2, 3, loc2)
-
-    # Now enable the flag on loc2 via PATCH.
-    r2 = c.patch(f"/api/storage/{loc2}", json={"existing_parts_only": True})
-    # If PATCH is not supported we just re-create with the flag knowing the
-    # prior entries already exist. But the flag needs to be True at query time.
-    if r2.status_code not in (200, 201):
+    # Now enable the flag on loc via PATCH.
+    r_patch = c.patch(f"/api/storage/{loc}", json={"existing_parts_only": True})
+    if r_patch.status_code not in (200, 201):
         # Fallback: the test is not applicable if storage patch isn't wired.
         pytest.skip("storage PATCH not available")
 
-    # part2 has prior positive history at loc2 — should be accepted.
-    r3 = c.post(
+    # part has prior positive history at loc — should be accepted.
+    r = c.post(
         "/api/stock/add",
-        json={"part_id": part2, "quantity": 2, "storage_location_id": loc2},
+        json={"part_id": part, "quantity": 2, "storage_location_id": loc},
     )
-    assert r3.status_code == 200, r3.text
+    assert r.status_code == 200, r.text
 
 
 # ---------------------------------------------------------------------------
@@ -347,3 +334,59 @@ def test_workspace_isolation_storage_constraints(c):
     )
     assert r.status_code == 409, r.text
     assert r.json().get("constraint") == "single_part_only"
+
+
+# ---------------------------------------------------------------------------
+# Concurrency — cross-part race against single_part_only destination.
+#
+# Two threads each fire `POST /api/stock/add` for *different parts* into
+# the same single_part_only empty location. Without the per-storage
+# advisory lock, both pass the `stock_for_storage(loc) == []` check on
+# stale reads and both insert — leaving the bin holding two parts in
+# violation of the invariant. With the lock, the second blocks on the
+# first's commit, then re-reads and sees the first part already there
+# and returns 409.
+# ---------------------------------------------------------------------------
+
+
+pytestmark_real_db = pytest.mark.real_db
+
+
+@pytest.mark.real_db
+def test_single_part_only_cross_part_race_blocked(c):
+    """Concurrent add of part A and part B into the same single_part_only
+    empty location must result in exactly one success — the per-storage
+    advisory lock serialises the read/check/write across different parts.
+    """
+    loc = _storage(c, "SPO-race", single_part_only=True)
+    part_a = _part(c, "RaceA")
+    part_b = _part(c, "RaceB")
+
+    cookie = next(ck for ck in c.cookies.jar)
+
+    results: list[int] = []
+    barrier = threading.Barrier(2)
+
+    def do_add(part_id: str) -> None:
+        client = TestClient(app)
+        client.cookies.set(cookie.name, cookie.value, domain=cookie.domain, path=cookie.path)
+        barrier.wait()  # both threads ready before either fires
+        r = client.post(
+            "/api/stock/add",
+            json={"part_id": part_id, "quantity": 1, "storage_location_id": loc},
+        )
+        results.append(r.status_code)
+
+    t1 = threading.Thread(target=do_add, args=(part_a,))
+    t2 = threading.Thread(target=do_add, args=(part_b,))
+    t1.start()
+    t2.start()
+    t1.join(timeout=10)
+    t2.join(timeout=10)
+
+    assert len(results) == 2
+    successes = sum(1 for s in results if s == 200)
+    conflicts = sum(1 for s in results if s == 409)
+    # Exactly one succeeds, one is rejected with the structured 409.
+    assert successes == 1, f"expected 1 success, got results={results}"
+    assert conflicts == 1, f"expected 1 conflict, got results={results}"


### PR DESCRIPTION
Closes #35

## Summary
- Add `_enforce_storage_constraints()` private helper in `stock/service.py` that uses `stock_for_storage()` (current positive balances) instead of historical row counts
- `add_stock` now enforces both `single_part_only` and `existing_parts_only` when a storage location is provided
- `move_stock` replaces the old broken `SELECT COUNT(*)` historical check with the correct helper
- `StockConflictError(StockError)` subclass added with `constraint` + `storage_location_id` attributes
- Routes catch `StockConflictError` → 409 with `{"message", "constraint", "storage_location_id"}` in detail
- Fix `conftest.py` to use alembic `"heads"` (plural) to handle the existing multi-head migration chain

## Tests
9 new tests in `backend/tests/test_storage_constraints.py`:
1. `single_part_only` rejects add of part B when part A has positive stock → 409
2. `single_part_only` allows add of same part A (re-adding)
3. `single_part_only` allows add of part B after all part-A stock removed (regression fix)
4. `single_part_only` rejects move of part B into location holding part A
5. `single_part_only` allows move of part B to historically-held but now-empty location (regression fix)
6. `existing_parts_only` rejects add of part with no prior history → 409
7. `existing_parts_only` allows add of part with prior positive history (even if currently zero)
8. Combined flags behavior
9. Workspace isolation via ws-filtered `stock_for_storage`

Backend: 546 passed, 1 skipped, 3 xfailed
Frontend: N/A