### PR TITLE
fix(fe): add error state handling to useQuery callsites in detail panels (#245)

### DIFF
--- a/web/src/routes/builds/BuildDetail.tsx
+++ b/web/src/routes/builds/BuildDetail.tsx
@@ -21,7 +21,7 @@ export default function BuildDetail() {
   const nav = useNavigate();
   const { workspaceId } = useAuth();
 
-  const { data } = useQuery({
+  const { data, isError, error } = useQuery({
     queryKey: useWsKey("build", buildId),
     queryFn: () => api.get<DetailOut>(`/builds/${buildId}`),
     enabled: !!buildId,
@@ -47,6 +47,7 @@ export default function BuildDetail() {
 
   const partsById = useMemo(() => new Map(parts?.map(p => [p.id, p]) ?? []), [parts]);
 
+  if (isError) return <div className="text-red-600 text-sm p-4">Failed to load build. {(error as Error)?.message}</div>;
   if (!data) return <div className="text-muted">Loading…</div>;
   const { build, shortage } = data;
   const isEditable = build.status === "planned" || build.status === "in_progress";

--- a/web/src/routes/builds/BuildDetail.tsx
+++ b/web/src/routes/builds/BuildDetail.tsx
@@ -47,7 +47,7 @@ export default function BuildDetail() {
 
   const partsById = useMemo(() => new Map(parts?.map(p => [p.id, p]) ?? []), [parts]);
 
-  if (isError) return <div className="text-red-600 text-sm p-4">Failed to load build. {(error as Error)?.message}</div>;
+  if (isError) return <div className="text-red-600 text-sm p-4">Failed to load build. {error instanceof ApiError ? error.userMessage : ""}</div>;
   if (!data) return <div className="text-muted">Loading…</div>;
   const { build, shortage } = data;
   const isEditable = build.status === "planned" || build.status === "in_progress";

--- a/web/src/routes/lots/LotDetail.tsx
+++ b/web/src/routes/lots/LotDetail.tsx
@@ -11,8 +11,9 @@ import type { Lot, Part, StockEntry, StorageLocation } from "@/types";
 
 export function LotLayout() {
   const { lotId } = useParams<{ lotId: string }>();
-  const { data } = useQuery({ queryKey: useWsKey("lot", lotId), queryFn: () => api.get<Lot>(`/lots/${lotId}`), enabled: !!lotId });
+  const { data, isError, error } = useQuery({ queryKey: useWsKey("lot", lotId), queryFn: () => api.get<Lot>(`/lots/${lotId}`), enabled: !!lotId });
   const { data: parts } = useQuery({ queryKey: useWsKey("parts"), queryFn: () => api.get<Part[]>("/parts") });
+  if (isError) return <div className="text-red-600 text-sm p-4">Failed to load lot. {(error as Error)?.message}</div>;
   if (!data) return <div className="text-muted">Loading…</div>;
   const part = parts?.find(p => p.id === data.part_id);
   const items = [
@@ -143,7 +144,8 @@ export function LotAdjust() {
 
 export function LotHistory() {
   const { lotId } = useParams();
-  const { data } = useQuery({ queryKey: useWsKey("lot", lotId, "history"), queryFn: () => api.get<StockEntry[]>(`/lots/${lotId}/history?limit=200`) });
+  const { data, isError, error } = useQuery({ queryKey: useWsKey("lot", lotId, "history"), queryFn: () => api.get<StockEntry[]>(`/lots/${lotId}/history?limit=200`) });
+  if (isError) return <div className="text-red-600 text-sm p-4">Failed to load history. {(error as Error)?.message}</div>;
   return (
     <div className="card overflow-hidden">
       <table className="table">

--- a/web/src/routes/lots/LotDetail.tsx
+++ b/web/src/routes/lots/LotDetail.tsx
@@ -1,7 +1,7 @@
 import { Outlet, useParams, useNavigate, useOutletContext } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
-import { api } from "@/lib/api";
+import { api, ApiError } from "@/lib/api";
 import { useAuth } from "@/lib/auth";
 import { useWsKey, lotMutationKeys } from "@/lib/queryKeys";
 import { formatDateTime } from "@/lib/format";
@@ -13,7 +13,7 @@ export function LotLayout() {
   const { lotId } = useParams<{ lotId: string }>();
   const { data, isError, error } = useQuery({ queryKey: useWsKey("lot", lotId), queryFn: () => api.get<Lot>(`/lots/${lotId}`), enabled: !!lotId });
   const { data: parts } = useQuery({ queryKey: useWsKey("parts"), queryFn: () => api.get<Part[]>("/parts") });
-  if (isError) return <div className="text-red-600 text-sm p-4">Failed to load lot. {(error as Error)?.message}</div>;
+  if (isError) return <div className="text-red-600 text-sm p-4">Failed to load lot. {error instanceof ApiError ? error.userMessage : ""}</div>;
   if (!data) return <div className="text-muted">Loading…</div>;
   const part = parts?.find(p => p.id === data.part_id);
   const items = [
@@ -145,7 +145,7 @@ export function LotAdjust() {
 export function LotHistory() {
   const { lotId } = useParams();
   const { data, isError, error } = useQuery({ queryKey: useWsKey("lot", lotId, "history"), queryFn: () => api.get<StockEntry[]>(`/lots/${lotId}/history?limit=200`) });
-  if (isError) return <div className="text-red-600 text-sm p-4">Failed to load history. {(error as Error)?.message}</div>;
+  if (isError) return <div className="text-red-600 text-sm p-4">Failed to load history. {error instanceof ApiError ? error.userMessage : ""}</div>;
   return (
     <div className="card overflow-hidden">
       <table className="table">

--- a/web/src/routes/orders/OrderDetail.tsx
+++ b/web/src/routes/orders/OrderDetail.tsx
@@ -42,7 +42,7 @@ export default function OrderDetail() {
   const confirm = useConfirm();
   const { workspaceId } = useAuth();
 
-  const { data } = useQuery({
+  const { data, isError, error } = useQuery({
     queryKey: useWsKey("order", orderId),
     queryFn: () => api.get<DetailOut>(`/orders/${orderId}`),
     enabled: !!orderId,
@@ -128,6 +128,7 @@ export default function OrderDetail() {
     },
   });
 
+  if (isError) return <div className="text-red-600 text-sm p-4">Failed to load order. {(error as Error)?.message}</div>;
   if (!data) return <div className="text-muted">Loading…</div>;
   const { order, entries } = data;
   const isClosed = order.status === "received" || order.status === "cancelled" || !!order.archived_at;

--- a/web/src/routes/orders/OrderDetail.tsx
+++ b/web/src/routes/orders/OrderDetail.tsx
@@ -128,7 +128,7 @@ export default function OrderDetail() {
     },
   });
 
-  if (isError) return <div className="text-red-600 text-sm p-4">Failed to load order. {(error as Error)?.message}</div>;
+  if (isError) return <div className="text-red-600 text-sm p-4">Failed to load order. {error instanceof ApiError ? error.userMessage : ""}</div>;
   if (!data) return <div className="text-muted">Loading…</div>;
   const { order, entries } = data;
   const isClosed = order.status === "received" || order.status === "cancelled" || !!order.archived_at;

--- a/web/src/routes/parts/detail/PartHistory.tsx
+++ b/web/src/routes/parts/detail/PartHistory.tsx
@@ -8,7 +8,7 @@ import { DataTable } from "@/components/DataTable";
 
 export default function PartHistory() {
   const { partId } = useParams();
-  const { data } = useQuery({
+  const { data, isError, error } = useQuery({
     queryKey: useWsKey("part", partId, "history"),
     queryFn: async () => {
       // history endpoint is global; filter client-side by part for now
@@ -18,6 +18,7 @@ export default function PartHistory() {
   });
   const { data: storage } = useQuery({ queryKey: useWsKey("storage"), queryFn: () => api.get<StorageLocation[]>("/storage") });
   const sName = new Map(storage?.map(s => [s.id, s.name]) ?? []);
+  if (isError) return <div className="text-red-600 text-sm p-4">Failed to load history. {(error as Error)?.message}</div>;
   return (
     <DataTable
       rows={data ?? []}

--- a/web/src/routes/parts/detail/PartHistory.tsx
+++ b/web/src/routes/parts/detail/PartHistory.tsx
@@ -1,6 +1,6 @@
 import { useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
-import { api } from "@/lib/api";
+import { api, ApiError } from "@/lib/api";
 import { useWsKey } from "@/lib/queryKeys";
 import { formatDateTime } from "@/lib/format";
 import type { StockEntry, StorageLocation } from "@/types";
@@ -18,7 +18,7 @@ export default function PartHistory() {
   });
   const { data: storage } = useQuery({ queryKey: useWsKey("storage"), queryFn: () => api.get<StorageLocation[]>("/storage") });
   const sName = new Map(storage?.map(s => [s.id, s.name]) ?? []);
-  if (isError) return <div className="text-red-600 text-sm p-4">Failed to load history. {(error as Error)?.message}</div>;
+  if (isError) return <div className="text-red-600 text-sm p-4">Failed to load history. {error instanceof ApiError ? error.userMessage : ""}</div>;
   return (
     <DataTable
       rows={data ?? []}

--- a/web/src/routes/parts/detail/PartLayout.tsx
+++ b/web/src/routes/parts/detail/PartLayout.tsx
@@ -8,12 +8,13 @@ import type { Part } from "@/types";
 
 export default function PartLayout() {
   const { partId } = useParams<{ partId: string }>();
-  const { data: part } = useQuery({
+  const { data: part, isError, error } = useQuery({
     queryKey: useWsKey("part", partId),
     queryFn: () => api.get<Part>(`/parts/${partId}`),
     enabled: !!partId,
   });
 
+  if (isError) return <div className="text-red-600 text-sm p-4">Failed to load part. {(error as Error)?.message}</div>;
   if (!part) return <div className="text-muted">Loading…</div>;
   const items = [
     { to: `/parts/${part.id}/info`, label: "Part info" },

--- a/web/src/routes/parts/detail/PartLayout.tsx
+++ b/web/src/routes/parts/detail/PartLayout.tsx
@@ -1,6 +1,6 @@
 import { Outlet, useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
-import { api } from "@/lib/api";
+import { api, ApiError } from "@/lib/api";
 import { useWsKey } from "@/lib/queryKeys";
 import EntityHeader from "@/components/EntityHeader";
 import SubNav from "@/components/SubNav";
@@ -14,7 +14,7 @@ export default function PartLayout() {
     enabled: !!partId,
   });
 
-  if (isError) return <div className="text-red-600 text-sm p-4">Failed to load part. {(error as Error)?.message}</div>;
+  if (isError) return <div className="text-red-600 text-sm p-4">Failed to load part. {error instanceof ApiError ? error.userMessage : ""}</div>;
   if (!part) return <div className="text-muted">Loading…</div>;
   const items = [
     { to: `/parts/${part.id}/info`, label: "Part info" },

--- a/web/src/routes/parts/detail/PartLots.tsx
+++ b/web/src/routes/parts/detail/PartLots.tsx
@@ -5,12 +5,15 @@ import { useWsKey } from "@/lib/queryKeys";
 import { formatDateTime } from "@/lib/format";
 import type { Lot } from "@/types";
 import { DataTable } from "@/components/DataTable";
+import QueryStateBoundary from "@/components/QueryStateBoundary";
 
 export default function PartLots() {
   const { partId } = useParams();
   const nav = useNavigate();
-  const { data } = useQuery({ queryKey: useWsKey("part", partId, "lots"), queryFn: () => api.get<Lot[]>(`/parts/${partId}/lots`) });
+  const lotsQuery = useQuery({ queryKey: useWsKey("part", partId, "lots"), queryFn: () => api.get<Lot[]>(`/parts/${partId}/lots`) });
+  const { data } = lotsQuery;
   return (
+    <QueryStateBoundary query={lotsQuery} resourceLabel="lots">
     <DataTable
       rows={data ?? []}
       rowKey={r => r.id}
@@ -28,5 +31,6 @@ export default function PartLots() {
         { key: "created_at", header: "Created", accessor: r => r.created_at, render: r => formatDateTime(r.created_at) },
       ]}
     />
+    </QueryStateBoundary>
   );
 }

--- a/web/src/routes/parts/detail/PartMembers.tsx
+++ b/web/src/routes/parts/detail/PartMembers.tsx
@@ -4,6 +4,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { api, ApiError } from "@/lib/api";
 import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
 import { useAuth } from "@/lib/auth";
+import QueryStateBoundary from "@/components/QueryStateBoundary";
 import type { Part } from "@/types";
 
 type Member = { id: string; member_part_id: string };
@@ -12,10 +13,11 @@ export default function PartMembers() {
   const { partId } = useParams();
   const qc = useQueryClient();
   const { workspaceId } = useAuth();
-  const { data: members } = useQuery({
+  const membersQuery = useQuery({
     queryKey: useWsKey("part", partId, "members"),
     queryFn: () => api.get<Member[]>(`/parts/${partId}/members`),
   });
+  const { data: members } = membersQuery;
   const { data: parts } = useQuery({ queryKey: useWsKey("parts"), queryFn: () => api.get<Part[]>("/parts") });
   const partsById = new Map(parts?.map(p => [p.id, p]) ?? []);
 
@@ -41,6 +43,7 @@ export default function PartMembers() {
   return (
     <div className="card p-4 max-w-2xl">
       <h3 className="text-md font-semibold mb-2">Meta-part members</h3>
+      <QueryStateBoundary query={membersQuery} resourceLabel="members">
       <p className="text-sm text-muted mb-3">
         A meta-part stands for any of its members. When a BOM line uses this meta-part,
         a build can consume from any member's stock.
@@ -70,6 +73,7 @@ export default function PartMembers() {
         </select>
         <button className="btn-primary" onClick={add}>Add</button>
       </div>
+      </QueryStateBoundary>
     </div>
   );
 }

--- a/web/src/routes/parts/detail/PartSourcing.tsx
+++ b/web/src/routes/parts/detail/PartSourcing.tsx
@@ -36,7 +36,7 @@ export default function PartSourcing() {
   const { workspaceId } = useAuth();
   const [refreshing, setRefreshing] = useState(false);
 
-  const { data, isLoading } = useQuery({
+  const { data, isLoading, isError, error } = useQuery({
     queryKey: useWsKey("part", part.id, "custom-fields"),
     queryFn: () =>
       api.get<CustomFieldRow[]>(`/custom-fields/by-object/part/${part.id}`),
@@ -109,7 +109,9 @@ export default function PartSourcing() {
           </button>
         </div>
       </div>
-      {isLoading ? (
+      {isError ? (
+        <div className="text-red-600 text-sm">Failed to load sourcing data. {(error as Error)?.message}</div>
+      ) : isLoading ? (
         <div className="text-muted text-sm">Loading…</div>
       ) : rows.length === 0 ? (
         <div className="text-sm text-muted py-4 text-center">

--- a/web/src/routes/parts/detail/PartSourcing.tsx
+++ b/web/src/routes/parts/detail/PartSourcing.tsx
@@ -110,7 +110,7 @@ export default function PartSourcing() {
         </div>
       </div>
       {isError ? (
-        <div className="text-red-600 text-sm">Failed to load sourcing data. {(error as Error)?.message}</div>
+        <div className="text-red-600 text-sm">Failed to load sourcing data. {error instanceof ApiError ? error.userMessage : ""}</div>
       ) : isLoading ? (
         <div className="text-muted text-sm">Loading…</div>
       ) : rows.length === 0 ? (

--- a/web/src/routes/parts/detail/PartSpecs.tsx
+++ b/web/src/routes/parts/detail/PartSpecs.tsx
@@ -46,7 +46,7 @@ export default function PartSpecs() {
   const qc = useQueryClient();
   const queryKey = useWsKey("part", part.id, "custom-fields");
 
-  const { data, isLoading } = useQuery({
+  const { data, isLoading, isError, error } = useQuery({
     queryKey,
     queryFn: () =>
       api.get<CustomFieldRow[]>(`/custom-fields/by-object/part/${part.id}`),
@@ -150,7 +150,9 @@ export default function PartSpecs() {
         </div>
       )}
 
-      {isLoading ? (
+      {isError ? (
+        <div className="text-red-600 text-sm">Failed to load specs. {(error as Error)?.message}</div>
+      ) : isLoading ? (
         <div className="text-muted text-sm">Loading…</div>
       ) : rows.length === 0 ? (
         <div className="text-sm text-muted py-4">

--- a/web/src/routes/parts/detail/PartSpecs.tsx
+++ b/web/src/routes/parts/detail/PartSpecs.tsx
@@ -151,7 +151,7 @@ export default function PartSpecs() {
       )}
 
       {isError ? (
-        <div className="text-red-600 text-sm">Failed to load specs. {(error as Error)?.message}</div>
+        <div className="text-red-600 text-sm">Failed to load specs. {error instanceof ApiError ? error.userMessage : ""}</div>
       ) : isLoading ? (
         <div className="text-muted text-sm">Loading…</div>
       ) : rows.length === 0 ? (

--- a/web/src/routes/parts/detail/PartStock.tsx
+++ b/web/src/routes/parts/detail/PartStock.tsx
@@ -11,13 +11,14 @@ type StockResp = {
 
 export default function PartStock() {
   const { partId } = useParams();
-  const { data } = useQuery({
+  const { data, isError, error } = useQuery({
     queryKey: useWsKey("part", partId, "stock"),
     queryFn: () => api.get<StockResp>(`/parts/${partId}/stock`),
   });
   const { data: storage } = useQuery({ queryKey: useWsKey("storage"), queryFn: () => api.get<StorageLocation[]>("/storage") });
   const storageById = new Map(storage?.map(s => [s.id, s.name]) ?? []);
 
+  if (isError) return <div className="text-red-600 text-sm p-4">Failed to load stock. {(error as Error)?.message}</div>;
   if (!data) return <div className="text-muted">Loading…</div>;
   return (
     <div>

--- a/web/src/routes/parts/detail/PartStock.tsx
+++ b/web/src/routes/parts/detail/PartStock.tsx
@@ -1,6 +1,6 @@
 import { useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
-import { api } from "@/lib/api";
+import { api, ApiError } from "@/lib/api";
 import { useWsKey } from "@/lib/queryKeys";
 import type { StorageLocation } from "@/types";
 
@@ -18,7 +18,7 @@ export default function PartStock() {
   const { data: storage } = useQuery({ queryKey: useWsKey("storage"), queryFn: () => api.get<StorageLocation[]>("/storage") });
   const storageById = new Map(storage?.map(s => [s.id, s.name]) ?? []);
 
-  if (isError) return <div className="text-red-600 text-sm p-4">Failed to load stock. {(error as Error)?.message}</div>;
+  if (isError) return <div className="text-red-600 text-sm p-4">Failed to load stock. {error instanceof ApiError ? error.userMessage : ""}</div>;
   if (!data) return <div className="text-muted">Loading…</div>;
   return (
     <div>

--- a/web/src/routes/parts/detail/PartSubstitutes.tsx
+++ b/web/src/routes/parts/detail/PartSubstitutes.tsx
@@ -4,6 +4,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api";
 import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
 import { useAuth } from "@/lib/auth";
+import QueryStateBoundary from "@/components/QueryStateBoundary";
 import type { Part } from "@/types";
 
 type Sub = { part_id: string; direction: string };
@@ -12,7 +13,8 @@ export default function PartSubstitutes() {
   const { partId } = useParams();
   const qc = useQueryClient();
   const { workspaceId } = useAuth();
-  const { data: subs } = useQuery({ queryKey: useWsKey("part", partId, "subs"), queryFn: () => api.get<Sub[]>(`/parts/${partId}/substitutes`) });
+  const subsQuery = useQuery({ queryKey: useWsKey("part", partId, "subs"), queryFn: () => api.get<Sub[]>(`/parts/${partId}/substitutes`) });
+  const { data: subs } = subsQuery;
   const { data: parts } = useQuery({ queryKey: useWsKey("parts"), queryFn: () => api.get<Part[]>("/parts") });
   const partsById = new Map(parts?.map(p => [p.id, p]) ?? []);
   const [pick, setPick] = useState("");
@@ -31,6 +33,7 @@ export default function PartSubstitutes() {
   return (
     <div className="card p-4 max-w-2xl">
       <h3 className="text-md font-semibold mb-2">Substitutes</h3>
+      <QueryStateBoundary query={subsQuery} resourceLabel="substitutes">
       <ul className="space-y-1 mb-3">
         {(subs ?? []).map(s => {
           const p = partsById.get(s.part_id);
@@ -50,6 +53,7 @@ export default function PartSubstitutes() {
         </select>
         <button className="btn-primary" onClick={add}>Add</button>
       </div>
+      </QueryStateBoundary>
     </div>
   );
 }

--- a/web/src/routes/projects/detail/ProjectBOM.tsx
+++ b/web/src/routes/projects/detail/ProjectBOM.tsx
@@ -8,15 +8,17 @@ import type { Part, ProjectEntry } from "@/types";
 import { useState } from "react";
 import { DataTable } from "@/components/DataTable";
 import EmptyState from "@/components/EmptyState";
+import QueryStateBoundary from "@/components/QueryStateBoundary";
 
 export default function ProjectBOM() {
   const { projectId } = useParams();
   const qc = useQueryClient();
   const { workspaceId } = useAuth();
-  const { data: entries } = useQuery({
+  const entriesQuery = useQuery({
     queryKey: useWsKey("project", projectId, "entries"),
     queryFn: () => api.get<ProjectEntry[]>(`/projects/${projectId}/entries`),
   });
+  const { data: entries } = entriesQuery;
   const { data: parts } = useQuery({ queryKey: useWsKey("parts"), queryFn: () => api.get<Part[]>("/parts") });
   const partsById = new Map(parts?.map(p => [p.id, p]) ?? []);
 
@@ -35,6 +37,7 @@ export default function ProjectBOM() {
 
   return (
     <div>
+      <QueryStateBoundary query={entriesQuery} resourceLabel="BOM entries">
       <DataTable
         rows={entries ?? []}
         rowKey={r => r.id}
@@ -88,6 +91,7 @@ export default function ProjectBOM() {
           },
         ]}
       />
+      </QueryStateBoundary>
     </div>
   );
 }

--- a/web/src/routes/projects/detail/ProjectBuilds.tsx
+++ b/web/src/routes/projects/detail/ProjectBuilds.tsx
@@ -6,15 +6,17 @@ import { useWsKey } from "@/lib/queryKeys";
 import { formatDateTime } from "@/lib/format";
 import { DataTable } from "@/components/DataTable";
 import EmptyState from "@/components/EmptyState";
+import QueryStateBoundary from "@/components/QueryStateBoundary";
 import type { Build } from "@/types";
 
 export default function ProjectBuilds() {
   const { projectId } = useParams<{ projectId: string }>();
-  const { data } = useQuery({
+  const buildsQuery = useQuery({
     queryKey: useWsKey("builds", { project: projectId }),
     queryFn: () => api.get<Build[]>(`/builds?project_id=${projectId}`),
     enabled: !!projectId,
   });
+  const { data } = buildsQuery;
 
   return (
     <div>
@@ -22,6 +24,7 @@ export default function ProjectBuilds() {
         <h3 className="text-md font-semibold">Builds against this project</h3>
         <Link to={`/builds/create?project_id=${projectId}`} className="btn-primary ml-auto">+ Build</Link>
       </div>
+      <QueryStateBoundary query={buildsQuery} resourceLabel="builds">
       <DataTable
         rows={data ?? []}
         rowKey={r => r.id}
@@ -46,6 +49,7 @@ export default function ProjectBuilds() {
           },
         ]}
       />
+      </QueryStateBoundary>
     </div>
   );
 }

--- a/web/src/routes/projects/detail/ProjectLayout.tsx
+++ b/web/src/routes/projects/detail/ProjectLayout.tsx
@@ -1,6 +1,6 @@
 import { Outlet, useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
-import { api } from "@/lib/api";
+import { api, ApiError } from "@/lib/api";
 import { useWsKey } from "@/lib/queryKeys";
 import EntityHeader from "@/components/EntityHeader";
 import SubNav from "@/components/SubNav";
@@ -9,7 +9,7 @@ import type { Project } from "@/types";
 export default function ProjectLayout() {
   const { projectId } = useParams<{ projectId: string }>();
   const { data, isError, error } = useQuery({ queryKey: useWsKey("project", projectId), queryFn: () => api.get<Project>(`/projects/${projectId}`), enabled: !!projectId });
-  if (isError) return <div className="text-red-600 text-sm p-4">Failed to load project. {(error as Error)?.message}</div>;
+  if (isError) return <div className="text-red-600 text-sm p-4">Failed to load project. {error instanceof ApiError ? error.userMessage : ""}</div>;
   if (!data) return <div className="text-muted">Loading…</div>;
   const items = [
     { to: `/projects/${data.id}/data`, label: "Project info" },

--- a/web/src/routes/projects/detail/ProjectLayout.tsx
+++ b/web/src/routes/projects/detail/ProjectLayout.tsx
@@ -8,7 +8,8 @@ import type { Project } from "@/types";
 
 export default function ProjectLayout() {
   const { projectId } = useParams<{ projectId: string }>();
-  const { data } = useQuery({ queryKey: useWsKey("project", projectId), queryFn: () => api.get<Project>(`/projects/${projectId}`), enabled: !!projectId });
+  const { data, isError, error } = useQuery({ queryKey: useWsKey("project", projectId), queryFn: () => api.get<Project>(`/projects/${projectId}`), enabled: !!projectId });
+  if (isError) return <div className="text-red-600 text-sm p-4">Failed to load project. {(error as Error)?.message}</div>;
   if (!data) return <div className="text-muted">Loading…</div>;
   const items = [
     { to: `/projects/${data.id}/data`, label: "Project info" },

--- a/web/src/routes/reports/Reports.tsx
+++ b/web/src/routes/reports/Reports.tsx
@@ -206,7 +206,7 @@ export function LowStockReport() {
     queryKey: useWsKey("report", "low-stock"),
     queryFn: () => api.get<LowStockRow[]>("/reports/low-stock"),
   });
-  if (isError) return <div className="text-red-600 text-sm p-4">Failed to load low-stock report. {(error as Error)?.message}</div>;
+  if (isError) return <div className="text-red-600 text-sm p-4">Failed to load low-stock report. {error instanceof ApiError ? error.userMessage : ""}</div>;
   if (isLoading) return <div className="text-muted">Loading…</div>;
   const rows = data ?? [];
 
@@ -275,7 +275,7 @@ export function StockValueReport() {
     queryKey: useWsKey("report", "stock-value"),
     queryFn: () => api.get<StockValue>("/reports/stock-value"),
   });
-  if (isError) return <div className="text-red-600 text-sm p-4">Failed to load stock value report. {(error as Error)?.message}</div>;
+  if (isError) return <div className="text-red-600 text-sm p-4">Failed to load stock value report. {error instanceof ApiError ? error.userMessage : ""}</div>;
   if (isLoading) return <div className="text-muted">Loading…</div>;
   if (!data) return null;
   return (

--- a/web/src/routes/reports/Reports.tsx
+++ b/web/src/routes/reports/Reports.tsx
@@ -202,10 +202,11 @@ export function LowStockReport() {
   const qc = useQueryClient();
   const { workspaceId } = useAuth();
   const [busy, setBusy] = useState(false);
-  const { data, isLoading } = useQuery({
+  const { data, isLoading, isError, error } = useQuery({
     queryKey: useWsKey("report", "low-stock"),
     queryFn: () => api.get<LowStockRow[]>("/reports/low-stock"),
   });
+  if (isError) return <div className="text-red-600 text-sm p-4">Failed to load low-stock report. {(error as Error)?.message}</div>;
   if (isLoading) return <div className="text-muted">Loading…</div>;
   const rows = data ?? [];
 
@@ -270,10 +271,11 @@ export function LowStockReport() {
 }
 
 export function StockValueReport() {
-  const { data, isLoading } = useQuery({
+  const { data, isLoading, isError, error } = useQuery({
     queryKey: useWsKey("report", "stock-value"),
     queryFn: () => api.get<StockValue>("/reports/stock-value"),
   });
+  if (isError) return <div className="text-red-600 text-sm p-4">Failed to load stock value report. {(error as Error)?.message}</div>;
   if (isLoading) return <div className="text-muted">Loading…</div>;
   if (!data) return null;
   return (

--- a/web/src/routes/storage/StorageDetail.tsx
+++ b/web/src/routes/storage/StorageDetail.tsx
@@ -6,17 +6,19 @@ import { useAuth } from "@/lib/auth";
 import { useWsKey, wsKeyOf, archiveStorageKeys } from "@/lib/queryKeys";
 import EntityHeader from "@/components/EntityHeader";
 import SubNav from "@/components/SubNav";
+import QueryStateBoundary from "@/components/QueryStateBoundary";
 import type { StorageLocation, Part, StockEntry } from "@/types";
 import { DataTable } from "@/components/DataTable";
 import { formatDateTime } from "@/lib/format";
 
 export function StorageDetailLayout() {
   const { storageId } = useParams<{ storageId: string }>();
-  const { data } = useQuery({
+  const { data, isError, error } = useQuery({
     queryKey: useWsKey("storage", storageId),
     queryFn: () => api.get<StorageLocation>(`/storage/${storageId}`),
     enabled: !!storageId,
   });
+  if (isError) return <div className="text-red-600 text-sm p-4">Failed to load storage location. {(error as Error)?.message}</div>;
   if (!data) return <div className="text-muted">Loading…</div>;
   const items = [
     { to: `/storage/${data.id}/info`, label: "Info" },
@@ -59,10 +61,11 @@ export function StorageDetailLayout() {
 
 export function StorageInfo() {
   const { storageId } = useParams();
-  const { data: rows } = useQuery({
+  const { data: rows, isError, error } = useQuery({
     queryKey: useWsKey("storage", storageId, "parts"),
     queryFn: () => api.get<{ part_id: string; lot_id: string | null; quantity: number }[]>(`/storage/${storageId}/parts`),
   });
+  if (isError) return <div className="text-red-600 text-sm p-4">Failed to load storage contents. {(error as Error)?.message}</div>;
   const { data: parts } = useQuery({ queryKey: useWsKey("parts"), queryFn: () => api.get<Part[]>("/parts") });
   const partName = new Map(parts?.map(p => [p.id, p.name]) ?? []);
   return (
@@ -90,13 +93,15 @@ export function StorageInfo() {
 
 export function StorageHistory() {
   const { storageId } = useParams();
-  const { data } = useQuery({
+  const historyQuery = useQuery({
     queryKey: useWsKey("storage", storageId, "history"),
     queryFn: () => api.get<StockEntry[]>(`/storage/${storageId}/history?limit=200`),
   });
+  const { data } = historyQuery;
   const { data: parts } = useQuery({ queryKey: useWsKey("parts"), queryFn: () => api.get<Part[]>("/parts") });
   const partName = new Map(parts?.map(p => [p.id, p.name]) ?? []);
   return (
+    <QueryStateBoundary query={historyQuery} resourceLabel="storage history">
     <DataTable
       rows={data ?? []}
       rowKey={r => r.id}
@@ -110,6 +115,7 @@ export function StorageHistory() {
         { key: "comments", header: "Comments", accessor: r => r.comments ?? "" },
       ]}
     />
+    </QueryStateBoundary>
   );
 }
 

--- a/web/src/routes/storage/StorageDetail.tsx
+++ b/web/src/routes/storage/StorageDetail.tsx
@@ -1,7 +1,7 @@
 import { Link, Outlet, useParams, NavLink, useNavigate } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { ScanLine } from "lucide-react";
-import { api } from "@/lib/api";
+import { api, ApiError } from "@/lib/api";
 import { useAuth } from "@/lib/auth";
 import { useWsKey, wsKeyOf, archiveStorageKeys } from "@/lib/queryKeys";
 import EntityHeader from "@/components/EntityHeader";
@@ -18,7 +18,7 @@ export function StorageDetailLayout() {
     queryFn: () => api.get<StorageLocation>(`/storage/${storageId}`),
     enabled: !!storageId,
   });
-  if (isError) return <div className="text-red-600 text-sm p-4">Failed to load storage location. {(error as Error)?.message}</div>;
+  if (isError) return <div className="text-red-600 text-sm p-4">Failed to load storage location. {error instanceof ApiError ? error.userMessage : ""}</div>;
   if (!data) return <div className="text-muted">Loading…</div>;
   const items = [
     { to: `/storage/${data.id}/info`, label: "Info" },
@@ -65,7 +65,7 @@ export function StorageInfo() {
     queryKey: useWsKey("storage", storageId, "parts"),
     queryFn: () => api.get<{ part_id: string; lot_id: string | null; quantity: number }[]>(`/storage/${storageId}/parts`),
   });
-  if (isError) return <div className="text-red-600 text-sm p-4">Failed to load storage contents. {(error as Error)?.message}</div>;
+  if (isError) return <div className="text-red-600 text-sm p-4">Failed to load storage contents. {error instanceof ApiError ? error.userMessage : ""}</div>;
   const { data: parts } = useQuery({ queryKey: useWsKey("parts"), queryFn: () => api.get<Part[]>("/parts") });
   const partName = new Map(parts?.map(p => [p.id, p.name]) ?? []);
   return (

--- a/web/src/routes/storage/StorageList.tsx
+++ b/web/src/routes/storage/StorageList.tsx
@@ -5,14 +5,16 @@ import { api } from "@/lib/api";
 import { useWsKey } from "@/lib/queryKeys";
 import { DataTable } from "@/components/DataTable";
 import EmptyState from "@/components/EmptyState";
+import QueryStateBoundary from "@/components/QueryStateBoundary";
 import type { StorageLocation } from "@/types";
 
 export default function StorageList({ archived = false }: { archived?: boolean }) {
   const nav = useNavigate();
-  const { data } = useQuery({
+  const storageQuery = useQuery({
     queryKey: useWsKey("storage", { archived }),
     queryFn: () => api.get<StorageLocation[]>(`/storage${archived ? "?archived=true" : ""}`),
   });
+  const { data } = storageQuery;
   return (
     <div>
       <div className="flex items-center gap-1 mb-3">
@@ -20,6 +22,7 @@ export default function StorageList({ archived = false }: { archived?: boolean }
         <NavLink to="/storage/archived" className={({ isActive }) => "btn " + (isActive ? "border-accent/50 text-accent" : "")}>Archived</NavLink>
         <Link to="/storage/create" className="btn-primary ml-auto">+ Storage</Link>
       </div>
+      <QueryStateBoundary query={storageQuery} resourceLabel="storage locations">
       <DataTable
         rows={data ?? []}
         rowKey={r => r.id}
@@ -49,6 +52,7 @@ export default function StorageList({ archived = false }: { archived?: boolean }
           { key: "is_full", header: "Full", accessor: r => r.is_full ? "yes" : "" },
         ]}
       />
+      </QueryStateBoundary>
     </div>
   );
 }


### PR DESCRIPTION
Closes #245

## Summary
- Swept 17 detail panel and sub-panel components in `web/src/routes/` for missing `isError` handling
- Layout-level panels (`PartLayout`, `ProjectLayout`, `LotLayout`, `StorageDetailLayout`, `OrderDetail`, `BuildDetail`) now render an inline error message instead of a blank page when the primary query fails
- Tab-level sub-panels (`PartStock`, `PartHistory`, `PartSpecs`, `PartSourcing`, `PartSubstitutes`, `PartMembers`, `PartLots`, `ProjectBOM`, `ProjectBuilds`, `StorageInfo`, `StorageHistory`, `LotHistory`) surface errors via `QueryStateBoundary` (with Retry button) or inline `if (isError)` guards
- Report components (`LowStockReport`, `StockValueReport`) added `isError` early returns alongside their existing `isLoading` checks
- `StorageList` wrapped with `QueryStateBoundary` to prevent silent blank list on error
- Used existing `QueryStateBoundary` component for queries that benefit from a Retry button; used `if (isError) return <div className="text-red-600 ...">` for layout-blocking queries following the pattern in the issue

## Tests
Backend: N/A
Frontend: `tsc -b && vite build` passed