### PR TITLE
fix(orders): acquire stock lock before reading entries to eliminate receive race (#247)

### DIFF
--- a/backend/app/domain/orders/service.py
+++ b/backend/app/domain/orders/service.py
@@ -50,23 +50,35 @@ def receive(
     if order.status == "cancelled":
         raise OrderError("order is cancelled")
 
+    # BE2-001 / #247: acquire the advisory stock-write lock BEFORE reading
+    # OrderEntry rows. Reading first and locking second is a TOCTOU race —
+    # a concurrent receive can slip through the `outstanding` guard while
+    # both threads hold stale in-memory `quantity_received` values.
+    #
+    # Fix: run a lightweight preliminary query to collect the part_ids for
+    # the lock call, acquire the lock, then re-query entries with
+    # FOR UPDATE so the values we act on are authoritative and pinned
+    # for the rest of this transaction.
+    preliminary_entries = (
+        db.query(OrderEntry.id, OrderEntry.part_id)
+        .filter(OrderEntry.workspace_id == workspace_id, OrderEntry.order_id == order.id)
+        .all()
+    )
+    lock_parts_for_stock_write(
+        db,
+        workspace_id=workspace_id,
+        part_ids=[row.part_id for row in preliminary_entries if row.part_id is not None],
+    )
+
+    # Re-query with FOR UPDATE after the lock so quantity_received reflects
+    # any in-flight writes that committed before we acquired the lock.
     entries_by_id: dict[UUID, OrderEntry] = {
         e.id: e
         for e in db.query(OrderEntry)
         .filter(OrderEntry.workspace_id == workspace_id, OrderEntry.order_id == order.id)
+        .with_for_update()
         .all()
     }
-
-    # BE2-001: receive is the order-side producer write. Lock every
-    # distinct part this receive touches (across all entries on this
-    # order, even if some lines target only a subset — keeps lock
-    # coverage symmetric with concurrent build_consume / remove paths
-    # on the same parts). Sorted-UUID order keeps it deadlock-safe.
-    lock_parts_for_stock_write(
-        db,
-        workspace_id=workspace_id,
-        part_ids=[e.part_id for e in entries_by_id.values() if e.part_id is not None],
-    )
 
     received_at = utcnow()
     created_lots: list[Lot] = []

--- a/backend/tests/test_orders_receive_concurrency.py
+++ b/backend/tests/test_orders_receive_concurrency.py
@@ -67,20 +67,6 @@ def _copy_cookies(src: TestClient, dst: TestClient) -> None:
         )
 
 
-@pytest.mark.xfail(
-    strict=False,
-    reason=(
-        "Real bug surfaced by this regression test (BE-001 follow-up). "
-        "domain/orders/service.py::receive loads OrderEntry rows BEFORE "
-        "acquiring lock_parts_for_stock_write, so after the lock both "
-        "threads still hold a stale in-memory `oe.quantity_received` "
-        "and both pass the `outstanding = qty_ordered - qty_received` "
-        "guard. Fix: re-load entries (or SELECT ... FOR UPDATE on the "
-        "OrderEntry rows) AFTER the advisory lock. xfail(strict=False) "
-        "lets the test go green when the receive path is hardened, at "
-        "which point the marker should be removed."
-    ),
-)
 def test_concurrent_receive_cannot_overshoot_qty_ordered(authed):
     """Two threads both try to fully receive the same 10-qty open line.
     Exactly one must succeed; quantity_received must never exceed
@@ -158,14 +144,6 @@ def test_concurrent_receive_cannot_overshoot_qty_ordered(authed):
     )
 
 
-@pytest.mark.xfail(
-    strict=False,
-    reason=(
-        "Same BE-001 follow-up bug as above: stale `quantity_received` "
-        "read before the lock is acquired. xfail(strict=False) until "
-        "receive is hardened to re-load the OrderEntry under the lock."
-    ),
-)
 def test_partial_receive_serialises(authed):
     """Both threads request a partial qty whose sum exceeds remaining.
     At least one must 4xx; final received must not exceed ordered."""


### PR DESCRIPTION
Closes #247

## Summary
- Restructure `receive` in `domain/orders/service.py` to acquire `lock_parts_for_stock_write` BEFORE reading `OrderEntry` rows
- Add a lightweight preliminary query to collect `part_ids` for the lock call (preserves workspace isolation — still filters by `workspace_id`)
- Re-query `OrderEntry` rows with `.with_for_update()` after lock acquisition so `quantity_received` is authoritative and any concurrent commits are visible
- Remove `@pytest.mark.xfail` from `test_concurrent_receive_cannot_overshoot_qty_ordered` and `test_partial_receive_serialises` in `tests/test_orders_receive_concurrency.py`

## Tests
Backend: 684 passed, 2 skipped, 3 deselected, 1 xfailed (pre-existing, unrelated), 63 warnings
Frontend: N/A