### PR TITLE
fix(assets): validate provider asset magic bytes before writing (#246)

### DIFF
--- a/backend/app/domain/parts/services/assets.py
+++ b/backend/app/domain/parts/services/assets.py
@@ -20,6 +20,11 @@ Hardening notes (SEC2-006):
   drop `image/svg+xml` from the MIME map entirely; an upstream that
   serves SVG ends up written with `.bin` (and our serve route forces
   `Content-Disposition: attachment` for non-image MIMEs anyway).
+- Magic-byte validation (SEC2-012). After downloading the body we check
+  its leading bytes against known file signatures. If the sniffed type
+  doesn't match the Content-Type-derived extension the download is
+  rejected and we return None. This prevents a compromised provider CDN
+  from delivering a payload that masquerades as an innocuous image or PDF.
 """
 from __future__ import annotations
 
@@ -52,6 +57,37 @@ _EXT_BY_MIME: dict[str, str] = {
     "image/webp": "webp",
     "application/pdf": "pdf",
 }
+
+# Magic-byte signatures for supported file types.
+# Each value is the byte prefix that must appear at the start of a valid file.
+# "webp" is special: it uses the RIFF container with "WEBP" at offset 8; the
+# prefix check only covers the RIFF header — a second check for "WEBP" is done
+# inside _sniff_ext.
+_MAGIC: dict[str, bytes] = {
+    "jpg": b"\xff\xd8\xff",
+    "png": b"\x89PNG",
+    "pdf": b"%PDF",
+    "gif": b"GIF8",
+    "webp": b"RIFF",
+}
+
+
+def _sniff_ext(header: bytes) -> str | None:
+    """Return the file-type extension whose magic bytes match `header`, or
+    None if no known signature matches.
+
+    Only the first 16 bytes of the body are needed (all _MAGIC prefixes are
+    ≤ 8 bytes); callers should pass `body[:16]` to keep memory usage low.
+    """
+    for ext, magic in _MAGIC.items():
+        if header[:len(magic)] == magic:
+            # RIFF container is used by both WebP and WAV. Confirm the
+            # "WEBP" marker at bytes 8-12 so we don't accept random RIFF.
+            if ext == "webp" and header[8:12] != b"WEBP":
+                continue
+            return ext
+    return None
+
 
 # Hostnames the helper is permitted to fetch from. Keep this narrow:
 # every entry here is part of the SSRF surface. New providers must be
@@ -148,6 +184,7 @@ def fetch_provider_asset(url: str, workspace_id: str, kind: str) -> str | None:
       - host resolves to a non-public IP (SSRF guard)
       - HTTP error (4xx/5xx) or 30x redirect
       - body > _MAX_BYTES
+      - magic bytes don't match the Content-Type-declared extension
       - any network exception
     Caller should fall back to the original URL in those cases.
     """
@@ -170,8 +207,23 @@ def fetch_provider_asset(url: str, workspace_id: str, kind: str) -> str | None:
     if not body or len(body) > _MAX_BYTES:
         return None
 
-    sha = hashlib.sha256(body).hexdigest()
     ext = _ext_from_response(resp, url)
+
+    # Magic-byte validation (SEC2-012). Skip check for opaque .bin fallback —
+    # those already carry a forced-download Content-Disposition when served.
+    if ext != "bin":
+        sniffed = _sniff_ext(body[:16])
+        if sniffed is not None and sniffed != ext:
+            log.warning(
+                "provider asset rejected: magic bytes (%s) do not match "
+                "declared extension (%s) from %s",
+                sniffed,
+                ext,
+                url,
+            )
+            return None
+
+    sha = hashlib.sha256(body).hexdigest()
     filename = f"{sha}.{ext}"
 
     # On-disk: {UPLOAD_DIR}/parts/{ws_id}/{filename}

--- a/backend/tests/test_provider_assets.py
+++ b/backend/tests/test_provider_assets.py
@@ -1,10 +1,12 @@
-"""Regression tests for SEC2-006 / SEC2-011 (provider-asset hardening).
+"""Regression tests for SEC2-006 / SEC2-011 / SEC2-012 (provider-asset hardening).
 
 Covers:
 - Host allow-list — only Mouser / DigiKey hosts pass.
 - DNS resolution to a non-public IP is rejected (SSRF guard).
 - Upstream SVG content-type is rejected (lands as `.bin`).
 - 30x upstream is treated as a refusal — no auto-redirect.
+- Magic-byte validation: body whose leading bytes don't match the
+  Content-Type-declared extension is rejected (SEC2-012).
 - The serve route forces `X-Content-Type-Options: nosniff` on every
   response and forces `Content-Disposition: attachment` for non-image
   MIMEs (PDF datasheets, opaque binaries).
@@ -138,6 +140,118 @@ def test_svg_url_suffix_lands_as_bin(monkeypatch, tmp_path):
     )
     assert out is not None
     assert out.endswith(".bin")
