### PR TITLE
fix: restore linear Alembic numbering after migration race

### DIFF
--- a/backend/alembic/versions/0034_bulk_import_idempotency.py
+++ b/backend/alembic/versions/0034_bulk_import_idempotency.py
@@ -1,12 +1,12 @@
 """Add bulk_import_idempotency table (BE2-003).
 
-Revision ID: 0035
-Revises: 0034
+Revision ID: 0034
+Revises: 0033
 Create Date: 2026-05-02
 
 Chain: 0030_audit_log -> 0031_search_pg_trgm_indexes ->
 0032_integer_quantities -> 0033_polymorphic_orphan_indexes ->
-0034_workspace_catalog_tokens -> 0035_bulk_import_idempotency.
+0034_bulk_import_idempotency.
 
 Adds an idempotency cache for POST /api/parts/bulk-import-from-scan.
 A (workspace_id, key) composite PK enforces workspace isolation; a
@@ -21,9 +21,9 @@ returned without re-running any provider calls.
 from __future__ import annotations
 
 import sqlalchemy as sa
-from alembic import op
 from sqlalchemy.dialects.postgresql import JSONB
 
+from alembic import op
 
 revision = "0034"
 down_revision = "0033"

--- a/backend/alembic/versions/0035_workspace_catalog_tokens.py
+++ b/backend/alembic/versions/0035_workspace_catalog_tokens.py
@@ -1,7 +1,7 @@
 """Multi-token catalog access: workspace_catalog_tokens child table.
 
-Revision ID: 0032
-Revises: 0031
+Revision ID: 0035
+Revises: 0034
 Create Date: 2026-05-02
 
 SEC2-019 / issue #77.
@@ -28,9 +28,9 @@ import hmac
 import os
 import uuid
 
-from alembic import op
 import sqlalchemy as sa
 
+from alembic import op
 
 revision = "0035"
 down_revision = "0034"


### PR DESCRIPTION
## Summary
- restore bulk-import idempotency as revision 0034 after 0033
- keep workspace catalog tokens as revision 0035 after 0034
- fix the workspace migration docstring metadata to match its revision

## Verification
- script-based migration graph check reports `heads: ['0035']`, no duplicate revisions, and no missing parents