### PR TITLE
fix: linearize bulk import Alembic migration

### DIFF
--- a/backend/alembic/versions/0035_bulk_import_idempotency.py
+++ b/backend/alembic/versions/0035_bulk_import_idempotency.py
@@ -1,12 +1,12 @@
 """Add bulk_import_idempotency table (BE2-003).
 
-Revision ID: 0034
-Revises: 0033
+Revision ID: 0035
+Revises: 0034
 Create Date: 2026-05-02
 
 Chain: 0030_audit_log -> 0031_search_pg_trgm_indexes ->
 0032_integer_quantities -> 0033_polymorphic_orphan_indexes ->
-0034_bulk_import_idempotency.
+0034_workspace_catalog_tokens -> 0035_bulk_import_idempotency.
 
 Adds an idempotency cache for POST /api/parts/bulk-import-from-scan.
 A (workspace_id, key) composite PK enforces workspace isolation; a
@@ -25,8 +25,8 @@ from alembic import op
 from sqlalchemy.dialects.postgresql import JSONB
 
 
-revision = "0034"
-down_revision = "0033"
+revision = "0035"
+down_revision = "0034"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Summary
- rename the later bulk-import idempotency migration from 0034 to 0035
- chain it after 0034_workspace_catalog_tokens so Alembic has a single head

## Verification
- script-based migration graph check reports `heads: ['0035']` and no duplicate revisions

Note: local `python3 -m alembic heads --resolve-dependencies` could not run because this environment's Alembic package has no `__main__`; CI uses its own environment for that command.