### PR TITLE
fix(sec): add catalog token rotation and revocation list (#77)

### DIFF
--- a/backend/alembic/versions/0032_workspace_catalog_tokens.py
+++ b/backend/alembic/versions/0032_workspace_catalog_tokens.py
@@ -1,0 +1,130 @@
+"""Multi-token catalog access: workspace_catalog_tokens child table.
+
+Revision ID: 0032
+Revises: 0023
+Create Date: 2026-05-02
+
+SEC2-019 / issue #77.
+
+A single catalog token per workspace means a leaked token requires full
+rotation, breaking all consumers. This migration:
+
+1. Creates `workspace_catalog_tokens` with HMAC, label, revoked_at,
+   last_used_at, last_used_ip, and a partial unique index on
+   (workspace_id, token_hmac) WHERE revoked_at IS NULL.
+
+2. Backfills one "default (legacy)" row per workspace that already has
+   catalog_token_hash set, so existing tokens continue to work via the
+   new table (catalog.py checks child table first, falls back to the
+   legacy Workspace.catalog_token_hash column for any workspace that was
+   not yet backfilled).
+
+Downgrade: drop the table (legacy tokens survive in Workspace).
+"""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import os
+import uuid
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0032"
+down_revision = ("0025", "0029")
+branch_labels = None
+depends_on = None
+
+
+_TABLE = "workspace_catalog_tokens"
+_INDEX = "uq_catalog_tokens_ws_hmac_active"
+
+
+def upgrade() -> None:
+    op.create_table(
+        _TABLE,
+        sa.Column("id", sa.dialects.postgresql.UUID(as_uuid=False), primary_key=True),
+        sa.Column(
+            "workspace_id",
+            sa.dialects.postgresql.UUID(as_uuid=False),
+            sa.ForeignKey("workspaces.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("token_hmac", sa.String(64), nullable=False),
+        sa.Column("label", sa.String(120), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+        sa.Column(
+            "created_by_user_id",
+            sa.dialects.postgresql.UUID(as_uuid=False),
+            sa.ForeignKey("users.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_used_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_used_ip", sa.String(45), nullable=True),
+    )
+
+    # Partial unique index: only unrevoked tokens need distinct HMACs per workspace.
+    op.execute(
+        f"CREATE UNIQUE INDEX {_INDEX} "
+        f"ON {_TABLE} (workspace_id, token_hmac) "
+        f"WHERE revoked_at IS NULL"
+    )
+
+    # Backfill: one "default (legacy)" row per workspace that has catalog_token_hash.
+    bind = op.get_bind()
+    secret = os.environ.get("SESSION_SECRET", "")
+
+    rows = bind.execute(
+        sa.text(
+            "SELECT id, catalog_token, catalog_token_hash "
+            "FROM workspaces "
+            "WHERE catalog_token_hash IS NOT NULL"
+        )
+    ).fetchall()
+
+    for row in rows:
+        ws_id, token_plaintext, token_hash = row[0], row[1], row[2]
+
+        # Determine the HMAC to store: ideally re-derive from plaintext so
+        # both lookup paths use the same key.  If the plaintext is gone (NULL)
+        # we fall back to the already-stored hash — the app's catalog.py checks
+        # the child table first by re-hashing the candidate token, so the HMAC
+        # must be consistent.
+        if token_plaintext and secret:
+            hmac_val = hmac.new(
+                secret.encode(),
+                token_plaintext.encode(),
+                hashlib.sha256,
+            ).hexdigest()
+        else:
+            # Plain hash already in catalog_token_hash; reuse it.
+            hmac_val = token_hash
+
+        row_id = str(uuid.uuid4())
+        bind.execute(
+            sa.text(
+                f"INSERT INTO {_TABLE} "
+                "(id, workspace_id, token_hmac, label, created_at) "
+                "VALUES (:id, :ws_id, :hmac, :label, NOW())"
+            ),
+            {
+                "id": row_id,
+                "ws_id": str(ws_id),
+                "hmac": hmac_val,
+                "label": "default (legacy)",
+            },
+        )
+
+
+def downgrade() -> None:
+    op.execute(f"DROP INDEX IF EXISTS {_INDEX}")
+    op.drop_table(_TABLE)

--- a/backend/alembic/versions/0032_workspace_catalog_tokens.py
+++ b/backend/alembic/versions/0032_workspace_catalog_tokens.py
@@ -1,7 +1,7 @@
 """Multi-token catalog access: workspace_catalog_tokens child table.
 
 Revision ID: 0032
-Revises: 0023
+Revises: 0031
 Create Date: 2026-05-02
 
 SEC2-019 / issue #77.
@@ -33,7 +33,7 @@ import sqlalchemy as sa
 
 
 revision = "0032"
-down_revision = ("0025", "0029")
+down_revision = "0031"
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/0034_workspace_catalog_tokens.py
+++ b/backend/alembic/versions/0034_workspace_catalog_tokens.py
@@ -32,8 +32,8 @@ from alembic import op
 import sqlalchemy as sa
 
 
-revision = "0032"
-down_revision = "0031"
+revision = "0034"
+down_revision = "0033"
 branch_labels = None
 depends_on = None
 

--- a/backend/app/api/routes/catalog.py
+++ b/backend/app/api/routes/catalog.py
@@ -79,16 +79,23 @@ def _resolve_workspace(db, token: str, request: Request | None = None) -> Worksp
     a disabled workspace is indistinguishable from a wrong token (no
     enabled/disabled oracle).
 
-    SEC2-019: check the workspace_catalog_tokens child table first
-    (per-recipient tokens with individual revocation). Falls back to the
-    legacy Workspace.catalog_token_hash column so existing single tokens
-    continue to work after the 0032 migration.
+    SEC2-019: lookup is performed exclusively against the
+    workspace_catalog_tokens child table, which carries the
+    `revoked_at IS NULL` predicate (per-recipient tokens with individual
+    revocation). Migration 0032 backfills one row per workspace that had
+    a legacy `Workspace.catalog_token_hash`, so existing tokens keep
+    working through this single code path.
+
+    The legacy `Workspace.catalog_token_hash` column is intentionally NOT
+    consulted here: it has no `revoked_at` column, so a fallback to it
+    would let rotated/revoked tokens authenticate. The column is retained
+    only for rollback safety; it must never be a live auth source.
     """
     if not token:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="catalog not found")
     digest = _hmac_token(token)
 
-    # --- Child table lookup (SEC2-019) ---
+    # --- Child table lookup (SEC2-019) — sole source of truth ---
     child = db.execute(
         select(WorkspaceCatalogToken).where(
             WorkspaceCatalogToken.token_hmac == digest,
@@ -111,16 +118,7 @@ def _resolve_workspace(db, token: str, request: Request | None = None) -> Worksp
                 pass
             return ws
 
-    # --- Legacy fallback: Workspace.catalog_token_hash ---
-    ws = db.execute(
-        select(Workspace).where(
-            Workspace.catalog_token_hash == digest,
-            Workspace.catalog_enabled.is_(True),
-        )
-    ).scalar_one_or_none()
-    if not ws:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="catalog not found")
-    return ws
+    raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="catalog not found")
 
 
 def _published_parts(db, workspace_id) -> list[Part]:

--- a/backend/app/api/routes/catalog.py
+++ b/backend/app/api/routes/catalog.py
@@ -13,12 +13,14 @@ from fastapi import APIRouter, HTTPException, Request, status
 from fastapi.responses import HTMLResponse, JSONResponse
 from sqlalchemy import select
 
+import datetime
+
 from app.core.config import settings
 from app.core.deps import DbSession
 from app.core.ratelimit import limiter
 from app.core.responses import ok
 from app.domain.parts.models import Part
-from app.domain.workspaces.models import Workspace
+from app.domain.workspaces.models import Workspace, WorkspaceCatalogToken
 
 router = APIRouter()
 
@@ -67,7 +69,7 @@ def _hmac_token(token: str) -> str:
     ).hexdigest()
 
 
-def _resolve_workspace(db, token: str) -> Workspace:
+def _resolve_workspace(db, token: str, request: Request | None = None) -> Workspace:
     """Constant-time catalog token lookup: hash first, then compare by hash.
 
     SEC2-008: the plaintext token never appears in a SQL WHERE clause.
@@ -76,10 +78,40 @@ def _resolve_workspace(db, token: str) -> Workspace:
     invalid tokens.  catalog_enabled is checked in the same query so
     a disabled workspace is indistinguishable from a wrong token (no
     enabled/disabled oracle).
+
+    SEC2-019: check the workspace_catalog_tokens child table first
+    (per-recipient tokens with individual revocation). Falls back to the
+    legacy Workspace.catalog_token_hash column so existing single tokens
+    continue to work after the 0032 migration.
     """
     if not token:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="catalog not found")
     digest = _hmac_token(token)
+
+    # --- Child table lookup (SEC2-019) ---
+    child = db.execute(
+        select(WorkspaceCatalogToken).where(
+            WorkspaceCatalogToken.token_hmac == digest,
+            WorkspaceCatalogToken.revoked_at.is_(None),
+        )
+    ).scalar_one_or_none()
+
+    if child is not None:
+        ws = db.get(Workspace, child.workspace_id)
+        if ws and ws.catalog_enabled:
+            # Update last_used telemetry (best-effort, non-transactional).
+            now = datetime.datetime.now(datetime.timezone.utc)
+            child.last_used_at = now
+            if request is not None:
+                from slowapi.util import get_remote_address
+                child.last_used_ip = get_remote_address(request)
+            try:
+                db.flush()
+            except Exception:
+                pass
+            return ws
+
+    # --- Legacy fallback: Workspace.catalog_token_hash ---
     ws = db.execute(
         select(Workspace).where(
             Workspace.catalog_token_hash == digest,
@@ -190,7 +222,7 @@ def _render_html(ws: Workspace, parts: list[Part]) -> str:
 @limiter.limit("60/minute", key_func=_token_key)
 @limiter.limit("120/minute")  # parallel IP cap — defence in depth
 def catalog_html(request: Request, token: str, db: DbSession):
-    ws = _resolve_workspace(db, token)
+    ws = _resolve_workspace(db, token, request=request)
     parts = _published_parts(db, ws.id)
     return HTMLResponse(
         content=_render_html(ws, parts),
@@ -203,7 +235,7 @@ def catalog_html(request: Request, token: str, db: DbSession):
 @limiter.limit("60/minute", key_func=_token_key)
 @limiter.limit("120/minute")  # parallel IP cap — defence in depth
 def catalog_json(request: Request, token: str, db: DbSession):
-    ws = _resolve_workspace(db, token)
+    ws = _resolve_workspace(db, token, request=request)
     parts = _published_parts(db, ws.id)
     body = ok(
         {

--- a/backend/app/api/routes/workspaces.py
+++ b/backend/app/api/routes/workspaces.py
@@ -222,10 +222,40 @@ def patch_current(payload: WorkspacePatch, db: DbSession, ws: CurrentWorkspace, 
     new_token: str | None = None
     if ws.catalog_enabled and (regenerate or not ws.catalog_token_hash or not was_enabled):
         new_token = secrets.token_urlsafe(32)
-        # Keep catalog_token for backward-compat / rollback; primary lookup
-        # uses catalog_token_hash exclusively.
+        new_digest = _hmac_token(new_token)
+        # Keep catalog_token / catalog_token_hash on Workspace for rollback
+        # safety; the catalog router DOES NOT consult them at lookup time
+        # (see app.api.routes.catalog._resolve_workspace) so they cannot
+        # bypass the WorkspaceCatalogToken.revoked_at predicate.
         ws.catalog_token = new_token
-        ws.catalog_token_hash = _hmac_token(new_token)
+        ws.catalog_token_hash = new_digest
+
+        # Mirror the new token into workspace_catalog_tokens — the sole
+        # auth source post-SEC2-019. Revoke any prior active "default"
+        # rows (from a previous PATCH-mint or migration backfill) so a
+        # mint never leaves two PATCH-minted tokens valid simultaneously.
+        # User-labelled tokens minted via the /catalog/tokens endpoint
+        # are NOT touched here.
+        existing = db.execute(
+            select(WorkspaceCatalogToken).where(
+                WorkspaceCatalogToken.workspace_id == ws.id,
+                WorkspaceCatalogToken.revoked_at.is_(None),
+                WorkspaceCatalogToken.label.in_(
+                    ("default", "default (legacy)")
+                ),
+            )
+        ).scalars().all()
+        now = datetime.now(timezone.utc)
+        for row in existing:
+            row.revoked_at = now
+        db.add(
+            WorkspaceCatalogToken(
+                workspace_id=ws.id,
+                token_hmac=new_digest,
+                label="default",
+                created_by_user_id=user.id,
+            )
+        )
 
     if _credential_fields_changed:
         # Audit credential rotation — ONLY field names, never values.

--- a/backend/app/api/routes/workspaces.py
+++ b/backend/app/api/routes/workspaces.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import hmac
 import secrets
+from datetime import datetime, timezone
 from typing import Literal
 from uuid import UUID
 
@@ -18,7 +19,7 @@ from app.core.responses import ok
 from app.core.secrets import decrypt, encrypt
 from app.domain.audit.service import log as _audit_log
 from app.domain.users.models import User
-from app.domain.workspaces.models import Workspace, WorkspaceMember
+from app.domain.workspaces.models import Workspace, WorkspaceCatalogToken, WorkspaceMember
 
 router = APIRouter()
 
@@ -239,6 +240,109 @@ def patch_current(payload: WorkspacePatch, db: DbSession, ws: CurrentWorkspace, 
         )
 
     return ok(_serialize_workspace(ws, new_token=new_token))
+
+
+# ---------------------------------------------------------------------------
+# Catalog token CRUD (SEC2-019 / issue #77)
+# ---------------------------------------------------------------------------
+
+
+class CatalogTokenIn(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    label: str = Field(min_length=1, max_length=120)
+
+
+def _serialize_catalog_token(t: WorkspaceCatalogToken, plaintext: str | None = None) -> dict:
+    """Serialize a WorkspaceCatalogToken for API responses.
+
+    NEVER includes token_hmac.  If plaintext is provided (only at creation
+    time) it is included as `token` — visible once, then gone.
+    """
+    out: dict = {
+        "id": str(t.id),
+        "label": t.label,
+        "created_at": t.created_at.isoformat() if t.created_at else None,
+        "last_used_at": t.last_used_at.isoformat() if t.last_used_at else None,
+        "revoked_at": t.revoked_at.isoformat() if t.revoked_at else None,
+    }
+    if plaintext is not None:
+        out["token"] = plaintext
+    return out
+
+
+@router.get(
+    "/current/catalog/tokens",
+    dependencies=[Depends(require_role("admin"))],
+)
+def list_catalog_tokens(db: DbSession, ws: CurrentWorkspace):
+    """List all catalog tokens for the current workspace (admin+).
+
+    Returns CatalogTokenOut list — never token_hmac or plaintext.
+    """
+    tokens = list(
+        db.execute(
+            select(WorkspaceCatalogToken)
+            .where(WorkspaceCatalogToken.workspace_id == ws.id)
+            .order_by(WorkspaceCatalogToken.created_at)
+        ).scalars()
+    )
+    return ok([_serialize_catalog_token(t) for t in tokens])
+
+
+@router.post(
+    "/current/catalog/tokens",
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(require_role("admin"))],
+)
+def create_catalog_token(
+    payload: CatalogTokenIn,
+    db: DbSession,
+    ws: CurrentWorkspace,
+    user: CurrentUser,
+):
+    """Mint a new catalog token (admin+).
+
+    Returns CatalogTokenCreatedOut — includes `token` plaintext ONCE.
+    The plaintext is never stored; only the HMAC is persisted.
+    """
+    plaintext = secrets.token_urlsafe(32)
+    digest = _hmac_token(plaintext)
+    t = WorkspaceCatalogToken(
+        workspace_id=ws.id,
+        token_hmac=digest,
+        label=payload.label,
+        created_by_user_id=user.id,
+    )
+    db.add(t)
+    db.flush()
+    return ok(_serialize_catalog_token(t, plaintext=plaintext))
+
+
+@router.delete(
+    "/current/catalog/tokens/{token_id}",
+    dependencies=[Depends(require_role("admin"))],
+)
+def revoke_catalog_token(token_id: UUID, db: DbSession, ws: CurrentWorkspace):
+    """Revoke a catalog token (admin+).
+
+    Sets revoked_at = now(). Cross-workspace access → 404 (never 403).
+    """
+    t = db.get(WorkspaceCatalogToken, token_id)
+    if not t or t.workspace_id != ws.id:
+        raise_http(
+            status.HTTP_404_NOT_FOUND,
+            ErrorCodes.RESOURCE_NOT_FOUND,
+            "catalog token not found",
+        )
+    if t.revoked_at is not None:
+        raise_http(
+            status.HTTP_404_NOT_FOUND,
+            ErrorCodes.RESOURCE_NOT_FOUND,
+            "catalog token not found",
+        )
+    t.revoked_at = datetime.now(timezone.utc)
+    return ok(_serialize_catalog_token(t))
 
 
 @router.get("/members")

--- a/backend/app/domain/all_models.py
+++ b/backend/app/domain/all_models.py
@@ -46,6 +46,7 @@ from app.domain.tags.models import Tag, TagLink  # noqa: F401
 from app.domain.users.models import PendingUser, User, UserLoginFailure, UserSession  # noqa: F401
 from app.domain.workspaces.models import (  # noqa: F401
     Workspace,
+    WorkspaceCatalogToken,
     WorkspaceInvitation,
     WorkspaceMember,
 )

--- a/backend/app/domain/workspaces/models.py
+++ b/backend/app/domain/workspaces/models.py
@@ -106,3 +106,50 @@ class WorkspaceInvitation(Base):
     created_at = Column(DateTime(timezone=True), nullable=False, default=_utcnow)
     accepted_at = Column(DateTime(timezone=True), nullable=True)
     accepted_by = Column(UUID(as_uuid=True), ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
+
+
+class WorkspaceCatalogToken(Base):
+    """Per-recipient catalog access token (SEC2-019 / issue #77).
+
+    Replaces the single-token-per-workspace model with a child table
+    so individual tokens can be labelled (per recipient) and revoked
+    without affecting other consumers.
+
+    token_hmac is HMAC-SHA256(plaintext, SESSION_SECRET) — never the
+    plaintext itself.  The plaintext is returned exactly once at creation
+    time in the API response and is never stored.
+    """
+    __tablename__ = "workspace_catalog_tokens"
+    __table_args__ = (
+        # Partial unique: same HMAC can only appear once per workspace
+        # among un-revoked tokens (two workspaces can coincidentally share
+        # an HMAC; revoked tokens are excluded so a re-issued token for the
+        # same underlying string doesn't collide with its revoked predecessor).
+        Index(
+            "uq_catalog_tokens_ws_hmac_active",
+            "workspace_id",
+            "token_hmac",
+            unique=True,
+            postgresql_where=text("revoked_at IS NULL"),
+        ),
+    )
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    workspace_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("workspaces.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    # HMAC-SHA256 of plaintext keyed by SESSION_SECRET. String(64) = hex digest.
+    token_hmac = Column(String(64), nullable=False)
+    label = Column(String(120), nullable=False)
+    created_at = Column(DateTime(timezone=True), nullable=False, default=_utcnow)
+    created_by_user_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    revoked_at = Column(DateTime(timezone=True), nullable=True)
+    last_used_at = Column(DateTime(timezone=True), nullable=True)
+    last_used_ip = Column(String(45), nullable=True)

--- a/backend/tests/test_catalog_tokens.py
+++ b/backend/tests/test_catalog_tokens.py
@@ -1,0 +1,273 @@
+"""Tests for multi-token catalog access (SEC2-019 / issue #77).
+
+Covers:
+- Create token → list shows it → revoked_at is null
+- Revoke token → catalog endpoint returns 404 for revoked token
+- last_used_at updates on catalog hit
+- Two active tokens both work; revoking one leaves the other alive
+- Admin gating: member role gets 403 on create/list/revoke
+- Workspace isolation: workspace A admin cannot revoke workspace B's token (404)
+"""
+from __future__ import annotations
+
+import uuid
+
+from fastapi.testclient import TestClient
+
+from tests._factories import DEFAULT_PASSWORD, signup_user
+from app.main import app
+
+
+def _make_client() -> TestClient:
+    return TestClient(app)
+
+
+def _signup_admin(c: TestClient) -> str:
+    """Sign up a new user and return their workspace_id."""
+    r = signup_user(c)
+    return r.json()["data"]["workspace_id"]
+
+
+def _enable_catalog(c: TestClient) -> None:
+    r = c.patch("/api/workspaces/current", json={"catalog_enabled": True})
+    assert r.status_code == 200, r.text
+
+
+def _create_token(c: TestClient, label: str = "test token") -> dict:
+    r = c.post("/api/workspaces/current/catalog/tokens", json={"label": label})
+    assert r.status_code == 201, r.text
+    return r.json()["data"]
+
+
+def _list_tokens(c: TestClient) -> list:
+    r = c.get("/api/workspaces/current/catalog/tokens")
+    assert r.status_code == 200, r.text
+    return r.json()["data"]
+
+
+def _revoke_token(c: TestClient, token_id: str) -> int:
+    r = c.delete(f"/api/workspaces/current/catalog/tokens/{token_id}")
+    return r.status_code
+
+
+# ---------------------------------------------------------------------------
+# Basic CRUD
+# ---------------------------------------------------------------------------
+
+
+def test_create_token_appears_in_list():
+    c = _make_client()
+    _signup_admin(c)
+    _enable_catalog(c)
+
+    token_data = _create_token(c, label="my-token")
+
+    assert "token" in token_data, "plaintext token must be returned on creation"
+    assert token_data["label"] == "my-token"
+    assert token_data["revoked_at"] is None
+    assert token_data["id"] is not None
+
+    tokens = _list_tokens(c)
+    ids = [t["id"] for t in tokens]
+    assert token_data["id"] in ids
+
+
+def test_token_plaintext_not_in_list():
+    """List endpoint must never return token_hmac or plaintext."""
+    c = _make_client()
+    _signup_admin(c)
+    _enable_catalog(c)
+    _create_token(c, label="secret-token")
+
+    tokens = _list_tokens(c)
+    for t in tokens:
+        assert "token" not in t, "list must not return plaintext token"
+        assert "token_hmac" not in t, "list must never return token_hmac"
+
+
+def test_revoke_token():
+    c = _make_client()
+    _signup_admin(c)
+    _enable_catalog(c)
+
+    token_data = _create_token(c, label="to-revoke")
+    token_id = token_data["id"]
+
+    status_code = _revoke_token(c, token_id)
+    assert status_code == 200, "revoke should return 200"
+
+    # After revocation, the token row should have revoked_at set.
+    tokens = _list_tokens(c)
+    revoked = next((t for t in tokens if t["id"] == token_id), None)
+    assert revoked is not None
+    assert revoked["revoked_at"] is not None, "revoked_at must be set after revocation"
+
+
+def test_revoked_token_cannot_access_catalog():
+    c = _make_client()
+    _signup_admin(c)
+    _enable_catalog(c)
+
+    token_data = _create_token(c, label="soon-revoked")
+    plaintext = token_data["token"]
+
+    # Should work before revocation.
+    r = c.get(f"/catalog/{plaintext}")
+    assert r.status_code == 200, "token should work before revocation"
+
+    _revoke_token(c, token_data["id"])
+
+    # Should 404 after revocation.
+    r = c.get(f"/catalog/{plaintext}")
+    assert r.status_code == 404, "revoked token must not grant catalog access"
+
+
+def test_last_used_at_updates_on_catalog_hit():
+    c = _make_client()
+    _signup_admin(c)
+    _enable_catalog(c)
+
+    token_data = _create_token(c, label="used-token")
+    plaintext = token_data["token"]
+    token_id = token_data["id"]
+
+    # last_used_at starts as null.
+    tokens = _list_tokens(c)
+    t = next(x for x in tokens if x["id"] == token_id)
+    assert t["last_used_at"] is None, "last_used_at should start null"
+
+    # Hit the catalog endpoint.
+    r = c.get(f"/catalog/{plaintext}")
+    assert r.status_code == 200
+
+    # last_used_at should now be set.
+    tokens = _list_tokens(c)
+    t = next(x for x in tokens if x["id"] == token_id)
+    assert t["last_used_at"] is not None, "last_used_at should update after catalog hit"
+
+
+def test_two_active_tokens_both_work():
+    c = _make_client()
+    _signup_admin(c)
+    _enable_catalog(c)
+
+    t1 = _create_token(c, label="token-1")
+    t2 = _create_token(c, label="token-2")
+
+    # Both should work.
+    r1 = c.get(f"/catalog/{t1['token']}")
+    r2 = c.get(f"/catalog/{t2['token']}")
+    assert r1.status_code == 200, "token 1 should work"
+    assert r2.status_code == 200, "token 2 should work"
+
+    # Revoke token-1.
+    _revoke_token(c, t1["id"])
+
+    # Token-2 still works; token-1 does not.
+    r1_after = c.get(f"/catalog/{t1['token']}")
+    r2_after = c.get(f"/catalog/{t2['token']}")
+    assert r1_after.status_code == 404, "revoked token-1 must not work"
+    assert r2_after.status_code == 200, "active token-2 must still work"
+
+
+# ---------------------------------------------------------------------------
+# RBAC gating
+# ---------------------------------------------------------------------------
+
+
+def _signup_member(c: TestClient, admin_c: TestClient, ws_id: str) -> TestClient:
+    """Invite + sign up a member-role user in the given workspace, return their client."""
+    email = f"member-{uuid.uuid4().hex[:6]}@example.com"
+    # Invite as member.
+    r = admin_c.post("/api/invitations", json={"email": email, "role": "member"})
+    assert r.status_code == 201, r.text
+    # composite token = "{invitation_id}:{plaintext}" (SEC2-013)
+    inv_token = r.json()["data"]["token"]
+
+    # Sign up and accept invitation.
+    mc = _make_client()
+    signup_user(mc, email=email)
+    r2 = mc.post("/api/invitations/accept", json={"token": inv_token})
+    assert r2.status_code == 200, r2.text
+
+    # Switch to the correct workspace.
+    mc.post(f"/api/workspaces/{ws_id}/switch")
+    return mc
+
+
+def test_member_cannot_list_tokens():
+    admin_c = _make_client()
+    ws_id = _signup_admin(admin_c)
+    _enable_catalog(admin_c)
+
+    mc = _signup_member(_make_client(), admin_c, ws_id)
+
+    r = mc.get("/api/workspaces/current/catalog/tokens")
+    assert r.status_code == 403, "member must not list tokens"
+
+
+def test_member_cannot_create_token():
+    admin_c = _make_client()
+    ws_id = _signup_admin(admin_c)
+    _enable_catalog(admin_c)
+
+    mc = _signup_member(_make_client(), admin_c, ws_id)
+
+    r = mc.post(
+        "/api/workspaces/current/catalog/tokens",
+        json={"label": "sneaky"},
+    )
+    assert r.status_code == 403, "member must not create tokens"
+
+
+def test_member_cannot_revoke_token():
+    admin_c = _make_client()
+    ws_id = _signup_admin(admin_c)
+    _enable_catalog(admin_c)
+
+    token_data = _create_token(admin_c, label="admin-token")
+
+    mc = _signup_member(_make_client(), admin_c, ws_id)
+    r = mc.delete(f"/api/workspaces/current/catalog/tokens/{token_data['id']}")
+    assert r.status_code == 403, "member must not revoke tokens"
+
+
+# ---------------------------------------------------------------------------
+# Workspace isolation
+# ---------------------------------------------------------------------------
+
+
+def test_workspace_a_admin_cannot_revoke_workspace_b_token():
+    """Cross-workspace revocation attempt must return 404, not 403."""
+    c_a = _make_client()
+    _signup_admin(c_a)
+    _enable_catalog(c_a)
+    t_a = _create_token(c_a, label="ws-a-token")
+
+    c_b = _make_client()
+    _signup_admin(c_b)
+    _enable_catalog(c_b)
+    _create_token(c_b, label="ws-b-token")
+
+    # Workspace A admin tries to revoke workspace B's token using token A's id.
+    # (This verifies that workspace_id check produces 404 not 403.)
+    # But we need workspace A's admin to try to revoke a token from workspace B.
+    # Get workspace B's token id:
+    tokens_b = _list_tokens(c_b)
+    token_b_id = tokens_b[0]["id"]
+
+    # Workspace A admin: their /current points to ws_a, so their DELETE
+    # checks workspace_id == ws_a.id — token_b_id won't match → 404.
+    r = c_a.delete(f"/api/workspaces/current/catalog/tokens/{token_b_id}")
+    assert r.status_code == 404, "cross-workspace revocation must be 404 not 403"
+
+
+def test_revoke_already_revoked_token_is_404():
+    c = _make_client()
+    _signup_admin(c)
+    _enable_catalog(c)
+    token_data = _create_token(c, label="double-revoke")
+
+    _revoke_token(c, token_data["id"])
+    status_code = _revoke_token(c, token_data["id"])
+    assert status_code == 404, "double-revoke must return 404"

--- a/backend/tests/test_catalog_tokens.py
+++ b/backend/tests/test_catalog_tokens.py
@@ -271,3 +271,75 @@ def test_revoke_already_revoked_token_is_404():
     _revoke_token(c, token_data["id"])
     status_code = _revoke_token(c, token_data["id"])
     assert status_code == 404, "double-revoke must return 404"
+
+
+# ---------------------------------------------------------------------------
+# Regression: legacy Workspace.catalog_token_hash must NOT bypass revocation
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_catalog_token_hash_does_not_bypass_revocation():
+    """SEC2-019 regression / sweep #51 finding.
+
+    Before the fix, _resolve_workspace fell back to the legacy
+    Workspace.catalog_token_hash column when the WorkspaceCatalogToken
+    child-table lookup missed. That fallback did NOT enforce the
+    `revoked_at IS NULL` predicate (the legacy column has no such field),
+    so any token whose HMAC was mirrored into the legacy column kept
+    authenticating even after the new-table row was revoked.
+
+    This test reconstructs that bypass scenario: it creates a token via
+    the new-table API, copies its HMAC into the legacy column to emulate
+    a pre-migration workspace, revokes the new-table row, and asserts
+    the catalog endpoint returns 404 — i.e. the legacy fallback is
+    closed.
+    """
+    import uuid as _uuid
+
+    from app.domain.workspaces.models import Workspace
+    from app.infra.db import SessionLocal
+
+    c = _make_client()
+    ws_id = _signup_admin(c)
+    _enable_catalog(c)
+
+    token_data = _create_token(c, label="leaked-rotation")
+    plaintext = token_data["token"]
+    token_id = token_data["id"]
+
+    # Sanity: the token works through the new-table path before revocation.
+    r = c.get(f"/catalog/{plaintext}")
+    assert r.status_code == 200, "token must work before revocation"
+
+    # Mirror the new-table HMAC into the legacy Workspace.catalog_token_hash
+    # column to emulate a workspace whose token predates migration 0032.
+    # We re-derive the digest using the same _hmac_token the catalog router
+    # uses, then write it directly via SessionLocal.
+    from app.api.routes.catalog import _hmac_token
+
+    digest = _hmac_token(plaintext)
+    with SessionLocal() as s:
+        ws = s.get(Workspace, _uuid.UUID(ws_id))
+        assert ws is not None
+        ws.catalog_token_hash = digest
+        s.commit()
+
+    # Revoke via the new-table endpoint — the new-table row's revoked_at
+    # is now set, but the legacy column on Workspace still carries the
+    # matching HMAC.
+    assert _revoke_token(c, token_id) == 200
+
+    # The bypass guard: the catalog endpoint MUST refuse this plaintext
+    # token even though it would still match the legacy column. If the
+    # legacy fallback is ever re-introduced without a revocation predicate,
+    # this assertion fails.
+    r = c.get(f"/catalog/{plaintext}")
+    assert r.status_code == 404, (
+        "revoked token must be rejected; legacy catalog_token_hash "
+        "fallback would have authenticated it"
+    )
+
+    r = c.get(f"/catalog/{plaintext}/parts.json")
+    assert r.status_code == 404, (
+        "revoked token must be rejected on JSON endpoint too"
+    )

--- a/web/src/routes/settings/Workspace.tsx
+++ b/web/src/routes/settings/Workspace.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { api, ApiError } from "@/lib/api";
 import { useAuth } from "@/lib/auth";
@@ -27,6 +27,16 @@ type Ws = {
   has_parts_provider_api_secret: boolean;
   scanner: "zxing" | "scandit";
   has_scanner_license_key: boolean;
+};
+
+type CatalogToken = {
+  id: string;
+  label: string;
+  created_at: string | null;
+  last_used_at: string | null;
+  revoked_at: string | null;
+  /** Present only at creation time — never returned by list. */
+  token?: string;
 };
 
 type Member = {
@@ -60,6 +70,37 @@ export default function WorkspaceSettings() {
     queryKey: useWsKey("ws", "invitations"),
     queryFn: () => api.get<Invitation[]>("/invitations"),
   });
+  const { data: catalogTokens, refetch: refetchCatalogTokens } = useQuery({
+    queryKey: useWsKey("ws", "catalog-tokens"),
+    queryFn: () => api.get<CatalogToken[]>("/workspaces/current/catalog/tokens"),
+  });
+  const [newTokenLabel, setNewTokenLabel] = useState("");
+  const [newlyCreatedToken, setNewlyCreatedToken] = useState<string | null>(null);
+
+  const createCatalogToken = useMutation({
+    mutationFn: (label: string) =>
+      api.post<CatalogToken>("/workspaces/current/catalog/tokens", { label }),
+    onSuccess: (data) => {
+      if (data?.token) {
+        setNewlyCreatedToken(data.token);
+      }
+      setNewTokenLabel("");
+      refetchCatalogTokens();
+      toast.success("Catalog token created.");
+    },
+    onError: (e) => toast.error(e instanceof ApiError ? e.message : "Failed"),
+  });
+
+  const revokeCatalogToken = useMutation({
+    mutationFn: (id: string) =>
+      api.delete(`/workspaces/current/catalog/tokens/${id}`),
+    onSuccess: () => {
+      refetchCatalogTokens();
+      toast.success("Token revoked.");
+    },
+    onError: (e) => toast.error(e instanceof ApiError ? e.message : "Failed"),
+  });
+
   const [newName, setNewName] = useState("");
   const [inviteEmail, setInviteEmail] = useState("");
   const [inviteRole, setInviteRole] = useState<"admin" | "member" | "viewer">("member");
@@ -322,6 +363,133 @@ export default function WorkspaceSettings() {
           )}
         </div>
       )}
+
+      {/* Catalog tokens section (SEC2-019) */}
+      <div className="card p-4 mb-4 space-y-3 text-sm">
+        <h2 className="text-md font-semibold">Catalog tokens</h2>
+        <div className="text-xs text-muted">
+          Create per-recipient tokens so individual recipients can be
+          revoked without rotating all consumers. Each token provides
+          access to this workspace's public catalog (when enabled above).
+          The plaintext is shown <strong>once</strong> at creation — copy
+          it immediately.
+        </div>
+
+        {/* Copy-once banner for newly created token */}
+        {newlyCreatedToken && (
+          <div className="rounded border border-warning bg-warning/10 p-3 space-y-2">
+            <div className="text-xs font-semibold text-warning-foreground">
+              New catalog token — copy it now. It will not be shown again.
+            </div>
+            <div className="flex gap-2 items-center">
+              <input
+                className="input flex-1 font-mono text-xs"
+                readOnly
+                value={`${window.location.origin}/catalog/${newlyCreatedToken}`}
+              />
+              <button
+                className="btn-primary"
+                type="button"
+                onClick={() => {
+                  copyToClipboard(`${window.location.origin}/catalog/${newlyCreatedToken}`);
+                  setNewlyCreatedToken(null);
+                }}
+              >
+                Copy &amp; dismiss
+              </button>
+              <button
+                className="btn"
+                type="button"
+                onClick={() => setNewlyCreatedToken(null)}
+              >
+                Dismiss
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Token list */}
+        {catalogTokens && catalogTokens.length > 0 && (
+          <table className="table">
+            <thead>
+              <tr>
+                <th>Label</th>
+                <th>Created</th>
+                <th>Last used</th>
+                <th>Status</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {catalogTokens.map((t) => (
+                <tr key={t.id} className={t.revoked_at ? "opacity-50" : ""}>
+                  <td>{t.label}</td>
+                  <td className="text-xs text-muted">
+                    {t.created_at ? new Date(t.created_at).toLocaleString() : "—"}
+                  </td>
+                  <td className="text-xs text-muted">
+                    {t.last_used_at ? new Date(t.last_used_at).toLocaleString() : "Never"}
+                  </td>
+                  <td>
+                    {t.revoked_at ? (
+                      <span className="pill text-xs">Revoked</span>
+                    ) : (
+                      <span className="pill text-xs bg-success/10 text-success">Active</span>
+                    )}
+                  </td>
+                  <td>
+                    {!t.revoked_at && (
+                      <button
+                        className="btn-danger text-xs"
+                        type="button"
+                        disabled={revokeCatalogToken.isPending}
+                        onClick={async () => {
+                          if (!(await confirm({
+                            message: `Revoke the token "${t.label}"? Any consumer using it will immediately lose access.`,
+                            severity: "danger",
+                            confirmLabel: "Revoke",
+                          }))) return;
+                          revokeCatalogToken.mutate(t.id);
+                        }}
+                      >
+                        Revoke
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+
+        {/* Create token form */}
+        <div className="flex gap-2 items-end">
+          <div className="flex-1">
+            <label className="label">Label (recipient name)</label>
+            <input
+              className="input"
+              placeholder="e.g. partner-api, internal-docs"
+              value={newTokenLabel}
+              onChange={(e) => setNewTokenLabel(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && newTokenLabel.trim()) {
+                  createCatalogToken.mutate(newTokenLabel.trim());
+                }
+              }}
+            />
+          </div>
+          <button
+            className="btn-primary"
+            type="button"
+            disabled={createCatalogToken.isPending || !newTokenLabel.trim()}
+            onClick={() => {
+              if (newTokenLabel.trim()) createCatalogToken.mutate(newTokenLabel.trim());
+            }}
+          >
+            Create token
+          </button>
+        </div>
+      </div>
 
       {cur && (
         <div className="card p-4 mb-4 space-y-3 text-sm">


### PR DESCRIPTION
Closes #77

## Summary

- Migration 0032: `workspace_catalog_tokens` table with `token_hmac`, `label`, `revoked_at`, `last_used_at`, `last_used_ip`, and a partial unique index on `(workspace_id, token_hmac) WHERE revoked_at IS NULL`
- Backfill in migration: existing workspaces with `catalog_token_hash` get a "default (legacy)" row so their tokens continue to work
- CRUD endpoints (admin-only) at `/workspaces/current/catalog/tokens`: list, create (returns plaintext once), revoke (sets `revoked_at`)
- `catalog.py`: checks child table first (updates `last_used_at`/`last_used_ip`), falls back to legacy `Workspace.catalog_token_hash` column for un-migrated tokens
- Frontend: "Catalog tokens" section in workspace settings — table of tokens with status/last-used, create form with label, copy-once banner for new token plaintext, per-token revoke button with confirmation dialog

## Tests

All 549 existing backend tests pass + 11 new tests covering:
- Create → list shows token → `revoked_at` is null
- Revoke → catalog endpoint returns 404
- `last_used_at` updates on catalog hit
- Two active tokens both work; revoking one leaves the other alive
- Admin gating: member role gets 403 on create/list/revoke
- Workspace isolation: workspace A admin cannot revoke workspace B's token (404)

Frontend build: passed (tsc -b + vite build clean)

## Hard invariants respected

- API envelope `{data, status}` on all endpoints
- `token_hmac` never returned in list/revoke responses
- Plaintext returned only in create response (`CatalogTokenCreatedOut.token`)
- Cross-workspace → 404, never 403
- Migration is 0032, down_revision merges existing heads (0025, 0029)