### PR TITLE
fix(fe): replace e.message with e.userMessage at 3 UI render sites (#249)

### DIFF
--- a/web/src/routes/auth/Verify.tsx
+++ b/web/src/routes/auth/Verify.tsx
@@ -48,7 +48,7 @@ export default function Verify() {
         setState("error");
         setErrMsg(
           e instanceof ApiError
-            ? e.message
+            ? e.userMessage
             : "Verification failed — please try again.",
         );
       });

--- a/web/src/routes/auth/__dom__/Verify.render.dom.test.tsx
+++ b/web/src/routes/auth/__dom__/Verify.render.dom.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * DOM render test for Verify.tsx (FE2-020 follow-up / issue #249).
+ *
+ * Pinned behaviour:
+ *  - When api.post() throws an ApiError, the component renders the
+ *    user-safe e.userMessage (category-mapped) rather than the raw
+ *    server-side e.message.
+ *
+ * This test was introduced to guard against regressions after the fix
+ * that replaced e.message with e.userMessage at the Verify callsite.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { api, ApiError } from "@/lib/api";
+import { useAuth } from "@/lib/auth";
+import Verify from "../Verify";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("@/lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api")>();
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      post: vi.fn(),
+    },
+  };
+});
+
+vi.mock("@/lib/auth", () => ({
+  useAuth: vi.fn(),
+  AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const mockPost = api.post as ReturnType<typeof vi.fn>;
+const mockUseAuth = useAuth as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  mockUseAuth.mockReturnValue({
+    me: null,
+    loading: false,
+    refresh: vi.fn().mockResolvedValue(undefined),
+    logout: vi.fn(),
+    workspaceId: null,
+    switchWorkspace: vi.fn(),
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function renderVerify(search = "?id=x&token=y") {
+  return render(
+    <MemoryRouter initialEntries={[{ pathname: "/verify", search }]}>
+      <Routes>
+        <Route path="/verify" element={<Verify />} />
+        <Route path="/parts" element={<div>parts-page</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("Verify — ApiError render", () => {
+  it("shows user-safe message and does NOT leak raw server detail", async () => {
+    const RAW_SERVER_MSG = "raw psycopg detail";
+    const USER_SAFE_MSG = "Something went wrong. Try again, or refresh.";
+
+    mockPost.mockRejectedValue(
+      new ApiError(
+        500,
+        { data: null, status: { category: "server_error", message: RAW_SERVER_MSG } },
+        RAW_SERVER_MSG,
+      ),
+    );
+
+    renderVerify("?id=x&token=y");
+
+    await waitFor(() => {
+      expect(screen.queryByText("Verifying your email…")).toBeNull();
+    });
+
+    const errorContainer = await screen.findByText(USER_SAFE_MSG);
+    expect(errorContainer).toBeDefined();
+
+    // The raw server string must NOT appear anywhere in the rendered output.
+    expect(screen.queryByText(new RegExp(RAW_SERVER_MSG))).toBeNull();
+  });
+});

--- a/web/src/routes/settings/Workspace.tsx
+++ b/web/src/routes/settings/Workspace.tsx
@@ -88,7 +88,7 @@ export default function WorkspaceSettings() {
       refetchCatalogTokens();
       toast.success("Catalog token created.");
     },
-    onError: (e) => toast.error(e instanceof ApiError ? e.message : "Failed"),
+    onError: (e) => toast.error(e instanceof ApiError ? e.userMessage : "Failed"),
   });
 
   const revokeCatalogToken = useMutation({
@@ -98,7 +98,7 @@ export default function WorkspaceSettings() {
       refetchCatalogTokens();
       toast.success("Token revoked.");
     },
-    onError: (e) => toast.error(e instanceof ApiError ? e.message : "Failed"),
+    onError: (e) => toast.error(e instanceof ApiError ? e.userMessage : "Failed"),
   });
 
   const [newName, setNewName] = useState("");


### PR DESCRIPTION
Closes #249

## Summary
- Fix 3 callsites that leaked raw server error strings into UI: `Verify.tsx` and `Workspace.tsx` (x2) now use `e.userMessage` instead of `e.message`
- Add `Verify.render.dom.test.tsx` asserting that a 500 `ApiError` with raw psycopg detail renders the user-safe category-mapped phrase and NOT the raw server string

## Tests
Backend: N/A (frontend-only change)
Frontend: all 199 tests pass, `tsc -b && vite build` clean