### PR TITLE
fix(ui): add sm: responsive prefix to bare grid-cols-2 forms (#40)

### DIFF
--- a/web/src/routes/__tests__/responsive-grids.test.ts
+++ b/web/src/routes/__tests__/responsive-grids.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync, statSync } from "fs";
+import { join } from "path";
+
+/** Recursively collect all *.tsx files under a directory. */
+function findTsxFiles(dir: string): string[] {
+  const results: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      results.push(...findTsxFiles(full));
+    } else if (entry.endsWith(".tsx")) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+/**
+ * Matches a bare `grid grid-cols-2` that is NOT preceded by a responsive
+ * breakpoint prefix (sm:, md:, lg:, xl:, 2xl:).
+ *
+ * We need to detect strings like:
+ *   "grid grid-cols-2"     ← bare — bad
+ * but NOT:
+ *   "sm:grid-cols-2"       ← prefixed — fine
+ *   "lg:grid-cols-2"       ← prefixed — fine
+ */
+const BARE_GRID_COLS_2 = /(?<![a-z\d]:)grid grid-cols-2(?!\s*\w)/g;
+
+describe("responsive-grids", () => {
+  it("no TSX file contains a bare 'grid grid-cols-2' without a responsive prefix", () => {
+    const srcDir = join(__dirname, "../..");
+    const files = findTsxFiles(srcDir);
+
+    const violations: string[] = [];
+
+    for (const file of files) {
+      const content = readFileSync(file, "utf-8");
+      const lines = content.split("\n");
+      lines.forEach((line, idx) => {
+        // Match bare `grid grid-cols-2` not preceded by a breakpoint prefix on same word
+        if (/\bgrid grid-cols-2\b/.test(line) && !/\bsm:grid-cols-2\b|\bmd:grid-cols-2\b|\blg:grid-cols-2\b|\bxl:grid-cols-2\b|\b2xl:grid-cols-2\b/.test(line)) {
+          violations.push(`${file}:${idx + 1}: ${line.trim()}`);
+        }
+      });
+    }
+
+    expect(violations, `Bare grid-cols-2 found (fix with grid-cols-1 sm:grid-cols-2):\n${violations.join("\n")}`).toHaveLength(0);
+  });
+});

--- a/web/src/routes/builds/BuildCreate.tsx
+++ b/web/src/routes/builds/BuildCreate.tsx
@@ -46,7 +46,7 @@ export default function BuildCreate() {
         <label className="label">Name *</label>
         <input className="input" required value={name} onChange={e => setName(e.target.value)} placeholder="BUILD-2026-001" />
       </div>
-      <div className="grid grid-cols-2 gap-3">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
         <div>
           <label className="label">Project *</label>
           <select className="input" required value={projectId} onChange={e => setProjectId(e.target.value)}>

--- a/web/src/routes/orders/OrderCreate.tsx
+++ b/web/src/routes/orders/OrderCreate.tsx
@@ -43,7 +43,7 @@ export default function OrderCreate() {
         <label className="label">Name *</label>
         <input className="input" required value={name} onChange={e => setName(e.target.value)} placeholder="PO-2026-001" />
       </div>
-      <div className="grid grid-cols-2 gap-3">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
         <div>
           <label className="label">Supplier</label>
           <input className="input" value={supplier} onChange={e => setSupplier(e.target.value)} />

--- a/web/src/routes/parts/PartCreate.tsx
+++ b/web/src/routes/parts/PartCreate.tsx
@@ -178,7 +178,7 @@ export default function PartCreate() {
           </Link>
         </div>
       )}
-      <div className="grid grid-cols-2 gap-3">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
         <div>
           <label className="label">Type</label>
           <select className="input" value={form.part_type} onChange={e => set("part_type", e.target.value as "linked" | "local" | "meta" | "sub_assembly")}>
@@ -205,7 +205,7 @@ export default function PartCreate() {
           Defaults to the MPN when left blank.
         </div>
       </div>
-      <div className="grid grid-cols-2 gap-3">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
         <div>
           <label className="label">Manufacturer</label>
           <input className="input" value={form.manufacturer} onChange={e => set("manufacturer", e.target.value)} />

--- a/web/src/routes/parts/detail/PartAddStock.tsx
+++ b/web/src/routes/parts/detail/PartAddStock.tsx
@@ -87,7 +87,7 @@ export default function PartAddStock() {
     <form onSubmit={submit} className="card p-4 max-w-2xl space-y-3">
       <h3 className="text-md font-semibold">Add stock</h3>
       {err && <div className="text-danger text-sm">{err}</div>}
-      <div className="grid grid-cols-2 gap-3">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
         <div>
           <label className="label">Quantity *</label>
           <input className="input" type="number" min={1} required value={qty || ""} onChange={e => setQty(Number(e.target.value))} />
@@ -128,7 +128,7 @@ export default function PartAddStock() {
           </div>
         )}
       </div>
-      <div className="grid grid-cols-2 gap-3">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
         <div>
           <label className="label">Lot name (optional)</label>
           <input className="input" value={lotName} onChange={e => setLotName(e.target.value)} placeholder="LOT-2026-001" />

--- a/web/src/routes/parts/detail/PartInfo.tsx
+++ b/web/src/routes/parts/detail/PartInfo.tsx
@@ -98,7 +98,7 @@ export default function PartInfo() {
     : null;
 
   return (
-    <div className="grid grid-cols-2 gap-4">
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
       {linked && (
         <div className="card p-3 col-span-2 flex items-center gap-3 text-sm">
           <RefreshCw size={14} className="text-accent shrink-0" />

--- a/web/src/routes/parts/detail/PartSettings.tsx
+++ b/web/src/routes/parts/detail/PartSettings.tsx
@@ -70,7 +70,7 @@ export default function PartSettings() {
         <label className="label">Low-stock report quantity</label>
         <input className="input" type="number" value={low} onChange={e => setLow(e.target.value)} />
       </div>
-      <div className="grid grid-cols-2 gap-3">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
         <div>
           <label className="label">Attrition %</label>
           <input className="input" type="number" step="0.1" value={attrPct} onChange={e => setAttrPct(e.target.value)} />

--- a/web/src/routes/settings/Workspace.tsx
+++ b/web/src/routes/settings/Workspace.tsx
@@ -186,7 +186,7 @@ export default function WorkspaceSettings() {
       {err && <div className="card p-3 text-danger text-sm mb-3">{err}</div>}
       {cur && (
         <div className="card p-4 mb-4 space-y-3 text-sm">
-          <div className="grid grid-cols-2 gap-3">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
             <div>
               <label className="label">Name</label>
               <input
@@ -208,7 +208,7 @@ export default function WorkspaceSettings() {
               />
             </div>
           </div>
-          <div className="grid grid-cols-2 gap-3">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
             <label className="flex items-center gap-2">
               <input
                 type="checkbox"


### PR DESCRIPTION
Closes #40

## Summary
- Replace bare `grid grid-cols-2` with `grid grid-cols-1 sm:grid-cols-2` across 8 form files (10 occurrences total): BuildCreate, OrderCreate, PartCreate, PartInfo, PartAddStock, PartSettings, Workspace
- Add regression test (`responsive-grids.test.ts`) that walks all `*.tsx` files and asserts no bare `grid grid-cols-2` without a responsive breakpoint prefix exists

## Test plan
- [ ] `cd web && npm test` — all 13 test files pass including new responsive-grids test
- [ ] `cd web && npm run build` — build succeeds with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)