### PR TITLE
refactor(fe): split ScanImport.tsx into Session/Queue/Actions sub-components (#119)

### DIFF
--- a/web/src/routes/parts/ScanImport.tsx
+++ b/web/src/routes/parts/ScanImport.tsx
@@ -1,211 +1,80 @@
+/**
+ * ScanImport — parent orchestrator (~150 lines). Sub-components under ./ScanImport/:
+ * ScanImportSession (camera+lookup), ScanImportQueue (row list), ScanImportActions
+ * (submit/storage/summary), hooks.ts (useScanImportRows), storage.ts, types.ts.
+ */
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import {
-  AlertTriangle,
-  CheckCircle2,
-  ExternalLink,
-  ImageOff,
-  Link2,
-  Loader2,
-  Minus,
-  Package,
-  Plus,
-  RotateCcw,
-  Trash2,
-} from "lucide-react";
-import Scanner, { ScanResult } from "@/components/scanner/Scanner";
 import { api, ApiError } from "@/lib/api";
 import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
 import { useAuth } from "@/lib/auth";
-import { parseBagCode, bagLotName, bagComments, bagSignature, type BagCode } from "@/lib/bagCode";
-import type {
-  MpnLookupResult,
-  Part,
-  StorageLocation,
-} from "@/types";
-// Shared types + tiny utilities lifted into a co-located module so the
-// upcoming sub-component split (#119: ScanImportSession, ScanImportRowEditor,
-// ScanImportSubmit) can import them without re-declaring. Step 1 of 4.
-import {
-  PROVIDER_LABEL,
-  SCAN_IMPORT_SYMBOLOGIES,
-  manufacturerMatches,
-  newRowId,
-  type ImportResponse,
-  type ImportResultRow,
-  type LookupState,
-  type Row,
-} from "./ScanImport/types";
-import { loadDraft, saveDraft, clearDraft } from "./ScanImport/storage";
-
-// "Service Unavailable", "upstream unavailable (TimeoutException)",
-// "DigiKey rate limit reached", connection-resets — anything that's
-// likely to clear on its own. Detected so we can retry transparently
-// instead of dumping the user back to "Service Unavailable" under the
-// MPN.
-function isTransientLookupFailure(err: unknown): boolean {
-  if (err instanceof ApiError) {
-    if (err.status >= 500) return true;
-    const msg = (err.message || "").toLowerCase();
-    return /unavailable|timeout|rate.?limit|temporar|503|504|502|connection/.test(msg);
-  }
-  if (err instanceof TypeError) {
-    // Browser fetch throws TypeError on connection abort / network change.
-    return true;
-  }
-  return false;
-}
-
-function isTransientResultMessage(msg: string | undefined | null): boolean {
-  if (!msg) return false;
-  return /unavailable|timeout|rate.?limit|temporar|service.?unavailable/i.test(msg);
-}
-
-const RETRY_DELAYS_MS = [800, 1600, 3000];
-
-async function lookupMpnWithRetry(mpn: string): Promise<MpnLookupResult> {
-  // First attempt + up to len(RETRY_DELAYS_MS) retries. We retry both on
-  // throws (5xx, network) and on 200-with-transient-message (the provider
-  // route swallows upstream failures and returns {found:false,message}).
-  for (let attempt = 0; attempt <= RETRY_DELAYS_MS.length; attempt++) {
-    try {
-      const res = await api.post<MpnLookupResult>("/parts/lookup-mpn", { mpn });
-      if (!res.found && isTransientResultMessage(res.message)) {
-        if (attempt < RETRY_DELAYS_MS.length) {
-          await new Promise(r => setTimeout(r, RETRY_DELAYS_MS[attempt]));
-          continue;
-        }
-      }
-      return res;
-    } catch (err) {
-      if (attempt < RETRY_DELAYS_MS.length && isTransientLookupFailure(err)) {
-        await new Promise(r => setTimeout(r, RETRY_DELAYS_MS[attempt]));
-        continue;
-      }
-      throw err;
-    }
-  }
-  // Exhausted retries on a transient — final attempt's result is what
-  // the operator gets to see. We never reach here because the loop
-  // either returns or throws on every iteration; TS just can't tell.
-  /* istanbul ignore next */
-  throw new Error("lookupMpnWithRetry: unreachable");
-}
+import { bagLotName, bagComments } from "@/lib/bagCode";
+import type { StorageLocation } from "@/types";
+import { useScanImportRows } from "./ScanImport/hooks";
+import { clearDraft, saveDraft } from "./ScanImport/storage";
+import { type ImportResponse, type LookupState, type Row } from "./ScanImport/types";
+import ScanImportSession from "./ScanImport/ScanImportSession";
+import ScanImportQueue from "./ScanImport/ScanImportQueue";
+import ScanImportActions from "./ScanImport/ScanImportActions";
 
 export default function ScanImport() {
   const nav = useNavigate();
   const qc = useQueryClient();
   const { workspaceId } = useAuth();
   const [searchParams] = useSearchParams();
-
-  // Dedup against the camera firing didScan continuously while a code is
-  // in frame: we key by signature first (catches the same bag re-read from
-  // a slightly different angle), and fall back to MPN for non-2D scans.
-  const seenSigs = useRef<Set<string>>(new Set());
-  const seenMpns = useRef<Set<string>>(new Set());
-
-  // Lazy initialiser: restore draft from sessionStorage on first render so
-  // the rows survive a Back-button, workspace switch, or tab refresh.
-  // seenSigs / seenMpns are rebuilt here so dedup is consistent.
-  const [rows, setRows] = useState<Row[]>(() => {
-    if (!workspaceId) return [];
-    const restored = loadDraft(workspaceId);
-    if (!restored) return [];
-    for (const r of restored) {
-      if (r.bagSig) seenSigs.current.add(r.bagSig);
-      seenMpns.current.add(r.bag.mpn);
-    }
-    return restored;
-  });
-
-  // Track how many rows were restored so we can surface the banner once.
-  const restoredCount = useRef<number>(rows.length);
-  // Whether the "restored N drafts" banner has been shown this session.
-  const restoredBannerShown = useRef(false);
-  // Capture the workspaceId at mount so the persist effect (and the
-  // restored-banner Discard action) cannot write/clear under a *different*
-  // workspace's storage key if a workspace switch fires before this route
-  // unmounts (workspace switcher is global; switchWorkspace flips
-  // workspaceId before the nav("/parts") tears the route down — see
-  // web/src/lib/auth.tsx). Without this guard we'd briefly leak the
-  // previous workspace's rows into workspace B's draft. Cross-workspace
-  // isolation is enforced in code, not the DB (see CLAUDE.md), so this
-  // needs an explicit guard rather than relying on render-ordering.
+  const { rows, setRows, seenSigs, seenMpns, removeRow, setQuantity } = useScanImportRows();
+  // wsId captured at mount guards draft writes/clears against workspace-switch races.
   const mountWsId = useRef<string | undefined>(workspaceId);
-
-  // Pre-select the storage when arriving via /storage/<id> "Scan into here"
-  // — the destination is whichever bin the user opened.
   const [storageId, setStorageId] = useState<string>(() => searchParams.get("storage_id") ?? "");
   const [submitting, setSubmitting] = useState(false);
   const [lastSummary, setLastSummary] = useState<ImportResponse | null>(null);
-  // Controls the "restored N drafts" banner visibility.
+  const restoredCount = useRef<number>(rows.length);
+  const restoredBannerShown = useRef(false);
   const [showRestoredBanner, setShowRestoredBanner] = useState(() => rows.length > 0);
 
-  // Show the restored-draft toast banner once on mount when rows were restored.
+  // Show restored-draft banner once on mount.
   useEffect(() => {
-    if (
-      !restoredBannerShown.current &&
-      restoredCount.current > 0 &&
-      showRestoredBanner
-    ) {
+    if (!restoredBannerShown.current && restoredCount.current > 0 && showRestoredBanner) {
       restoredBannerShown.current = true;
       const n = restoredCount.current;
-      toast.info(
-        `Restored ${n} draft scan${n === 1 ? "" : "s"} from your previous session.`,
-        {
-          duration: 8000,
-          action: {
-            label: "Discard",
-            onClick: () => {
-              setRows([]);
-              seenSigs.current.clear();
-              seenMpns.current.clear();
-              // Use the wsId captured at mount, not the live `workspaceId`
-              // closure, so a workspace switch between mount and click
-              // can't cause us to clearDraft() against the wrong key.
-              const wsId = mountWsId.current;
-              if (wsId) clearDraft(wsId);
-              setShowRestoredBanner(false);
-            },
+      toast.info(`Restored ${n} draft scan${n === 1 ? "" : "s"} from your previous session.`, {
+        duration: 8000,
+        action: {
+          label: "Discard",
+          onClick: () => {
+            setRows([]);
+            seenSigs.current.clear();
+            seenMpns.current.clear();
+            const wsId = mountWsId.current;
+            if (wsId) clearDraft(wsId);
+            setShowRestoredBanner(false);
           },
         },
-      );
+      });
     }
-    // Only run once on mount.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Persist rows to sessionStorage whenever they change.
-  // Bail if the live workspaceId no longer matches the one captured at
-  // mount — a workspace switch flips workspaceId before the route
-  // unmounts, and we mustn't write workspace A's rows under workspace
-  // B's storage key.
+  // Persist rows to sessionStorage on every change.
   useEffect(() => {
     const wsId = mountWsId.current;
-    if (!wsId) return;
-    if (workspaceId !== wsId) return;
+    if (!wsId || workspaceId !== wsId) return;
     saveDraft(wsId, rows);
   }, [rows, workspaceId]);
 
-  // Warn before unload when there are unsaved importable rows.
+  // Warn on unload when there are unsaved rows.
   useEffect(() => {
     function handleBeforeUnload(e: BeforeUnloadEvent) {
-      const importable = rows.filter(r => r.state.kind === "found");
-      const hasPending = rows.some(
-        r => r.state.kind === "found" || r.state.kind === "pending",
-      );
-      if (rows.length > 0 && (importable.length > 0 || hasPending)) {
-        e.preventDefault();
-      }
+      const hasPending = rows.some(r => r.state.kind === "found" || r.state.kind === "pending");
+      if (rows.length > 0 && hasPending) e.preventDefault();
     }
     window.addEventListener("beforeunload", handleBeforeUnload);
     return () => window.removeEventListener("beforeunload", handleBeforeUnload);
   }, [rows]);
 
-  // Honour ?storage_id= even when the URL changes mid-session (e.g. a
-  // back-button navigation drops us back here from Storage).
+  // Honour ?storage_id= changes mid-session.
   useEffect(() => {
     const fromUrl = searchParams.get("storage_id");
     if (fromUrl && fromUrl !== storageId) setStorageId(fromUrl);
@@ -217,70 +86,15 @@ export default function ScanImport() {
     queryFn: () => api.get<StorageLocation[]>("/storage"),
   });
 
-  const handleScan = useCallback(async (s: ScanResult) => {
-    const parsed = parseBagCode(s.data);
-    const sig = await bagSignature(s.data);
-    const mpn = parsed.mpn.trim();
-    if (!mpn) return;
-    // Dedup by signature first (the same physical bag re-fires the scan
-    // event while it's in frame), then by MPN as a fallback for 1D codes
-    // and crypto-less browsers.
-    if (sig && seenSigs.current.has(sig)) return;
-    if (!sig && seenMpns.current.has(mpn)) return;
-    if (sig) seenSigs.current.add(sig);
-    seenMpns.current.add(mpn);
-
-    const rowId = newRowId();
-    const initialQty = parsed.quantity ?? 0;
-    setRows(prev => [
-      ...prev,
-      { rowId, bag: parsed, bagSig: sig, quantity: initialQty, state: { kind: "pending" } },
-    ]);
-
-    const setState = (state: LookupState) =>
-      setRows(prev => prev.map(r => (r.rowId === rowId ? { ...r, state } : r)));
-
-    try {
-      // 1. Bag-rescan check — only meaningful when we have a signature,
-      //    since the lookup is signature-based.
-      if (sig) {
-        const prior = await api.get<{
-          part_id: string;
-          lot_id: string | null;
-          storage_location_id: string | null;
-          quantity: number;
-        } | null>(`/parts/by-bag-signature/${sig}`);
-        if (prior) {
-          setState({
-            kind: "bag_rescan",
-            part_id: prior.part_id,
-            lot_id: prior.lot_id,
-            storage_location_id: prior.storage_location_id,
-            quantity: prior.quantity,
-          });
-          return;
-        }
-      }
-
-      // 2. Same-MPN duplicate (different bag, same part).
-      const dupes = await api.get<Part[]>(`/parts?mpn=${encodeURIComponent(mpn)}`);
-      if (dupes.length > 0) {
-        setState({ kind: "duplicate", existing: dupes[0] });
-        return;
-      }
-
-      // 3. New part — provider lookup with auto-retry on transient
-      //    upstream failures (5xx, "Service Unavailable", timeouts).
-      const lookup = await lookupMpnWithRetry(mpn);
-      if (lookup.found && lookup.result) {
-        setState({ kind: "found", result: lookup.result, provider: lookup.provider });
-      } else {
-        setState({ kind: "error", message: lookup.message || "no match" });
-      }
-    } catch (e) {
-      setState({ kind: "error", message: e instanceof ApiError ? e.userMessage : "Lookup failed" });
-    }
-  }, []);
+  const handleRow = useCallback(
+    (row: Row) => setRows(prev => [...prev, row]),
+    [setRows],
+  );
+  const handleLookupUpdate = useCallback(
+    (rowId: string, next: LookupState) =>
+      setRows(prev => prev.map(r => (r.rowId === rowId ? { ...r, state: next } : r))),
+    [setRows],
+  );
 
   async function quickRemoveFromBag(rowId: string, quantity: number) {
     const row = rows.find(r => r.rowId === rowId);
@@ -289,15 +103,11 @@ export default function ScanImport() {
     if (quantity <= 0 || quantity > st.quantity) return;
     try {
       await api.post(`/parts/${st.part_id}/quick-remove-bag`, {
-        quantity,
-        lot_id: st.lot_id,
-        storage_location_id: st.storage_location_id,
+        quantity, lot_id: st.lot_id, storage_location_id: st.storage_location_id,
       });
       setRows(prev =>
         prev.map(r =>
-          r.rowId === rowId
-            ? { ...r, state: { kind: "consumed", partId: st.part_id, quantity } }
-            : r,
+          r.rowId === rowId ? { ...r, state: { kind: "consumed", partId: st.part_id, quantity } } : r,
         ),
       );
       qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "part", st.part_id) });
@@ -308,33 +118,10 @@ export default function ScanImport() {
     }
   }
 
-  const importable = useMemo(
-    () => rows.filter(r => r.state.kind === "found"),
-    [rows]
-  );
-
-  function removeRow(rowId: string) {
-    setRows(prev => {
-      const dropped = prev.find(r => r.rowId === rowId);
-      if (dropped) {
-        seenMpns.current.delete(dropped.bag.mpn);
-        if (dropped.bagSig) seenSigs.current.delete(dropped.bagSig);
-      }
-      return prev.filter(r => r.rowId !== rowId);
-    });
-  }
-
-  function setQuantity(rowId: string, qty: number) {
-    setRows(prev =>
-      prev.map(r => (r.rowId === rowId ? { ...r, quantity: Math.max(0, qty | 0) } : r))
-    );
-  }
+  const importable = useMemo(() => rows.filter(r => r.state.kind === "found"), [rows]);
 
   async function submitAll() {
-    if (importable.length === 0) {
-      toast.error("Nothing to import.");
-      return;
-    }
+    if (importable.length === 0) { toast.error("Nothing to import."); return; }
     setSubmitting(true);
     try {
       const out = await api.post<ImportResponse>("/parts/bulk-import-from-scan", {
@@ -349,32 +136,26 @@ export default function ScanImport() {
         })),
       });
       setLastSummary(out);
-      // Drop rows that were just imported successfully so the operator
-      // can keep scanning new bags without losing duplicate / errored rows.
-      const importedMpns = new Set(
-        out.rows.filter(r => r.status === "created").map(r => r.mpn)
-      );
+      const importedMpns = new Set(out.rows.filter(r => r.status === "created").map(r => r.mpn));
       setRows(prev => {
         const remaining = prev.filter(r => !importedMpns.has(r.bag.mpn));
-        // If every row was imported, clear the draft completely; otherwise
-        // the updated (smaller) rows list will be persisted by the rows
-        // effect. Use the wsId captured at mount so a mid-flight workspace
-        // switch can't redirect this clear to a different key.
         const wsId = mountWsId.current;
-        if (remaining.length === 0 && wsId) {
-          clearDraft(wsId);
-        }
+        if (remaining.length === 0 && wsId) clearDraft(wsId);
         return remaining;
       });
       importedMpns.forEach(m => seenMpns.current.delete(m));
-      toast.success(
-        `Imported ${out.summary.created} part${out.summary.created === 1 ? "" : "s"}.`
-      );
+      toast.success(`Imported ${out.summary.created} part${out.summary.created === 1 ? "" : "s"}.`);
     } catch (e) {
       toast.error(e instanceof ApiError ? e.userMessage : "Import failed");
     } finally {
       setSubmitting(false);
     }
+  }
+
+  function handleOpenExisting(row: Row) {
+    if (row.state.kind === "duplicate") nav(`/parts/${row.state.existing.id}/info`);
+    else if (row.state.kind === "bag_rescan") nav(`/parts/${row.state.part_id}/info`);
+    else if (row.state.kind === "consumed") nav(`/parts/${row.state.partId}/info`);
   }
 
   return (
@@ -383,392 +164,32 @@ export default function ScanImport() {
         <h1 className="text-xl font-semibold">Scan to import</h1>
         <Link to="/parts" className="btn">Back to parts</Link>
       </div>
-
       <div className="grid md:grid-cols-2 gap-4">
-        {/* Camera column */}
-        <div className="card p-3">
-          <Scanner
-            onScan={handleScan}
-            symbologies={SCAN_IMPORT_SYMBOLOGIES}
-            className="flex flex-col h-[55vh]"
-          />
-          <div className="mt-3 text-xs text-muted leading-relaxed">
-            Aim at the <strong className="text-text">2D Data Matrix</strong>{" "}
-            (the small square code) on a Mouser or DigiKey bag — that's the
-            one that carries the full part record. The plain 1D barcodes
-            alongside it only contain individual fields and won't resolve
-            to a part. Duplicates already in your library are flagged
-            automatically.
-          </div>
-        </div>
-
-        {/* List + import column */}
-        <div className="card p-3 flex flex-col">
-          <div className="flex items-center justify-between mb-3">
-            <h2 className="text-md font-semibold">
-              Scanned ({rows.length})
-            </h2>
-            <button
-              type="button"
-              className="btn-primary"
-              disabled={submitting || importable.length === 0}
-              onClick={submitAll}
-            >
-              {submitting ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
-              Import {importable.length > 0 ? `(${importable.length})` : ""}
-            </button>
-          </div>
-
-          <div className="mb-3 text-xs text-muted">
-            <label className="block mb-1">Initial stock location (optional)</label>
-            <select
-              className="input w-full"
-              value={storageId}
-              onChange={e => setStorageId(e.target.value)}
-            >
-              <option value="">— file later (no location) —</option>
-              {(storages ?? []).filter(s => !s.archived_at).map(s => (
-                <option key={s.id} value={s.id}>{s.name}</option>
-              ))}
-            </select>
-            <div className="mt-1">
-              Each row's quantity (from the bag's Q field, or your edits)
-              lands on-hand at import. Pick a location to file it directly,
-              or leave blank to record it without a location and move it
-              later from the Stock view.
-            </div>
-          </div>
-
-          {lastSummary && (
-            <div className="mb-3 rounded-md border border-border bg-panel2/50 p-2 text-xs">
-              Last import:{" "}
-              <span className="text-accent">{lastSummary.summary.created} created</span>
-              {lastSummary.summary.duplicate > 0 && (
-                <>, <span className="text-warning">{lastSummary.summary.duplicate} duplicate</span></>
-              )}
-              {lastSummary.summary.lookup_failed > 0 && (
-                <>, <span className="text-danger">{lastSummary.summary.lookup_failed} not found</span></>
-              )}
-              .
-            </div>
-          )}
-
-          <div className="overflow-y-auto flex-1 -mx-3 px-3 space-y-2">
-            {rows.length === 0 && (
-              <div className="text-sm text-muted py-6 text-center">
-                No scans yet — point the camera at a bag's 2D code.
-              </div>
-            )}
-            {rows.map(r => (
-              <ScanCard
-                key={r.rowId}
-                row={r}
-                onRemove={() => removeRow(r.rowId)}
-                onQuantity={q => setQuantity(r.rowId, q)}
-                onOpenExisting={() => {
-                  if (r.state.kind === "duplicate") nav(`/parts/${r.state.existing.id}/info`);
-                  else if (r.state.kind === "bag_rescan") nav(`/parts/${r.state.part_id}/info`);
-                  else if (r.state.kind === "consumed") nav(`/parts/${r.state.partId}/info`);
-                }}
-                onQuickRemove={(qty) => quickRemoveFromBag(r.rowId, qty)}
-              />
-            ))}
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function BagRescanCard({
-  quantity,
-  onOpenExisting,
-  onQuickRemove,
-}: {
-  /** Total qty in the recognised bag — caps the stepper. */
-  quantity: number;
-  onOpenExisting: () => void;
-  onQuickRemove: (qty: number) => void;
-}) {
-  // Default to 1 — most "I'm taking some out of this bag" actions are
-  // for a single unit. Operator can step up via the +/- buttons or
-  // type a number directly. Capped at the bag's available qty.
-  const [qty, setQty] = useState(1);
-  const cap = Math.max(1, quantity);
-  function step(delta: number) {
-    setQty(q => Math.min(cap, Math.max(1, q + delta)));
-  }
-  return (
-    <div className="flex items-start gap-2 text-sm">
-      <RotateCcw className="h-4 w-4 text-accent shrink-0 mt-0.5" />
-      <div className="flex-1">
-        <div>
-          Recognised — this bag was imported earlier
-          {quantity > 0 && (
-            <> (bag had qty <span className="font-mono">{quantity}</span>)</>
-          )}
-          .
-        </div>
-        <div className="flex flex-wrap items-center gap-2 mt-2">
-          <button
-            type="button"
-            className="btn-ghost btn-sm inline-flex items-center gap-1"
-            onClick={onOpenExisting}
-          >
-            <Link2 size={12} /> Open part
-          </button>
-          <div className="flex items-center gap-1 ml-auto">
-            <button
-              type="button"
-              className="btn-ghost btn-sm h-8 w-8 inline-flex items-center justify-center"
-              onClick={() => step(-1)}
-              disabled={qty <= 1}
-              aria-label="Decrease quantity"
-            >
-              <Minus size={14} />
-            </button>
-            <input
-              type="number"
-              className="input w-16 text-center"
-              min={1}
-              max={cap}
-              value={qty}
-              onChange={e => setQty(Math.max(1, Math.min(cap, parseInt(e.target.value, 10) || 1)))}
-            />
-            <button
-              type="button"
-              className="btn-ghost btn-sm h-8 w-8 inline-flex items-center justify-center"
-              onClick={() => step(1)}
-              disabled={qty >= cap}
-              aria-label="Increase quantity"
-            >
-              <Plus size={14} />
-            </button>
-          </div>
-          <button
-            type="button"
-            className="btn-primary btn-sm inline-flex items-center gap-1"
-            onClick={() => onQuickRemove(qty)}
-            disabled={cap <= 0 || qty <= 0 || qty > cap}
-            title={`Remove ${qty} unit${qty === 1 ? "" : "s"} from this lot`}
-          >
-            <Minus size={12} /> Remove {qty}
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function ScanCard({
-  row,
-  onRemove,
-  onQuantity,
-  onOpenExisting,
-  onQuickRemove,
-}: {
-  row: Row;
-  onRemove: () => void;
-  onQuantity: (q: number) => void;
-  onOpenExisting: () => void;
-  onQuickRemove: (qty: number) => void;
-}) {
-  return (
-    <div className="rounded-md border border-border bg-panel2/40 p-3">
-      <div className="flex items-start justify-between gap-2">
-        <div className="font-mono text-sm">{row.bag.mpn}</div>
-        <button
-          type="button"
-          className="btn-ghost btn-sm"
-          onClick={onRemove}
-          aria-label={`Remove ${row.bag.mpn}`}
-        >
-          <Trash2 size={14} className="text-danger" />
-        </button>
-      </div>
-      <div className="mt-2">
-        {row.state.kind === "pending" && (
-          <div className="flex items-center gap-2 text-sm text-muted">
-            <Loader2 className="h-4 w-4 animate-spin" /> Looking up…
-          </div>
-        )}
-        {row.state.kind === "duplicate" && (
-          <div className="flex items-start gap-2 text-sm">
-            <AlertTriangle className="h-4 w-4 text-warning shrink-0 mt-0.5" />
-            <div>
-              <div>Already in library: <span className="font-medium">{row.state.existing.name}</span></div>
-              <button
-                type="button"
-                className="text-accent hover:underline text-xs mt-1 inline-flex items-center gap-1"
-                onClick={onOpenExisting}
-              >
-                <Link2 size={12} /> Open existing part
-              </button>
-            </div>
-          </div>
-        )}
-        {row.state.kind === "bag_rescan" && (
-          <BagRescanCard
-            quantity={row.state.quantity}
-            onOpenExisting={onOpenExisting}
-            onQuickRemove={onQuickRemove}
-          />
-        )}
-        {row.state.kind === "consumed" && (
-          <div className="flex items-start gap-2 text-sm text-success">
-            <CheckCircle2 className="h-4 w-4 shrink-0 mt-0.5" />
-            <div>
-              Removed {row.state.quantity} from this bag.{" "}
-              <button
-                type="button"
-                className="text-accent hover:underline text-xs ml-1"
-                onClick={onOpenExisting}
-              >
-                Open part
-              </button>
-            </div>
-          </div>
-        )}
-        {row.state.kind === "error" && (
-          <div className="flex items-start gap-2 text-sm">
-            <AlertTriangle className="h-4 w-4 text-danger shrink-0 mt-0.5" />
-            <div className="text-danger">{row.state.message}</div>
-          </div>
-        )}
-        {row.state.kind === "found" && (
-          <FoundDetails
-            state={row.state}
-            bag={row.bag}
-            qty={row.quantity}
-            onQuantity={onQuantity}
-          />
-        )}
-      </div>
-    </div>
-  );
-}
-
-function FoundDetails({
-  state,
-  bag,
-  qty,
-  onQuantity,
-}: {
-  state: Extract<LookupState, { kind: "found" }>;
-  bag: BagCode;
-  qty: number;
-  onQuantity: (q: number) => void;
-}) {
-  const r = state.result;
-  const mfrMismatch = !manufacturerMatches(bag.manufacturer, r.manufacturer);
-  const lotName = bagLotName(bag);
-  const comments = bagComments(bag);
-  return (
-    <div>
-      <div className="flex items-start gap-2">
-        <CheckCircle2 className="h-4 w-4 text-accent shrink-0 mt-0.5" />
-        <div className="flex-1">
-          <div className="text-sm">
-            <span className="font-medium">{r.manufacturer ?? "—"}</span>
-            <span className="text-muted ml-2 text-xs">
-              {PROVIDER_LABEL[state.provider] ?? state.provider}
-            </span>
-          </div>
-          {mfrMismatch && (
-            <div className="mt-1 text-xs text-warning inline-flex items-start gap-1">
-              <AlertTriangle size={12} className="shrink-0 mt-0.5" />
-              <span>
-                Bag says <span className="font-medium">{bag.manufacturer}</span> —
-                provider returned <span className="font-medium">{r.manufacturer}</span>.
-                Double-check this is the right part before importing.
-              </span>
-            </div>
-          )}
-          {r.description && (
-            <div className="text-xs text-muted mt-1">{r.description}</div>
-          )}
-          <div className="flex flex-wrap gap-x-3 gap-y-1 mt-2 text-xs">
-            {r.footprint && (
-              <span className="inline-flex items-center gap-1">
-                <Package size={12} /> {r.footprint}
-              </span>
-            )}
-            {r.category && <span className="text-muted">{r.category}</span>}
-            {r.source_url && (
-              <a
-                className="text-accent hover:underline inline-flex items-center gap-1"
-                href={r.source_url}
-                target="_blank"
-                rel="noreferrer"
-              >
-                <ExternalLink size={12} /> Product page
-              </a>
-            )}
-          </div>
-        </div>
-        {r.image_url ? (
-          <img
-            src={r.image_url}
-            alt=""
-            className="w-12 h-12 rounded border border-border object-contain bg-white"
-            onError={e => { (e.target as HTMLImageElement).style.display = "none"; }}
-          />
-        ) : (
-          <div className="w-12 h-12 rounded border border-border flex items-center justify-center text-muted">
-            <ImageOff size={16} />
-          </div>
-        )}
-      </div>
-
-      {/* Traceability — anything the bag carried in MIL-STD-130N fields.
-          Saved verbatim onto the lot/stock-entry at import time. */}
-      {(lotName || comments || bag.serial) && (
-        <div className="mt-2 rounded border border-border/60 bg-panel/40 px-2 py-1.5 text-xs">
-          <div className="text-muted uppercase tracking-wider text-[10px] mb-0.5">
-            Traceability
-          </div>
-          {lotName && <div>{lotName}</div>}
-          {bag.serial && <div>Serial: <span className="font-mono">{bag.serial}</span></div>}
-          {comments && <div className="text-muted">{comments}</div>}
-        </div>
-      )}
-
-      {/* Top spec rows (capped) — gives a glance at parametric data */}
-      {r.specs.length > 0 && (
-        <details className="mt-2">
-          <summary className="text-xs text-muted cursor-pointer">
-            {r.specs.length} spec{r.specs.length === 1 ? "" : "s"}
-          </summary>
-          <div className="mt-1 grid grid-cols-[max-content_1fr] gap-x-2 gap-y-0.5 text-xs">
-            {r.specs.slice(0, 12).map(s => (
-              <div key={s.key} className="contents">
-                <div className="text-muted">{s.key}</div>
-                <div className="font-mono break-all">{s.value}</div>
-              </div>
-            ))}
-            {r.specs.length > 12 && (
-              <div className="col-span-2 text-muted italic">
-                …and {r.specs.length - 12} more (visible after import)
-              </div>
-            )}
-          </div>
-        </details>
-      )}
-
-      <div className="mt-3 flex items-center gap-2">
-        <label className="text-xs text-muted">Qty</label>
-        <input
-          type="number"
-          min={0}
-          className="input w-24 text-sm"
-          value={qty}
-          onChange={e => onQuantity(parseInt(e.target.value, 10) || 0)}
+        <ScanImportSession
+          seenSigs={seenSigs}
+          seenMpns={seenMpns}
+          onRow={handleRow}
+          onLookupUpdate={handleLookupUpdate}
         />
-        <span className="text-xs text-muted">
-          {qty === 0
-            ? "no initial stock entry"
-            : `lands ${qty} on-hand at import`}
-        </span>
+        <div className="card p-3 flex flex-col">
+          <ScanImportActions
+            rowCount={rows.length}
+            importableCount={importable.length}
+            submitting={submitting}
+            storageId={storageId}
+            storages={storages}
+            lastSummary={lastSummary}
+            onStorageChange={setStorageId}
+            onSubmit={submitAll}
+          />
+          <ScanImportQueue
+            rows={rows}
+            onRemove={removeRow}
+            onQuantity={setQuantity}
+            onOpenExisting={handleOpenExisting}
+            onQuickRemove={(rowId, qty) => quickRemoveFromBag(rowId, qty)}
+          />
+        </div>
       </div>
     </div>
   );

--- a/web/src/routes/parts/ScanImport/ScanImportActions.tsx
+++ b/web/src/routes/parts/ScanImport/ScanImportActions.tsx
@@ -1,0 +1,103 @@
+/**
+ * ScanImportActions — the submit/control panel for the scan queue.
+ *
+ * Renders:
+ *  - Import button (disabled when nothing importable or submitting)
+ *  - Storage location selector
+ *  - Last-import summary card
+ *
+ * Purely presentational — all async logic lives in the parent (ScanImport).
+ */
+import { Loader2 } from "lucide-react";
+import type { StorageLocation } from "@/types";
+import type { ImportResponse } from "./types";
+
+interface ScanImportActionsProps {
+  rowCount: number;
+  importableCount: number;
+  submitting: boolean;
+  storageId: string;
+  storages: StorageLocation[] | undefined;
+  lastSummary: ImportResponse | null;
+  onStorageChange: (id: string) => void;
+  onSubmit: () => void;
+}
+
+export default function ScanImportActions({
+  rowCount,
+  importableCount,
+  submitting,
+  storageId,
+  storages,
+  lastSummary,
+  onStorageChange,
+  onSubmit,
+}: ScanImportActionsProps) {
+  return (
+    <>
+      {/* Header row: count + import button */}
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="text-md font-semibold">Scanned ({rowCount})</h2>
+        <button
+          type="button"
+          className="btn-primary"
+          disabled={submitting || importableCount === 0}
+          onClick={onSubmit}
+        >
+          {submitting ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+          Import {importableCount > 0 ? `(${importableCount})` : ""}
+        </button>
+      </div>
+
+      {/* Storage location selector */}
+      <div className="mb-3 text-xs text-muted">
+        <label className="block mb-1">Initial stock location (optional)</label>
+        <select
+          className="input w-full"
+          value={storageId}
+          onChange={e => onStorageChange(e.target.value)}
+        >
+          <option value="">— file later (no location) —</option>
+          {(storages ?? [])
+            .filter(s => !s.archived_at)
+            .map(s => (
+              <option key={s.id} value={s.id}>
+                {s.name}
+              </option>
+            ))}
+        </select>
+        <div className="mt-1">
+          Each row's quantity (from the bag's Q field, or your edits) lands
+          on-hand at import. Pick a location to file it directly, or leave
+          blank to record it without a location and move it later from the
+          Stock view.
+        </div>
+      </div>
+
+      {/* Last-import summary card */}
+      {lastSummary && (
+        <div className="mb-3 rounded-md border border-border bg-panel2/50 p-2 text-xs">
+          Last import:{" "}
+          <span className="text-accent">{lastSummary.summary.created} created</span>
+          {lastSummary.summary.duplicate > 0 && (
+            <>
+              ,{" "}
+              <span className="text-warning">
+                {lastSummary.summary.duplicate} duplicate
+              </span>
+            </>
+          )}
+          {lastSummary.summary.lookup_failed > 0 && (
+            <>
+              ,{" "}
+              <span className="text-danger">
+                {lastSummary.summary.lookup_failed} not found
+              </span>
+            </>
+          )}
+          .
+        </div>
+      )}
+    </>
+  );
+}

--- a/web/src/routes/parts/ScanImport/ScanImportQueue.tsx
+++ b/web/src/routes/parts/ScanImport/ScanImportQueue.tsx
@@ -1,0 +1,371 @@
+/**
+ * ScanImportQueue — the scrollable list of scanned rows.
+ *
+ * Renders each row as a ScanCard; inline helpers BagRescanCard and
+ * FoundDetails keep the visual logic co-located without exporting them.
+ *
+ * Props:
+ *  rows          — current scan queue (from parent / useScanImportRows)
+ *  onRemove      — remove a row by rowId
+ *  onQuantity    — update a row's qty by rowId
+ *  onOpenExisting — navigate to an existing part (duplicate / bag_rescan / consumed)
+ *  onQuickRemove — quick-remove N units from a bag_rescan row
+ */
+import { useState } from "react";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  ExternalLink,
+  ImageOff,
+  Link2,
+  Loader2,
+  Minus,
+  Package,
+  Plus,
+  RotateCcw,
+  Trash2,
+} from "lucide-react";
+import { bagLotName, bagComments, type BagCode } from "@/lib/bagCode";
+import { PROVIDER_LABEL, manufacturerMatches, type LookupState, type Row } from "./types";
+
+// ─── BagRescanCard ────────────────────────────────────────────────────────────
+
+function BagRescanCard({
+  quantity,
+  onOpenExisting,
+  onQuickRemove,
+}: {
+  quantity: number;
+  onOpenExisting: () => void;
+  onQuickRemove: (qty: number) => void;
+}) {
+  const [qty, setQty] = useState(1);
+  const cap = Math.max(1, quantity);
+  function step(delta: number) {
+    setQty(q => Math.min(cap, Math.max(1, q + delta)));
+  }
+  return (
+    <div className="flex items-start gap-2 text-sm">
+      <RotateCcw className="h-4 w-4 text-accent shrink-0 mt-0.5" />
+      <div className="flex-1">
+        <div>
+          Recognised — this bag was imported earlier
+          {quantity > 0 && (
+            <> (bag had qty <span className="font-mono">{quantity}</span>)</>
+          )}
+          .
+        </div>
+        <div className="flex flex-wrap items-center gap-2 mt-2">
+          <button
+            type="button"
+            className="btn-ghost btn-sm inline-flex items-center gap-1"
+            onClick={onOpenExisting}
+          >
+            <Link2 size={12} /> Open part
+          </button>
+          <div className="flex items-center gap-1 ml-auto">
+            <button
+              type="button"
+              className="btn-ghost btn-sm h-8 w-8 inline-flex items-center justify-center"
+              onClick={() => step(-1)}
+              disabled={qty <= 1}
+              aria-label="Decrease quantity"
+            >
+              <Minus size={14} />
+            </button>
+            <input
+              type="number"
+              className="input w-16 text-center"
+              min={1}
+              max={cap}
+              value={qty}
+              onChange={e =>
+                setQty(Math.max(1, Math.min(cap, parseInt(e.target.value, 10) || 1)))
+              }
+            />
+            <button
+              type="button"
+              className="btn-ghost btn-sm h-8 w-8 inline-flex items-center justify-center"
+              onClick={() => step(1)}
+              disabled={qty >= cap}
+              aria-label="Increase quantity"
+            >
+              <Plus size={14} />
+            </button>
+          </div>
+          <button
+            type="button"
+            className="btn-primary btn-sm inline-flex items-center gap-1"
+            onClick={() => onQuickRemove(qty)}
+            disabled={cap <= 0 || qty <= 0 || qty > cap}
+            title={`Remove ${qty} unit${qty === 1 ? "" : "s"} from this lot`}
+          >
+            <Minus size={12} /> Remove {qty}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── FoundDetails ─────────────────────────────────────────────────────────────
+
+function FoundDetails({
+  state,
+  bag,
+  qty,
+  onQuantity,
+}: {
+  state: Extract<LookupState, { kind: "found" }>;
+  bag: BagCode;
+  qty: number;
+  onQuantity: (q: number) => void;
+}) {
+  const r = state.result;
+  const mfrMismatch = !manufacturerMatches(bag.manufacturer, r.manufacturer);
+  const lotName = bagLotName(bag);
+  const comments = bagComments(bag);
+  return (
+    <div>
+      <div className="flex items-start gap-2">
+        <CheckCircle2 className="h-4 w-4 text-accent shrink-0 mt-0.5" />
+        <div className="flex-1">
+          <div className="text-sm">
+            <span className="font-medium">{r.manufacturer ?? "—"}</span>
+            <span className="text-muted ml-2 text-xs">
+              {PROVIDER_LABEL[state.provider] ?? state.provider}
+            </span>
+          </div>
+          {mfrMismatch && (
+            <div className="mt-1 text-xs text-warning inline-flex items-start gap-1">
+              <AlertTriangle size={12} className="shrink-0 mt-0.5" />
+              <span>
+                Bag says <span className="font-medium">{bag.manufacturer}</span> —
+                provider returned <span className="font-medium">{r.manufacturer}</span>.
+                Double-check this is the right part before importing.
+              </span>
+            </div>
+          )}
+          {r.description && (
+            <div className="text-xs text-muted mt-1">{r.description}</div>
+          )}
+          <div className="flex flex-wrap gap-x-3 gap-y-1 mt-2 text-xs">
+            {r.footprint && (
+              <span className="inline-flex items-center gap-1">
+                <Package size={12} /> {r.footprint}
+              </span>
+            )}
+            {r.category && <span className="text-muted">{r.category}</span>}
+            {r.source_url && (
+              <a
+                className="text-accent hover:underline inline-flex items-center gap-1"
+                href={r.source_url}
+                target="_blank"
+                rel="noreferrer"
+              >
+                <ExternalLink size={12} /> Product page
+              </a>
+            )}
+          </div>
+        </div>
+        {r.image_url ? (
+          <img
+            src={r.image_url}
+            alt=""
+            className="w-12 h-12 rounded border border-border object-contain bg-white"
+            onError={e => {
+              (e.target as HTMLImageElement).style.display = "none";
+            }}
+          />
+        ) : (
+          <div className="w-12 h-12 rounded border border-border flex items-center justify-center text-muted">
+            <ImageOff size={16} />
+          </div>
+        )}
+      </div>
+
+      {/* Traceability — anything the bag carried in MIL-STD-130N fields. */}
+      {(lotName || comments || bag.serial) && (
+        <div className="mt-2 rounded border border-border/60 bg-panel/40 px-2 py-1.5 text-xs">
+          <div className="text-muted uppercase tracking-wider text-[10px] mb-0.5">
+            Traceability
+          </div>
+          {lotName && <div>{lotName}</div>}
+          {bag.serial && (
+            <div>
+              Serial: <span className="font-mono">{bag.serial}</span>
+            </div>
+          )}
+          {comments && <div className="text-muted">{comments}</div>}
+        </div>
+      )}
+
+      {/* Top spec rows (capped) */}
+      {r.specs.length > 0 && (
+        <details className="mt-2">
+          <summary className="text-xs text-muted cursor-pointer">
+            {r.specs.length} spec{r.specs.length === 1 ? "" : "s"}
+          </summary>
+          <div className="mt-1 grid grid-cols-[max-content_1fr] gap-x-2 gap-y-0.5 text-xs">
+            {r.specs.slice(0, 12).map(s => (
+              <div key={s.key} className="contents">
+                <div className="text-muted">{s.key}</div>
+                <div className="font-mono break-all">{s.value}</div>
+              </div>
+            ))}
+            {r.specs.length > 12 && (
+              <div className="col-span-2 text-muted italic">
+                …and {r.specs.length - 12} more (visible after import)
+              </div>
+            )}
+          </div>
+        </details>
+      )}
+
+      <div className="mt-3 flex items-center gap-2">
+        <label className="text-xs text-muted">Qty</label>
+        <input
+          type="number"
+          min={0}
+          className="input w-24 text-sm"
+          value={qty}
+          onChange={e => onQuantity(parseInt(e.target.value, 10) || 0)}
+        />
+        <span className="text-xs text-muted">
+          {qty === 0 ? "no initial stock entry" : `lands ${qty} on-hand at import`}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+// ─── ScanCard ─────────────────────────────────────────────────────────────────
+
+function ScanCard({
+  row,
+  onRemove,
+  onQuantity,
+  onOpenExisting,
+  onQuickRemove,
+}: {
+  row: Row;
+  onRemove: () => void;
+  onQuantity: (q: number) => void;
+  onOpenExisting: () => void;
+  onQuickRemove: (qty: number) => void;
+}) {
+  return (
+    <div className="rounded-md border border-border bg-panel2/40 p-3">
+      <div className="flex items-start justify-between gap-2">
+        <div className="font-mono text-sm">{row.bag.mpn}</div>
+        <button
+          type="button"
+          className="btn-ghost btn-sm"
+          onClick={onRemove}
+          aria-label={`Remove ${row.bag.mpn}`}
+        >
+          <Trash2 size={14} className="text-danger" />
+        </button>
+      </div>
+      <div className="mt-2">
+        {row.state.kind === "pending" && (
+          <div className="flex items-center gap-2 text-sm text-muted">
+            <Loader2 className="h-4 w-4 animate-spin" /> Looking up…
+          </div>
+        )}
+        {row.state.kind === "duplicate" && (
+          <div className="flex items-start gap-2 text-sm">
+            <AlertTriangle className="h-4 w-4 text-warning shrink-0 mt-0.5" />
+            <div>
+              <div>
+                Already in library:{" "}
+                <span className="font-medium">{row.state.existing.name}</span>
+              </div>
+              <button
+                type="button"
+                className="text-accent hover:underline text-xs mt-1 inline-flex items-center gap-1"
+                onClick={onOpenExisting}
+              >
+                <Link2 size={12} /> Open existing part
+              </button>
+            </div>
+          </div>
+        )}
+        {row.state.kind === "bag_rescan" && (
+          <BagRescanCard
+            quantity={row.state.quantity}
+            onOpenExisting={onOpenExisting}
+            onQuickRemove={onQuickRemove}
+          />
+        )}
+        {row.state.kind === "consumed" && (
+          <div className="flex items-start gap-2 text-sm text-success">
+            <CheckCircle2 className="h-4 w-4 shrink-0 mt-0.5" />
+            <div>
+              Removed {row.state.quantity} from this bag.{" "}
+              <button
+                type="button"
+                className="text-accent hover:underline text-xs ml-1"
+                onClick={onOpenExisting}
+              >
+                Open part
+              </button>
+            </div>
+          </div>
+        )}
+        {row.state.kind === "error" && (
+          <div className="flex items-start gap-2 text-sm">
+            <AlertTriangle className="h-4 w-4 text-danger shrink-0 mt-0.5" />
+            <div className="text-danger">{row.state.message}</div>
+          </div>
+        )}
+        {row.state.kind === "found" && (
+          <FoundDetails
+            state={row.state}
+            bag={row.bag}
+            qty={row.quantity}
+            onQuantity={onQuantity}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── ScanImportQueue (exported) ───────────────────────────────────────────────
+
+interface ScanImportQueueProps {
+  rows: Row[];
+  onRemove: (rowId: string) => void;
+  onQuantity: (rowId: string, qty: number) => void;
+  onOpenExisting: (row: Row) => void;
+  onQuickRemove: (rowId: string, qty: number) => void;
+}
+
+export default function ScanImportQueue({
+  rows,
+  onRemove,
+  onQuantity,
+  onOpenExisting,
+  onQuickRemove,
+}: ScanImportQueueProps) {
+  return (
+    <div className="overflow-y-auto flex-1 -mx-3 px-3 space-y-2">
+      {rows.length === 0 && (
+        <div className="text-sm text-muted py-6 text-center">
+          No scans yet — point the camera at a bag's 2D code.
+        </div>
+      )}
+      {rows.map(r => (
+        <ScanCard
+          key={r.rowId}
+          row={r}
+          onRemove={() => onRemove(r.rowId)}
+          onQuantity={q => onQuantity(r.rowId, q)}
+          onOpenExisting={() => onOpenExisting(r)}
+          onQuickRemove={qty => onQuickRemove(r.rowId, qty)}
+        />
+      ))}
+    </div>
+  );
+}

--- a/web/src/routes/parts/ScanImport/ScanImportSession.tsx
+++ b/web/src/routes/parts/ScanImport/ScanImportSession.tsx
@@ -1,0 +1,167 @@
+/**
+ * ScanImportSession — camera viewport + per-scan lookup pipeline.
+ *
+ * Responsibilities:
+ *  - Render the <Scanner> with module-level SCAN_IMPORT_SYMBOLOGIES (FE CRIT-2:
+ *    keeping the array module-level prevents the multi-MB SDK from being torn
+ *    down on every parent re-render).
+ *  - Run the per-scan pipeline: dedup by sig/MPN → bag-rescan check →
+ *    duplicate-MPN check → provider lookup with retry-with-backoff.
+ *  - Emits new rows via `onRow(row)` and state updates via
+ *    `onLookupUpdate(rowId, nextState)`.
+ *
+ * It does NOT own `rows` state — the parent (ScanImport) owns it.
+ */
+import { useCallback } from "react";
+import type React from "react";
+import Scanner, { type ScanResult } from "@/components/scanner/Scanner";
+import { api, ApiError } from "@/lib/api";
+import { parseBagCode, bagSignature } from "@/lib/bagCode";
+import type { MpnLookupResult, Part } from "@/types";
+import {
+  SCAN_IMPORT_SYMBOLOGIES,
+  newRowId,
+  type LookupState,
+  type Row,
+} from "./types";
+
+// ─── transient-failure helpers ───────────────────────────────────────────────
+
+function isTransientLookupFailure(err: unknown): boolean {
+  if (err instanceof ApiError) {
+    if (err.status >= 500) return true;
+    const msg = (err.message || "").toLowerCase();
+    return /unavailable|timeout|rate.?limit|temporar|503|504|502|connection/.test(msg);
+  }
+  if (err instanceof TypeError) return true; // network abort
+  return false;
+}
+
+function isTransientResultMessage(msg: string | undefined | null): boolean {
+  if (!msg) return false;
+  return /unavailable|timeout|rate.?limit|temporar|service.?unavailable/i.test(msg);
+}
+
+const RETRY_DELAYS_MS = [800, 1600, 3000];
+
+async function lookupMpnWithRetry(mpn: string): Promise<MpnLookupResult> {
+  for (let attempt = 0; attempt <= RETRY_DELAYS_MS.length; attempt++) {
+    try {
+      const res = await api.post<MpnLookupResult>("/parts/lookup-mpn", { mpn });
+      if (!res.found && isTransientResultMessage(res.message)) {
+        if (attempt < RETRY_DELAYS_MS.length) {
+          await new Promise(r => setTimeout(r, RETRY_DELAYS_MS[attempt]));
+          continue;
+        }
+      }
+      return res;
+    } catch (err) {
+      if (attempt < RETRY_DELAYS_MS.length && isTransientLookupFailure(err)) {
+        await new Promise(r => setTimeout(r, RETRY_DELAYS_MS[attempt]));
+        continue;
+      }
+      throw err;
+    }
+  }
+  /* istanbul ignore next */
+  throw new Error("lookupMpnWithRetry: unreachable");
+}
+
+// ─── component ───────────────────────────────────────────────────────────────
+
+interface ScanImportSessionProps {
+  seenSigs: React.MutableRefObject<Set<string>>;
+  seenMpns: React.MutableRefObject<Set<string>>;
+  onRow: (row: Row) => void;
+  onLookupUpdate: (rowId: string, next: LookupState) => void;
+}
+
+export default function ScanImportSession({
+  seenSigs,
+  seenMpns,
+  onRow,
+  onLookupUpdate,
+}: ScanImportSessionProps) {
+  const handleScan = useCallback(
+    async (s: ScanResult) => {
+      const parsed = parseBagCode(s.data);
+      const sig = await bagSignature(s.data);
+      const mpn = parsed.mpn.trim();
+      if (!mpn) return;
+
+      // Dedup by signature first, MPN as fallback.
+      if (sig && seenSigs.current.has(sig)) return;
+      if (!sig && seenMpns.current.has(mpn)) return;
+      if (sig) seenSigs.current.add(sig);
+      seenMpns.current.add(mpn);
+
+      const rowId = newRowId();
+      const initialQty = parsed.quantity ?? 0;
+      onRow({ rowId, bag: parsed, bagSig: sig, quantity: initialQty, state: { kind: "pending" } });
+
+      const setState = (next: LookupState) => onLookupUpdate(rowId, next);
+
+      try {
+        // 1. Bag-rescan check.
+        if (sig) {
+          const prior = await api.get<{
+            part_id: string;
+            lot_id: string | null;
+            storage_location_id: string | null;
+            quantity: number;
+          } | null>(`/parts/by-bag-signature/${sig}`);
+          if (prior) {
+            setState({
+              kind: "bag_rescan",
+              part_id: prior.part_id,
+              lot_id: prior.lot_id,
+              storage_location_id: prior.storage_location_id,
+              quantity: prior.quantity,
+            });
+            return;
+          }
+        }
+
+        // 2. Same-MPN duplicate.
+        const dupes = await api.get<Part[]>(`/parts?mpn=${encodeURIComponent(mpn)}`);
+        if (dupes.length > 0) {
+          setState({ kind: "duplicate", existing: dupes[0] });
+          return;
+        }
+
+        // 3. Provider lookup with auto-retry.
+        const lookup = await lookupMpnWithRetry(mpn);
+        if (lookup.found && lookup.result) {
+          setState({ kind: "found", result: lookup.result, provider: lookup.provider });
+        } else {
+          setState({ kind: "error", message: lookup.message || "no match" });
+        }
+      } catch (e) {
+        setState({
+          kind: "error",
+          message: e instanceof ApiError ? e.userMessage : "Lookup failed",
+        });
+      }
+    },
+    // seenSigs / seenMpns are refs; onRow / onLookupUpdate are stable callbacks.
+    [seenSigs, seenMpns, onRow, onLookupUpdate],
+  );
+
+  return (
+    <div className="card p-3">
+      <Scanner
+        onScan={handleScan}
+        symbologies={SCAN_IMPORT_SYMBOLOGIES}
+        className="flex flex-col h-[55vh]"
+      />
+      <div className="mt-3 text-xs text-muted leading-relaxed">
+        Aim at the <strong className="text-text">2D Data Matrix</strong>{" "}
+        (the small square code) on a Mouser or DigiKey bag — that's the
+        one that carries the full part record. The plain 1D barcodes
+        alongside it only contain individual fields and won't resolve
+        to a part. Duplicates already in your library are flagged
+        automatically.
+      </div>
+    </div>
+  );
+}

--- a/web/src/routes/parts/ScanImport/__dom__/ScanImportActions.dom.test.tsx
+++ b/web/src/routes/parts/ScanImport/__dom__/ScanImportActions.dom.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * DOM tests for ScanImportActions (#119 — ScanImport split).
+ *
+ * Verifies the submit button, storage selector, and last-summary card
+ * render and respond correctly, without any network or camera interaction.
+ */
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import ScanImportActions from "../ScanImportActions";
+import type { ImportResponse } from "../types";
+import type { StorageLocation } from "@/types";
+
+// ─── fixtures ─────────────────────────────────────────────────────────────────
+
+const STORAGES: StorageLocation[] = [
+  {
+    id: "s1",
+    name: "Shelf A",
+    archived_at: null,
+    description: null,
+    single_part_only: false,
+    existing_parts_only: false,
+    is_full: false,
+  },
+  {
+    id: "s2",
+    name: "Shelf B (archived)",
+    archived_at: "2024-02-01T00:00:00Z",
+    description: null,
+    single_part_only: false,
+    existing_parts_only: false,
+    is_full: false,
+  },
+];
+
+const SUMMARY_ALL_CREATED: ImportResponse = {
+  rows: [],
+  summary: { created: 3, duplicate: 0, bag_rescan: 0, lookup_failed: 0, invalid: 0 },
+  provider: "mouser",
+};
+
+const SUMMARY_WITH_DUPES: ImportResponse = {
+  rows: [],
+  summary: { created: 1, duplicate: 2, bag_rescan: 0, lookup_failed: 1, invalid: 0 },
+  provider: "mouser",
+};
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+function renderActions(overrides: Partial<Parameters<typeof ScanImportActions>[0]> = {}) {
+  const onStorageChange = vi.fn();
+  const onSubmit = vi.fn();
+  render(
+    <ScanImportActions
+      rowCount={2}
+      importableCount={2}
+      submitting={false}
+      storageId=""
+      storages={STORAGES}
+      lastSummary={null}
+      onStorageChange={onStorageChange}
+      onSubmit={onSubmit}
+      {...overrides}
+    />,
+  );
+  return { onStorageChange, onSubmit };
+}
+
+beforeEach(() => {
+  vi.spyOn(console, "error").mockImplementation(() => undefined);
+  vi.spyOn(console, "warn").mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+// ─── tests ────────────────────────────────────────────────────────────────────
+
+describe("ScanImportActions", () => {
+  it("renders the scanned row count in the heading", () => {
+    renderActions({ rowCount: 5 });
+    expect(screen.getByText("Scanned (5)")).toBeTruthy();
+  });
+
+  it("shows importable count on the import button", () => {
+    renderActions({ importableCount: 3 });
+    expect(screen.getByRole("button", { name: /Import \(3\)/i })).toBeTruthy();
+  });
+
+  it("disables import button when importableCount is 0", () => {
+    renderActions({ importableCount: 0 });
+    const btn = screen.getByRole("button", { name: /Import/i });
+    expect((btn as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("disables import button while submitting", () => {
+    renderActions({ importableCount: 2, submitting: true });
+    const btn = screen.getByRole("button", { name: /Import/i });
+    expect((btn as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("calls onSubmit when import button is clicked", () => {
+    const { onSubmit } = renderActions({ importableCount: 1 });
+    fireEvent.click(screen.getByRole("button", { name: /Import/i }));
+    expect(onSubmit).toHaveBeenCalledOnce();
+  });
+
+  it("renders active (non-archived) storage options", () => {
+    renderActions();
+    expect(screen.getByRole("option", { name: "Shelf A" })).toBeTruthy();
+  });
+
+  it("hides archived storage locations", () => {
+    renderActions();
+    expect(screen.queryByRole("option", { name: /Shelf B/i })).toBeNull();
+  });
+
+  it("calls onStorageChange when storage select changes", () => {
+    const { onStorageChange } = renderActions();
+    const select = screen.getByRole("combobox");
+    fireEvent.change(select, { target: { value: "s1" } });
+    expect(onStorageChange).toHaveBeenCalledWith("s1");
+  });
+
+  it("does not render summary card when lastSummary is null", () => {
+    renderActions({ lastSummary: null });
+    expect(screen.queryByText(/Last import/i)).toBeNull();
+  });
+
+  it("renders summary card with created count", () => {
+    renderActions({ lastSummary: SUMMARY_ALL_CREATED });
+    expect(screen.getByText(/Last import/i)).toBeTruthy();
+    expect(screen.getByText("3 created")).toBeTruthy();
+  });
+
+  it("renders duplicate and not-found counts in summary", () => {
+    renderActions({ lastSummary: SUMMARY_WITH_DUPES });
+    expect(screen.getByText("2 duplicate")).toBeTruthy();
+    expect(screen.getByText("1 not found")).toBeTruthy();
+  });
+
+  it("does not render duplicate count when zero", () => {
+    renderActions({ lastSummary: SUMMARY_ALL_CREATED });
+    expect(screen.queryByText(/duplicate/i)).toBeNull();
+  });
+});

--- a/web/src/routes/parts/ScanImport/__dom__/ScanImportQueue.dom.test.tsx
+++ b/web/src/routes/parts/ScanImport/__dom__/ScanImportQueue.dom.test.tsx
@@ -1,0 +1,199 @@
+/**
+ * DOM tests for ScanImportQueue (#119 — ScanImport split).
+ *
+ * Exercises rendering of different row states without mounting the camera
+ * SDK or making network requests.
+ */
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import ScanImportQueue from "../ScanImportQueue";
+import type { Row } from "../types";
+
+// ─── fixtures ─────────────────────────────────────────────────────────────────
+
+function makeBag(mpn = "GRM155R71C104KA88D") {
+  return { mpn, manufacturer: "Murata", quantity: 10, raw: "raw" };
+}
+
+function makeRow(overrides: Partial<Row>): Row {
+  return {
+    rowId: "r1",
+    bag: makeBag(),
+    bagSig: "sig1",
+    quantity: 10,
+    state: { kind: "pending" },
+    ...overrides,
+  };
+}
+
+const FOUND_STATE: Row["state"] = {
+  kind: "found",
+  result: {
+    mpn: "GRM155R71C104KA88D",
+    manufacturer: "Murata",
+    description: "100nF 0402",
+    category: "Capacitors",
+    footprint: "0402",
+    datasheet_url: null,
+    image_url: null,
+    source_url: "https://mouser.com/x",
+    specs: [{ key: "Capacitance", value: "100nF" }],
+  },
+  provider: "mouser",
+};
+
+const DUPLICATE_STATE: Row["state"] = {
+  kind: "duplicate",
+  existing: {
+    id: "part-abc",
+    part_type: "local",
+    name: "GRM Capacitor",
+    mpn: "GRM155R71C104KA88D",
+    manufacturer: "Murata",
+    internal_part_number: null,
+    description: null,
+    footprint: null,
+    notes_markdown: null,
+    low_stock_report_quantity: null,
+    attrition_percentage: 0,
+    attrition_min_quantity: 0,
+    default_storage_location_id: null,
+    default_storage_mandatory: false,
+    serialized: false,
+    linked_provider: null,
+    linked_external_id: null,
+    last_refresh_at: null,
+    description_locally_edited: false,
+    archived_at: null,
+    on_hand: null,
+    reserved: 0,
+    available: 0,
+    image_url: null,
+  },
+};
+
+const BAG_RESCAN_STATE: Row["state"] = {
+  kind: "bag_rescan",
+  part_id: "part-xyz",
+  lot_id: null,
+  storage_location_id: null,
+  quantity: 5,
+};
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+function renderQueue(rows: Row[], overrides?: Partial<Parameters<typeof ScanImportQueue>[0]>) {
+  const onRemove = vi.fn();
+  const onQuantity = vi.fn();
+  const onOpenExisting = vi.fn();
+  const onQuickRemove = vi.fn();
+  render(
+    <ScanImportQueue
+      rows={rows}
+      onRemove={onRemove}
+      onQuantity={onQuantity}
+      onOpenExisting={onOpenExisting}
+      onQuickRemove={onQuickRemove}
+      {...overrides}
+    />,
+  );
+  return { onRemove, onQuantity, onOpenExisting, onQuickRemove };
+}
+
+beforeEach(() => {
+  vi.spyOn(console, "error").mockImplementation(() => undefined);
+  vi.spyOn(console, "warn").mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+// ─── tests ────────────────────────────────────────────────────────────────────
+
+describe("ScanImportQueue", () => {
+  it("shows empty-state message when rows is empty", () => {
+    renderQueue([]);
+    expect(screen.getByText(/No scans yet/i)).toBeTruthy();
+  });
+
+  it("renders the MPN for each row", () => {
+    const rows = [
+      makeRow({ rowId: "r1", bag: makeBag("MPN-001") }),
+      makeRow({ rowId: "r2", bag: makeBag("MPN-002") }),
+    ];
+    renderQueue(rows);
+    expect(screen.getByText("MPN-001")).toBeTruthy();
+    expect(screen.getByText("MPN-002")).toBeTruthy();
+  });
+
+  it("renders a spinner for pending rows", () => {
+    renderQueue([makeRow({ state: { kind: "pending" } })]);
+    expect(screen.getByText(/Looking up/i)).toBeTruthy();
+  });
+
+  it("renders duplicate warning and part name", () => {
+    renderQueue([makeRow({ state: DUPLICATE_STATE })]);
+    expect(screen.getByText(/Already in library/i)).toBeTruthy();
+    expect(screen.getByText("GRM Capacitor")).toBeTruthy();
+  });
+
+  it("calls onRemove when the trash button is clicked", () => {
+    const { onRemove } = renderQueue([makeRow({ rowId: "row-99" })]);
+    const trashBtn = screen.getByRole("button", { name: /Remove GRM155R71C104KA88D/i });
+    fireEvent.click(trashBtn);
+    expect(onRemove).toHaveBeenCalledWith("row-99");
+  });
+
+  it("renders found details with manufacturer", () => {
+    renderQueue([makeRow({ state: FOUND_STATE })]);
+    expect(screen.getByText("Murata")).toBeTruthy();
+    expect(screen.getByText("Mouser")).toBeTruthy();
+  });
+
+  it("renders bag_rescan state with RotateCcw icon text", () => {
+    renderQueue([makeRow({ state: BAG_RESCAN_STATE })]);
+    expect(screen.getByText(/Recognised/i)).toBeTruthy();
+    expect(screen.getByText(/bag had qty/i)).toBeTruthy();
+  });
+
+  it("calls onQuickRemove when Remove button is clicked in bag_rescan card", () => {
+    const { onQuickRemove } = renderQueue([makeRow({ rowId: "row-rescan", state: BAG_RESCAN_STATE })]);
+    const removeBtn = screen.getByRole("button", { name: /Remove 1/i });
+    fireEvent.click(removeBtn);
+    expect(onQuickRemove).toHaveBeenCalledWith("row-rescan", 1);
+  });
+
+  it("renders error state with message", () => {
+    renderQueue([makeRow({ state: { kind: "error", message: "Service unavailable" } })]);
+    expect(screen.getByText("Service unavailable")).toBeTruthy();
+  });
+
+  it("renders consumed state", () => {
+    renderQueue([
+      makeRow({ state: { kind: "consumed", partId: "part-abc", quantity: 3 } }),
+    ]);
+    expect(screen.getByText(/Removed 3 from this bag/i)).toBeTruthy();
+  });
+
+  it("calls onOpenExisting for duplicate row", () => {
+    const { onOpenExisting } = renderQueue([makeRow({ rowId: "dup-row", state: DUPLICATE_STATE })]);
+    const openBtn = screen.getByRole("button", { name: /Open existing part/i });
+    fireEvent.click(openBtn);
+    expect(onOpenExisting).toHaveBeenCalledWith(
+      expect.objectContaining({ rowId: "dup-row" }),
+    );
+  });
+
+  it("calls onQuantity when qty input changes in found row", () => {
+    const { onQuantity } = renderQueue([makeRow({ rowId: "found-row", state: FOUND_STATE, quantity: 5 })]);
+    // The qty label is not associated via htmlFor — query by value/type directly.
+    const inputs = screen.getAllByRole("spinbutton");
+    // The qty input for a found row is the one with value "5".
+    const qtyInput = inputs.find(el => (el as HTMLInputElement).value === "5")!;
+    fireEvent.change(qtyInput, { target: { value: "12" } });
+    expect(onQuantity).toHaveBeenCalledWith("found-row", 12);
+  });
+});

--- a/web/src/routes/parts/ScanImport/hooks.ts
+++ b/web/src/routes/parts/ScanImport/hooks.ts
@@ -1,0 +1,53 @@
+/**
+ * useScanImportRows — manages the mutable scan-queue state that the parent
+ * orchestrator passes down to ScanImportQueue and ScanImportActions.
+ *
+ * Encapsulates:
+ *  - rows state + setRows
+ *  - seenSigs / seenMpns dedup refs
+ *  - removeRow / setQuantity helpers
+ *  - draft restore (loadDraft) + initial seenSigs/seenMpns rebuild
+ */
+import { useRef, useState } from "react";
+import { useAuth } from "@/lib/auth";
+import { loadDraft } from "./storage";
+import { type Row } from "./types";
+
+export function useScanImportRows() {
+  const { workspaceId } = useAuth();
+
+  // Dedup refs — keyed by signature first, then MPN.
+  const seenSigs = useRef<Set<string>>(new Set());
+  const seenMpns = useRef<Set<string>>(new Set());
+
+  // Lazy initialiser: restore draft from sessionStorage.
+  const [rows, setRows] = useState<Row[]>(() => {
+    if (!workspaceId) return [];
+    const restored = loadDraft(workspaceId);
+    if (!restored) return [];
+    for (const r of restored) {
+      if (r.bagSig) seenSigs.current.add(r.bagSig);
+      seenMpns.current.add(r.bag.mpn);
+    }
+    return restored;
+  });
+
+  function removeRow(rowId: string) {
+    setRows(prev => {
+      const dropped = prev.find(r => r.rowId === rowId);
+      if (dropped) {
+        seenMpns.current.delete(dropped.bag.mpn);
+        if (dropped.bagSig) seenSigs.current.delete(dropped.bagSig);
+      }
+      return prev.filter(r => r.rowId !== rowId);
+    });
+  }
+
+  function setQuantity(rowId: string, qty: number) {
+    setRows(prev =>
+      prev.map(r => (r.rowId === rowId ? { ...r, quantity: Math.max(0, qty | 0) } : r))
+    );
+  }
+
+  return { rows, setRows, seenSigs, seenMpns, removeRow, setQuantity };
+}


### PR DESCRIPTION
Closes #119

## Summary
- Split 728-line `ScanImport.tsx` into three co-located sub-components under `web/src/routes/parts/ScanImport/`:
  - `ScanImportSession.tsx` — camera viewport, per-scan lookup pipeline, retry-with-backoff (167 lines)
  - `ScanImportQueue.tsx` — scrollable row list with `BagRescanCard` and `FoundDetails` inline (371 lines)
  - `ScanImportActions.tsx` — import button, storage selector, last-summary card (103 lines, purely presentational)
- Extract `useScanImportRows()` hook in `hooks.ts` (rows state, dedup refs, removeRow/setQuantity helpers)
- Parent `ScanImport.tsx` shrinks from 728 → 196 lines; zero behaviour change
- `SCAN_IMPORT_SYMBOLOGIES` remains module-level (FE CRIT-2: prevents scanner SDK teardown on re-render)

## Tests
- Added `ScanImport/__dom__/ScanImportQueue.dom.test.tsx` — 11 cases covering all row states
- Added `ScanImport/__dom__/ScanImportActions.dom.test.tsx` — 12 cases covering button states, storage selector, summary card
- All 219 tests pass; `tsc -b` + `vite build` green

## Backend
N/A — frontend-only refactor