### PR TITLE
fix(parts): replace per-row quantity queries with bulk fetch in list_parts (#243)

### DIFF
--- a/backend/app/api/routes/parts.py
+++ b/backend/app/api/routes/parts.py
@@ -51,6 +51,7 @@ from app.domain.stock.schemas import AddStockIn, LotInput
 from app.domain.stock.service import (
     StockError,
     add_stock,
+    bulk_current_quantities,
     reserved_quantity,
     stock_summary_for_part,
     total_for_part,
@@ -219,15 +220,16 @@ def list_parts(
         )
         next_cursor = None
 
-    image_urls = _image_urls_for_parts(db, ws.id, [p.id for p in parts])
+    part_ids = [p.id for p in parts]
+    image_urls = _image_urls_for_parts(db, ws.id, part_ids)
+    on_hand_map = bulk_current_quantities(db, workspace_id=ws.id, part_ids=part_ids, status="on_hand")
+    reserved_map = bulk_current_quantities(db, workspace_id=ws.id, part_ids=part_ids, status="reserved")
     items = []
     for p in parts:
-        on_hand = total_for_part(db, workspace_id=ws.id, part_id=p.id)
-        reserved = reserved_quantity(db, workspace_id=ws.id, part_id=p.id)
         items.append(_serialize(
             p,
-            on_hand=on_hand,
-            reserved=reserved,
+            on_hand=on_hand_map.get(p.id, 0),
+            reserved=reserved_map.get(p.id, 0),
             image_url=image_urls.get(p.id),
         ))
     if use_paged:


### PR DESCRIPTION
Closes #243

## Summary
- `bulk_current_quantities` already existed in `domain/stock/service.py` — added it to the import in `parts.py`
- Replaced the O(N) per-row `total_for_part` + `reserved_quantity` calls in `list_parts` with two bulk calls (`status="on_hand"` and `status="reserved"`)
- Reduces DB round-trips from 2N+1 to 3 for the parts listing endpoint
- Results mapped back per-part via `.get(p.id, 0)` (missing key → 0, consistent with original behaviour)

## Tests
Backend: 682 passed, 2 skipped — all green
Frontend: N/A