+
+
+# ---------------------------------------------------------------------------
+# Magic-byte validation (SEC2-012)
+# ---------------------------------------------------------------------------
+
+
+def test_magic_bytes_mismatch_png_declared_pdf_rejected(monkeypatch, tmp_path):
+    """Body starts with PDF magic but Content-Type says image/png → rejected."""
+    monkeypatch.setattr(settings(), "UPLOAD_DIR", str(tmp_path), raising=False)
+    monkeypatch.setattr(assets.socket, "gethostbyname", lambda _h: "93.184.216.34")
+    monkeypatch.setattr(
+        assets, "_http_get",
+        lambda _u: _resp(body=b"%PDF-1.4 this is not a PNG", content_type="image/png"),
+    )
+    out = assets.fetch_provider_asset(
+        "https://media.digikey.com/fake.png", str(uuid.uuid4()), "image"
+    )
+    assert out is None, "PDF magic masquerading as PNG must be rejected"
+
+
+def test_magic_bytes_mismatch_jpg_declared_pdf_rejected(monkeypatch, tmp_path):
+    """Body starts with JPEG magic but Content-Type says application/pdf → rejected."""
+    monkeypatch.setattr(settings(), "UPLOAD_DIR", str(tmp_path), raising=False)
+    monkeypatch.setattr(assets.socket, "gethostbyname", lambda _h: "93.184.216.34")
+    jpeg_magic = b"\xff\xd8\xff\xe0" + b"\x00" * 12
+    monkeypatch.setattr(
+        assets, "_http_get",
+        lambda _u: _resp(body=jpeg_magic, content_type="application/pdf"),
+    )
+    out = assets.fetch_provider_asset(
+        "https://media.digikey.com/fake.pdf", str(uuid.uuid4()), "datasheet"
+    )
+    assert out is None, "JPEG magic masquerading as PDF must be rejected"
+
+
+def test_magic_bytes_match_png_accepted(monkeypatch, tmp_path):
+    """Body starts with PNG magic and Content-Type says image/png → accepted."""
+    monkeypatch.setattr(settings(), "UPLOAD_DIR", str(tmp_path), raising=False)
+    monkeypatch.setattr(assets.socket, "gethostbyname", lambda _h: "93.184.216.34")
+    png_body = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
+    monkeypatch.setattr(
+        assets, "_http_get",
+        lambda _u: _resp(body=png_body, content_type="image/png"),
+    )
+    out = assets.fetch_provider_asset(
+        "https://media.digikey.com/real.png", str(uuid.uuid4()), "image"
+    )
+    assert out is not None
+    assert out.endswith(".png")
+
+
+def test_magic_bytes_match_pdf_accepted(monkeypatch, tmp_path):
+    """Body starts with PDF magic and Content-Type says application/pdf → accepted."""
+    monkeypatch.setattr(settings(), "UPLOAD_DIR", str(tmp_path), raising=False)
+    monkeypatch.setattr(assets.socket, "gethostbyname", lambda _h: "93.184.216.34")
+    pdf_body = b"%PDF-1.4 fake content"
+    monkeypatch.setattr(
+        assets, "_http_get",
+        lambda _u: _resp(body=pdf_body, content_type="application/pdf"),
+    )
+    out = assets.fetch_provider_asset(
+        "https://media.digikey.com/real.pdf", str(uuid.uuid4()), "datasheet"
+    )
+    assert out is not None
+    assert out.endswith(".pdf")
+
+
+def test_magic_bytes_unknown_body_with_known_ext_accepted(monkeypatch, tmp_path):
+    """If _sniff_ext returns None (unknown magic bytes), we don't block —
+    the file type just can't be sniffed so we trust the Content-Type."""
+    monkeypatch.setattr(settings(), "UPLOAD_DIR", str(tmp_path), raising=False)
+    monkeypatch.setattr(assets.socket, "gethostbyname", lambda _h: "93.184.216.34")
+    # Body with no recognisable magic prefix.
+    monkeypatch.setattr(
+        assets, "_http_get",
+        lambda _u: _resp(body=b"\x00\x00\x00\x00unknown format bytes", content_type="image/png"),
+    )
+    out = assets.fetch_provider_asset(
+        "https://media.digikey.com/opaque.png", str(uuid.uuid4()), "image"
+    )
+    # sniff is None → no rejection, falls through.
+    assert out is not None
+    assert out.endswith(".png")
+
+
+def test_magic_bytes_gif_mismatch_rejected(monkeypatch, tmp_path):
+    """PNG body disguised as GIF (Content-Type image/gif) is rejected."""
+    monkeypatch.setattr(settings(), "UPLOAD_DIR", str(tmp_path), raising=False)
+    monkeypatch.setattr(assets.socket, "gethostbyname", lambda _h: "93.184.216.34")
+    png_body = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
+    monkeypatch.setattr(
+        assets, "_http_get",
+        lambda _u: _resp(body=png_body, content_type="image/gif"),
+    )
+    out = assets.fetch_provider_asset(
+        "https://media.digikey.com/fake.gif", str(uuid.uuid4()), "image"
+    )
+    assert out is None, "PNG magic masquerading as GIF must be rejected"
+
+
+def test_sniff_ext_returns_correct_types():
+    """Unit test for the _sniff_ext helper in isolation."""
+    assert assets._sniff_ext(b"\xff\xd8\xff\xe0" + b"\x00" * 12) == "jpg"
+    assert assets._sniff_ext(b"\x89PNG\r\n\x1a\n" + b"\x00" * 8) == "png"
+    assert assets._sniff_ext(b"%PDF-1.4 content") == "pdf"
+    assert assets._sniff_ext(b"GIF89a content") == "gif"
+    assert assets._sniff_ext(b"RIFF\x00\x00\x00\x00WEBP") == "webp"
+    # Unknown magic → None
+    assert assets._sniff_ext(b"\x00\x00\x00\x00junk") is None
+    # RIFF without WEBP marker → None (not a WebP)
+    assert assets._sniff_ext(b"RIFF\x00\x00\x00\x00WAVEfmt ") is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #246

## Summary
- Add `_MAGIC` dict mapping extension to byte prefix signatures (jpg, png, pdf, gif, webp)
- Add `_sniff_ext(header: bytes) -> str | None` helper that matches leading bytes against `_MAGIC`, with RIFF/WebP disambiguation
- After downloading provider asset body, call `_sniff_ext(body[:16])` and reject (return `None`) if the sniffed type contradicts the Content-Type-derived extension; unknown magic (sniff=None) passes through to preserve fail-tolerant behaviour
- Add 7 new unit tests in `test_provider_assets.py` covering mismatch rejection (PDF-as-PNG, JPEG-as-PDF, PNG-as-GIF), valid acceptance (matching magic), unknown-magic pass-through, and `_sniff_ext` helper in isolation

## Tests
Backend: 677 passed, 27/27 asset tests passed. Pre-existing failures in unrelated test files (test_integer_quantities, test_activity_pagination, test_history_limits, test_invitations) unchanged by this PR.
Frontend: N/A