### PR TITLE
feat(be): add cursor pagination to lot/storage history endpoints (#250)

### DIFF
--- a/backend/app/api/routes/lots.py
+++ b/backend/app/api/routes/lots.py
@@ -7,9 +7,11 @@ from fastapi import APIRouter, HTTPException, Query, status
 from sqlalchemy import select
 
 from app.core.deps import CurrentUser, CurrentWorkspace, DbSession
+from app.core.pagination import decode_cursor, paginate
 from app.core.responses import ok
 from app.domain.lots.models import Lot
 from app.domain.lots.schemas import LotAdjustIn, LotPatch
+from app.domain.stock.models import StockEntry
 from app.domain.stock.schemas import AdjustStockIn, MoveStockIn
 from app.domain.stock.service import (
     StockError,
@@ -122,20 +124,47 @@ def adjust_lot(lot_id: UUID, payload: LotAdjustIn, db: DbSession, ws: CurrentWor
     return ok({"id": str(e.id) if e else None, "delta": e.quantity_delta if e else 0})
 
 
+def _serialize_entry(e: StockEntry) -> dict:
+    return {
+        "id": str(e.id),
+        "quantity_delta": e.quantity_delta,
+        "storage_location_id": str(e.storage_location_id) if e.storage_location_id else None,
+        "operation_type": e.operation_type,
+        "comments": e.comments,
+        "occurred_at": e.occurred_at.isoformat(),
+    }
+
+
 @router.get("/{lot_id}/history")
-def lot_history(lot_id: UUID, db: DbSession, ws: CurrentWorkspace, limit: int = Query(default=200, le=1000)):
+def lot_history(
+    lot_id: UUID,
+    db: DbSession,
+    ws: CurrentWorkspace,
+    limit: int = Query(default=200, le=1000),
+    cursor: str | None = Query(default=None),
+    paged: bool = Query(default=False),
+):
     l = _get(db, ws.id, lot_id)
+
+    if cursor is not None or paged:
+        # Cursor-paginated path (opt-in).
+        decoded_cursor = decode_cursor(cursor) if cursor is not None else None
+        stmt = (
+            select(StockEntry)
+            .where(StockEntry.workspace_id == ws.id)
+            .where(StockEntry.lot_id == l.id)
+        )
+        rows, next_cursor = paginate(
+            db,
+            stmt,
+            sort_col=StockEntry.occurred_at,
+            id_col=StockEntry.id,
+            cursor=decoded_cursor,
+            limit=limit,
+            asc=False,
+        )
+        return ok({"items": [_serialize_entry(e) for e in rows], "next_cursor": next_cursor})
+
+    # Legacy bare-list path — unchanged (FE uses ?limit=200).
     rows = history_for_lot(db, workspace_id=ws.id, lot_id=l.id, limit=limit)
-    return ok(
-        [
-            {
-                "id": str(e.id),
-                "quantity_delta": e.quantity_delta,
-                "storage_location_id": str(e.storage_location_id) if e.storage_location_id else None,
-                "operation_type": e.operation_type,
-                "comments": e.comments,
-                "occurred_at": e.occurred_at.isoformat(),
-            }
-            for e in rows
-        ]
-    )
+    return ok([_serialize_entry(e) for e in rows])

--- a/backend/app/api/routes/storage.py
+++ b/backend/app/api/routes/storage.py
@@ -7,8 +7,10 @@ from sqlalchemy import or_, select
 
 from app.api._helpers import require_resource_access
 from app.core.deps import CurrentUser, CurrentWorkspace, DbSession
+from app.core.pagination import decode_cursor, paginate
 from app.core.responses import ok
 from app.core.time import utcnow
+from app.domain.stock.models import StockEntry
 from app.domain.storage.models import StorageLocation
 from app.domain.storage.schemas import StorageIn, StoragePatch
 from app.domain.stock.service import (
@@ -148,21 +150,48 @@ def storage_parts(storage_id: UUID, db: DbSession, ws: CurrentWorkspace):
     )
 
 
+def _serialize_storage_entry(e: StockEntry) -> dict:
+    return {
+        "id": str(e.id),
+        "part_id": str(e.part_id),
+        "lot_id": str(e.lot_id) if e.lot_id else None,
+        "quantity_delta": e.quantity_delta,
+        "operation_type": e.operation_type,
+        "comments": e.comments,
+        "occurred_at": e.occurred_at.isoformat(),
+    }
+
+
 @router.get("/{storage_id}/history")
-def storage_history(storage_id: UUID, db: DbSession, ws: CurrentWorkspace, limit: int = Query(default=200, le=1000)):
+def storage_history(
+    storage_id: UUID,
+    db: DbSession,
+    ws: CurrentWorkspace,
+    limit: int = Query(default=200, le=1000),
+    cursor: str | None = Query(default=None),
+    paged: bool = Query(default=False),
+):
     s = _get(db, ws.id, storage_id)
+
+    if cursor is not None or paged:
+        # Cursor-paginated path (opt-in).
+        decoded_cursor = decode_cursor(cursor) if cursor is not None else None
+        stmt = (
+            select(StockEntry)
+            .where(StockEntry.workspace_id == ws.id)
+            .where(StockEntry.storage_location_id == s.id)
+        )
+        rows, next_cursor = paginate(
+            db,
+            stmt,
+            sort_col=StockEntry.occurred_at,
+            id_col=StockEntry.id,
+            cursor=decoded_cursor,
+            limit=limit,
+            asc=False,
+        )
+        return ok({"items": [_serialize_storage_entry(e) for e in rows], "next_cursor": next_cursor})
+
+    # Legacy bare-list path — unchanged (FE uses ?limit=200).
     rows = history_for_storage(db, workspace_id=ws.id, storage_location_id=s.id, limit=limit)
-    return ok(
-        [
-            {
-                "id": str(e.id),
-                "part_id": str(e.part_id),
-                "lot_id": str(e.lot_id) if e.lot_id else None,
-                "quantity_delta": e.quantity_delta,
-                "operation_type": e.operation_type,
-                "comments": e.comments,
-                "occurred_at": e.occurred_at.isoformat(),
-            }
-            for e in rows
-        ]
-    )
+    return ok([_serialize_storage_entry(e) for e in rows])

--- a/backend/tests/test_history_limits.py
+++ b/backend/tests/test_history_limits.py
@@ -157,3 +157,193 @@ def test_storage_history_foreign_workspace_404(c: TestClient, c2: TestClient):
     _part_id, storage_id = _seed_storage_history(c, n_pairs=5)
     r = c2.get(f"/api/storage/{storage_id}/history?limit=200")
     assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Helpers for cursor-pagination tests
+# ---------------------------------------------------------------------------
+
+def _walk_lot_history_pages(client: TestClient, lot_id: str, page_size: int) -> list[dict]:
+    """Walk all cursor pages for a lot history and return all items."""
+    all_items: list[dict] = []
+    cursor: str | None = None
+    while True:
+        url = f"/api/lots/{lot_id}/history?paged=true&limit={page_size}"
+        if cursor:
+            url += f"&cursor={cursor}"
+        r = client.get(url)
+        assert r.status_code == 200, r.text
+        body = r.json()["data"]
+        all_items.extend(body["items"])
+        cursor = body["next_cursor"]
+        if not cursor:
+            break
+    return all_items
+
+
+def _walk_storage_history_pages(client: TestClient, storage_id: str, page_size: int) -> list[dict]:
+    """Walk all cursor pages for a storage history and return all items."""
+    all_items: list[dict] = []
+    cursor: str | None = None
+    while True:
+        url = f"/api/storage/{storage_id}/history?paged=true&limit={page_size}"
+        if cursor:
+            url += f"&cursor={cursor}"
+        r = client.get(url)
+        assert r.status_code == 200, r.text
+        body = r.json()["data"]
+        all_items.extend(body["items"])
+        cursor = body["next_cursor"]
+        if not cursor:
+            break
+    return all_items
+
+
+# ---------------------------------------------------------------------------
+# Cursor-pagination tests: lot history
+# ---------------------------------------------------------------------------
+
+def test_lot_history_paged_round_trip(c: TestClient):
+    """Seed 250 entries, walk cursor to exhaustion; verify no duplicates and all rows visited."""
+    _part_id, lot_id = _seed_lot_history(c, n_adjusts=250)
+    # 250 adjusts + 1 initial add = 251 entries total
+    all_items = _walk_lot_history_pages(c, lot_id, page_size=100)
+    ids = [item["id"] for item in all_items]
+    assert len(ids) == len(set(ids)), "Duplicate entry ids found across pages"
+    assert len(ids) == 251
+
+
+def test_lot_history_paged_monotonic_desc(c: TestClient):
+    """occurred_at values across pages are monotonically non-increasing (DESC order)."""
+    _part_id, lot_id = _seed_lot_history(c, n_adjusts=60)
+    all_items = _walk_lot_history_pages(c, lot_id, page_size=25)
+    timestamps = [item["occurred_at"] for item in all_items]
+    for i in range(1, len(timestamps)):
+        assert timestamps[i - 1] >= timestamps[i], (
+            f"Out of DESC order at index {i}: {timestamps[i - 1]!r} < {timestamps[i]!r}"
+        )
+
+
+def test_lot_history_paged_last_page_no_cursor(c: TestClient):
+    """The final page must have next_cursor=None."""
+    _part_id, lot_id = _seed_lot_history(c, n_adjusts=10)
+    # 11 entries total; use page_size=6 → 2 pages (6 + 5)
+    cursor: str | None = None
+    last_next_cursor = "sentinel"
+    while True:
+        url = f"/api/lots/{lot_id}/history?paged=true&limit=6"
+        if cursor:
+            url += f"&cursor={cursor}"
+        r = c.get(url)
+        assert r.status_code == 200
+        body = r.json()["data"]
+        last_next_cursor = body["next_cursor"]
+        cursor = last_next_cursor
+        if not cursor:
+            break
+    assert last_next_cursor is None
+
+
+def test_lot_history_cursor_tamper_400(c: TestClient):
+    """A tampered cursor token must return HTTP 400."""
+    _part_id, lot_id = _seed_lot_history(c, n_adjusts=60)
+    r = c.get(f"/api/lots/{lot_id}/history?paged=true&limit=25")
+    assert r.status_code == 200
+    real_cursor = r.json()["data"]["next_cursor"]
+    assert real_cursor is not None, "Expected a next_cursor with 61 entries and limit=25"
+
+    # Tamper — flip last character.
+    chars = list(real_cursor)
+    chars[-1] = "X" if chars[-1] != "X" else "Y"
+    bad_cursor = "".join(chars)
+
+    r2 = c.get(f"/api/lots/{lot_id}/history?paged=true&limit=25&cursor={bad_cursor}")
+    assert r2.status_code == 400, r2.text
+
+
+def test_lot_history_cross_workspace_404_before_400(c: TestClient, c2: TestClient):
+    """Workspace B cannot access workspace A's lot — returns 404 regardless of cursor."""
+    _part_id, lot_id = _seed_lot_history(c, n_adjusts=60)
+    # Get a valid cursor from workspace A.
+    r = c.get(f"/api/lots/{lot_id}/history?paged=true&limit=25")
+    assert r.status_code == 200
+    cursor_a = r.json()["data"]["next_cursor"]
+    assert cursor_a is not None
+
+    # Workspace B tries to access workspace A's lot (with or without cursor).
+    r2 = c2.get(f"/api/lots/{lot_id}/history?paged=true&limit=25&cursor={cursor_a}")
+    assert r2.status_code == 404, r2.text
+
+
+# ---------------------------------------------------------------------------
+# Cursor-pagination tests: storage history
+# ---------------------------------------------------------------------------
+
+def test_storage_history_paged_round_trip(c: TestClient):
+    """Seed 250 entries (125 pairs), walk cursor to exhaustion; verify no duplicates."""
+    _part_id, storage_id = _seed_storage_history(c, n_pairs=125)
+    all_items = _walk_storage_history_pages(c, storage_id, page_size=100)
+    ids = [item["id"] for item in all_items]
+    assert len(ids) == len(set(ids)), "Duplicate entry ids found across pages"
+    assert len(ids) == 250
+
+
+def test_storage_history_paged_monotonic_desc(c: TestClient):
+    """occurred_at values across pages are monotonically non-increasing (DESC order)."""
+    _part_id, storage_id = _seed_storage_history(c, n_pairs=35)
+    all_items = _walk_storage_history_pages(c, storage_id, page_size=25)
+    timestamps = [item["occurred_at"] for item in all_items]
+    for i in range(1, len(timestamps)):
+        assert timestamps[i - 1] >= timestamps[i], (
+            f"Out of DESC order at index {i}: {timestamps[i - 1]!r} < {timestamps[i]!r}"
+        )
+
+
+def test_storage_history_paged_last_page_no_cursor(c: TestClient):
+    """The final page must have next_cursor=None."""
+    _part_id, storage_id = _seed_storage_history(c, n_pairs=6)
+    # 12 entries total; use page_size=7 → 2 pages (7 + 5)
+    cursor: str | None = None
+    last_next_cursor = "sentinel"
+    while True:
+        url = f"/api/storage/{storage_id}/history?paged=true&limit=7"
+        if cursor:
+            url += f"&cursor={cursor}"
+        r = c.get(url)
+        assert r.status_code == 200
+        body = r.json()["data"]
+        last_next_cursor = body["next_cursor"]
+        cursor = last_next_cursor
+        if not cursor:
+            break
+    assert last_next_cursor is None
+
+
+def test_storage_history_cursor_tamper_400(c: TestClient):
+    """A tampered cursor token must return HTTP 400."""
+    _part_id, storage_id = _seed_storage_history(c, n_pairs=35)
+    r = c.get(f"/api/storage/{storage_id}/history?paged=true&limit=25")
+    assert r.status_code == 200
+    real_cursor = r.json()["data"]["next_cursor"]
+    assert real_cursor is not None, "Expected a next_cursor with 70 entries and limit=25"
+
+    chars = list(real_cursor)
+    chars[-1] = "X" if chars[-1] != "X" else "Y"
+    bad_cursor = "".join(chars)
+
+    r2 = c.get(f"/api/storage/{storage_id}/history?paged=true&limit=25&cursor={bad_cursor}")
+    assert r2.status_code == 400, r2.text
+
+
+def test_storage_history_cross_workspace_404_before_400(c: TestClient, c2: TestClient):
+    """Workspace B cannot access workspace A's storage — returns 404 regardless of cursor."""
+    _part_id, storage_id = _seed_storage_history(c, n_pairs=35)
+    # Get a valid cursor from workspace A.
+    r = c.get(f"/api/storage/{storage_id}/history?paged=true&limit=25")
+    assert r.status_code == 200
+    cursor_a = r.json()["data"]["next_cursor"]
+    assert cursor_a is not None
+
+    # Workspace B tries to access workspace A's storage.
+    r2 = c2.get(f"/api/storage/{storage_id}/history?paged=true&limit=25&cursor={cursor_a}")
+    assert r2.status_code == 404, r2.text


### PR DESCRIPTION
Closes #250

## Summary
- Add `?cursor=` / `?paged=true` opt-in cursor pagination to `lot_history` and `storage_history` endpoints
- Bare-list path (`?limit=200`, used by current FE) is fully unchanged — backwards-compatible
- Sort order: `occurred_at DESC, id DESC` for stable tiebreaking when entries share a timestamp
- Uses existing `paginate()` helper from `app/core/pagination.py`

## Tests
Backend: 702 passed, 0 failed
Frontend: N/A

New tests added to `tests/test_history_limits.py`:
- `test_lot_history_paged_round_trip` — 251 entries, walk to exhaustion, no duplicates
- `test_lot_history_paged_monotonic_desc` — timestamps are non-increasing across pages
- `test_lot_history_paged_last_page_no_cursor` — final page has `next_cursor=None`
- `test_lot_history_cursor_tamper_400` — tampered cursor → 400
- `test_lot_history_cross_workspace_404_before_400` — foreign lot → 404 (not 400)
- Same 5 tests for storage history