### PR TITLE
fix(orders): assert part belongs to workspace before adding order entry (#242)

### DIFF
--- a/backend/app/api/routes/orders.py
+++ b/backend/app/api/routes/orders.py
@@ -6,12 +6,13 @@ from uuid import UUID
 from fastapi import APIRouter, HTTPException, Query, Request, status
 from sqlalchemy import and_, or_, select
 
-from app.api._helpers import assert_child_in_parent, require_resource_access
+from app.api._helpers import assert_child_in_parent, assert_in_workspace, require_resource_access
 from app.api.routes._activity import _DEFAULT_LIMIT, _MAX_LIMIT, build_activity
 from app.core.deps import CurrentUser, CurrentWorkspace, DbSession
 from app.core.responses import ok
 from app.core.time import utcnow
 from app.domain.orders.models import Order, OrderEntry
+from app.domain.parts.models import Part
 from app.domain.stock.models import StockEntry
 from app.domain.orders.schemas import (
     OrderCreateIn,
@@ -24,6 +25,17 @@ from app.domain.orders.service import OrderError, receive
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
+
+
+def _assert_part_live(db, ws_id: UUID, part_id) -> None:
+    """Assert that a part exists in the current workspace and is not archived.
+    Raises 404 if the part is missing or belongs to another workspace,
+    matching the pattern in projects.py (BE2-016)."""
+    if part_id is None:
+        return
+    part = assert_in_workspace(db, Part, part_id, ws_id, label="part")
+    if part.archived_at is not None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="part not found")
 
 
 def _serialize(o: Order, *, totals: tuple[int, int] | None = None) -> dict:
@@ -128,6 +140,7 @@ def create_order(payload: OrderCreateIn, db: DbSession, ws: CurrentWorkspace, us
     db.add(o)
     db.flush()
     for idx, ein in enumerate(payload.entries):
+        _assert_part_live(db, ws.id, ein.part_id)
         db.add(
             OrderEntry(
                 workspace_id=ws.id,
@@ -216,6 +229,7 @@ def restore_order(order_id: UUID, db: DbSession, ws: CurrentWorkspace, user: Cur
 @router.post("/{order_id}/entries", status_code=status.HTTP_201_CREATED)
 def add_entry(order_id: UUID, payload: OrderEntryIn, db: DbSession, ws: CurrentWorkspace, user: CurrentUser):
     o = _get_order(db, ws.id, order_id)
+    _assert_part_live(db, ws.id, payload.part_id)
     next_idx = (
         db.execute(
             select(OrderEntry.order_index)
@@ -250,6 +264,8 @@ def patch_entry(order_id: UUID, entry_id: UUID, payload: OrderEntryPatch, db: Db
     o = _get_order(db, ws.id, order_id)
     e = assert_child_in_parent(db, OrderEntry, entry_id, o, parent_fk="order_id", label="entry")
     data = payload.model_dump(exclude_unset=True)
+    if "part_id" in data:
+        _assert_part_live(db, ws.id, data["part_id"])
     if "quantity_ordered" in data and data["quantity_ordered"] is not None:
         if data["quantity_ordered"] < e.quantity_received:
             raise HTTPException(

--- a/backend/tests/test_workspace_isolation.py
+++ b/backend/tests/test_workspace_isolation.py
@@ -589,16 +589,12 @@ def test_orders_isolation_get_and_archive_404_across_workspaces():
 
 
 def test_orders_create_rejects_foreign_part_id_via_entries():
-    """Create-order with an entries[].part_id from another workspace.
-    Without ws-validation, a B caller could embed A's part UUID in an
-    OrderEntry, leaking the existence-oracle and binding the entry to
+    """Create-order with an entries[].part_id from another workspace must
+    return 404. Without ws-validation, a B caller could embed A's part UUID
+    in an OrderEntry, leaking the existence-oracle and binding the entry to
     a foreign row."""
     a, b = _two_workspaces()
     part_a = _create_part(a, "A-part")
-    # Pydantic accepts the body — the question is whether the server
-    # validates the FK against the workspace. If it doesn't (today's
-    # state), the row lands; this test is the regression pin for when
-    # we tighten the receiving end.
     r = b.post(
         "/api/orders",
         json={
@@ -608,13 +604,22 @@ def test_orders_create_rejects_foreign_part_id_via_entries():
             ],
         },
     )
-    # If the server validates: 404. If it doesn't: 200 (today's
-    # behaviour, recorded for explicitness). Either is fine here — but
-    # the real isolation guarantee is `b.get("/api/parts")` MUST NOT
-    # include part_a, asserted next.
-    assert r.status_code in (200, 201, 404)
-    rows = b.get("/api/parts").json()["data"]
-    assert all(p["id"] != part_a for p in rows)
+    assert r.status_code == 404
+
+
+def test_orders_add_entry_rejects_foreign_part_id():
+    """POST /api/orders/{id}/entries with a part_id from another workspace
+    must return 404 (workspace isolation on add_entry)."""
+    a, b = _two_workspaces()
+    part_a = _create_part(a, "A-part-entry")
+    # B creates its own order
+    order_b = b.post("/api/orders", json={"name": "B-order"}).json()["data"]["id"]
+    # B tries to add an entry referencing A's part
+    r = b.post(
+        f"/api/orders/{order_b}/entries",
+        json={"part_id": part_a, "name": "smuggled", "quantity_ordered": 1},
+    )
+    assert r.status_code == 404
 
 
 def test_invitations_token_redemption_does_not_cross_workspaces():


### PR DESCRIPTION
Closes #242

## Summary
- Add `_assert_part_live` helper in `orders.py` that verifies a part exists in the current workspace and is not archived (same pattern as `projects.py`)
- Call it in `create_order` for each entry with a `part_id` before persisting
- Call it in `add_entry` before persisting the new OrderEntry
- Call it in `patch_entry` when `part_id` is updated (same attack surface)
- Update existing weak regression test to assert 404 (was `in (200, 201, 404)`)
- Add new regression test `test_orders_add_entry_rejects_foreign_part_id` for the `add_entry` path

## Tests
Backend: 683 passed, 2 skipped, 3 xfailed
Frontend: N/A