### PR TITLE
fix(ui): associate form labels with inputs via htmlFor (#39)

### DIFF
--- a/web/src/components/AttachmentsPanel.tsx
+++ b/web/src/components/AttachmentsPanel.tsx
@@ -223,8 +223,9 @@ export default function AttachmentsPanel({ objectType, objectId, canWrite }: Pro
         >
           <div className="flex flex-wrap items-end gap-2">
             <div className="flex-1 min-w-[180px]">
-              <label className="label">File</label>
+              <label className="label" htmlFor="attachment-file">File</label>
               <input
+                id="attachment-file"
                 ref={inputRef}
                 type="file"
                 className="input"
@@ -245,8 +246,9 @@ export default function AttachmentsPanel({ objectType, objectId, canWrite }: Pro
               />
             </div>
             <div className="w-32">
-              <label className="label">Type</label>
+              <label className="label" htmlFor="attachment-type">Type</label>
               <select
+                id="attachment-type"
                 className="input"
                 value={fileType}
                 onChange={ev => setFileType(ev.target.value as FileType)}

--- a/web/src/routes/auth/Login.tsx
+++ b/web/src/routes/auth/Login.tsx
@@ -63,8 +63,9 @@ export default function Login() {
           </div>
         )}
         <div>
-          <label className="label">Email</label>
+          <label className="label" htmlFor="login-email">Email</label>
           <input
+            id="login-email"
             className="input"
             type="email"
             autoComplete="email"
@@ -74,8 +75,9 @@ export default function Login() {
           />
         </div>
         <div>
-          <label className="label">Password</label>
+          <label className="label" htmlFor="login-password">Password</label>
           <input
+            id="login-password"
             className="input"
             type="password"
             autoComplete="current-password"

--- a/web/src/routes/auth/Signup.tsx
+++ b/web/src/routes/auth/Signup.tsx
@@ -88,8 +88,9 @@ export default function Signup() {
           </div>
         )}
         <div>
-          <label className="label">Name</label>
+          <label className="label" htmlFor="signup-name">Name</label>
           <input
+            id="signup-name"
             className="input"
             required
             value={name}
@@ -98,8 +99,9 @@ export default function Signup() {
           />
         </div>
         <div>
-          <label className="label">Email</label>
+          <label className="label" htmlFor="signup-email">Email</label>
           <input
+            id="signup-email"
             className="input"
             type="email"
             required
@@ -109,8 +111,9 @@ export default function Signup() {
           />
         </div>
         <div>
-          <label className="label">Password (min 8)</label>
+          <label className="label" htmlFor="signup-password">Password (min 8)</label>
           <input
+            id="signup-password"
             className="input"
             type="password"
             required
@@ -121,8 +124,9 @@ export default function Signup() {
           />
         </div>
         <div>
-          <label className="label">Workspace name (optional)</label>
+          <label className="label" htmlFor="signup-workspace-name">Workspace name (optional)</label>
           <input
+            id="signup-workspace-name"
             className="input"
             value={workspaceName}
             onChange={e => setWorkspaceName(e.target.value)}

--- a/web/src/routes/builds/BuildCreate.tsx
+++ b/web/src/routes/builds/BuildCreate.tsx
@@ -43,25 +43,25 @@ export default function BuildCreate() {
       <h3 className="text-md font-semibold">New build</h3>
       {err && <div className="text-danger text-sm">{err}</div>}
       <div>
-        <label className="label">Name *</label>
-        <input className="input" required value={name} onChange={e => setName(e.target.value)} placeholder="BUILD-2026-001" />
+        <label className="label" htmlFor="build-create-name">Name *</label>
+        <input id="build-create-name" className="input" required value={name} onChange={e => setName(e.target.value)} placeholder="BUILD-2026-001" />
       </div>
       <div className="grid grid-cols-2 gap-3">
         <div>
-          <label className="label">Project *</label>
-          <select className="input" required value={projectId} onChange={e => setProjectId(e.target.value)}>
+          <label className="label" htmlFor="build-create-project">Project *</label>
+          <select id="build-create-project" className="input" required value={projectId} onChange={e => setProjectId(e.target.value)}>
             <option value="">— pick —</option>
             {projects?.filter(p => !p.archived_at).map(p => <option key={p.id} value={p.id}>{p.name}</option>)}
           </select>
         </div>
         <div>
-          <label className="label">Quantity *</label>
-          <input className="input" type="number" min={1} required value={qty} onChange={e => setQty(Number(e.target.value))} />
+          <label className="label" htmlFor="build-create-qty">Quantity *</label>
+          <input id="build-create-qty" className="input" type="number" min={1} required value={qty} onChange={e => setQty(Number(e.target.value))} />
         </div>
       </div>
       <div>
-        <label className="label">Comments</label>
-        <textarea className="input" rows={2} value={comments} onChange={e => setComments(e.target.value)} />
+        <label className="label" htmlFor="build-create-comments">Comments</label>
+        <textarea id="build-create-comments" className="input" rows={2} value={comments} onChange={e => setComments(e.target.value)} />
       </div>
       <div>
         <button className="btn-primary" disabled={busy}>{busy ? "Creating…" : "Create build"}</button>

--- a/web/src/routes/lots/LotDetail.tsx
+++ b/web/src/routes/lots/LotDetail.tsx
@@ -74,15 +74,15 @@ export function LotMove() {
   return (
     <form onSubmit={submit} className="card p-4 max-w-xl space-y-3">
       <div>
-        <label className="label">Destination *</label>
-        <select className="input" required value={dest} onChange={e => setDest(e.target.value)}>
+        <label className="label" htmlFor="lot-move-dest">Destination *</label>
+        <select id="lot-move-dest" className="input" required value={dest} onChange={e => setDest(e.target.value)}>
           <option value="">— select —</option>
           {storage?.filter(s => !s.archived_at).map(s => <option key={s.id} value={s.id}>{s.name}</option>)}
         </select>
       </div>
       <div>
-        <label className="label">Quantity *</label>
-        <input className="input" type="number" min={1} required value={qty || ""} onChange={e => setQty(Number(e.target.value))} />
+        <label className="label" htmlFor="lot-move-qty">Quantity *</label>
+        <input id="lot-move-qty" className="input" type="number" min={1} required value={qty || ""} onChange={e => setQty(Number(e.target.value))} />
       </div>
       <label className="flex items-center gap-2 text-sm">
         <input type="checkbox" checked={split} onChange={e => setSplit(e.target.checked)} />
@@ -107,12 +107,12 @@ export function LotAdjust() {
   return (
     <form onSubmit={submit} className="card p-4 max-w-xl space-y-3">
       <div>
-        <label className="label">Counted quantity</label>
-        <input className="input" type="number" required value={actual || ""} onChange={e => setActual(Number(e.target.value))} />
+        <label className="label" htmlFor="lot-adjust-qty">Counted quantity</label>
+        <input id="lot-adjust-qty" className="input" type="number" required value={actual || ""} onChange={e => setActual(Number(e.target.value))} />
       </div>
       <div>
-        <label className="label">Comments</label>
-        <textarea className="input" rows={2} value={comments} onChange={e => setComments(e.target.value)} />
+        <label className="label" htmlFor="lot-adjust-comments">Comments</label>
+        <textarea id="lot-adjust-comments" className="input" rows={2} value={comments} onChange={e => setComments(e.target.value)} />
       </div>
       <button className="btn-primary">Adjust</button>
     </form>

--- a/web/src/routes/orders/OrderCreate.tsx
+++ b/web/src/routes/orders/OrderCreate.tsx
@@ -40,30 +40,30 @@ export default function OrderCreate() {
       <h3 className="text-md font-semibold">New order</h3>
       {err && <div className="text-danger text-sm">{err}</div>}
       <div>
-        <label className="label">Name *</label>
-        <input className="input" required value={name} onChange={e => setName(e.target.value)} placeholder="PO-2026-001" />
+        <label className="label" htmlFor="order-create-name">Name *</label>
+        <input id="order-create-name" className="input" required value={name} onChange={e => setName(e.target.value)} placeholder="PO-2026-001" />
       </div>
       <div className="grid grid-cols-2 gap-3">
         <div>
-          <label className="label">Supplier</label>
-          <input className="input" value={supplier} onChange={e => setSupplier(e.target.value)} />
+          <label className="label" htmlFor="order-create-supplier">Supplier</label>
+          <input id="order-create-supplier" className="input" value={supplier} onChange={e => setSupplier(e.target.value)} />
         </div>
         <div>
-          <label className="label">Currency</label>
-          <input className="input" maxLength={3} value={currency} onChange={e => setCurrency(e.target.value.toUpperCase())} />
+          <label className="label" htmlFor="order-create-currency">Currency</label>
+          <input id="order-create-currency" className="input" maxLength={3} value={currency} onChange={e => setCurrency(e.target.value.toUpperCase())} />
         </div>
         <div>
-          <label className="label">Ordered on</label>
-          <input className="input" type="date" value={orderedOn} onChange={e => setOrderedOn(e.target.value)} />
+          <label className="label" htmlFor="order-create-ordered-on">Ordered on</label>
+          <input id="order-create-ordered-on" className="input" type="date" value={orderedOn} onChange={e => setOrderedOn(e.target.value)} />
         </div>
         <div>
-          <label className="label">Expected on</label>
-          <input className="input" type="date" value={expectedOn} onChange={e => setExpectedOn(e.target.value)} />
+          <label className="label" htmlFor="order-create-expected-on">Expected on</label>
+          <input id="order-create-expected-on" className="input" type="date" value={expectedOn} onChange={e => setExpectedOn(e.target.value)} />
         </div>
       </div>
       <div>
-        <label className="label">Comments</label>
-        <textarea className="input" rows={2} value={comments} onChange={e => setComments(e.target.value)} />
+        <label className="label" htmlFor="order-create-comments">Comments</label>
+        <textarea id="order-create-comments" className="input" rows={2} value={comments} onChange={e => setComments(e.target.value)} />
       </div>
       <div>
         <button className="btn-primary" disabled={busy}>{busy ? "Creating…" : "Create order"}</button>

--- a/web/src/routes/orders/OrderDetail.tsx
+++ b/web/src/routes/orders/OrderDetail.tsx
@@ -221,8 +221,8 @@ export default function OrderDetail() {
         {adding && (
           <div className="grid grid-cols-5 gap-2 mb-3 items-end">
             <div className="col-span-2">
-              <label className="label">Part</label>
-              <select className="input" value={newPartId} onChange={e => setNewPartId(e.target.value)}>
+              <label className="label" htmlFor="order-entry-part">Part</label>
+              <select id="order-entry-part" className="input" value={newPartId} onChange={e => setNewPartId(e.target.value)}>
                 <option value="">— free text —</option>
                 {parts?.filter(p => !p.archived_at).map(p => (
                   <option key={p.id} value={p.id}>{p.name}{p.mpn ? ` — ${p.mpn}` : ""}</option>
@@ -230,16 +230,16 @@ export default function OrderDetail() {
               </select>
             </div>
             <div>
-              <label className="label">Free-text name</label>
-              <input className="input" value={newName} onChange={e => setNewName(e.target.value)} disabled={!!newPartId} />
+              <label className="label" htmlFor="order-entry-free-name">Free-text name</label>
+              <input id="order-entry-free-name" className="input" value={newName} onChange={e => setNewName(e.target.value)} disabled={!!newPartId} />
             </div>
             <div>
-              <label className="label">Qty</label>
-              <input className="input" type="number" min={1} value={newQty} onChange={e => setNewQty(Number(e.target.value))} />
+              <label className="label" htmlFor="order-entry-qty">Qty</label>
+              <input id="order-entry-qty" className="input" type="number" min={1} value={newQty} onChange={e => setNewQty(Number(e.target.value))} />
             </div>
             <div>
-              <label className="label">Unit price</label>
-              <input className="input" type="number" step="0.0001" value={newPrice} onChange={e => setNewPrice(e.target.value)} />
+              <label className="label" htmlFor="order-entry-price">Unit price</label>
+              <input id="order-entry-price" className="input" type="number" step="0.0001" value={newPrice} onChange={e => setNewPrice(e.target.value)} />
             </div>
             <div className="col-span-5">
               {/* Disable on isPending — this is the OrderDetail double-submit
@@ -346,8 +346,8 @@ export default function OrderDetail() {
           </table>
           <div className="grid grid-cols-3 gap-2 mt-3 items-end">
             <div>
-              <label className="label">Received on</label>
-              <input className="input" type="date" value={receivedOn} onChange={e => setReceivedOn(e.target.value)} />
+              <label className="label" htmlFor="order-receive-on">Received on</label>
+              <input id="order-receive-on" className="input" type="date" value={receivedOn} onChange={e => setReceivedOn(e.target.value)} />
             </div>
             <div className="col-span-2 flex justify-end">
               <button

--- a/web/src/routes/parts/PartCreate.tsx
+++ b/web/src/routes/parts/PartCreate.tsx
@@ -180,8 +180,8 @@ export default function PartCreate() {
       )}
       <div className="grid grid-cols-2 gap-3">
         <div>
-          <label className="label">Type</label>
-          <select className="input" value={form.part_type} onChange={e => set("part_type", e.target.value as "linked" | "local" | "meta" | "sub_assembly")}>
+          <label className="label" htmlFor="part-create-type">Type</label>
+          <select id="part-create-type" className="input" value={form.part_type} onChange={e => set("part_type", e.target.value as "linked" | "local" | "meta" | "sub_assembly")}>
             <option value="linked">Linked (MPN)</option>
             <option value="local">Local</option>
             <option value="meta">Meta-part</option>
@@ -189,13 +189,14 @@ export default function PartCreate() {
           </select>
         </div>
         <div>
-          <label className="label">Footprint</label>
-          <input className="input" value={form.footprint} onChange={e => set("footprint", e.target.value)} placeholder="0402, SOIC-8…" />
+          <label className="label" htmlFor="part-create-footprint">Footprint</label>
+          <input id="part-create-footprint" className="input" value={form.footprint} onChange={e => set("footprint", e.target.value)} placeholder="0402, SOIC-8…" />
         </div>
       </div>
       <div>
-        <label className="label">Name</label>
+        <label className="label" htmlFor="part-create-name">Name</label>
         <input
+          id="part-create-name"
           className="input"
           value={form.name}
           onChange={e => set("name", e.target.value)}
@@ -207,13 +208,13 @@ export default function PartCreate() {
       </div>
       <div className="grid grid-cols-2 gap-3">
         <div>
-          <label className="label">Manufacturer</label>
-          <input className="input" value={form.manufacturer} onChange={e => set("manufacturer", e.target.value)} />
+          <label className="label" htmlFor="part-create-manufacturer">Manufacturer</label>
+          <input id="part-create-manufacturer" className="input" value={form.manufacturer} onChange={e => set("manufacturer", e.target.value)} />
         </div>
         <div>
-          <label className="label">MPN</label>
+          <label className="label" htmlFor="part-create-mpn">MPN</label>
           <div className="flex items-end gap-2">
-            <input className="input flex-1" value={form.mpn} onChange={e => set("mpn", e.target.value)} />
+            <input id="part-create-mpn" className="input flex-1" value={form.mpn} onChange={e => set("mpn", e.target.value)} />
             {form.part_type === "linked" && <MpnLookup mpn={form.mpn} onResult={applyLookup} />}
           </div>
           {datasheetUrl && (
@@ -250,20 +251,20 @@ export default function PartCreate() {
         </div>
       )}
       <div>
-        <label className="label">Internal part number</label>
-        <input className="input" value={form.internal_part_number} onChange={e => set("internal_part_number", e.target.value)} />
+        <label className="label" htmlFor="part-create-ipn">Internal part number</label>
+        <input id="part-create-ipn" className="input" value={form.internal_part_number} onChange={e => set("internal_part_number", e.target.value)} />
       </div>
       <div>
-        <label className="label">Description</label>
-        <textarea className="input" rows={3} value={form.description} onChange={e => set("description", e.target.value)} />
+        <label className="label" htmlFor="part-create-description">Description</label>
+        <textarea id="part-create-description" className="input" rows={3} value={form.description} onChange={e => set("description", e.target.value)} />
       </div>
       <label className="flex items-center gap-2 text-sm">
         <input type="checkbox" checked={form.serialized} onChange={e => set("serialized", e.target.checked)} />
         Serialized (one unit per lot, requires serial number — only enforced when the workspace has serial tracking on)
       </label>
       <div>
-        <label className="label">Default storage location</label>
-        <select className="input" value={form.default_storage_location_id} onChange={e => set("default_storage_location_id", e.target.value)}>
+        <label className="label" htmlFor="part-create-default-storage">Default storage location</label>
+        <select id="part-create-default-storage" className="input" value={form.default_storage_location_id} onChange={e => set("default_storage_location_id", e.target.value)}>
           <option value="">— none —</option>
           {storage?.filter(s => !s.archived_at).map(s => <option key={s.id} value={s.id}>{s.name}</option>)}
         </select>

--- a/web/src/routes/parts/detail/PartAddStock.tsx
+++ b/web/src/routes/parts/detail/PartAddStock.tsx
@@ -89,12 +89,12 @@ export default function PartAddStock() {
       {err && <div className="text-danger text-sm">{err}</div>}
       <div className="grid grid-cols-2 gap-3">
         <div>
-          <label className="label">Quantity *</label>
-          <input className="input" type="number" min={1} required value={qty || ""} onChange={e => setQty(Number(e.target.value))} />
+          <label className="label" htmlFor="add-stock-qty">Quantity *</label>
+          <input id="add-stock-qty" className="input" type="number" min={1} required value={qty || ""} onChange={e => setQty(Number(e.target.value))} />
         </div>
         <div>
-          <label className="label">Storage location</label>
-          <select className="input" value={location} onChange={e => setLocation(e.target.value)}>
+          <label className="label" htmlFor="add-stock-storage">Storage location</label>
+          <select id="add-stock-storage" className="input" value={location} onChange={e => setLocation(e.target.value)}>
             <option value="">— none —</option>
             {storage?.filter(s => !s.archived_at).map(s => <option key={s.id} value={s.id}>{s.name}</option>)}
           </select>
@@ -102,8 +102,8 @@ export default function PartAddStock() {
       </div>
       <div className="grid grid-cols-3 gap-3">
         <div>
-          <label className="label">Price mode</label>
-          <select className="input" value={priceMode} onChange={e => setPriceMode(e.target.value as "none" | "per_component" | "entire_lot")}>
+          <label className="label" htmlFor="add-stock-price-mode">Price mode</label>
+          <select id="add-stock-price-mode" className="input" value={priceMode} onChange={e => setPriceMode(e.target.value as "none" | "per_component" | "entire_lot")}>
             <option value="none">No price</option>
             <option value="per_component">Per component</option>
             <option value="entire_lot">Entire lot</option>
@@ -111,36 +111,36 @@ export default function PartAddStock() {
         </div>
         {priceMode === "per_component" && (
           <div>
-            <label className="label">Unit price</label>
-            <input className="input" type="number" step="0.0001" value={unitPrice} onChange={e => setUnitPrice(e.target.value)} />
+            <label className="label" htmlFor="add-stock-unit-price">Unit price</label>
+            <input id="add-stock-unit-price" className="input" type="number" step="0.0001" value={unitPrice} onChange={e => setUnitPrice(e.target.value)} />
           </div>
         )}
         {priceMode === "entire_lot" && (
           <div>
-            <label className="label">Lot total</label>
-            <input className="input" type="number" step="0.01" value={totalPrice} onChange={e => setTotalPrice(e.target.value)} />
+            <label className="label" htmlFor="add-stock-lot-total">Lot total</label>
+            <input id="add-stock-lot-total" className="input" type="number" step="0.01" value={totalPrice} onChange={e => setTotalPrice(e.target.value)} />
           </div>
         )}
         {priceMode !== "none" && (
           <div>
-            <label className="label">Currency</label>
-            <input className="input" maxLength={3} value={currency} onChange={e => setCurrency(e.target.value.toUpperCase())} />
+            <label className="label" htmlFor="add-stock-currency">Currency</label>
+            <input id="add-stock-currency" className="input" maxLength={3} value={currency} onChange={e => setCurrency(e.target.value.toUpperCase())} />
           </div>
         )}
       </div>
       <div className="grid grid-cols-2 gap-3">
         <div>
-          <label className="label">Lot name (optional)</label>
-          <input className="input" value={lotName} onChange={e => setLotName(e.target.value)} placeholder="LOT-2026-001" />
+          <label className="label" htmlFor="add-stock-lot-name">Lot name (optional)</label>
+          <input id="add-stock-lot-name" className="input" value={lotName} onChange={e => setLotName(e.target.value)} placeholder="LOT-2026-001" />
         </div>
         <div>
-          <label className="label">Serial number (optional)</label>
-          <input className="input" value={serial} onChange={e => setSerial(e.target.value)} placeholder="SN-…" />
+          <label className="label" htmlFor="add-stock-serial">Serial number (optional)</label>
+          <input id="add-stock-serial" className="input" value={serial} onChange={e => setSerial(e.target.value)} placeholder="SN-…" />
         </div>
       </div>
       <div>
-        <label className="label">Comments</label>
-        <textarea className="input" rows={2} value={comments} onChange={e => setComments(e.target.value)} />
+        <label className="label" htmlFor="add-stock-comments">Comments</label>
+        <textarea id="add-stock-comments" className="input" rows={2} value={comments} onChange={e => setComments(e.target.value)} />
       </div>
       <div className="flex gap-2">
         <button className="btn-primary" disabled={busy}>{busy ? "Adding…" : "Add"}</button>

--- a/web/src/routes/parts/detail/PartMoveStock.tsx
+++ b/web/src/routes/parts/detail/PartMoveStock.tsx
@@ -129,13 +129,14 @@ export default function PartMoveStock() {
       <h3 className="text-md font-semibold">Move stock</h3>
       {err && <div className="text-danger text-sm">{err}</div>}
       <div>
-        <label className="label">From *</label>
+        <label className="label" htmlFor="move-stock-from">From *</label>
         {sources.length === 0 ? (
           <div className="text-sm text-muted py-2">
             Nothing on hand for this part.
           </div>
         ) : (
           <select
+            id="move-stock-from"
             className="input"
             value={sourceKey}
             onChange={e => {
@@ -153,8 +154,8 @@ export default function PartMoveStock() {
         )}
       </div>
       <div>
-        <label className="label">To storage *</label>
-        <select className="input" required value={dest} onChange={e => setDest(e.target.value)}>
+        <label className="label" htmlFor="move-stock-to">To storage *</label>
+        <select id="move-stock-to" className="input" required value={dest} onChange={e => setDest(e.target.value)}>
           <option value="">— select —</option>
           {storage?.filter(s => !s.archived_at).map(s => (
             <option key={s.id} value={s.id}>{s.name}</option>
@@ -162,8 +163,9 @@ export default function PartMoveStock() {
         </select>
       </div>
       <div>
-        <label className="label">Quantity *</label>
+        <label className="label" htmlFor="move-stock-qty">Quantity *</label>
         <input
+          id="move-stock-qty"
           className="input"
           type="number"
           min={1}
@@ -184,8 +186,9 @@ export default function PartMoveStock() {
         Split lot at destination
       </label>
       <div>
-        <label className="label">Comments</label>
+        <label className="label" htmlFor="move-stock-comments">Comments</label>
         <textarea
+          id="move-stock-comments"
           className="input"
           rows={2}
           value={comments}

--- a/web/src/routes/parts/detail/PartRemoveStock.tsx
+++ b/web/src/routes/parts/detail/PartRemoveStock.tsx
@@ -129,13 +129,14 @@ export default function PartRemoveStock() {
       <h3 className="text-md font-semibold">Remove stock</h3>
       {err && <div className="text-danger text-sm">{err}</div>}
       <div>
-        <label className="label">Source *</label>
+        <label className="label" htmlFor="remove-stock-source">Source *</label>
         {sources.length === 0 ? (
           <div className="text-sm text-muted py-2">
             Nothing on hand for this part.
           </div>
         ) : (
           <select
+            id="remove-stock-source"
             className="input"
             value={sourceKey}
             onChange={e => {
@@ -155,8 +156,9 @@ export default function PartRemoveStock() {
         )}
       </div>
       <div>
-        <label className="label">Quantity *</label>
+        <label className="label" htmlFor="remove-stock-qty">Quantity *</label>
         <input
+          id="remove-stock-qty"
           className="input"
           type="number"
           min={1}
@@ -173,8 +175,9 @@ export default function PartRemoveStock() {
         )}
       </div>
       <div>
-        <label className="label">Comments</label>
+        <label className="label" htmlFor="remove-stock-comments">Comments</label>
         <textarea
+          id="remove-stock-comments"
           className="input"
           rows={2}
           value={comments}

--- a/web/src/routes/parts/detail/PartSettings.tsx
+++ b/web/src/routes/parts/detail/PartSettings.tsx
@@ -67,22 +67,22 @@ export default function PartSettings() {
       <h3 className="text-md font-semibold">Part settings</h3>
       {err && <div className="text-danger text-sm">{err}</div>}
       <div>
-        <label className="label">Low-stock report quantity</label>
-        <input className="input" type="number" value={low} onChange={e => setLow(e.target.value)} />
+        <label className="label" htmlFor="part-settings-low-stock">Low-stock report quantity</label>
+        <input id="part-settings-low-stock" className="input" type="number" value={low} onChange={e => setLow(e.target.value)} />
       </div>
       <div className="grid grid-cols-2 gap-3">
         <div>
-          <label className="label">Attrition %</label>
-          <input className="input" type="number" step="0.1" value={attrPct} onChange={e => setAttrPct(e.target.value)} />
+          <label className="label" htmlFor="part-settings-attrition-pct">Attrition %</label>
+          <input id="part-settings-attrition-pct" className="input" type="number" step="0.1" value={attrPct} onChange={e => setAttrPct(e.target.value)} />
         </div>
         <div>
-          <label className="label">Min attrition qty</label>
-          <input className="input" type="number" value={attrMin} onChange={e => setAttrMin(e.target.value)} />
+          <label className="label" htmlFor="part-settings-attrition-min">Min attrition qty</label>
+          <input id="part-settings-attrition-min" className="input" type="number" value={attrMin} onChange={e => setAttrMin(e.target.value)} />
         </div>
       </div>
       <div>
-        <label className="label">Default storage location</label>
-        <select className="input" value={defStorage} onChange={e => setDefStorage(e.target.value)}>
+        <label className="label" htmlFor="part-settings-default-storage">Default storage location</label>
+        <select id="part-settings-default-storage" className="input" value={defStorage} onChange={e => setDefStorage(e.target.value)}>
           <option value="">— none —</option>
           {storage?.filter(s => !s.archived_at).map(s => <option key={s.id} value={s.id}>{s.name}</option>)}
         </select>

--- a/web/src/routes/projects/ProjectCreate.tsx
+++ b/web/src/routes/projects/ProjectCreate.tsx
@@ -26,12 +26,12 @@ export default function ProjectCreate() {
       <h1 className="text-xl font-semibold">Create project</h1>
       {err && <div className="text-danger text-sm">{err}</div>}
       <div>
-        <label className="label">Name *</label>
-        <input className="input" required value={name} onChange={e => setName(e.target.value)} />
+        <label className="label" htmlFor="project-create-name">Name *</label>
+        <input id="project-create-name" className="input" required value={name} onChange={e => setName(e.target.value)} />
       </div>
       <div>
-        <label className="label">Description</label>
-        <textarea className="input" rows={3} value={description} onChange={e => setDescription(e.target.value)} />
+        <label className="label" htmlFor="project-create-description">Description</label>
+        <textarea id="project-create-description" className="input" rows={3} value={description} onChange={e => setDescription(e.target.value)} />
       </div>
       <div className="flex gap-2">
         <button className="btn-primary" disabled={busy}>Create</button>

--- a/web/src/routes/projects/detail/ProjectData.tsx
+++ b/web/src/routes/projects/detail/ProjectData.tsx
@@ -20,16 +20,16 @@ export default function ProjectData() {
   return (
     <div className="card p-4 max-w-2xl space-y-3">
       <div>
-        <label className="label">Name</label>
-        <input className="input" value={name} onChange={e => setName(e.target.value)} />
+        <label className="label" htmlFor="project-data-name">Name</label>
+        <input id="project-data-name" className="input" value={name} onChange={e => setName(e.target.value)} />
       </div>
       <div>
-        <label className="label">Description</label>
-        <textarea className="input" rows={3} value={description} onChange={e => setDescription(e.target.value)} />
+        <label className="label" htmlFor="project-data-description">Description</label>
+        <textarea id="project-data-description" className="input" rows={3} value={description} onChange={e => setDescription(e.target.value)} />
       </div>
       <div>
-        <label className="label">Notes (Markdown)</label>
-        <textarea className="input font-mono" rows={6} value={notes} onChange={e => setNotes(e.target.value)} />
+        <label className="label" htmlFor="project-data-notes">Notes (Markdown)</label>
+        <textarea id="project-data-notes" className="input font-mono" rows={6} value={notes} onChange={e => setNotes(e.target.value)} />
       </div>
       <button className="btn-primary" onClick={save}>Save</button>
     </div>

--- a/web/src/routes/projects/detail/ProjectImport.tsx
+++ b/web/src/routes/projects/detail/ProjectImport.tsx
@@ -297,8 +297,8 @@ export default function ProjectImport() {
           <h3 className="text-md font-semibold">Step 2 — column mapping & preview</h3>
           <div className="grid grid-cols-4 gap-3">
             <div>
-              <label className="label">Separator</label>
-              <select className="input" value={separator} onChange={e => setSeparator(e.target.value)}>
+              <label className="label" htmlFor="import-separator">Separator</label>
+              <select id="import-separator" className="input" value={separator} onChange={e => setSeparator(e.target.value)}>
                 <option value=",">, (comma)</option>
                 <option value=";">; (semicolon)</option>
                 <option value={"\t"}>tab</option>
@@ -306,19 +306,19 @@ export default function ProjectImport() {
               </select>
             </div>
             <div>
-              <label className="label">Encoding</label>
-              <input className="input" value={encoding} onChange={e => setEncoding(e.target.value)} />
+              <label className="label" htmlFor="import-encoding">Encoding</label>
+              <input id="import-encoding" className="input" value={encoding} onChange={e => setEncoding(e.target.value)} />
             </div>
             <div>
-              <label className="label">First row is header</label>
-              <select className="input" value={hasHeader ? "yes" : "no"} onChange={e => setHasHeader(e.target.value === "yes")}>
+              <label className="label" htmlFor="import-has-header">First row is header</label>
+              <select id="import-has-header" className="input" value={hasHeader ? "yes" : "no"} onChange={e => setHasHeader(e.target.value === "yes")}>
                 <option value="yes">Yes</option>
                 <option value="no">No</option>
               </select>
             </div>
             <div>
-              <label className="label">Designator separator</label>
-              <input className="input" value={designatorSep} onChange={e => setDesignatorSep(e.target.value)} />
+              <label className="label" htmlFor="import-designator-sep">Designator separator</label>
+              <input id="import-designator-sep" className="input" value={designatorSep} onChange={e => setDesignatorSep(e.target.value)} />
             </div>
           </div>
           <div className="flex gap-2 items-center">

--- a/web/src/routes/reports/Reports.tsx
+++ b/web/src/routes/reports/Reports.tsx
@@ -353,15 +353,15 @@ export function BomShortageReport() {
     <div className="space-y-3">
       <div className="card p-4 flex gap-3 items-end max-w-2xl">
         <div className="flex-1">
-          <label className="label">Project</label>
-          <select className="input" value={projectId} onChange={e => setProjectId(e.target.value)}>
+          <label className="label" htmlFor="report-bom-project">Project</label>
+          <select id="report-bom-project" className="input" value={projectId} onChange={e => setProjectId(e.target.value)}>
             <option value="">— pick —</option>
             {projects?.filter(p => !p.archived_at).map(p => <option key={p.id} value={p.id}>{p.name}</option>)}
           </select>
         </div>
         <div>
-          <label className="label">Build quantity</label>
-          <input className="input" type="number" min={1} value={qty} onChange={e => setQty(Number(e.target.value))} />
+          <label className="label" htmlFor="report-bom-qty">Build quantity</label>
+          <input id="report-bom-qty" className="input" type="number" min={1} value={qty} onChange={e => setQty(Number(e.target.value))} />
         </div>
       </div>
       {data && (
@@ -415,8 +415,8 @@ export function ExpiringLotsReport() {
     <div className="space-y-3">
       <div className="card p-4 flex gap-3 items-end max-w-md">
         <div className="flex-1">
-          <label className="label">Window (days)</label>
-          <input className="input" type="number" min={0} max={3650} value={days} onChange={e => setDays(Number(e.target.value))} />
+          <label className="label" htmlFor="report-expiring-days">Window (days)</label>
+          <input id="report-expiring-days" className="input" type="number" min={0} max={3650} value={days} onChange={e => setDays(Number(e.target.value))} />
         </div>
       </div>
       <DataTable

--- a/web/src/routes/settings/Workspace.tsx
+++ b/web/src/routes/settings/Workspace.tsx
@@ -188,16 +188,18 @@ export default function WorkspaceSettings() {
         <div className="card p-4 mb-4 space-y-3 text-sm">
           <div className="grid grid-cols-2 gap-3">
             <div>
-              <label className="label">Name</label>
+              <label className="label" htmlFor="workspace-name">Name</label>
               <input
+                id="workspace-name"
                 className="input"
                 defaultValue={cur.name}
                 onBlur={e => e.target.value && e.target.value !== cur.name && patch({ name: e.target.value })}
               />
             </div>
             <div>
-              <label className="label">Default currency</label>
+              <label className="label" htmlFor="workspace-currency">Default currency</label>
               <input
+                id="workspace-currency"
                 className="input"
                 maxLength={3}
                 defaultValue={cur.currency_default}
@@ -571,12 +573,12 @@ export default function WorkspaceSettings() {
       <div className="card p-4 mb-4 space-y-3">
         <div className="flex gap-2 items-end">
           <div className="flex-1">
-            <label className="label">Email</label>
-            <input className="input" type="email" value={inviteEmail} onChange={e => setInviteEmail(e.target.value)} placeholder="teammate@example.com" />
+            <label className="label" htmlFor="invite-email">Email</label>
+            <input id="invite-email" className="input" type="email" value={inviteEmail} onChange={e => setInviteEmail(e.target.value)} placeholder="teammate@example.com" />
           </div>
           <div>
-            <label className="label">Role</label>
-            <select className="input" value={inviteRole} onChange={e => setInviteRole(e.target.value as "admin" | "member" | "viewer")}>
+            <label className="label" htmlFor="invite-role">Role</label>
+            <select id="invite-role" className="input" value={inviteRole} onChange={e => setInviteRole(e.target.value as "admin" | "member" | "viewer")}>
               <option value="admin">admin</option>
               <option value="member">member</option>
               <option value="viewer">viewer</option>

--- a/web/src/routes/storage/StorageCreate.tsx
+++ b/web/src/routes/storage/StorageCreate.tsx
@@ -37,12 +37,12 @@ export default function StorageCreate() {
       <h1 className="text-xl font-semibold">Create storage location</h1>
       {err && <div className="text-danger text-sm">{err}</div>}
       <div>
-        <label className="label">Name *</label>
-        <input className="input" required value={form.name} onChange={e => set("name", e.target.value)} />
+        <label className="label" htmlFor="storage-create-name">Name *</label>
+        <input id="storage-create-name" className="input" required value={form.name} onChange={e => set("name", e.target.value)} />
       </div>
       <div>
-        <label className="label">Description</label>
-        <textarea className="input" rows={3} value={form.description} onChange={e => set("description", e.target.value)} />
+        <label className="label" htmlFor="storage-create-description">Description</label>
+        <textarea id="storage-create-description" className="input" rows={3} value={form.description} onChange={e => set("description", e.target.value)} />
       </div>
       <label className="flex items-center gap-2 text-sm">
         <input type="checkbox" checked={form.single_part_only} onChange={e => set("single_part_only", e.target.checked)} />


### PR DESCRIPTION
Closes #39

## Summary
- Add `htmlFor` + matching `id` to all sibling-paired `<label className="label">` / input pairs across 18 files: auth (Login, Signup), parts (PartCreate, PartSettings, PartAddStock, PartRemoveStock, PartMoveStock), orders (OrderCreate, OrderDetail), storage (StorageCreate), projects (ProjectCreate, ProjectData, ProjectImport), builds (BuildCreate), reports (Reports), lots (LotDetail), settings (Workspace), and components (AttachmentsPanel)
- Wrap-style labels (those with `<input>` as a child) are left unchanged — they already associate implicitly
- Used semantic hard-coded ids (e.g. `login-email`, `signup-password`, `add-stock-qty`)

## Tests
Backend: N/A
Frontend build: passed (`tsc -b` + `vite build` clean)