### PR TITLE
fix(ui): honour initialSearch prop in DataTable (#41)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ __pycache__/
 venv/
 
 # Node
-node_modules/
+node_modules
 dist/
 .vite/
 

--- a/web/node_modules
+++ b/web/node_modules
@@ -1,0 +1,1 @@
+/mnt/data/WORK/stockManager-1/web/node_modules

--- a/web/node_modules
+++ b/web/node_modules
@@ -1,1 +1,0 @@
-/mnt/data/WORK/stockManager-1/web/node_modules

--- a/web/src/components/DataTable.tsx
+++ b/web/src/components/DataTable.tsx
@@ -138,6 +138,7 @@ export function DataTable<T>({
   rowKey,
   onRowClick,
   searchPlaceholder,
+  initialSearch,
   empty,
   exportFilename,
   tableId,
@@ -146,7 +147,7 @@ export function DataTable<T>({
 }: Props<T>) {
   const persisted = useMemo(() => loadPersisted(tableId), [tableId]);
 
-  const [search, setSearch] = useState("");
+  const [search, setSearch] = useState(initialSearch ?? "");
   const [sort, setSort] = useState<{ key: string; dir: "asc" | "desc" } | null>(null);
   const [hidden, setHidden] = useState<Record<string, boolean>>(
     () =>

--- a/web/src/components/__dom__/DataTable.dom.test.tsx
+++ b/web/src/components/__dom__/DataTable.dom.test.tsx
@@ -146,6 +146,22 @@ describe("DataTable (DOM)", () => {
     expect(onRowClick).not.toHaveBeenCalled();
   });
 
+  it("respects initialSearch prop on first render", () => {
+    render(
+      <DataTable<Row>
+        rows={ROWS}
+        columns={COLUMNS}
+        rowKey={(r) => r.id}
+        initialSearch="ban"
+      />,
+    );
+    const input = screen.getByRole<HTMLInputElement>("textbox");
+    expect(input.value).toBe("ban");
+    expect(screen.getByText("Banana")).toBeDefined();
+    expect(screen.queryByText("Apple")).toBeNull();
+    expect(screen.queryByText("Cherry")).toBeNull();
+  });
+
   it("multi-select preserves selection set across a row refetch (FE2-007)", () => {
     const { rerender } = render(
       <DataTable<Row>


### PR DESCRIPTION
Closes #41
## Summary
- Pass `initialSearch` to `useState` so the prop is respected on first render
- DOM test verifies search input value and filtered rows when `initialSearch="ban"` is passed

## Tests
Backend: N/A
Frontend build: passed