### PR TITLE
ci: switch lint gates to baseline-blocking delta detection (#253)

### DIFF
--- a/.eslint-baseline.txt
+++ b/.eslint-baseline.txt
@@ -1,0 +1,7 @@
+src/components/scanner/ZxingScanner.tsx:361:30: The ref value 'videoRef.current' will likely have changed by the time this effect cleanup function runs. If this ref points to a node rendered by React, copy 'videoRef.current' to a variable inside the effect, and use that variable in the cleanup function. [Warning/react-hooks/exhaustive-deps]
+src/lib/bagCode.ts:164:14: Unexpected control character(s) in regular expression: \x1e, \x1d. [Error/no-control-regex]
+src/lib/bagCode.ts:91:22: Unexpected control character(s) in regular expression: \x1c, \x1d, \x1e, \x1f, \x04. [Error/no-control-regex]
+src/routes/orders/OrderDetail.tsx:54:9: 'storageById' is assigned a value but never used. Allowed unused vars must match /^_/u. [Warning/@typescript-eslint/no-unused-vars]
+src/routes/parts/ScanImport.tsx:37:8: 'ImportResultRow' is defined but never used. Allowed unused vars must match /^_/u. [Warning/@typescript-eslint/no-unused-vars]
+src/routes/storage/StorageDetail.tsx:1:35: 'NavLink' is defined but never used. Allowed unused vars must match /^_/u. [Warning/@typescript-eslint/no-unused-vars]
+src/routes/__tests__/responsive-grids.test.ts:29:7: 'BARE_GRID_COLS_2' is assigned a value but never used. Allowed unused vars must match /^_/u. [Warning/@typescript-eslint/no-unused-vars]

--- a/.eslint-baseline.txt
+++ b/.eslint-baseline.txt
@@ -2,6 +2,7 @@ src/components/scanner/ZxingScanner.tsx:361:30: The ref value 'videoRef.current'
 src/lib/bagCode.ts:164:14: Unexpected control character(s) in regular expression: \x1e, \x1d. [Error/no-control-regex]
 src/lib/bagCode.ts:91:22: Unexpected control character(s) in regular expression: \x1c, \x1d, \x1e, \x1f, \x04. [Error/no-control-regex]
 src/routes/orders/OrderDetail.tsx:54:9: 'storageById' is assigned a value but never used. Allowed unused vars must match /^_/u. [Warning/@typescript-eslint/no-unused-vars]
+src/routes/parts/PartsList.tsx:1:31: 'useState' is defined but never used. Allowed unused vars must match /^_/u. [Warning/@typescript-eslint/no-unused-vars]
 src/routes/parts/detail/__dom__/PartLayout.navigation.dom.test.tsx:109:10: 'renderWith' is defined but never used. Allowed unused vars must match /^_/u. [Warning/@typescript-eslint/no-unused-vars]
 src/routes/storage/StorageDetail.tsx:1:35: 'NavLink' is defined but never used. Allowed unused vars must match /^_/u. [Warning/@typescript-eslint/no-unused-vars]
 src/routes/__tests__/responsive-grids.test.ts:29:7: 'BARE_GRID_COLS_2' is assigned a value but never used. Allowed unused vars must match /^_/u. [Warning/@typescript-eslint/no-unused-vars]

--- a/.eslint-baseline.txt
+++ b/.eslint-baseline.txt
@@ -2,6 +2,6 @@ src/components/scanner/ZxingScanner.tsx:361:30: The ref value 'videoRef.current'
 src/lib/bagCode.ts:164:14: Unexpected control character(s) in regular expression: \x1e, \x1d. [Error/no-control-regex]
 src/lib/bagCode.ts:91:22: Unexpected control character(s) in regular expression: \x1c, \x1d, \x1e, \x1f, \x04. [Error/no-control-regex]
 src/routes/orders/OrderDetail.tsx:54:9: 'storageById' is assigned a value but never used. Allowed unused vars must match /^_/u. [Warning/@typescript-eslint/no-unused-vars]
-src/routes/parts/ScanImport.tsx:37:8: 'ImportResultRow' is defined but never used. Allowed unused vars must match /^_/u. [Warning/@typescript-eslint/no-unused-vars]
+src/routes/parts/detail/__dom__/PartLayout.navigation.dom.test.tsx:109:10: 'renderWith' is defined but never used. Allowed unused vars must match /^_/u. [Warning/@typescript-eslint/no-unused-vars]
 src/routes/storage/StorageDetail.tsx:1:35: 'NavLink' is defined but never used. Allowed unused vars must match /^_/u. [Warning/@typescript-eslint/no-unused-vars]
 src/routes/__tests__/responsive-grids.test.ts:29:7: 'BARE_GRID_COLS_2' is assigned a value but never used. Allowed unused vars must match /^_/u. [Warning/@typescript-eslint/no-unused-vars]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,12 +111,17 @@ jobs:
           uv sync --frozen --extra dev
           echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
 
-      # Static analysis gate — CQ-005 / issue #121. `--exit-zero` so
-      # the first land is non-blocking; flip off in a follow-up PR
-      # once the existing violations are triaged.
+      # Static analysis gate — CQ-005 / issue #253. Baseline-blocking:
+      # fails only on NEW violations not present in .ruff-baseline.txt.
+      # To update the baseline after intentional fixes, see
+      # docs/development.md — "Updating lint baselines".
       - name: ruff
         working-directory: backend
-        run: ruff check app --exit-zero
+        run: |
+          LINT_CMD="ruff check app --output-format=concise" \
+          BASELINE_FILE="../.ruff-baseline.txt" \
+          WORK_DIR="." \
+          bash ../scripts/lint-delta.sh
 
       # SEC2-018: fast pre-pytest gate — fail if any HTTPException passes
       # traceback / stack-trace data in its detail= argument.
@@ -177,12 +182,17 @@ jobs:
         working-directory: web
         run: npm ci
 
-      # Static analysis gate — CQ-005 / issue #121. `|| true` so the
-      # first land is non-blocking; flip off in a follow-up PR once
-      # the existing violations are triaged.
+      # Static analysis gate — CQ-005 / issue #253. Baseline-blocking:
+      # fails only on NEW violations not present in .eslint-baseline.txt.
+      # To update the baseline after intentional fixes, see
+      # docs/development.md — "Updating lint baselines".
       - name: eslint
         working-directory: web
-        run: npm run lint || true
+        run: |
+          LINT_CMD="npm run lint -- --format=unix" \
+          BASELINE_FILE="../.eslint-baseline.txt" \
+          WORK_DIR="." \
+          bash ../scripts/lint-delta.sh
 
       - name: Vitest
         working-directory: web

--- a/.ruff-baseline.txt
+++ b/.ruff-baseline.txt
@@ -1,105 +1,91 @@
-[*] 44 fixable with the `--fix` option.
-app/api/routes/_activity.py:33:1: I001 [*] Import block is un-sorted or un-formatted
-app/api/routes/attachments.py:1:1: I001 [*] Import block is un-sorted or un-formatted
-app/api/routes/attachments.py:17:5: F401 [*] `app.core.deps.CurrentUser` imported but unused
-app/api/routes/attachments.py:8:20: F401 [*] `typing.Annotated` imported but unused
+app/api/routes/attachments.py:16:5: F401 [*] `app.core.deps.CurrentUser` imported but unused
+app/api/routes/attachments.py:6:20: F401 [*] `typing.Annotated` imported but unused
 app/api/routes/auth.py:137:101: E501 Line too long (111 > 100)
 app/api/routes/auth.py:301:101: E501 Line too long (107 > 100)
-app/api/routes/bom_presets.py:72:101: E501 Line too long (112 > 100)
+app/api/routes/bom_presets.py:63:101: E501 Line too long (111 > 100)
+app/api/routes/bom_presets.py:73:101: E501 Line too long (112 > 100)
 app/api/routes/builds.py:112:101: E501 Line too long (111 > 100)
 app/api/routes/builds.py:188:16: F821 Undefined name `datetime`
 app/api/routes/builds.py:191:25: F821 Undefined name `datetime`
 app/api/routes/builds.py:68:101: E501 Line too long (102 > 100)
+app/api/routes/catalog.py:121:101: E501 Line too long (105 > 100)
 app/api/routes/catalog.py:168:101: E501 Line too long (132 > 100)
 app/api/routes/catalog.py:172:101: E501 Line too long (108 > 100)
 app/api/routes/catalog.py:173:101: E501 Line too long (149 > 100)
 app/api/routes/catalog.py:211:101: E501 Line too long (101 > 100)
 app/api/routes/catalog.py:214:101: E501 Line too long (108 > 100)
-app/api/routes/catalog.py:6:1: I001 [*] Import block is un-sorted or un-formatted
-app/api/routes/custom_fields.py:42:101: E501 Line too long (101 > 100)
+app/api/routes/catalog.py:95:101: E501 Line too long (109 > 100)
+app/api/routes/custom_fields.py:43:101: E501 Line too long (101 > 100)
 app/api/routes/invitations.py:401:101: E501 Line too long (129 > 100)
-app/api/routes/lots.py:100:5: E741 Ambiguous variable name: `l`
-app/api/routes/lots.py:111:101: E501 Line too long (107 > 100)
-app/api/routes/lots.py:112:5: E741 Ambiguous variable name: `l`
-app/api/routes/lots.py:147:5: E741 Ambiguous variable name: `l`
-app/api/routes/lots.py:27:16: E741 Ambiguous variable name: `l`
+app/api/routes/lots.py:100:101: E501 Line too long (105 > 100)
+app/api/routes/lots.py:101:5: E741 Ambiguous variable name: `l`
+app/api/routes/lots.py:112:101: E501 Line too long (107 > 100)
+app/api/routes/lots.py:113:5: E741 Ambiguous variable name: `l`
+app/api/routes/lots.py:148:5: E741 Ambiguous variable name: `l`
+app/api/routes/lots.py:28:16: E741 Ambiguous variable name: `l`
 app/api/routes/lots.py:3:22: F401 [*] `datetime.datetime` imported but unused
 app/api/routes/lots.py:3:32: F401 [*] `datetime.timezone` imported but unused
-app/api/routes/lots.py:39:101: E501 Line too long (104 > 100)
-app/api/routes/lots.py:61:9: E741 Ambiguous variable name: `l`
-app/api/routes/lots.py:68:5: E741 Ambiguous variable name: `l`
-app/api/routes/lots.py:76:5: E741 Ambiguous variable name: `l`
-app/api/routes/lots.py:82:101: E501 Line too long (103 > 100)
-app/api/routes/lots.py:83:5: E741 Ambiguous variable name: `l`
-app/api/routes/lots.py:99:101: E501 Line too long (105 > 100)
+app/api/routes/lots.py:40:101: E501 Line too long (104 > 100)
+app/api/routes/lots.py:62:9: E741 Ambiguous variable name: `l`
+app/api/routes/lots.py:69:5: E741 Ambiguous variable name: `l`
+app/api/routes/lots.py:71:101: E501 Line too long (101 > 100)
+app/api/routes/lots.py:77:5: E741 Ambiguous variable name: `l`
+app/api/routes/lots.py:83:101: E501 Line too long (103 > 100)
+app/api/routes/lots.py:84:5: E741 Ambiguous variable name: `l`
+app/api/routes/lots.py:91:101: E501 Line too long (107 > 100)
 app/api/routes/orders.py:111:101: E501 Line too long (102 > 100)
 app/api/routes/orders.py:114:101: E501 Line too long (110 > 100)
-app/api/routes/orders.py:1:1: I001 [*] Import block is un-sorted or un-formatted
 app/api/routes/orders.py:175:101: E501 Line too long (111 > 100)
-app/api/routes/orders.py:189:1: I001 [*] Import block is un-sorted or un-formatted
-app/api/routes/orders.py:231:101: E501 Line too long (109 > 100)
-app/api/routes/orders.py:264:101: E501 Line too long (130 > 100)
-app/api/routes/orders.py:293:101: E501 Line too long (110 > 100)
-app/api/routes/orders.py:317:16: F821 Undefined name `datetime`
-app/api/routes/orders.py:320:25: F821 Undefined name `datetime`
-app/api/routes/parts_assets.py:9:1: I001 [*] Import block is un-sorted or un-formatted
-app/api/routes/parts_core.py:119:101: E501 Line too long (102 > 100)
-app/api/routes/parts_core.py:120:101: E501 Line too long (104 > 100)
-app/api/routes/parts_core.py:218:101: E501 Line too long (106 > 100)
-app/api/routes/parts_core.py:232:101: E501 Line too long (114 > 100)
-app/api/routes/parts_core.py:301:1: I001 [*] Import block is un-sorted or un-formatted
-app/api/routes/parts_core.py:487:101: E501 Line too long (111 > 100)
-app/api/routes/parts_core.py:503:101: E501 Line too long (115 > 100)
-app/api/routes/parts_core.py:513:101: E501 Line too long (112 > 100)
-app/api/routes/parts_core.py:521:17: E741 Ambiguous variable name: `l`
-app/api/routes/parts_core.py:6:1: I001 [*] Import block is un-sorted or un-formatted
+app/api/routes/orders.py:232:101: E501 Line too long (109 > 100)
+app/api/routes/orders.py:265:101: E501 Line too long (130 > 100)
+app/api/routes/orders.py:294:101: E501 Line too long (110 > 100)
+app/api/routes/orders.py:318:16: F821 Undefined name `datetime`
+app/api/routes/orders.py:321:25: F821 Undefined name `datetime`
+app/api/routes/parts_core.py:123:101: E501 Line too long (102 > 100)
+app/api/routes/parts_core.py:124:101: E501 Line too long (104 > 100)
+app/api/routes/parts_core.py:222:101: E501 Line too long (106 > 100)
+app/api/routes/parts_core.py:236:101: E501 Line too long (114 > 100)
+app/api/routes/parts_core.py:492:101: E501 Line too long (111 > 100)
+app/api/routes/parts_core.py:508:101: E501 Line too long (115 > 100)
+app/api/routes/parts_core.py:518:101: E501 Line too long (112 > 100)
+app/api/routes/parts_core.py:526:17: E741 Ambiguous variable name: `l`
 app/api/routes/parts_scan.py:396:101: E501 Line too long (104 > 100)
-app/api/routes/_parts_shared.py:14:1: I001 [*] Import block is un-sorted or un-formatted
-app/api/routes/_parts_shared.py:67:101: E501 Line too long (117 > 100)
-app/api/routes/projects.py:109:101: E501 Line too long (117 > 100)
-app/api/routes/projects.py:125:1: I001 [*] Import block is un-sorted or un-formatted
-app/api/routes/projects.py:172:101: E501 Line too long (148 > 100)
-app/api/routes/projects.py:189:101: E501 Line too long (109 > 100)
-app/api/routes/projects.py:229:101: E501 Line too long (130 > 100)
-app/api/routes/projects.py:261:101: E501 Line too long (117 > 100)
-app/api/routes/projects.py:271:101: E501 Line too long (129 > 100)
-app/api/routes/projects.py:36:101: E501 Line too long (126 > 100)
-app/api/routes/projects.py:70:101: E501 Line too long (106 > 100)
-app/api/routes/projects.py:79:101: E501 Line too long (101 > 100)
-app/api/routes/reports.py:131:101: E501 Line too long (127 > 100)
-app/api/routes/reports.py:160:9: E741 Ambiguous variable name: `l`
-app/api/routes/reports.py:85:101: E501 Line too long (110 > 100)
-app/api/routes/reports.py:96:25: E741 Ambiguous variable name: `l`
+app/api/routes/_parts_shared.py:102:101: E501 Line too long (103 > 100)
+app/api/routes/_parts_shared.py:69:101: E501 Line too long (117 > 100)
+app/api/routes/_parts_shared.py:97:101: E501 Line too long (103 > 100)
+app/api/routes/projects.py:100:101: E501 Line too long (109 > 100)
+app/api/routes/projects.py:110:101: E501 Line too long (117 > 100)
+app/api/routes/projects.py:174:101: E501 Line too long (148 > 100)
+app/api/routes/projects.py:191:101: E501 Line too long (109 > 100)
+app/api/routes/projects.py:231:101: E501 Line too long (130 > 100)
+app/api/routes/projects.py:263:101: E501 Line too long (117 > 100)
+app/api/routes/projects.py:273:101: E501 Line too long (129 > 100)
+app/api/routes/projects.py:37:101: E501 Line too long (126 > 100)
+app/api/routes/projects.py:71:101: E501 Line too long (106 > 100)
+app/api/routes/projects.py:80:101: E501 Line too long (101 > 100)
+app/api/routes/reports.py:132:101: E501 Line too long (127 > 100)
+app/api/routes/reports.py:161:9: E741 Ambiguous variable name: `l`
+app/api/routes/reports.py:86:101: E501 Line too long (110 > 100)
+app/api/routes/reports.py:97:25: E741 Ambiguous variable name: `l`
 app/api/routes/search.py:112:101: E501 Line too long (118 > 100)
 app/api/routes/search.py:115:87: E741 Ambiguous variable name: `l`
 app/api/routes/search.py:76:101: E501 Line too long (102 > 100)
 app/api/routes/search.py:85:101: E501 Line too long (103 > 100)
-app/api/routes/sentry_tunnel.py:24:1: I001 [*] Import block is un-sorted or un-formatted
-app/api/routes/stock.py:1:1: I001 [*] Import block is un-sorted or un-formatted
 app/api/routes/stock.py:62:101: E501 Line too long (101 > 100)
-app/api/routes/storage.py:1:1: I001 [*] Import block is un-sorted or un-formatted
 app/api/routes/storage.py:193:101: E501 Line too long (101 > 100)
-app/api/routes/storage.py:46:101: E501 Line too long (107 > 100)
-app/api/routes/storage.py:50:101: E501 Line too long (105 > 100)
-app/api/routes/storage.py:85:101: E501 Line too long (115 > 100)
+app/api/routes/storage.py:47:101: E501 Line too long (107 > 100)
+app/api/routes/storage.py:51:101: E501 Line too long (105 > 100)
+app/api/routes/storage.py:76:101: E501 Line too long (109 > 100)
+app/api/routes/storage.py:86:101: E501 Line too long (115 > 100)
 app/api/routes/tags.py:36:101: E501 Line too long (111 > 100)
 app/api/routes/tags.py:98:101: E501 Line too long (113 > 100)
-app/api/routes/workspaces.py:1:1: I001 [*] Import block is un-sorted or un-formatted
-app/api/routes/workspaces.py:21:101: E501 Line too long (104 > 100)
-app/api/routes/workspaces.py:379:101: E501 Line too long (112 > 100)
-app/api/routes/workspaces.py:43:101: E501 Line too long (117 > 100)
-app/api/routes/workspaces.py:78:101: E501 Line too long (124 > 100)
-app/core/config.py:1:1: I001 [*] Import block is un-sorted or un-formatted
-app/core/config.py:153:101: E501 Line too long (107 > 100)
-app/core/errors.py:37:1: I001 [*] Import block is un-sorted or un-formatted
-app/core/logging.py:23:1: I001 [*] Import block is un-sorted or un-formatted
-app/core/ratelimit.py:13:1: I001 [*] Import block is un-sorted or un-formatted
+app/api/routes/workspaces.py:384:101: E501 Line too long (112 > 100)
+app/api/routes/workspaces.py:48:101: E501 Line too long (117 > 100)
+app/api/routes/workspaces.py:83:101: E501 Line too long (124 > 100)
+app/core/config.py:154:101: E501 Line too long (107 > 100)
 app/core/responses.py:149:101: E501 Line too long (109 > 100)
-app/core/secrets.py:35:1: I001 [*] Import block is un-sorted or un-formatted
-app/core/secrets.py:60:101: E501 Line too long (105 > 100)
-app/core/_secrets_v0016.py:31:1: I001 [*] Import block is un-sorted or un-formatted
-app/core/_secrets_v0016.py:54:101: E501 Line too long (105 > 100)
-app/domain/all_models.py:26:1: I001 [*] Import block is un-sorted or un-formatted
+app/core/secrets.py:59:101: E501 Line too long (105 > 100)
+app/core/_secrets_v0016.py:53:101: E501 Line too long (105 > 100)
 app/domain/builds/models.py:27:101: E501 Line too long (106 > 100)
 app/domain/builds/models.py:29:101: E501 Line too long (108 > 100)
 app/domain/builds/models.py:32:101: E501 Line too long (105 > 100)
@@ -110,11 +96,8 @@ app/domain/builds/service.py:25:1: E402 Module level import not at top of file
 app/domain/builds/service.py:26:1: E402 Module level import not at top of file
 app/domain/builds/service.py:27:1: E402 Module level import not at top of file
 app/domain/builds/service.py:9:21: F401 [*] `decimal.Decimal` imported but unused
-app/domain/custom_fields/schemas.py:10:1: I001 [*] Import block is un-sorted or un-formatted
-app/domain/lots/models.py:1:1: I001 [*] Import block is un-sorted or un-formatted
 app/domain/lots/models.py:24:101: E501 Line too long (112 > 100)
 app/domain/lots/models.py:27:101: E501 Line too long (105 > 100)
-app/domain/lots/schemas.py:10:1: I001 [*] Import block is un-sorted or un-formatted
 app/domain/_mixins.py:15:101: E501 Line too long (122 > 100)
 app/domain/_mixins.py:18:101: E501 Line too long (103 > 100)
 app/domain/_mixins.py:19:101: E501 Line too long (103 > 100)
@@ -128,24 +111,17 @@ app/domain/orders/service.py:19:1: E402 Module level import not at top of file
 app/domain/orders/service.py:20:1: E402 Module level import not at top of file
 app/domain/orders/service.py:21:1: E402 Module level import not at top of file
 app/domain/orders/service.py:99:101: E501 Line too long (101 > 100)
-app/domain/parts/models.py:108:101: E501 Line too long (117 > 100)
-app/domain/parts/models.py:109:101: E501 Line too long (112 > 100)
-app/domain/parts/models.py:119:101: E501 Line too long (112 > 100)
-app/domain/parts/models.py:1:1: I001 [*] Import block is un-sorted or un-formatted
-app/domain/parts/models.py:120:101: E501 Line too long (123 > 100)
-app/domain/parts/models.py:60:101: E501 Line too long (101 > 100)
-app/domain/parts/models.py:69:101: E501 Line too long (106 > 100)
-app/domain/parts/models.py:96:101: E501 Line too long (112 > 100)
-app/domain/parts/providers/digikey.py:14:1: I001 [*] Import block is un-sorted or un-formatted
-app/domain/parts/providers/mouser.py:2:1: I001 [*] Import block is un-sorted or un-formatted
-app/domain/parts/schemas.py:15:1: I001 [*] Import block is un-sorted or un-formatted
-app/domain/parts/services/assets.py:29:1: I001 [*] Import block is un-sorted or un-formatted
-app/domain/parts/services/bag_signature.py:30:1: I001 [*] Import block is un-sorted or un-formatted
-app/domain/projects/bom_import.py:116:101: E501 Line too long (106 > 100)
+app/domain/parts/models.py:107:101: E501 Line too long (117 > 100)
+app/domain/parts/models.py:108:101: E501 Line too long (112 > 100)
+app/domain/parts/models.py:118:101: E501 Line too long (112 > 100)
+app/domain/parts/models.py:119:101: E501 Line too long (123 > 100)
+app/domain/parts/models.py:59:101: E501 Line too long (101 > 100)
+app/domain/parts/models.py:68:101: E501 Line too long (106 > 100)
+app/domain/parts/models.py:95:101: E501 Line too long (112 > 100)
+app/domain/projects/bom_import.py:115:101: E501 Line too long (106 > 100)
 app/domain/projects/bom_import.py:13:24: F401 [*] `sqlalchemy.and_` imported but unused
-app/domain/projects/bom_import.py:176:101: E501 Line too long (103 > 100)
-app/domain/projects/bom_import.py:2:1: I001 [*] Import block is un-sorted or un-formatted
-app/domain/projects/bom_import.py:258:101: E501 Line too long (103 > 100)
+app/domain/projects/bom_import.py:175:101: E501 Line too long (103 > 100)
+app/domain/projects/bom_import.py:257:101: E501 Line too long (103 > 100)
 app/domain/projects/bom_import.py:8:20: F401 [*] `typing.Iterable` imported but unused
 app/domain/projects/models.py:68:101: E501 Line too long (106 > 100)
 app/domain/projects/models.py:69:101: E501 Line too long (104 > 100)
@@ -160,17 +136,13 @@ app/domain/stock/service.py:284:101: E501 Line too long (102 > 100)
 app/domain/stock/service.py:385:101: E501 Line too long (106 > 100)
 app/domain/stock/service.py:416:101: E501 Line too long (109 > 100)
 app/domain/stock/service.py:587:101: E501 Line too long (101 > 100)
-app/domain/storage/schemas.py:10:1: I001 [*] Import block is un-sorted or un-formatted
-app/domain/tags/schemas.py:10:1: I001 [*] Import block is un-sorted or un-formatted
 app/domain/users/models.py:34:101: E501 Line too long (112 > 100)
-app/domain/users/schemas.py:10:1: I001 [*] Import block is un-sorted or un-formatted
 app/domain/workspaces/models.py:101:101: E501 Line too long (103 > 100)
 app/domain/workspaces/models.py:104:101: E501 Line too long (104 > 100)
 app/domain/workspaces/models.py:29:101: E501 Line too long (107 > 100)
 app/domain/workspaces/models.py:62:101: E501 Line too long (122 > 100)
 app/domain/workspaces/models.py:63:101: E501 Line too long (112 > 100)
 app/domain/workspaces/models.py:87:101: E501 Line too long (122 > 100)
-app/domain/workspaces/schemas.py:11:1: I001 [*] Import block is un-sorted or un-formatted
 app/main.py:101:1: E402 Module level import not at top of file
 app/main.py:125:1: E402 Module level import not at top of file
 app/main.py:126:1: E402 Module level import not at top of file
@@ -185,4 +157,3 @@ app/main.py:376:101: E501 Line too long (102 > 100)
 app/main.py:377:101: E501 Line too long (114 > 100)
 app/main.py:383:101: E501 Line too long (114 > 100)
 app/main.py:384:101: E501 Line too long (120 > 100)
-Found 186 errors.

--- a/.ruff-baseline.txt
+++ b/.ruff-baseline.txt
@@ -1,10 +1,11 @@
+[*] 45 fixable with the `--fix` option.
 app/api/routes/_activity.py:33:1: I001 [*] Import block is un-sorted or un-formatted
 app/api/routes/attachments.py:1:1: I001 [*] Import block is un-sorted or un-formatted
 app/api/routes/attachments.py:17:5: F401 [*] `app.core.deps.CurrentUser` imported but unused
 app/api/routes/attachments.py:8:20: F401 [*] `typing.Annotated` imported but unused
-app/api/routes/auth.py:165:101: E501 Line too long (111 > 100)
-app/api/routes/auth.py:329:101: E501 Line too long (107 > 100)
-app/api/routes/bom_presets.py:86:101: E501 Line too long (112 > 100)
+app/api/routes/auth.py:137:101: E501 Line too long (111 > 100)
+app/api/routes/auth.py:301:101: E501 Line too long (107 > 100)
+app/api/routes/bom_presets.py:72:101: E501 Line too long (112 > 100)
 app/api/routes/builds.py:112:101: E501 Line too long (111 > 100)
 app/api/routes/builds.py:188:16: F821 Undefined name `datetime`
 app/api/routes/builds.py:191:25: F821 Undefined name `datetime`
@@ -15,24 +16,22 @@ app/api/routes/catalog.py:173:101: E501 Line too long (149 > 100)
 app/api/routes/catalog.py:211:101: E501 Line too long (101 > 100)
 app/api/routes/catalog.py:214:101: E501 Line too long (108 > 100)
 app/api/routes/catalog.py:6:1: I001 [*] Import block is un-sorted or un-formatted
-app/api/routes/custom_fields.py:51:101: E501 Line too long (101 > 100)
-app/api/routes/invitations.py:421:101: E501 Line too long (129 > 100)
-app/api/routes/lots.py:107:101: E501 Line too long (105 > 100)
-app/api/routes/lots.py:108:5: E741 Ambiguous variable name: `l`
-app/api/routes/lots.py:127:101: E501 Line too long (107 > 100)
-app/api/routes/lots.py:128:5: E741 Ambiguous variable name: `l`
-app/api/routes/lots.py:144:101: E501 Line too long (109 > 100)
-app/api/routes/lots.py:145:5: E741 Ambiguous variable name: `l`
-app/api/routes/lots.py:152:101: E501 Line too long (101 > 100)
-app/api/routes/lots.py:25:16: E741 Ambiguous variable name: `l`
+app/api/routes/custom_fields.py:42:101: E501 Line too long (101 > 100)
+app/api/routes/invitations.py:401:101: E501 Line too long (129 > 100)
+app/api/routes/lots.py:100:5: E741 Ambiguous variable name: `l`
+app/api/routes/lots.py:111:101: E501 Line too long (107 > 100)
+app/api/routes/lots.py:112:5: E741 Ambiguous variable name: `l`
+app/api/routes/lots.py:147:5: E741 Ambiguous variable name: `l`
+app/api/routes/lots.py:27:16: E741 Ambiguous variable name: `l`
 app/api/routes/lots.py:3:22: F401 [*] `datetime.datetime` imported but unused
 app/api/routes/lots.py:3:32: F401 [*] `datetime.timezone` imported but unused
-app/api/routes/lots.py:37:101: E501 Line too long (104 > 100)
-app/api/routes/lots.py:59:9: E741 Ambiguous variable name: `l`
-app/api/routes/lots.py:66:5: E741 Ambiguous variable name: `l`
-app/api/routes/lots.py:74:5: E741 Ambiguous variable name: `l`
-app/api/routes/lots.py:90:101: E501 Line too long (103 > 100)
-app/api/routes/lots.py:91:5: E741 Ambiguous variable name: `l`
+app/api/routes/lots.py:39:101: E501 Line too long (104 > 100)
+app/api/routes/lots.py:61:9: E741 Ambiguous variable name: `l`
+app/api/routes/lots.py:68:5: E741 Ambiguous variable name: `l`
+app/api/routes/lots.py:76:5: E741 Ambiguous variable name: `l`
+app/api/routes/lots.py:82:101: E501 Line too long (103 > 100)
+app/api/routes/lots.py:83:5: E741 Ambiguous variable name: `l`
+app/api/routes/lots.py:99:101: E501 Line too long (105 > 100)
 app/api/routes/orders.py:111:101: E501 Line too long (102 > 100)
 app/api/routes/orders.py:114:101: E501 Line too long (110 > 100)
 app/api/routes/orders.py:1:1: I001 [*] Import block is un-sorted or un-formatted
@@ -43,21 +42,19 @@ app/api/routes/orders.py:263:101: E501 Line too long (130 > 100)
 app/api/routes/orders.py:292:101: E501 Line too long (110 > 100)
 app/api/routes/orders.py:316:16: F821 Undefined name `datetime`
 app/api/routes/orders.py:319:25: F821 Undefined name `datetime`
-app/api/routes/parts.py:1:1: I001 [*] Import block is un-sorted or un-formatted
-app/api/routes/parts.py:1279:101: E501 Line too long (104 > 100)
-app/api/routes/parts.py:225:101: E501 Line too long (102 > 100)
-app/api/routes/parts.py:226:101: E501 Line too long (104 > 100)
-app/api/routes/parts.py:324:101: E501 Line too long (106 > 100)
-app/api/routes/parts.py:338:101: E501 Line too long (114 > 100)
-app/api/routes/parts.py:407:1: I001 [*] Import block is un-sorted or un-formatted
-app/api/routes/parts.py:44:5: F401 [*] `app.domain.parts.schemas.ScanImportRow` imported but unused
-app/api/routes/parts.py:592:101: E501 Line too long (111 > 100)
-app/api/routes/parts.py:60:42: F401 [*] `app.domain.workspaces.models.Workspace` imported but unused
-app/api/routes/parts.py:608:101: E501 Line too long (115 > 100)
-app/api/routes/parts.py:618:101: E501 Line too long (112 > 100)
-app/api/routes/parts.py:626:17: E741 Ambiguous variable name: `l`
-app/api/routes/parts.py:739:1: I001 [*] Import block is un-sorted or un-formatted
-app/api/routes/parts.py:739:43: F401 [*] `sqlalchemy.tuple_` imported but unused
+app/api/routes/parts_assets.py:9:1: I001 [*] Import block is un-sorted or un-formatted
+app/api/routes/parts_core.py:119:101: E501 Line too long (102 > 100)
+app/api/routes/parts_core.py:120:101: E501 Line too long (104 > 100)
+app/api/routes/parts_core.py:218:101: E501 Line too long (106 > 100)
+app/api/routes/parts_core.py:232:101: E501 Line too long (114 > 100)
+app/api/routes/parts_core.py:301:1: I001 [*] Import block is un-sorted or un-formatted
+app/api/routes/parts_core.py:486:101: E501 Line too long (111 > 100)
+app/api/routes/parts_core.py:502:101: E501 Line too long (115 > 100)
+app/api/routes/parts_core.py:512:101: E501 Line too long (112 > 100)
+app/api/routes/parts_core.py:520:17: E741 Ambiguous variable name: `l`
+app/api/routes/parts_core.py:6:1: I001 [*] Import block is un-sorted or un-formatted
+app/api/routes/parts_core.py:633:1: I001 [*] Import block is un-sorted or un-formatted
+app/api/routes/parts_scan.py:396:101: E501 Line too long (104 > 100)
 app/api/routes/_parts_shared.py:14:1: I001 [*] Import block is un-sorted or un-formatted
 app/api/routes/_parts_shared.py:67:101: E501 Line too long (117 > 100)
 app/api/routes/projects.py:109:101: E501 Line too long (117 > 100)
@@ -66,7 +63,7 @@ app/api/routes/projects.py:171:101: E501 Line too long (148 > 100)
 app/api/routes/projects.py:188:101: E501 Line too long (109 > 100)
 app/api/routes/projects.py:228:101: E501 Line too long (130 > 100)
 app/api/routes/projects.py:260:101: E501 Line too long (117 > 100)
-app/api/routes/projects.py:276:101: E501 Line too long (129 > 100)
+app/api/routes/projects.py:270:101: E501 Line too long (129 > 100)
 app/api/routes/projects.py:36:101: E501 Line too long (126 > 100)
 app/api/routes/projects.py:70:101: E501 Line too long (106 > 100)
 app/api/routes/projects.py:79:101: E501 Line too long (101 > 100)
@@ -81,16 +78,18 @@ app/api/routes/search.py:85:101: E501 Line too long (103 > 100)
 app/api/routes/sentry_tunnel.py:24:1: I001 [*] Import block is un-sorted or un-formatted
 app/api/routes/stock.py:1:1: I001 [*] Import block is un-sorted or un-formatted
 app/api/routes/stock.py:62:101: E501 Line too long (101 > 100)
-app/api/routes/storage.py:103:101: E501 Line too long (115 > 100)
 app/api/routes/storage.py:1:1: I001 [*] Import block is un-sorted or un-formatted
-app/api/routes/storage.py:172:101: E501 Line too long (117 > 100)
-app/api/routes/storage.py:64:101: E501 Line too long (107 > 100)
-app/api/routes/storage.py:68:101: E501 Line too long (105 > 100)
-app/api/routes/tags.py:113:101: E501 Line too long (113 > 100)
-app/api/routes/tags.py:43:101: E501 Line too long (111 > 100)
-app/api/routes/workspaces.py:423:101: E501 Line too long (112 > 100)
-app/api/routes/workspaces.py:51:101: E501 Line too long (117 > 100)
-app/api/routes/workspaces.py:86:101: E501 Line too long (124 > 100)
+app/api/routes/storage.py:193:101: E501 Line too long (101 > 100)
+app/api/routes/storage.py:46:101: E501 Line too long (107 > 100)
+app/api/routes/storage.py:50:101: E501 Line too long (105 > 100)
+app/api/routes/storage.py:85:101: E501 Line too long (115 > 100)
+app/api/routes/tags.py:36:101: E501 Line too long (111 > 100)
+app/api/routes/tags.py:98:101: E501 Line too long (113 > 100)
+app/api/routes/workspaces.py:1:1: I001 [*] Import block is un-sorted or un-formatted
+app/api/routes/workspaces.py:21:101: E501 Line too long (104 > 100)
+app/api/routes/workspaces.py:379:101: E501 Line too long (112 > 100)
+app/api/routes/workspaces.py:43:101: E501 Line too long (117 > 100)
+app/api/routes/workspaces.py:78:101: E501 Line too long (124 > 100)
 app/core/config.py:1:1: I001 [*] Import block is un-sorted or un-formatted
 app/core/config.py:153:101: E501 Line too long (107 > 100)
 app/core/errors.py:37:1: I001 [*] Import block is un-sorted or un-formatted
@@ -112,9 +111,11 @@ app/domain/builds/service.py:25:1: E402 Module level import not at top of file
 app/domain/builds/service.py:26:1: E402 Module level import not at top of file
 app/domain/builds/service.py:27:1: E402 Module level import not at top of file
 app/domain/builds/service.py:9:21: F401 [*] `decimal.Decimal` imported but unused
+app/domain/custom_fields/schemas.py:10:1: I001 [*] Import block is un-sorted or un-formatted
 app/domain/lots/models.py:1:1: I001 [*] Import block is un-sorted or un-formatted
 app/domain/lots/models.py:24:101: E501 Line too long (112 > 100)
 app/domain/lots/models.py:27:101: E501 Line too long (105 > 100)
+app/domain/lots/schemas.py:10:1: I001 [*] Import block is un-sorted or un-formatted
 app/domain/_mixins.py:15:101: E501 Line too long (122 > 100)
 app/domain/_mixins.py:18:101: E501 Line too long (103 > 100)
 app/domain/_mixins.py:19:101: E501 Line too long (103 > 100)
@@ -160,21 +161,29 @@ app/domain/stock/service.py:284:101: E501 Line too long (102 > 100)
 app/domain/stock/service.py:385:101: E501 Line too long (106 > 100)
 app/domain/stock/service.py:416:101: E501 Line too long (109 > 100)
 app/domain/stock/service.py:587:101: E501 Line too long (101 > 100)
+app/domain/storage/schemas.py:10:1: I001 [*] Import block is un-sorted or un-formatted
+app/domain/tags/schemas.py:10:1: I001 [*] Import block is un-sorted or un-formatted
 app/domain/users/models.py:34:101: E501 Line too long (112 > 100)
+app/domain/users/schemas.py:10:1: I001 [*] Import block is un-sorted or un-formatted
 app/domain/workspaces/models.py:101:101: E501 Line too long (103 > 100)
 app/domain/workspaces/models.py:104:101: E501 Line too long (104 > 100)
 app/domain/workspaces/models.py:29:101: E501 Line too long (107 > 100)
 app/domain/workspaces/models.py:62:101: E501 Line too long (122 > 100)
 app/domain/workspaces/models.py:63:101: E501 Line too long (112 > 100)
 app/domain/workspaces/models.py:87:101: E501 Line too long (122 > 100)
+app/domain/workspaces/schemas.py:11:1: I001 [*] Import block is un-sorted or un-formatted
 app/main.py:101:1: E402 Module level import not at top of file
-app/main.py:123:1: E402 Module level import not at top of file
-app/main.py:124:1: E402 Module level import not at top of file
 app/main.py:125:1: E402 Module level import not at top of file
 app/main.py:126:1: E402 Module level import not at top of file
-app/main.py:366:101: E501 Line too long (102 > 100)
-app/main.py:369:101: E501 Line too long (105 > 100)
-app/main.py:372:101: E501 Line too long (102 > 100)
-app/main.py:373:101: E501 Line too long (114 > 100)
-app/main.py:379:101: E501 Line too long (114 > 100)
-app/main.py:380:101: E501 Line too long (120 > 100)
+app/main.py:127:1: E402 Module level import not at top of file
+app/main.py:128:1: E402 Module level import not at top of file
+app/main.py:367:101: E501 Line too long (101 > 100)
+app/main.py:368:101: E501 Line too long (103 > 100)
+app/main.py:369:101: E501 Line too long (101 > 100)
+app/main.py:370:101: E501 Line too long (102 > 100)
+app/main.py:373:101: E501 Line too long (105 > 100)
+app/main.py:376:101: E501 Line too long (102 > 100)
+app/main.py:377:101: E501 Line too long (114 > 100)
+app/main.py:383:101: E501 Line too long (114 > 100)
+app/main.py:384:101: E501 Line too long (120 > 100)
+Found 187 errors.

--- a/.ruff-baseline.txt
+++ b/.ruff-baseline.txt
@@ -1,4 +1,4 @@
-[*] 45 fixable with the `--fix` option.
+[*] 44 fixable with the `--fix` option.
 app/api/routes/_activity.py:33:1: I001 [*] Import block is un-sorted or un-formatted
 app/api/routes/attachments.py:1:1: I001 [*] Import block is un-sorted or un-formatted
 app/api/routes/attachments.py:17:5: F401 [*] `app.core.deps.CurrentUser` imported but unused
@@ -37,33 +37,32 @@ app/api/routes/orders.py:114:101: E501 Line too long (110 > 100)
 app/api/routes/orders.py:1:1: I001 [*] Import block is un-sorted or un-formatted
 app/api/routes/orders.py:175:101: E501 Line too long (111 > 100)
 app/api/routes/orders.py:189:1: I001 [*] Import block is un-sorted or un-formatted
-app/api/routes/orders.py:230:101: E501 Line too long (109 > 100)
-app/api/routes/orders.py:263:101: E501 Line too long (130 > 100)
-app/api/routes/orders.py:292:101: E501 Line too long (110 > 100)
-app/api/routes/orders.py:316:16: F821 Undefined name `datetime`
-app/api/routes/orders.py:319:25: F821 Undefined name `datetime`
+app/api/routes/orders.py:231:101: E501 Line too long (109 > 100)
+app/api/routes/orders.py:264:101: E501 Line too long (130 > 100)
+app/api/routes/orders.py:293:101: E501 Line too long (110 > 100)
+app/api/routes/orders.py:317:16: F821 Undefined name `datetime`
+app/api/routes/orders.py:320:25: F821 Undefined name `datetime`
 app/api/routes/parts_assets.py:9:1: I001 [*] Import block is un-sorted or un-formatted
 app/api/routes/parts_core.py:119:101: E501 Line too long (102 > 100)
 app/api/routes/parts_core.py:120:101: E501 Line too long (104 > 100)
 app/api/routes/parts_core.py:218:101: E501 Line too long (106 > 100)
 app/api/routes/parts_core.py:232:101: E501 Line too long (114 > 100)
 app/api/routes/parts_core.py:301:1: I001 [*] Import block is un-sorted or un-formatted
-app/api/routes/parts_core.py:486:101: E501 Line too long (111 > 100)
-app/api/routes/parts_core.py:502:101: E501 Line too long (115 > 100)
-app/api/routes/parts_core.py:512:101: E501 Line too long (112 > 100)
-app/api/routes/parts_core.py:520:17: E741 Ambiguous variable name: `l`
+app/api/routes/parts_core.py:487:101: E501 Line too long (111 > 100)
+app/api/routes/parts_core.py:503:101: E501 Line too long (115 > 100)
+app/api/routes/parts_core.py:513:101: E501 Line too long (112 > 100)
+app/api/routes/parts_core.py:521:17: E741 Ambiguous variable name: `l`
 app/api/routes/parts_core.py:6:1: I001 [*] Import block is un-sorted or un-formatted
-app/api/routes/parts_core.py:633:1: I001 [*] Import block is un-sorted or un-formatted
 app/api/routes/parts_scan.py:396:101: E501 Line too long (104 > 100)
 app/api/routes/_parts_shared.py:14:1: I001 [*] Import block is un-sorted or un-formatted
 app/api/routes/_parts_shared.py:67:101: E501 Line too long (117 > 100)
 app/api/routes/projects.py:109:101: E501 Line too long (117 > 100)
 app/api/routes/projects.py:125:1: I001 [*] Import block is un-sorted or un-formatted
-app/api/routes/projects.py:171:101: E501 Line too long (148 > 100)
-app/api/routes/projects.py:188:101: E501 Line too long (109 > 100)
-app/api/routes/projects.py:228:101: E501 Line too long (130 > 100)
-app/api/routes/projects.py:260:101: E501 Line too long (117 > 100)
-app/api/routes/projects.py:270:101: E501 Line too long (129 > 100)
+app/api/routes/projects.py:172:101: E501 Line too long (148 > 100)
+app/api/routes/projects.py:189:101: E501 Line too long (109 > 100)
+app/api/routes/projects.py:229:101: E501 Line too long (130 > 100)
+app/api/routes/projects.py:261:101: E501 Line too long (117 > 100)
+app/api/routes/projects.py:271:101: E501 Line too long (129 > 100)
 app/api/routes/projects.py:36:101: E501 Line too long (126 > 100)
 app/api/routes/projects.py:70:101: E501 Line too long (106 > 100)
 app/api/routes/projects.py:79:101: E501 Line too long (101 > 100)
@@ -186,4 +185,4 @@ app/main.py:376:101: E501 Line too long (102 > 100)
 app/main.py:377:101: E501 Line too long (114 > 100)
 app/main.py:383:101: E501 Line too long (114 > 100)
 app/main.py:384:101: E501 Line too long (120 > 100)
-Found 187 errors.
+Found 186 errors.

--- a/.ruff-baseline.txt
+++ b/.ruff-baseline.txt
@@ -1,0 +1,180 @@
+app/api/routes/_activity.py:33:1: I001 [*] Import block is un-sorted or un-formatted
+app/api/routes/attachments.py:1:1: I001 [*] Import block is un-sorted or un-formatted
+app/api/routes/attachments.py:17:5: F401 [*] `app.core.deps.CurrentUser` imported but unused
+app/api/routes/attachments.py:8:20: F401 [*] `typing.Annotated` imported but unused
+app/api/routes/auth.py:165:101: E501 Line too long (111 > 100)
+app/api/routes/auth.py:329:101: E501 Line too long (107 > 100)
+app/api/routes/bom_presets.py:86:101: E501 Line too long (112 > 100)
+app/api/routes/builds.py:112:101: E501 Line too long (111 > 100)
+app/api/routes/builds.py:188:16: F821 Undefined name `datetime`
+app/api/routes/builds.py:191:25: F821 Undefined name `datetime`
+app/api/routes/builds.py:68:101: E501 Line too long (102 > 100)
+app/api/routes/catalog.py:168:101: E501 Line too long (132 > 100)
+app/api/routes/catalog.py:172:101: E501 Line too long (108 > 100)
+app/api/routes/catalog.py:173:101: E501 Line too long (149 > 100)
+app/api/routes/catalog.py:211:101: E501 Line too long (101 > 100)
+app/api/routes/catalog.py:214:101: E501 Line too long (108 > 100)
+app/api/routes/catalog.py:6:1: I001 [*] Import block is un-sorted or un-formatted
+app/api/routes/custom_fields.py:51:101: E501 Line too long (101 > 100)
+app/api/routes/invitations.py:421:101: E501 Line too long (129 > 100)
+app/api/routes/lots.py:107:101: E501 Line too long (105 > 100)
+app/api/routes/lots.py:108:5: E741 Ambiguous variable name: `l`
+app/api/routes/lots.py:127:101: E501 Line too long (107 > 100)
+app/api/routes/lots.py:128:5: E741 Ambiguous variable name: `l`
+app/api/routes/lots.py:144:101: E501 Line too long (109 > 100)
+app/api/routes/lots.py:145:5: E741 Ambiguous variable name: `l`
+app/api/routes/lots.py:152:101: E501 Line too long (101 > 100)
+app/api/routes/lots.py:25:16: E741 Ambiguous variable name: `l`
+app/api/routes/lots.py:3:22: F401 [*] `datetime.datetime` imported but unused
+app/api/routes/lots.py:3:32: F401 [*] `datetime.timezone` imported but unused
+app/api/routes/lots.py:37:101: E501 Line too long (104 > 100)
+app/api/routes/lots.py:59:9: E741 Ambiguous variable name: `l`
+app/api/routes/lots.py:66:5: E741 Ambiguous variable name: `l`
+app/api/routes/lots.py:74:5: E741 Ambiguous variable name: `l`
+app/api/routes/lots.py:90:101: E501 Line too long (103 > 100)
+app/api/routes/lots.py:91:5: E741 Ambiguous variable name: `l`
+app/api/routes/orders.py:111:101: E501 Line too long (102 > 100)
+app/api/routes/orders.py:114:101: E501 Line too long (110 > 100)
+app/api/routes/orders.py:1:1: I001 [*] Import block is un-sorted or un-formatted
+app/api/routes/orders.py:175:101: E501 Line too long (111 > 100)
+app/api/routes/orders.py:189:1: I001 [*] Import block is un-sorted or un-formatted
+app/api/routes/orders.py:230:101: E501 Line too long (109 > 100)
+app/api/routes/orders.py:263:101: E501 Line too long (130 > 100)
+app/api/routes/orders.py:292:101: E501 Line too long (110 > 100)
+app/api/routes/orders.py:316:16: F821 Undefined name `datetime`
+app/api/routes/orders.py:319:25: F821 Undefined name `datetime`
+app/api/routes/parts.py:1:1: I001 [*] Import block is un-sorted or un-formatted
+app/api/routes/parts.py:1279:101: E501 Line too long (104 > 100)
+app/api/routes/parts.py:225:101: E501 Line too long (102 > 100)
+app/api/routes/parts.py:226:101: E501 Line too long (104 > 100)
+app/api/routes/parts.py:324:101: E501 Line too long (106 > 100)
+app/api/routes/parts.py:338:101: E501 Line too long (114 > 100)
+app/api/routes/parts.py:407:1: I001 [*] Import block is un-sorted or un-formatted
+app/api/routes/parts.py:44:5: F401 [*] `app.domain.parts.schemas.ScanImportRow` imported but unused
+app/api/routes/parts.py:592:101: E501 Line too long (111 > 100)
+app/api/routes/parts.py:60:42: F401 [*] `app.domain.workspaces.models.Workspace` imported but unused
+app/api/routes/parts.py:608:101: E501 Line too long (115 > 100)
+app/api/routes/parts.py:618:101: E501 Line too long (112 > 100)
+app/api/routes/parts.py:626:17: E741 Ambiguous variable name: `l`
+app/api/routes/parts.py:739:1: I001 [*] Import block is un-sorted or un-formatted
+app/api/routes/parts.py:739:43: F401 [*] `sqlalchemy.tuple_` imported but unused
+app/api/routes/_parts_shared.py:14:1: I001 [*] Import block is un-sorted or un-formatted
+app/api/routes/_parts_shared.py:67:101: E501 Line too long (117 > 100)
+app/api/routes/projects.py:109:101: E501 Line too long (117 > 100)
+app/api/routes/projects.py:125:1: I001 [*] Import block is un-sorted or un-formatted
+app/api/routes/projects.py:171:101: E501 Line too long (148 > 100)
+app/api/routes/projects.py:188:101: E501 Line too long (109 > 100)
+app/api/routes/projects.py:228:101: E501 Line too long (130 > 100)
+app/api/routes/projects.py:260:101: E501 Line too long (117 > 100)
+app/api/routes/projects.py:276:101: E501 Line too long (129 > 100)
+app/api/routes/projects.py:36:101: E501 Line too long (126 > 100)
+app/api/routes/projects.py:70:101: E501 Line too long (106 > 100)
+app/api/routes/projects.py:79:101: E501 Line too long (101 > 100)
+app/api/routes/reports.py:131:101: E501 Line too long (127 > 100)
+app/api/routes/reports.py:160:9: E741 Ambiguous variable name: `l`
+app/api/routes/reports.py:85:101: E501 Line too long (110 > 100)
+app/api/routes/reports.py:96:25: E741 Ambiguous variable name: `l`
+app/api/routes/search.py:112:101: E501 Line too long (118 > 100)
+app/api/routes/search.py:115:87: E741 Ambiguous variable name: `l`
+app/api/routes/search.py:76:101: E501 Line too long (102 > 100)
+app/api/routes/search.py:85:101: E501 Line too long (103 > 100)
+app/api/routes/sentry_tunnel.py:24:1: I001 [*] Import block is un-sorted or un-formatted
+app/api/routes/stock.py:1:1: I001 [*] Import block is un-sorted or un-formatted
+app/api/routes/stock.py:62:101: E501 Line too long (101 > 100)
+app/api/routes/storage.py:103:101: E501 Line too long (115 > 100)
+app/api/routes/storage.py:1:1: I001 [*] Import block is un-sorted or un-formatted
+app/api/routes/storage.py:172:101: E501 Line too long (117 > 100)
+app/api/routes/storage.py:64:101: E501 Line too long (107 > 100)
+app/api/routes/storage.py:68:101: E501 Line too long (105 > 100)
+app/api/routes/tags.py:113:101: E501 Line too long (113 > 100)
+app/api/routes/tags.py:43:101: E501 Line too long (111 > 100)
+app/api/routes/workspaces.py:423:101: E501 Line too long (112 > 100)
+app/api/routes/workspaces.py:51:101: E501 Line too long (117 > 100)
+app/api/routes/workspaces.py:86:101: E501 Line too long (124 > 100)
+app/core/config.py:1:1: I001 [*] Import block is un-sorted or un-formatted
+app/core/config.py:153:101: E501 Line too long (107 > 100)
+app/core/errors.py:37:1: I001 [*] Import block is un-sorted or un-formatted
+app/core/logging.py:23:1: I001 [*] Import block is un-sorted or un-formatted
+app/core/ratelimit.py:13:1: I001 [*] Import block is un-sorted or un-formatted
+app/core/responses.py:149:101: E501 Line too long (109 > 100)
+app/core/secrets.py:35:1: I001 [*] Import block is un-sorted or un-formatted
+app/core/secrets.py:60:101: E501 Line too long (105 > 100)
+app/core/_secrets_v0016.py:31:1: I001 [*] Import block is un-sorted or un-formatted
+app/core/_secrets_v0016.py:54:101: E501 Line too long (105 > 100)
+app/domain/all_models.py:26:1: I001 [*] Import block is un-sorted or un-formatted
+app/domain/builds/models.py:27:101: E501 Line too long (106 > 100)
+app/domain/builds/models.py:29:101: E501 Line too long (108 > 100)
+app/domain/builds/models.py:32:101: E501 Line too long (105 > 100)
+app/domain/builds/service.py:22:1: E402 Module level import not at top of file
+app/domain/builds/service.py:23:1: E402 Module level import not at top of file
+app/domain/builds/service.py:24:1: E402 Module level import not at top of file
+app/domain/builds/service.py:25:1: E402 Module level import not at top of file
+app/domain/builds/service.py:26:1: E402 Module level import not at top of file
+app/domain/builds/service.py:27:1: E402 Module level import not at top of file
+app/domain/builds/service.py:9:21: F401 [*] `decimal.Decimal` imported but unused
+app/domain/lots/models.py:1:1: I001 [*] Import block is un-sorted or un-formatted
+app/domain/lots/models.py:24:101: E501 Line too long (112 > 100)
+app/domain/lots/models.py:27:101: E501 Line too long (105 > 100)
+app/domain/_mixins.py:15:101: E501 Line too long (122 > 100)
+app/domain/_mixins.py:18:101: E501 Line too long (103 > 100)
+app/domain/_mixins.py:19:101: E501 Line too long (103 > 100)
+app/domain/orders/models.py:37:101: E501 Line too long (105 > 100)
+app/domain/orders/models.py:55:101: E501 Line too long (102 > 100)
+app/domain/orders/service.py:16:1: E402 Module level import not at top of file
+app/domain/orders/service.py:17:1: E402 Module level import not at top of file
+app/domain/orders/service.py:18:1: E402 Module level import not at top of file
+app/domain/orders/service.py:190:32: E741 Ambiguous variable name: `l`
+app/domain/orders/service.py:19:1: E402 Module level import not at top of file
+app/domain/orders/service.py:20:1: E402 Module level import not at top of file
+app/domain/orders/service.py:21:1: E402 Module level import not at top of file
+app/domain/orders/service.py:99:101: E501 Line too long (101 > 100)
+app/domain/parts/models.py:108:101: E501 Line too long (117 > 100)
+app/domain/parts/models.py:109:101: E501 Line too long (112 > 100)
+app/domain/parts/models.py:119:101: E501 Line too long (112 > 100)
+app/domain/parts/models.py:1:1: I001 [*] Import block is un-sorted or un-formatted
+app/domain/parts/models.py:120:101: E501 Line too long (123 > 100)
+app/domain/parts/models.py:60:101: E501 Line too long (101 > 100)
+app/domain/parts/models.py:69:101: E501 Line too long (106 > 100)
+app/domain/parts/models.py:96:101: E501 Line too long (112 > 100)
+app/domain/parts/providers/digikey.py:14:1: I001 [*] Import block is un-sorted or un-formatted
+app/domain/parts/providers/mouser.py:2:1: I001 [*] Import block is un-sorted or un-formatted
+app/domain/parts/schemas.py:15:1: I001 [*] Import block is un-sorted or un-formatted
+app/domain/parts/services/assets.py:29:1: I001 [*] Import block is un-sorted or un-formatted
+app/domain/parts/services/bag_signature.py:30:1: I001 [*] Import block is un-sorted or un-formatted
+app/domain/projects/bom_import.py:116:101: E501 Line too long (106 > 100)
+app/domain/projects/bom_import.py:13:24: F401 [*] `sqlalchemy.and_` imported but unused
+app/domain/projects/bom_import.py:176:101: E501 Line too long (103 > 100)
+app/domain/projects/bom_import.py:2:1: I001 [*] Import block is un-sorted or un-formatted
+app/domain/projects/bom_import.py:258:101: E501 Line too long (103 > 100)
+app/domain/projects/bom_import.py:8:20: F401 [*] `typing.Iterable` imported but unused
+app/domain/projects/models.py:68:101: E501 Line too long (106 > 100)
+app/domain/projects/models.py:69:101: E501 Line too long (104 > 100)
+app/domain/projects/models.py:71:101: E501 Line too long (105 > 100)
+app/domain/stock/models.py:49:101: E501 Line too long (110 > 100)
+app/domain/stock/models.py:60:101: E501 Line too long (117 > 100)
+app/domain/stock/models.py:74:101: E501 Line too long (106 > 100)
+app/domain/stock/models.py:86:101: E501 Line too long (103 > 100)
+app/domain/stock/service.py:10:24: F401 [*] `sqlalchemy.and_` imported but unused
+app/domain/stock/service.py:10:36: F401 [*] `sqlalchemy.or_` imported but unused
+app/domain/stock/service.py:284:101: E501 Line too long (102 > 100)
+app/domain/stock/service.py:385:101: E501 Line too long (106 > 100)
+app/domain/stock/service.py:416:101: E501 Line too long (109 > 100)
+app/domain/stock/service.py:587:101: E501 Line too long (101 > 100)
+app/domain/users/models.py:34:101: E501 Line too long (112 > 100)
+app/domain/workspaces/models.py:101:101: E501 Line too long (103 > 100)
+app/domain/workspaces/models.py:104:101: E501 Line too long (104 > 100)
+app/domain/workspaces/models.py:29:101: E501 Line too long (107 > 100)
+app/domain/workspaces/models.py:62:101: E501 Line too long (122 > 100)
+app/domain/workspaces/models.py:63:101: E501 Line too long (112 > 100)
+app/domain/workspaces/models.py:87:101: E501 Line too long (122 > 100)
+app/main.py:101:1: E402 Module level import not at top of file
+app/main.py:123:1: E402 Module level import not at top of file
+app/main.py:124:1: E402 Module level import not at top of file
+app/main.py:125:1: E402 Module level import not at top of file
+app/main.py:126:1: E402 Module level import not at top of file
+app/main.py:366:101: E501 Line too long (102 > 100)
+app/main.py:369:101: E501 Line too long (105 > 100)
+app/main.py:372:101: E501 Line too long (102 > 100)
+app/main.py:373:101: E501 Line too long (114 > 100)
+app/main.py:379:101: E501 Line too long (114 > 100)
+app/main.py:380:101: E501 Line too long (120 > 100)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,9 +56,12 @@ TEST_DATABASE_URL=postgresql+psycopg://stockmgr:stockmgr@127.0.0.1:5432/stockmgr
 
 ### Build / lint
 
-There is **no Python linter and no JS linter configured**. CI's only
-static check is `tsc -b` (run as part of `npm run build`) and `pytest`.
-Don't add tooling without asking.
+CI runs both `ruff` (Python) and `eslint` (JS/TS) as **baseline-blocking**
+gates — they fail only on violations that are NEW relative to the
+checked-in baselines (`.ruff-baseline.txt` and `.eslint-baseline.txt`).
+`tsc -b` (via `npm run build`) and `pytest` are the other static checks.
+To update the baselines after intentional cleanup, see
+`docs/development.md` — "Updating lint baselines".
 
 ### Migrations
 

--- a/backend/app/api/routes/_activity.py
+++ b/backend/app/api/routes/_activity.py
@@ -40,7 +40,6 @@ from sqlalchemy.orm import Session
 from app.domain.stock.models import StockEntry
 from app.domain.users.models import User
 
-
 _DEFAULT_LIMIT = 50
 _MAX_LIMIT = 200
 

--- a/backend/app/api/routes/_parts_shared.py
+++ b/backend/app/api/routes/_parts_shared.py
@@ -19,6 +19,7 @@ from sqlalchemy import select
 from app.core.errors import ErrorCodes, raise_http
 from app.domain.custom_fields.models import CustomField
 from app.domain.parts.models import Part
+
 # Re-export request schemas from the canonical domain location (CQ-006).
 # Kept importable here for back-compat with split files (#118 step 2-4).
 from app.domain.parts.schemas import BulkDeleteIn, PartIn, PartPatch  # noqa: F401

--- a/backend/app/api/routes/attachments.py
+++ b/backend/app/api/routes/attachments.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 import os
 import re
 import uuid as uuidlib
-from uuid import UUID
-
 from typing import Annotated
+from uuid import UUID
 
 from fastapi import APIRouter, Depends, File, Form, UploadFile, status
 from fastapi.responses import FileResponse

--- a/backend/app/api/routes/catalog.py
+++ b/backend/app/api/routes/catalog.py
@@ -5,6 +5,7 @@ require_member_for_writes — anyone with the URL gets to read.
 """
 from __future__ import annotations
 
+import datetime
 import hashlib
 import hmac
 from html import escape
@@ -12,8 +13,6 @@ from html import escape
 from fastapi import APIRouter, Request, status
 from fastapi.responses import HTMLResponse, JSONResponse
 from sqlalchemy import select
-
-import datetime
 
 from app.core.config import settings
 from app.core.deps import DbSession

--- a/backend/app/api/routes/orders.py
+++ b/backend/app/api/routes/orders.py
@@ -187,6 +187,7 @@ def patch_order(order_id: UUID, payload: OrderPatchIn, db: DbSession, ws: Curren
 @router.post("/{order_id}/archive")
 def archive_order(order_id: UUID, db: DbSession, ws: CurrentWorkspace, user: CurrentUser):
     from sqlalchemy import func, select as sa_select
+
     from app.domain.attachments.models import Attachment
     from app.domain.custom_fields.models import CustomField as CF
     from app.domain.tags.models import TagLink

--- a/backend/app/api/routes/orders.py
+++ b/backend/app/api/routes/orders.py
@@ -12,8 +12,6 @@ from app.core.deps import CurrentUser, CurrentWorkspace, DbSession
 from app.core.responses import ok
 from app.core.time import utcnow
 from app.domain.orders.models import Order, OrderEntry
-from app.domain.parts.models import Part
-from app.domain.stock.models import StockEntry
 from app.domain.orders.schemas import (
     OrderCreateIn,
     OrderEntryIn,
@@ -22,6 +20,8 @@ from app.domain.orders.schemas import (
     ReceiveIn,
 )
 from app.domain.orders.service import OrderError, receive
+from app.domain.parts.models import Part
+from app.domain.stock.models import StockEntry
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -186,7 +186,8 @@ def patch_order(order_id: UUID, payload: OrderPatchIn, db: DbSession, ws: Curren
 # workspace's order_id gets 404, not 403.
 @router.post("/{order_id}/archive")
 def archive_order(order_id: UUID, db: DbSession, ws: CurrentWorkspace, user: CurrentUser):
-    from sqlalchemy import func, select as sa_select
+    from sqlalchemy import func
+    from sqlalchemy import select as sa_select
 
     from app.domain.attachments.models import Attachment
     from app.domain.custom_fields.models import CustomField as CF

--- a/backend/app/api/routes/parts_assets.py
+++ b/backend/app/api/routes/parts_assets.py
@@ -9,6 +9,7 @@ No URL structure changes from the original monolithic parts.py.
 from __future__ import annotations
 
 import os
+from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, Query, Request, status
 from fastapi.responses import FileResponse
@@ -16,6 +17,8 @@ from sqlalchemy import select
 
 from app.api.routes._parts_shared import (
     get_part as _get_part,
+)
+from app.api.routes._parts_shared import (
     serialize_part as _serialize,
 )
 from app.core.config import settings
@@ -29,7 +32,6 @@ from app.domain.parts.providers import make_provider
 from app.domain.parts.services.assets import fetch_provider_asset
 from app.domain.parts.services.provider_cache import lookup_fresh
 from app.domain.stock.service import reserved_quantity, total_for_part
-from uuid import UUID
 
 router = APIRouter()
 

--- a/backend/app/api/routes/parts_core.py
+++ b/backend/app/api/routes/parts_core.py
@@ -17,7 +17,11 @@ from app.api._helpers import assert_in_workspace, require_resource_access
 from app.api.routes._activity import _DEFAULT_LIMIT, _MAX_LIMIT, build_activity
 from app.api.routes._parts_shared import (
     get_part as _get_part,
+)
+from app.api.routes._parts_shared import (
     image_urls_for_parts as _image_urls_for_parts,
+)
+from app.api.routes._parts_shared import (
     serialize_part as _serialize,
 )
 from app.core.deps import CurrentUser, CurrentWorkspace, DbSession, require_role
@@ -26,6 +30,7 @@ from app.core.ratelimit import limiter, workspace_key
 from app.core.responses import Envelope, ok
 from app.core.time import utcnow
 from app.domain.audit.service import log as _audit_log
+from app.domain.custom_fields.models import CustomField
 from app.domain.parts.models import Part, PartMetaMember, PartSubstitute
 from app.domain.parts.schemas import (
     BulkDeleteIn,
@@ -34,7 +39,6 @@ from app.domain.parts.schemas import (
     PartPatch,
     SubstituteIn,
 )
-from app.domain.custom_fields.models import CustomField
 from app.domain.stock.models import StockEntry
 from app.domain.stock.service import (
     bulk_current_quantities,
@@ -298,7 +302,8 @@ def archive_part(
     ws: CurrentWorkspace,
     user: CurrentUser,
 ):
-    from sqlalchemy import func, select as sa_select
+    from sqlalchemy import func
+    from sqlalchemy import select as sa_select
 
     from app.domain.attachments.models import Attachment
     from app.domain.custom_fields.models import CustomField as CF

--- a/backend/app/api/routes/parts_core.py
+++ b/backend/app/api/routes/parts_core.py
@@ -299,6 +299,7 @@ def archive_part(
     user: CurrentUser,
 ):
     from sqlalchemy import func, select as sa_select
+
     from app.domain.attachments.models import Attachment
     from app.domain.custom_fields.models import CustomField as CF
     from app.domain.tags.models import TagLink
@@ -630,7 +631,7 @@ def part_activity(
         .where(StockEntry.part_id == p.id)
     )
     if cursor_at is not None and before_id is not None:
-        from sqlalchemy import or_, and_
+        from sqlalchemy import and_, or_
         stmt = stmt.where(
             or_(
                 StockEntry.occurred_at < cursor_at,

--- a/backend/app/api/routes/projects.py
+++ b/backend/app/api/routes/projects.py
@@ -124,6 +124,7 @@ def patch_project(project_id: UUID, payload: ProjectPatchIn, db: DbSession, ws: 
 @router.post("/{project_id}/archive")
 def archive_project(project_id: UUID, db: DbSession, ws: CurrentWorkspace, user: CurrentUser):
     from sqlalchemy import func, select as sa_select
+
     from app.domain.attachments.models import Attachment
     from app.domain.custom_fields.models import CustomField as CF
     from app.domain.tags.models import TagLink

--- a/backend/app/api/routes/projects.py
+++ b/backend/app/api/routes/projects.py
@@ -123,7 +123,8 @@ def patch_project(project_id: UUID, payload: ProjectPatchIn, db: DbSession, ws: 
 # workspace's project_id gets 404, not 403.
 @router.post("/{project_id}/archive")
 def archive_project(project_id: UUID, db: DbSession, ws: CurrentWorkspace, user: CurrentUser):
-    from sqlalchemy import func, select as sa_select
+    from sqlalchemy import func
+    from sqlalchemy import select as sa_select
 
     from app.domain.attachments.models import Attachment
     from app.domain.custom_fields.models import CustomField as CF

--- a/backend/app/api/routes/sentry_tunnel.py
+++ b/backend/app/api/routes/sentry_tunnel.py
@@ -33,7 +33,6 @@ from app.core.config import settings
 from app.core.errors import ErrorCodes, raise_http
 from app.core.ratelimit import limiter
 
-
 router = APIRouter()
 
 

--- a/backend/app/api/routes/stock.py
+++ b/backend/app/api/routes/stock.py
@@ -4,13 +4,13 @@ from fastapi import APIRouter, HTTPException, Query, status
 
 from app.core.deps import CurrentUser, CurrentWorkspace, DbSession
 from app.core.responses import Envelope, ok
+from app.domain.parts.services.bag_signature import compute_bag_signature
 from app.domain.stock.schemas import (
     AddStockIn,
     AdjustStockIn,
     MoveStockIn,
     RemoveStockIn,
 )
-from app.domain.parts.services.bag_signature import compute_bag_signature
 from app.domain.stock.service import (
     StockConflictError,
     StockError,

--- a/backend/app/api/routes/storage.py
+++ b/backend/app/api/routes/storage.py
@@ -12,12 +12,12 @@ from app.core.pagination import decode_cursor, paginate
 from app.core.responses import ok
 from app.core.time import utcnow
 from app.domain.stock.models import StockEntry
-from app.domain.storage.models import StorageLocation
-from app.domain.storage.schemas import StorageIn, StoragePatch
 from app.domain.stock.service import (
     history_for_storage,
     stock_for_storage,
 )
+from app.domain.storage.models import StorageLocation
+from app.domain.storage.schemas import StorageIn, StoragePatch
 
 router = APIRouter()
 

--- a/backend/app/api/routes/workspaces.py
+++ b/backend/app/api/routes/workspaces.py
@@ -18,7 +18,12 @@ from app.core.secrets import decrypt, encrypt
 from app.domain.audit.service import log as _audit_log
 from app.domain.users.models import User
 from app.domain.workspaces.models import Workspace, WorkspaceCatalogToken, WorkspaceMember
-from app.domain.workspaces.schemas import CatalogTokenIn, MemberPatch, WorkspaceCreateIn, WorkspacePatch
+from app.domain.workspaces.schemas import (
+    CatalogTokenIn,
+    MemberPatch,
+    WorkspaceCreateIn,
+    WorkspacePatch,
+)
 
 router = APIRouter()
 

--- a/backend/app/core/_secrets_v0016.py
+++ b/backend/app/core/_secrets_v0016.py
@@ -36,7 +36,6 @@ from cryptography.fernet import Fernet, InvalidToken
 
 from app.core.logging import get_logger
 
-
 log = get_logger(__name__)
 
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import urllib.parse
 from functools import lru_cache
+
 from pydantic import model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 

--- a/backend/app/core/errors.py
+++ b/backend/app/core/errors.py
@@ -40,7 +40,6 @@ from typing import Any, NoReturn
 
 from fastapi import HTTPException
 
-
 # Default human-readable messages keyed by status code. Used when the
 # caller passes `message=None` so a route only has to pick a `code`.
 _DEFAULT_MESSAGES: dict[int, str] = {

--- a/backend/app/core/logging.py
+++ b/backend/app/core/logging.py
@@ -27,7 +27,6 @@ import logging
 import sys
 from typing import Any
 
-
 _CONFIGURED = False
 
 

--- a/backend/app/core/ratelimit.py
+++ b/backend/app/core/ratelimit.py
@@ -18,7 +18,6 @@ from slowapi.util import get_remote_address
 
 from app.core.config import settings
 
-
 limiter = Limiter(
     key_func=get_remote_address,
     enabled=settings().APP_ENV == "prod",

--- a/backend/app/core/secrets.py
+++ b/backend/app/core/secrets.py
@@ -40,7 +40,6 @@ from cryptography.fernet import Fernet, InvalidToken
 
 from app.core.logging import get_logger
 
-
 log = get_logger(__name__)
 
 

--- a/backend/app/domain/all_models.py
+++ b/backend/app/domain/all_models.py
@@ -23,8 +23,8 @@ The test in step (1) does not replace step (2) — it only catches the
 case where step (1) was forgotten.
 """
 
-from app.domain.audit.models import AuditLog  # noqa: F401
 from app.domain.attachments.models import Attachment  # noqa: F401
+from app.domain.audit.models import AuditLog  # noqa: F401
 from app.domain.builds.models import Build  # noqa: F401
 from app.domain.custom_fields.models import CustomField  # noqa: F401
 from app.domain.lots.models import Lot  # noqa: F401

--- a/backend/app/domain/custom_fields/schemas.py
+++ b/backend/app/domain/custom_fields/schemas.py
@@ -13,7 +13,6 @@ from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field
 
-
 __all__ = [
     "CustomFieldIn",
 ]

--- a/backend/app/domain/lots/models.py
+++ b/backend/app/domain/lots/models.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 from sqlalchemy import Column, Date, ForeignKey, Index, Integer, Numeric, String, Text
+from sqlalchemy.dialects.postgresql import UUID
 
 from app.domain._mixins import WorkspaceOwned
 from app.infra.db import Base
-from sqlalchemy.dialects.postgresql import UUID
 
 
 class Lot(WorkspaceOwned, Base):

--- a/backend/app/domain/lots/schemas.py
+++ b/backend/app/domain/lots/schemas.py
@@ -13,7 +13,6 @@ from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict
 
-
 __all__ = [
     "LotPatch",
     "LotAdjustIn",

--- a/backend/app/domain/parts/models.py
+++ b/backend/app/domain/parts/models.py
@@ -16,8 +16,7 @@ from sqlalchemy import (
     func,
     text,
 )
-from sqlalchemy.dialects.postgresql import JSONB
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.dialects.postgresql import JSONB, UUID
 
 from app.domain._mixins import WorkspaceOwned
 from app.infra.db import Base

--- a/backend/app/domain/parts/providers/digikey.py
+++ b/backend/app/domain/parts/providers/digikey.py
@@ -21,7 +21,6 @@ import httpx
 
 from app.domain.parts.providers.base import MpnLookupResult
 
-
 _API_BASE = "https://api.digikey.com"
 _TOKEN_PATH = "/v1/oauth2/token"
 _PRODUCT_DETAILS_PATH = "/products/v4/search/{mpn}/productdetails"

--- a/backend/app/domain/parts/providers/mouser.py
+++ b/backend/app/domain/parts/providers/mouser.py
@@ -8,7 +8,6 @@ import httpx
 
 from app.domain.parts.providers.base import MpnLookupResult
 
-
 _ENDPOINT = "https://api.mouser.com/api/v1/search/partnumber"
 _TIMEOUT_SEC = 8.0  # Cap upstream wall-clock to prevent worker stall (BE2-011).
 

--- a/backend/app/domain/parts/schemas.py
+++ b/backend/app/domain/parts/schemas.py
@@ -21,7 +21,6 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from app.domain.stock.schemas import BagSignatureStr
 
-
 __all__ = [
     "PartIn",
     "PartPatch",

--- a/backend/app/domain/parts/services/assets.py
+++ b/backend/app/domain/parts/services/assets.py
@@ -28,17 +28,16 @@ Hardening notes (SEC2-006):
 """
 from __future__ import annotations
 
+import hashlib
 import ipaddress
 import logging
-import socket
-import hashlib
 import os
+import socket
 from urllib.parse import urlparse
 
 import httpx
 
 from app.core.config import settings
-
 
 log = logging.getLogger(__name__)
 

--- a/backend/app/domain/parts/services/bag_signature.py
+++ b/backend/app/domain/parts/services/bag_signature.py
@@ -31,7 +31,6 @@ from __future__ import annotations
 
 import hashlib
 
-
 # ECMAScript WhiteSpace + LineTerminator characters — the characters that
 # JavaScript's String.prototype.trim() removes.  This is intentionally a
 # strict subset of Python's str.isspace() universe: Python also considers

--- a/backend/app/domain/projects/bom_import.py
+++ b/backend/app/domain/projects/bom_import.py
@@ -25,7 +25,6 @@ from app.domain.projects.schemas import (
     BomPreviewRow,
 )
 
-
 # SEC2-007 / BE2-006 — second line of defence. The schema caps the
 # base64 input at 5 MB; this caps the decoded body at 4 MB and the row
 # count at 10 000 so a malicious payload that squeaks past the schema

--- a/backend/app/domain/storage/schemas.py
+++ b/backend/app/domain/storage/schemas.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 from pydantic import BaseModel, ConfigDict, Field
 
-
 __all__ = [
     "StorageIn",
     "StoragePatch",

--- a/backend/app/domain/tags/schemas.py
+++ b/backend/app/domain/tags/schemas.py
@@ -13,7 +13,6 @@ from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict
 
-
 __all__ = [
     "TagIn",
     "TagLinkIn",

--- a/backend/app/domain/users/schemas.py
+++ b/backend/app/domain/users/schemas.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 from pydantic import BaseModel, ConfigDict, EmailStr, Field
 
-
 __all__ = [
     "SignupIn",
     "LoginIn",

--- a/backend/app/domain/workspaces/schemas.py
+++ b/backend/app/domain/workspaces/schemas.py
@@ -14,7 +14,6 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, EmailStr, Field
 
-
 __all__ = [
     "WorkspaceCreateIn",
     "WorkspacePatch",

--- a/docs/development.md
+++ b/docs/development.md
@@ -64,6 +64,42 @@ uv export --format requirements-txt --hashes --no-dev --no-emit-project \
     -o requirements.lock
 ```
 
+## Lint gates and baselines
+
+CI enforces lint via `scripts/lint-delta.sh`, which compares current linter
+output against checked-in baseline files and fails only on NEW violations.
+This means you can introduce a PR without being blocked by pre-existing
+warnings — but you must not add new ones.
+
+Baseline files live at the repo root:
+
+| File | Linter |
+|------|--------|
+| `.ruff-baseline.txt` | `ruff check app` (Python, runs from `backend/`) |
+| `.eslint-baseline.txt` | `eslint src --format=unix` (JS/TS, runs from `web/`) |
+
+### Updating lint baselines
+
+After fixing a batch of pre-existing violations, regenerate the baselines
+and commit them together with the fixes:
+
+```bash
+# Python (ruff)
+cd backend
+ruff check app --output-format=concise 2>/dev/null \
+  | grep -E '^app/' | sort > ../.ruff-baseline.txt
+
+# JS/TS (eslint)
+cd web
+npm run lint -- --format=unix 2>/dev/null \
+  | grep -E '^[^[:space:]].+:[0-9]+:[0-9]+:' \
+  | sed "s|^$(pwd)/||g" \
+  | sort > ../.eslint-baseline.txt
+```
+
+Commit both baseline files alongside the code fix. The CI delta check will
+then see the new (smaller) baseline and pass.
+
 ## Running tests outside Docker
 
 The backend test suite needs Postgres. With a local Postgres and

--- a/scripts/lint-delta.sh
+++ b/scripts/lint-delta.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# lint-delta.sh — run a linter and fail only on NEW violations.
+#
+# Usage:
+#   LINT_CMD="<command>"  BASELINE_FILE="<path>"  bash scripts/lint-delta.sh
+#
+# The linter output is filtered to lines that look like lint diagnostics
+# (i.e. lines matching <file>:<line>:<col>: …) and compared against the
+# checked-in baseline. Exit 1 iff there are new violations not in the
+# baseline.
+#
+# To regenerate a baseline after intentional cleanup:
+#   See "Updating lint baselines" in docs/development.md
+
+set -euo pipefail
+
+: "${LINT_CMD:?LINT_CMD must be set}"
+: "${BASELINE_FILE:?BASELINE_FILE must be set}"
+: "${WORK_DIR:-.}"
+
+if [ ! -f "$BASELINE_FILE" ]; then
+  echo "ERROR: baseline file not found: $BASELINE_FILE" >&2
+  exit 1
+fi
+
+TMPFILE=$(mktemp)
+trap 'rm -f "$TMPFILE"' EXIT
+
+# Run linter; capture output; ignore its exit code (we decide pass/fail)
+(cd "$WORK_DIR" && eval "$LINT_CMD") 2>&1 \
+  | grep -E '^[^[:space:]].+:[0-9]+:[0-9]+:' \
+  | sed "s|^$(pwd)/||g" \
+  | sort > "$TMPFILE" || true
+
+# Find lines present in current output but NOT in baseline
+NEW_VIOLATIONS=$(comm -23 "$TMPFILE" <(sort "$BASELINE_FILE"))
+
+if [ -n "$NEW_VIOLATIONS" ]; then
+  echo ""
+  echo "=== NEW lint violations (not in baseline $BASELINE_FILE) ==="
+  echo "$NEW_VIOLATIONS"
+  echo ""
+  echo "Fix the new violations, or update the baseline if they are intentional:"
+  echo "  See docs/development.md — 'Updating lint baselines'"
+  exit 1
+fi
+
+FIXED=$(comm -23 <(sort "$BASELINE_FILE") "$TMPFILE" | wc -l | tr -d ' ')
+CURRENT=$(wc -l < "$TMPFILE" | tr -d ' ')
+echo "lint-delta: no new violations (baseline: $(wc -l < "$BASELINE_FILE" | tr -d ' '), current: $CURRENT, fixed since baseline: $FIXED)"

--- a/web/src/routes/storage/StorageDetail.tsx
+++ b/web/src/routes/storage/StorageDetail.tsx
@@ -61,12 +61,14 @@ export function StorageDetailLayout() {
 
 export function StorageInfo() {
   const { storageId } = useParams();
+  const storagePartsKey = useWsKey("storage", storageId, "parts");
+  const partsKey = useWsKey("parts");
   const { data: rows, isError, error } = useQuery({
-    queryKey: useWsKey("storage", storageId, "parts"),
+    queryKey: storagePartsKey,
     queryFn: () => api.get<{ part_id: string; lot_id: string | null; quantity: number }[]>(`/storage/${storageId}/parts`),
   });
+  const { data: parts } = useQuery({ queryKey: partsKey, queryFn: () => api.get<Part[]>("/parts") });
   if (isError) return <div className="text-red-600 text-sm p-4">Failed to load storage contents. {error instanceof ApiError ? error.userMessage : ""}</div>;
-  const { data: parts } = useQuery({ queryKey: useWsKey("parts"), queryFn: () => api.get<Part[]>("/parts") });
   const partName = new Map(parts?.map(p => [p.id, p.name]) ?? []);
   return (
     <div className="card overflow-hidden">


### PR DESCRIPTION
Closes #253

## Summary
- Add `.ruff-baseline.txt` and `.eslint-baseline.txt` checked-in baselines capturing current violations
- Add `scripts/lint-delta.sh` — parametrised helper that runs a linter, filters to diagnostic lines, and fails only on violations not in the baseline
- Update `ci.yml` ruff and eslint steps: replace `--exit-zero` / `|| true` with baseline-blocking delta detection
- Update `CLAUDE.md` to reflect that lint gates are now baseline-blocking
- Update `docs/development.md` with "Updating lint baselines" recipe

## Tests
- Verified `lint-delta.sh` passes locally with current codebase (no new violations)
- Verified `lint-delta.sh` exits 1 when a synthetic new violation is injected

🤖 Generated with [Claude Code](https://claude.com/claude-code)