### PR TITLE
fix(fe): migrate remaining forms to useApiMutation (#248)

### DIFF
--- a/web/src/routes/auth/Login.tsx
+++ b/web/src/routes/auth/Login.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Link, useLocation, useNavigate, type Location } from "react-router-dom";
 import { api, ApiError } from "@/lib/api";
 import { useAuth } from "@/lib/auth";
+import { useApiMutation } from "@/lib/mutations";
 import AuthShell from "./AuthShell";
 
 export default function Login() {
@@ -14,7 +15,6 @@ export default function Login() {
   // SEC2-014: the server returns retry_after_seconds on a 429 lockout
   // response. Show a countdown so the user knows how long to wait.
   const [retryAfter, setRetryAfter] = useState<number | null>(null);
-  const [busy, setBusy] = useState(false);
 
   // `from` is set by `<Gate>` (and by the 401 handler in auth.tsx) when
   // an authed page bounced the user here. Replay the original target on
@@ -22,16 +22,14 @@ export default function Login() {
   const fromLoc = (location.state as { from?: Location } | null)?.from;
   const fromPath = fromLoc ? `${fromLoc.pathname}${fromLoc.search}${fromLoc.hash}` : null;
 
-  async function submit(e: React.FormEvent) {
-    e.preventDefault();
-    setErr(null);
-    setRetryAfter(null);
-    setBusy(true);
-    try {
-      await api.post("/auth/login", { email, password });
+  const loginMutation = useApiMutation<unknown, { email: string; password: string }>({
+    mutationKey: ["auth", "login"],
+    mutationFn: ({ email, password }) => api.post("/auth/login", { email, password }),
+    onSuccess: async () => {
       await refresh();
       nav(fromPath || "/parts", { replace: true });
-    } catch (e) {
+    },
+    onError: (e) => {
       if (e instanceof ApiError) {
         // SEC2-014: per-account lockout returns 429 with retry_after_seconds.
         const body = e.body as Record<string, unknown> | null;
@@ -44,9 +42,16 @@ export default function Login() {
       } else {
         setErr("Login failed");
       }
-    } finally {
-      setBusy(false);
-    }
+    },
+  });
+
+  const busy = loginMutation.isPending;
+
+  function submit(e: React.FormEvent) {
+    e.preventDefault();
+    setErr(null);
+    setRetryAfter(null);
+    loginMutation.mutate({ email, password });
   }
 
   return (

--- a/web/src/routes/auth/Signup.tsx
+++ b/web/src/routes/auth/Signup.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Link, useLocation, useNavigate, type Location } from "react-router-dom";
 import { api, ApiError } from "@/lib/api";
 import { useAuth } from "@/lib/auth";
+import { useApiMutation } from "@/lib/mutations";
 import AuthShell from "./AuthShell";
 
 export default function Signup() {
@@ -13,7 +14,6 @@ export default function Signup() {
   const [password, setPassword] = useState("");
   const [workspaceName, setWorkspaceName] = useState("");
   const [err, setErr] = useState<string | null>(null);
-  const [busy, setBusy] = useState(false);
   // SEC2-014: when the server enables email-verification the signup
   // returns 202 with status="verification_sent" instead of 200 with
   // a session cookie. We show a "check your inbox" view in that case.
@@ -24,17 +24,10 @@ export default function Signup() {
   const fromLoc = (location.state as { from?: Location } | null)?.from;
   const fromPath = fromLoc ? `${fromLoc.pathname}${fromLoc.search}${fromLoc.hash}` : null;
 
-  async function submit(e: React.FormEvent) {
-    e.preventDefault();
-    setErr(null);
-    setBusy(true);
-    try {
-      const data = await api.post("/auth/signup", {
-        name,
-        email,
-        password,
-        workspace_name: workspaceName || undefined,
-      });
+  const signupMutation = useApiMutation<unknown, { name: string; email: string; password: string; workspace_name?: string }>({
+    mutationKey: ["auth", "signup"],
+    mutationFn: (payload) => api.post("/auth/signup", payload),
+    onSuccess: async (data) => {
       // SEC2-014: email-verification path returns {status: "verification_sent"}.
       if ((data as { status?: string }).status === "verification_sent") {
         setVerificationSent(true);
@@ -43,11 +36,23 @@ export default function Signup() {
       // Legacy / dev path: immediate session — refresh and navigate.
       await refresh();
       nav(fromPath || "/parts", { replace: true });
-    } catch (e) {
+    },
+    onError: (e) => {
       setErr(e instanceof ApiError ? e.userMessage : "Signup failed");
-    } finally {
-      setBusy(false);
-    }
+    },
+  });
+
+  const busy = signupMutation.isPending;
+
+  function submit(e: React.FormEvent) {
+    e.preventDefault();
+    setErr(null);
+    signupMutation.mutate({
+      name,
+      email,
+      password,
+      workspace_name: workspaceName || undefined,
+    });
   }
 
   // "Check your inbox" view shown after a 202 verification_sent response.

--- a/web/src/routes/builds/BuildCreate.tsx
+++ b/web/src/routes/builds/BuildCreate.tsx
@@ -2,8 +2,16 @@ import { useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { api, ApiError } from "@/lib/api";
+import { useApiMutation } from "@/lib/mutations";
 import { useWsKey } from "@/lib/queryKeys";
 import type { Build, Project } from "@/types";
+
+type BuildCreatePayload = {
+  name: string;
+  project_id: string;
+  quantity: number;
+  comments?: string;
+};
 
 export default function BuildCreate() {
   const nav = useNavigate();
@@ -16,26 +24,30 @@ export default function BuildCreate() {
   const [projectId, setProjectId] = useState(params.get("project_id") ?? "");
   const [qty, setQty] = useState(1);
   const [comments, setComments] = useState("");
-  const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
 
-  async function submit(e: React.FormEvent) {
-    e.preventDefault();
-    setBusy(true);
-    setErr(null);
-    try {
-      const b = await api.post<Build>("/builds", {
-        name,
-        project_id: projectId,
-        quantity: qty,
-        comments: comments || undefined,
-      });
+  const createMutation = useApiMutation<Build, BuildCreatePayload>({
+    mutationKey: ["build", "create"],
+    mutationFn: (payload) => api.post<Build>("/builds", payload),
+    onSuccess: (b) => {
       nav(`/builds/${b.id}`);
-    } catch (e) {
+    },
+    onError: (e) => {
       setErr(e instanceof ApiError ? e.userMessage : "Failed");
-    } finally {
-      setBusy(false);
-    }
+    },
+  });
+
+  const busy = createMutation.isPending;
+
+  function submit(e: React.FormEvent) {
+    e.preventDefault();
+    setErr(null);
+    createMutation.mutate({
+      name,
+      project_id: projectId,
+      quantity: qty,
+      comments: comments || undefined,
+    });
   }
 
   return (

--- a/web/src/routes/builds/BuildDetail.tsx
+++ b/web/src/routes/builds/BuildDetail.tsx
@@ -22,7 +22,7 @@ export default function BuildDetail() {
   const nav = useNavigate();
   const { workspaceId } = useAuth();
 
-  const { data } = useQuery({
+  const { data, isError, error } = useQuery({
     queryKey: useWsKey("build", buildId),
     queryFn: () => api.get<DetailOut>(`/builds/${buildId}`),
     enabled: !!buildId,
@@ -72,6 +72,7 @@ export default function BuildDetail() {
   });
 
 
+  if (isError) return <div className="text-red-600 text-sm p-4">Failed to load build. {error instanceof ApiError ? error.userMessage : ""}</div>;
   if (!data) return <div className="text-muted">Loading…</div>;
   const { build, shortage } = data;
   const isEditable = build.status === "planned" || build.status === "in_progress";

--- a/web/src/routes/builds/BuildDetail.tsx
+++ b/web/src/routes/builds/BuildDetail.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { api, ApiError } from "@/lib/api";
+import { useApiMutation } from "@/lib/mutations";
 import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
 import { useAuth } from "@/lib/auth";
 import { formatDateTime } from "@/lib/format";
@@ -21,7 +22,7 @@ export default function BuildDetail() {
   const nav = useNavigate();
   const { workspaceId } = useAuth();
 
-  const { data, isError, error } = useQuery({
+  const { data } = useQuery({
     queryKey: useWsKey("build", buildId),
     queryFn: () => api.get<DetailOut>(`/builds/${buildId}`),
     enabled: !!buildId,
@@ -42,12 +43,35 @@ export default function BuildDetail() {
 
   // consumption plan: project_entry_id → list of consume rows
   const [plan, setPlan] = useState<Record<string, ConsumeRow[]>>({});
-  const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
 
   const partsById = useMemo(() => new Map(parts?.map(p => [p.id, p]) ?? []), [parts]);
 
-  if (isError) return <div className="text-red-600 text-sm p-4">Failed to load build. {error instanceof ApiError ? error.userMessage : ""}</div>;
+  type ConsumePayload = {
+    lines: {
+      project_entry_id: string;
+      part_id: string;
+      quantity: number;
+      storage_location_id?: string;
+    }[];
+  };
+
+  const consumeMutation = useApiMutation<unknown, ConsumePayload>({
+    mutationKey: ["build", buildId, "consume"],
+    mutationFn: (payload) => api.post(`/builds/${buildId}/consume`, payload),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "build", buildId) });
+      qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "parts") });
+      toast.success("Build complete — stock decremented.");
+    },
+    onError: (e) => {
+      const m = e instanceof ApiError ? e.userMessage : "Build failed";
+      setErr(m);
+      toast.error(m);
+    },
+  });
+
+
   if (!data) return <div className="text-muted">Loading…</div>;
   const { build, shortage } = data;
   const isEditable = build.status === "planned" || build.status === "in_progress";
@@ -57,6 +81,8 @@ export default function BuildDetail() {
     ? shortage.reduce((sum, s) => sum + s.required, 0)
     : 0;
   const reservedLines = reservationsActive ? shortage.length : 0;
+
+  const busy = consumeMutation.isPending;
 
   function suggestedFill(s: BuildShortageRow): ConsumeRow[] {
     if (s.required <= s.available) {
@@ -75,33 +101,21 @@ export default function BuildDetail() {
     setPlan(next);
   }
 
-  async function doConsume() {
+  function doConsume() {
     setErr(null);
-    setBusy(true);
-    try {
-      const lines = Object.entries(plan).flatMap(([entryId, rows]) =>
-        rows.filter(r => r.quantity > 0).map(r => ({
-          project_entry_id: entryId,
-          part_id: r.part_id,
-          quantity: r.quantity,
-          storage_location_id: r.storage_location_id || undefined,
-        })),
-      );
-      if (lines.length === 0) {
-        setErr("No lines.");
-        return;
-      }
-      await api.post(`/builds/${buildId}/consume`, { lines });
-      qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "build", buildId) });
-      qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "parts") });
-      toast.success("Build complete — stock decremented.");
-    } catch (e) {
-      const m = e instanceof ApiError ? e.userMessage : "Build failed";
-      setErr(m);
-      toast.error(m);
-    } finally {
-      setBusy(false);
+    const lines = Object.entries(plan).flatMap(([entryId, rows]) =>
+      rows.filter(r => r.quantity > 0).map(r => ({
+        project_entry_id: entryId,
+        part_id: r.part_id,
+        quantity: r.quantity,
+        storage_location_id: r.storage_location_id || undefined,
+      })),
+    );
+    if (lines.length === 0) {
+      setErr("No lines.");
+      return;
     }
+    consumeMutation.mutate({ lines });
   }
 
   async function doArchive() {

--- a/web/src/routes/orders/OrderCreate.tsx
+++ b/web/src/routes/orders/OrderCreate.tsx
@@ -1,38 +1,58 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { useQueryClient } from "@tanstack/react-query";
 import { api, ApiError } from "@/lib/api";
+import { useAuth } from "@/lib/auth";
+import { useApiMutation } from "@/lib/mutations";
+import { wsKeyOf } from "@/lib/queryKeys";
 import type { Order } from "@/types";
+
+type OrderCreatePayload = {
+  name: string;
+  supplier?: string;
+  currency?: string;
+  ordered_on?: string;
+  expected_on?: string;
+  comments?: string;
+};
 
 export default function OrderCreate() {
   const nav = useNavigate();
+  const qc = useQueryClient();
+  const { workspaceId } = useAuth();
   const [name, setName] = useState("");
   const [supplier, setSupplier] = useState("");
   const [currency, setCurrency] = useState("USD");
   const [orderedOn, setOrderedOn] = useState("");
   const [expectedOn, setExpectedOn] = useState("");
   const [comments, setComments] = useState("");
-  const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
 
-  async function submit(e: React.FormEvent) {
-    e.preventDefault();
-    setBusy(true);
-    setErr(null);
-    try {
-      const o = await api.post<Order>("/orders", {
-        name,
-        supplier: supplier || undefined,
-        currency: currency || undefined,
-        ordered_on: orderedOn || undefined,
-        expected_on: expectedOn || undefined,
-        comments: comments || undefined,
-      });
+  const createMutation = useApiMutation<Order, OrderCreatePayload>({
+    mutationKey: ["order", "create"],
+    mutationFn: (payload) => api.post<Order>("/orders", payload),
+    onSuccess: (o) => {
+      qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "orders") });
       nav(`/orders/${o.id}`);
-    } catch (e) {
+    },
+    onError: (e) => {
       setErr(e instanceof ApiError ? e.userMessage : "Failed");
-    } finally {
-      setBusy(false);
-    }
+    },
+  });
+
+  const busy = createMutation.isPending;
+
+  function submit(e: React.FormEvent) {
+    e.preventDefault();
+    setErr(null);
+    createMutation.mutate({
+      name,
+      supplier: supplier || undefined,
+      currency: currency || undefined,
+      ordered_on: orderedOn || undefined,
+      expected_on: expectedOn || undefined,
+      comments: comments || undefined,
+    });
   }
 
   return (

--- a/web/src/routes/parts/PartsList.tsx
+++ b/web/src/routes/parts/PartsList.tsx
@@ -4,6 +4,7 @@ import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { Boxes, ImageOff, Loader2, Trash2 } from "lucide-react";
 import { api, ApiError, getPaged } from "@/lib/api";
+import { useApiMutation } from "@/lib/mutations";
 import { PagedPartsSchema } from "@/lib/schemas";
 import type { Part } from "@/lib/schemas";
 import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
@@ -23,7 +24,26 @@ export default function PartsList({ archived = false }: { archived?: boolean }) 
   const { workspaceId } = useAuth();
   // Use a distinct key so archived/active lists don't share cache entries.
   const partsKey = useWsKey("parts", "paged", { archived });
-  const [busy, setBusy] = useState(false);
+
+  const bulkDeleteMutation = useApiMutation<{ archived_ids: string[]; skipped: number }, { part_ids: string[] }>({
+    mutationKey: ["parts", "bulk-delete"],
+    mutationFn: (payload) =>
+      api.post<{ archived_ids: string[]; skipped: number }>("/parts/bulk-delete", payload),
+    onSuccess: (res, payload) => {
+      qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "parts") });
+      const ids = payload.part_ids;
+      toast.success(
+        res.archived_ids.length === ids.length
+          ? `Archived ${res.archived_ids.length} part${res.archived_ids.length === 1 ? "" : "s"}.`
+          : `Archived ${res.archived_ids.length} of ${ids.length}; ${res.skipped} skipped.`,
+      );
+    },
+    onError: (e) => {
+      toast.error(e instanceof ApiError ? e.userMessage : "Bulk delete failed");
+    },
+  });
+
+  const busy = bulkDeleteMutation.isPending;
 
   // `paged=true` opts into the cursor-paged response shape
   // (`{items, next_cursor}`). Without it, GET /parts returns a bare list
@@ -96,24 +116,8 @@ export default function PartsList({ archived = false }: { archived?: boolean }) 
       confirmLabel: "Archive",
     });
     if (!ok) return;
-    setBusy(true);
-    try {
-      const res = await api.post<{ archived_ids: string[]; skipped: number }>(
-        "/parts/bulk-delete",
-        { part_ids: ids },
-      );
-      qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "parts") });
-      clear();
-      toast.success(
-        res.archived_ids.length === ids.length
-          ? `Archived ${res.archived_ids.length} part${res.archived_ids.length === 1 ? "" : "s"}.`
-          : `Archived ${res.archived_ids.length} of ${ids.length}; ${res.skipped} skipped.`,
-      );
-    } catch (e) {
-      toast.error(e instanceof ApiError ? e.userMessage : "Bulk delete failed");
-    } finally {
-      setBusy(false);
-    }
+    clear();
+    bulkDeleteMutation.mutate({ part_ids: ids });
   }
 
   return (

--- a/web/src/routes/parts/detail/PartSpecs.tsx
+++ b/web/src/routes/parts/detail/PartSpecs.tsx
@@ -4,6 +4,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { Plus, RotateCcw, Trash2 } from "lucide-react";
 import { api, ApiError } from "@/lib/api";
+import { useApiMutation } from "@/lib/mutations";
 import { isSpecKey } from "@/lib/providerCatalog";
 import { useWsKey } from "@/lib/queryKeys";
 import { useConfirm } from "@/components/ConfirmDialog";
@@ -54,32 +55,36 @@ export default function PartSpecs() {
 
   const [newKey, setNewKey] = useState("");
   const [newValue, setNewValue] = useState("");
-  const [busy, setBusy] = useState(false);
 
-  async function add() {
+  const addMutation = useApiMutation<unknown, { object_type: string; object_id: string; key: string; value: string }>({
+    mutationKey: ["part", part.id, "spec-add"],
+    mutationFn: (payload) => api.post("/custom-fields", payload),
+    onSuccess: () => {
+      setNewKey("");
+      setNewValue("");
+      qc.invalidateQueries({ queryKey });
+      toast.success("Spec added.");
+    },
+    onError: (e) => {
+      toast.error(e instanceof ApiError ? e.userMessage : "Failed");
+    },
+  });
+
+  const busy = addMutation.isPending;
+
+  function add() {
     const k = newKey.trim();
     const v = newValue.trim();
     if (!k) {
       toast.error("Key is required.");
       return;
     }
-    setBusy(true);
-    try {
-      await api.post("/custom-fields", {
-        object_type: "part",
-        object_id: part.id,
-        key: k,
-        value: v,
-      });
-      setNewKey("");
-      setNewValue("");
-      qc.invalidateQueries({ queryKey });
-      toast.success("Spec added.");
-    } catch (e) {
-      toast.error(e instanceof ApiError ? e.userMessage : "Failed");
-    } finally {
-      setBusy(false);
-    }
+    addMutation.mutate({
+      object_type: "part",
+      object_id: part.id,
+      key: k,
+      value: v,
+    });
   }
 
   async function update(row: CustomFieldRow, newValueText: string) {

--- a/web/src/routes/projects/ProjectCreate.tsx
+++ b/web/src/routes/projects/ProjectCreate.tsx
@@ -1,25 +1,31 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { api, ApiError } from "@/lib/api";
+import { useApiMutation } from "@/lib/mutations";
 
 export default function ProjectCreate() {
   const nav = useNavigate();
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [err, setErr] = useState<string | null>(null);
-  const [busy, setBusy] = useState(false);
-  async function submit(e: React.FormEvent) {
-    e.preventDefault();
-    setBusy(true);
-    setErr(null);
-    try {
-      const res = await api.post<{ id: string }>("/projects", { name, description: description || null });
+
+  const createMutation = useApiMutation<{ id: string }, { name: string; description: string | null }>({
+    mutationKey: ["project", "create"],
+    mutationFn: (payload) => api.post<{ id: string }>("/projects", payload),
+    onSuccess: (res) => {
       nav(`/projects/${res.id}/data`);
-    } catch (e) {
+    },
+    onError: (e) => {
       setErr(e instanceof ApiError ? e.userMessage : "Failed");
-    } finally {
-      setBusy(false);
-    }
+    },
+  });
+
+  const busy = createMutation.isPending;
+
+  function submit(e: React.FormEvent) {
+    e.preventDefault();
+    setErr(null);
+    createMutation.mutate({ name, description: description || null });
   }
   return (
     <form onSubmit={submit} className="card p-4 max-w-xl space-y-3">

--- a/web/src/routes/projects/detail/ProjectImport.tsx
+++ b/web/src/routes/projects/detail/ProjectImport.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { api, ApiError } from "@/lib/api";
+import { useApiMutation } from "@/lib/mutations";
 import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
 import { useAuth } from "@/lib/auth";
 import { useConfirm, usePrompt } from "@/components/ConfirmDialog";
@@ -119,6 +120,29 @@ export default function ProjectImport() {
   const [busy, setBusy] = useState(false);
   const [uploadProgress, setUploadProgress] = useState<number | null>(null);
   const [result, setResult] = useState<{ inserted: number; matched: number; unmatched: number } | null>(null);
+
+  type CommitPayload = {
+    text_b64: string;
+    separator: string;
+    encoding: string;
+    has_header: boolean;
+    mapping: Mapping[];
+    designator_separator: string;
+  };
+
+  const commitMutation = useApiMutation<{ inserted: number; matched: number; unmatched: number }, CommitPayload>({
+    mutationKey: ["project", projectId, "bom-import"],
+    mutationFn: (payload) =>
+      api.post<{ inserted: number; matched: number; unmatched: number }>(`/projects/${projectId}/bom/import`, payload),
+    onSuccess: (res) => {
+      setResult(res);
+      qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "project", projectId, "entries") });
+      setStep("done");
+    },
+    onError: (e) => {
+      setErr(e instanceof ApiError ? e.userMessage : "Import failed");
+    },
+  });
   const { data: presets, refetch: refetchPresets } = useQuery({
     queryKey: useWsKey("bom-presets"),
     queryFn: () => api.get<Preset[]>("/bom-presets"),
@@ -221,26 +245,16 @@ export default function ProjectImport() {
     }
   }
 
-  async function commit() {
-    setBusy(true);
+  function commit() {
     setErr(null);
-    try {
-      const res = await api.post<{ inserted: number; matched: number; unmatched: number }>(`/projects/${projectId}/bom/import`, {
-        text_b64: b64,
-        separator,
-        encoding,
-        has_header: hasHeader,
-        mapping,
-        designator_separator: designatorSep,
-      });
-      setResult(res);
-      qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "project", projectId, "entries") });
-      setStep("done");
-    } catch (e) {
-      setErr(e instanceof ApiError ? e.userMessage : "Import failed");
-    } finally {
-      setBusy(false);
-    }
+    commitMutation.mutate({
+      text_b64: b64,
+      separator,
+      encoding,
+      has_header: hasHeader,
+      mapping,
+      designator_separator: designatorSep,
+    });
   }
 
   if (step === "done") {
@@ -382,7 +396,7 @@ export default function ProjectImport() {
           </div>
 
           <div className="flex gap-2">
-            <button className="btn-primary" onClick={commit} disabled={busy}>{busy ? "Importing…" : "Import BOM"}</button>
+            <button className="btn-primary" onClick={commit} disabled={commitMutation.isPending}>{commitMutation.isPending ? "Importing…" : "Import BOM"}</button>
             <button className="btn" onClick={() => setStep("upload")}>Back</button>
           </div>
         </div>

--- a/web/src/routes/reports/Reports.tsx
+++ b/web/src/routes/reports/Reports.tsx
@@ -202,7 +202,7 @@ export function LowStockReport() {
   const nav = useNavigate();
   const qc = useQueryClient();
   const { workspaceId } = useAuth();
-  const { data, isLoading } = useQuery({
+  const { data, isLoading, isError, error } = useQuery({
     queryKey: useWsKey("report", "low-stock"),
     queryFn: () => api.get<LowStockRow[]>("/reports/low-stock"),
   });
@@ -215,6 +215,7 @@ export function LowStockReport() {
   });
 
 
+  if (isError) return <div className="text-red-600 text-sm p-4">Failed to load low-stock report. {error instanceof ApiError ? error.userMessage : ""}</div>;
   if (isLoading) return <div className="text-muted">Loading…</div>;
   const rows = data ?? [];
   const busy = restockMutation.isPending;

--- a/web/src/routes/reports/Reports.tsx
+++ b/web/src/routes/reports/Reports.tsx
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 import { BarChart3, ShoppingCart } from "lucide-react";
 import { api, ApiError } from "@/lib/api";
 import { useAuth } from "@/lib/auth";
+import { useApiMutation } from "@/lib/mutations";
 import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
 import { formatDate, formatMoney } from "@/lib/format";
 import { DataTable } from "@/components/DataTable";
@@ -201,29 +202,29 @@ export function LowStockReport() {
   const nav = useNavigate();
   const qc = useQueryClient();
   const { workspaceId } = useAuth();
-  const [busy, setBusy] = useState(false);
-  const { data, isLoading, isError, error } = useQuery({
+  const { data, isLoading } = useQuery({
     queryKey: useWsKey("report", "low-stock"),
     queryFn: () => api.get<LowStockRow[]>("/reports/low-stock"),
   });
-  if (isError) return <div className="text-red-600 text-sm p-4">Failed to load low-stock report. {error instanceof ApiError ? error.userMessage : ""}</div>;
+
+  const restockMutation = useApiMutation<void, { name: string; lines: { part_id: string; quantity: number }[] }>({
+    mutationKey: ["report", "low-stock", "restock"],
+    mutationFn: async ({ name, lines }) => {
+      await createRestockOrder(name, lines, nav, qc, workspaceId);
+    },
+  });
+
+
   if (isLoading) return <div className="text-muted">Loading…</div>;
   const rows = data ?? [];
+  const busy = restockMutation.isPending;
 
-  async function orderShortages() {
+  function orderShortages() {
     if (busy || rows.length === 0) return;
-    setBusy(true);
-    try {
-      await createRestockOrder(
-        `Restock ${todayISO()}`,
-        rows.map(r => ({ part_id: r.part_id, quantity: Math.max(1, r.short_by) })),
-        nav,
-        qc,
-        workspaceId,
-      );
-    } finally {
-      setBusy(false);
-    }
+    restockMutation.mutate({
+      name: `Restock ${todayISO()}`,
+      lines: rows.map(r => ({ part_id: r.part_id, quantity: Math.max(1, r.short_by) })),
+    });
   }
 
   return (
@@ -324,7 +325,6 @@ export function BomShortageReport() {
   const { data: projects } = useQuery({ queryKey: useWsKey("projects"), queryFn: () => api.get<Project[]>("/projects") });
   const [projectId, setProjectId] = useState("");
   const [qty, setQty] = useState(1);
-  const [busy, setBusy] = useState(false);
   const { data } = useQuery({
     queryKey: useWsKey("report", "bom", projectId, qty),
     queryFn: () => api.get<Shortage>(`/reports/bom-shortage?project_id=${projectId}&quantity=${qty}`),
@@ -334,21 +334,22 @@ export function BomShortageReport() {
   const shortages = data?.rows.filter(r => r.short_by > 0) ?? [];
   const projectName = projects?.find(p => p.id === projectId)?.name;
 
-  async function orderShortages() {
+  const restockMutation = useApiMutation<void, { name: string; lines: { part_id: string; quantity: number }[] }>({
+    mutationKey: ["report", "bom", "restock"],
+    mutationFn: async ({ name, lines }) => {
+      await createRestockOrder(name, lines, nav, qc, workspaceId);
+    },
+  });
+
+  const busy = restockMutation.isPending;
+
+  function orderShortages() {
     if (busy || shortages.length === 0) return;
-    setBusy(true);
-    try {
-      const subject = projectName ? `${projectName} × ${qty}` : `build × ${qty}`;
-      await createRestockOrder(
-        `BOM restock — ${subject} (${todayISO()})`,
-        shortages.map(r => ({ part_id: r.part_id, quantity: r.short_by })),
-        nav,
-        qc,
-        workspaceId,
-      );
-    } finally {
-      setBusy(false);
-    }
+    const subject = projectName ? `${projectName} × ${qty}` : `build × ${qty}`;
+    restockMutation.mutate({
+      name: `BOM restock — ${subject} (${todayISO()})`,
+      lines: shortages.map(r => ({ part_id: r.part_id, quantity: r.short_by })),
+    });
   }
 
   return (

--- a/web/src/routes/settings/Account.tsx
+++ b/web/src/routes/settings/Account.tsx
@@ -1,24 +1,19 @@
 import { useState } from "react";
 import { api, ApiError } from "@/lib/api";
 import { useAuth } from "@/lib/auth";
+import { useApiMutation } from "@/lib/mutations";
 
 export default function Account() {
   const { me, refresh, switchWorkspace } = useAuth();
   const [token, setToken] = useState("");
-  const [busy, setBusy] = useState(false);
   const [msg, setMsg] = useState<string | null>(null);
   const [err, setErr] = useState<string | null>(null);
 
-  async function accept() {
-    if (!token.trim()) return;
-    setBusy(true);
-    setErr(null);
-    setMsg(null);
-    try {
-      const out = await api.post<{ workspace_id: string; workspace_name: string; role: string }>(
-        "/invitations/accept",
-        { token: token.trim() },
-      );
+  const acceptMutation = useApiMutation<{ workspace_id: string; workspace_name: string; role: string }, { token: string }>({
+    mutationKey: ["account", "update"],
+    mutationFn: (payload) =>
+      api.post<{ workspace_id: string; workspace_name: string; role: string }>("/invitations/accept", payload),
+    onSuccess: async (out) => {
       setMsg(`Joined "${out.workspace_name}" as ${out.role}.`);
       setToken("");
       // Refresh /auth/me so the new workspace appears in the picker,
@@ -26,11 +21,19 @@ export default function Account() {
       // cache and navigates without a full page reload (FE2-003).
       await refresh();
       await switchWorkspace(out.workspace_id);
-    } catch (e) {
+    },
+    onError: (e) => {
       setErr(e instanceof ApiError ? e.userMessage : "Failed");
-    } finally {
-      setBusy(false);
-    }
+    },
+  });
+
+  const busy = acceptMutation.isPending;
+
+  function accept() {
+    if (!token.trim()) return;
+    setErr(null);
+    setMsg(null);
+    acceptMutation.mutate({ token: token.trim() });
   }
 
   if (!me) return null;

--- a/web/src/routes/settings/Workspace.tsx
+++ b/web/src/routes/settings/Workspace.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { api, ApiError } from "@/lib/api";
 import { useAuth } from "@/lib/auth";
+import { useApiMutation } from "@/lib/mutations";
 import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
 import { useConfirm } from "@/components/ConfirmDialog";
 
@@ -106,10 +107,40 @@ export default function WorkspaceSettings() {
   const [inviteRole, setInviteRole] = useState<"admin" | "member" | "viewer">("member");
   const [providerKey, setProviderKey] = useState("");
   const [providerSecret, setProviderSecret] = useState("");
-  const [providerKeyBusy, setProviderKeyBusy] = useState(false);
   const [scannerLicense, setScannerLicense] = useState("");
-  const [scannerBusy, setScannerBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
+
+  const providerKeyMutation = useApiMutation<unknown, Record<string, string>>({
+    mutationKey: ["workspace", "provider-key"],
+    mutationFn: (body) => api.patch("/workspaces/current", body),
+    onSuccess: (_, body) => {
+      qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "ws", "current") });
+      setProviderKey("");
+      setProviderSecret("");
+      const cleared = Object.values(body).every(v => v === "");
+      toast.success(cleared ? "Credentials cleared." : "Credentials saved.");
+    },
+    onError: (e) => {
+      toast.error(e instanceof ApiError ? e.userMessage : "Failed");
+    },
+  });
+
+  const scannerKeyMutation = useApiMutation<unknown, { scanner_license_key: string }>({
+    mutationKey: ["workspace", "scanner-key"],
+    mutationFn: (body) => api.patch("/workspaces/current", body),
+    onSuccess: (_, body) => {
+      qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "ws", "current") });
+      qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "ws", "scanner", "license-key") });
+      setScannerLicense("");
+      toast.success(body.scanner_license_key ? "License key saved." : "License key cleared.");
+    },
+    onError: (e) => {
+      toast.error(e instanceof ApiError ? e.userMessage : "Failed");
+    },
+  });
+
+  const providerKeyBusy = providerKeyMutation.isPending;
+  const scannerBusy = scannerKeyMutation.isPending;
   /**
    * SEC2-008 copy-once token: when the backend returns catalog_token_plaintext
    * (freshly minted or regenerated token) we stash it here and render a
@@ -538,24 +569,13 @@ export default function WorkspaceSettings() {
                   type="button"
                   className="btn-primary"
                   disabled={providerKeyBusy || (!providerKey && !providerSecret)}
-                  onClick={async () => {
-                    setProviderKeyBusy(true);
-                    try {
-                      const body: Record<string, string> = {};
-                      // Only send fields the user actually changed (the
-                      // backend leaves omitted fields alone).
-                      if (providerKey) body.parts_provider_api_key = providerKey;
-                      if (providerSecret) body.parts_provider_api_secret = providerSecret;
-                      await api.patch("/workspaces/current", body);
-                      qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "ws", "current") });
-                      setProviderKey("");
-                      setProviderSecret("");
-                      toast.success("Credentials saved.");
-                    } catch (e) {
-                      toast.error(e instanceof ApiError ? e.userMessage : "Failed");
-                    } finally {
-                      setProviderKeyBusy(false);
-                    }
+                  onClick={() => {
+                    const body: Record<string, string> = {};
+                    // Only send fields the user actually changed (the
+                    // backend leaves omitted fields alone).
+                    if (providerKey) body.parts_provider_api_key = providerKey;
+                    if (providerSecret) body.parts_provider_api_secret = providerSecret;
+                    providerKeyMutation.mutate(body);
                   }}
                 >
                   Save
@@ -571,19 +591,10 @@ export default function WorkspaceSettings() {
                         severity: "danger",
                         confirmLabel: "Clear",
                       }))) return;
-                      setProviderKeyBusy(true);
-                      try {
-                        await api.patch("/workspaces/current", {
-                          parts_provider_api_key: "",
-                          parts_provider_api_secret: "",
-                        });
-                        qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "ws", "current") });
-                        toast.success("Credentials cleared.");
-                      } catch (e) {
-                        toast.error(e instanceof ApiError ? e.userMessage : "Failed");
-                      } finally {
-                        setProviderKeyBusy(false);
-                      }
+                      providerKeyMutation.mutate({
+                        parts_provider_api_key: "",
+                        parts_provider_api_secret: "",
+                      });
                     }}
                   >
                     Clear
@@ -613,20 +624,8 @@ export default function WorkspaceSettings() {
                   type="button"
                   className="btn-primary"
                   disabled={providerKeyBusy}
-                  onClick={async () => {
-                    setProviderKeyBusy(true);
-                    try {
-                      await api.patch("/workspaces/current", {
-                        parts_provider_api_key: providerKey,
-                      });
-                      qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "ws", "current") });
-                      setProviderKey("");
-                      toast.success(providerKey ? "API key saved." : "API key cleared.");
-                    } catch (e) {
-                      toast.error(e instanceof ApiError ? e.userMessage : "Failed");
-                    } finally {
-                      setProviderKeyBusy(false);
-                    }
+                  onClick={() => {
+                    providerKeyMutation.mutate({ parts_provider_api_key: providerKey });
                   }}
                 >
                   {providerKey ? "Save" : (cur.has_parts_provider_api_key ? "Clear" : "Save")}
@@ -675,21 +674,8 @@ export default function WorkspaceSettings() {
                   type="button"
                   className="btn-primary"
                   disabled={scannerBusy}
-                  onClick={async () => {
-                    setScannerBusy(true);
-                    try {
-                      await api.patch("/workspaces/current", {
-                        scanner_license_key: scannerLicense,
-                      });
-                      qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "ws", "current") });
-                      qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "ws", "scanner", "license-key") });
-                      setScannerLicense("");
-                      toast.success(scannerLicense ? "License key saved." : "License key cleared.");
-                    } catch (e) {
-                      toast.error(e instanceof ApiError ? e.userMessage : "Failed");
-                    } finally {
-                      setScannerBusy(false);
-                    }
+                  onClick={() => {
+                    scannerKeyMutation.mutate({ scanner_license_key: scannerLicense });
                   }}
                 >
                   {scannerLicense ? "Save" : (cur.has_scanner_license_key ? "Clear" : "Save")}

--- a/web/src/routes/storage/StorageCreate.tsx
+++ b/web/src/routes/storage/StorageCreate.tsx
@@ -1,10 +1,19 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { api, ApiError } from "@/lib/api";
+import { useApiMutation } from "@/lib/mutations";
+
+type StorageCreatePayload = {
+  name: string;
+  description: string;
+  single_part_only: boolean;
+  existing_parts_only: boolean;
+  is_full: boolean;
+};
 
 export default function StorageCreate() {
   const nav = useNavigate();
-  const [form, setForm] = useState({
+  const [form, setForm] = useState<StorageCreatePayload>({
     name: "",
     description: "",
     single_part_only: false,
@@ -12,24 +21,28 @@ export default function StorageCreate() {
     is_full: false,
   });
   const [err, setErr] = useState<string | null>(null);
-  const [busy, setBusy] = useState(false);
 
   function set<K extends keyof typeof form>(k: K, v: (typeof form)[K]) {
     setForm(f => ({ ...f, [k]: v }));
   }
 
-  async function submit(e: React.FormEvent) {
-    e.preventDefault();
-    setBusy(true);
-    setErr(null);
-    try {
-      const res = await api.post<{ id: string }>("/storage", form);
+  const createMutation = useApiMutation<{ id: string }, StorageCreatePayload>({
+    mutationKey: ["storage", "create"],
+    mutationFn: (payload) => api.post<{ id: string }>("/storage", payload),
+    onSuccess: (res) => {
       nav(`/storage/${res.id}/info`);
-    } catch (e) {
+    },
+    onError: (e) => {
       setErr(e instanceof ApiError ? e.userMessage : "Failed");
-    } finally {
-      setBusy(false);
-    }
+    },
+  });
+
+  const busy = createMutation.isPending;
+
+  function submit(e: React.FormEvent) {
+    e.preventDefault();
+    setErr(null);
+    createMutation.mutate(form);
   }
 
   return (


### PR DESCRIPTION
Closes #248

## Summary
- Migrate 13 forms from `useState(false)+try/catch` to `useApiMutation`
- Enables uniform 401 handling via `MutationCache.onError` for all write paths
- Prevents double-submit races on slow networks via TanStack mutation dedup
- All invalidations use `wsKeyOf(workspaceId, ...)` for workspace isolation

Files migrated:
- `auth/Login.tsx` — mutationKey: `["auth","login"]`
- `auth/Signup.tsx` — mutationKey: `["auth","signup"]`
- `orders/OrderCreate.tsx` — mutationKey: `["order","create"]`
- `builds/BuildCreate.tsx` — mutationKey: `["build","create"]`
- `builds/BuildDetail.tsx` — consume action
- `projects/ProjectCreate.tsx` — mutationKey: `["project","create"]`
- `projects/detail/ProjectImport.tsx` — commit (BOM import) action
- `storage/StorageCreate.tsx` — mutationKey: `["storage","create"]`
- `settings/Account.tsx` — accept invitation
- `parts/PartsList.tsx` — bulk archive action
- `reports/Reports.tsx` — restock-order creation in LowStock and BomShortage reports
- `parts/detail/PartSpecs.tsx` — add-spec action
- `settings/Workspace.tsx` — provider key save and scanner key save

## Tests
Backend: N/A
Frontend: 195 tests passed, build passed (`tsc -b && vite build`)