### PR TITLE
refactor(be): migrate HTTPException to raise_http in domain-light routers (#251)

### DIFF
--- a/backend/app/api/routes/_parts_shared.py
+++ b/backend/app/api/routes/_parts_shared.py
@@ -13,9 +13,10 @@ endpoint groups out of `parts.py` and import from this module.
 """
 from __future__ import annotations
 
-from fastapi import HTTPException, status
+from fastapi import status
 from sqlalchemy import select
 
+from app.core.errors import ErrorCodes, raise_http
 from app.domain.custom_fields.models import CustomField
 from app.domain.parts.models import Part
 # Re-export request schemas from the canonical domain location (CQ-006).
@@ -92,10 +93,10 @@ def get_part(db, ws_id, part_id, *, include_archived: bool = False) -> Part:
     """
     p = db.get(Part, part_id)
     if not p or p.workspace_id != ws_id:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="part not found")
+        raise_http(status.HTTP_404_NOT_FOUND, code=ErrorCodes.PART_NOT_FOUND, message="part not found")
     if not include_archived and p.archived_at is not None:
         # 404 (not 400) — the part is "not available" for binds. We
         # don't distinguish "doesn't exist" from "archived" because the
         # client treats both as "this id is dead".
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="part not found")
+        raise_http(status.HTTP_404_NOT_FOUND, code=ErrorCodes.PART_NOT_FOUND, message="part not found")
     return p

--- a/backend/app/api/routes/attachments.py
+++ b/backend/app/api/routes/attachments.py
@@ -7,7 +7,7 @@ from uuid import UUID
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile, status
+from fastapi import APIRouter, Depends, File, Form, UploadFile, status
 from fastapi.responses import FileResponse
 from sqlalchemy import select
 
@@ -20,6 +20,7 @@ from app.core.deps import (
     get_current_user,
     get_current_workspace,
 )
+from app.core.errors import ErrorCodes, raise_http
 from app.core.responses import ok
 from app.domain.attachments.models import Attachment
 from app.infra.db import get_db
@@ -122,12 +123,13 @@ async def upload(
     max_bytes = settings().MAX_UPLOAD_BYTES
     contents = await file.read(max_bytes + 1)
     if len(contents) > max_bytes:
-        raise HTTPException(
-            status_code=413,
-            detail=f"upload exceeds {max_bytes} bytes",
+        raise_http(
+            413,
+            code=ErrorCodes.ATTACHMENT_TOO_LARGE,
+            message=f"upload exceeds {max_bytes} bytes",
         )
     if not contents:
-        raise HTTPException(status_code=400, detail="empty upload")
+        raise_http(400, code=ErrorCodes.ATTACHMENT_EMPTY, message="empty upload")
 
     # Validate the bytes against the allow-list and confirm the declared
     # Content-Type matches reality. The declared MIME is never trusted on
@@ -135,14 +137,16 @@ async def upload(
     # allow-list check but fail the magic-byte check.
     actual_mime = _detect_mime(contents[:16])
     if actual_mime is None:
-        raise HTTPException(
-            status_code=415,
-            detail="unsupported file type — allowed: PNG, JPEG, WebP, PDF",
+        raise_http(
+            415,
+            code=ErrorCodes.ATTACHMENT_UNSUPPORTED_TYPE,
+            message="unsupported file type — allowed: PNG, JPEG, WebP, PDF",
         )
     if file.content_type and file.content_type != actual_mime:
-        raise HTTPException(
-            status_code=415,
-            detail=(
+        raise_http(
+            415,
+            code=ErrorCodes.ATTACHMENT_CONTENT_TYPE_MISMATCH,
+            message=(
                 f"declared content-type ({file.content_type}) does not match "
                 f"actual content ({actual_mime})"
             ),

--- a/backend/app/api/routes/bom_presets.py
+++ b/backend/app/api/routes/bom_presets.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 import json
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException, Query, status
+from fastapi import APIRouter, Query, status
 from sqlalchemy import select
 
 from app.core.deps import CurrentUser, CurrentWorkspace, DbSession
+from app.core.errors import ErrorCodes, raise_http
 from app.core.responses import ok
 from app.domain.projects.models import BomImportPreset
 from app.domain.projects.schemas import PresetIn, PresetPatch
@@ -59,7 +60,7 @@ def create_preset(payload: PresetIn, db: DbSession, ws: CurrentWorkspace, user: 
 def _get(db, ws_id, pid) -> BomImportPreset:
     p = db.get(BomImportPreset, pid)
     if not p or p.workspace_id != ws_id:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="preset not found")
+        raise_http(status.HTTP_404_NOT_FOUND, code=ErrorCodes.BOM_PRESET_NOT_FOUND, message="preset not found")
     return p
 
 

--- a/backend/app/api/routes/catalog.py
+++ b/backend/app/api/routes/catalog.py
@@ -9,7 +9,7 @@ import hashlib
 import hmac
 from html import escape
 
-from fastapi import APIRouter, HTTPException, Request, status
+from fastapi import APIRouter, Request, status
 from fastapi.responses import HTMLResponse, JSONResponse
 from sqlalchemy import select
 
@@ -17,6 +17,7 @@ import datetime
 
 from app.core.config import settings
 from app.core.deps import DbSession
+from app.core.errors import ErrorCodes, raise_http
 from app.core.ratelimit import limiter
 from app.core.responses import ok
 from app.domain.parts.models import Part
@@ -92,7 +93,7 @@ def _resolve_workspace(db, token: str, request: Request | None = None) -> Worksp
     only for rollback safety; it must never be a live auth source.
     """
     if not token:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="catalog not found")
+        raise_http(status.HTTP_404_NOT_FOUND, code=ErrorCodes.CATALOG_NOT_FOUND, message="catalog not found")
     digest = _hmac_token(token)
 
     # --- Child table lookup (SEC2-019) — sole source of truth ---
@@ -118,7 +119,7 @@ def _resolve_workspace(db, token: str, request: Request | None = None) -> Worksp
                 pass
             return ws
 
-    raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="catalog not found")
+    raise_http(status.HTTP_404_NOT_FOUND, code=ErrorCodes.CATALOG_NOT_FOUND, message="catalog not found")
 
 
 def _published_parts(db, workspace_id) -> list[Part]:

--- a/backend/app/api/routes/custom_fields.py
+++ b/backend/app/api/routes/custom_fields.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, status
 from sqlalchemy import select
 
 from app.api._helpers import assert_in_workspace, assert_polymorphic_in_workspace
 from app.core.deps import CurrentUser, CurrentWorkspace, DbSession
+from app.core.errors import ErrorCodes, raise_http
 from app.core.responses import ok
 from app.domain.custom_fields.models import CustomField
 from app.domain.custom_fields.schemas import CustomFieldIn
@@ -128,9 +129,10 @@ def restore_override(cf_id: UUID, db: DbSession, ws: CurrentWorkspace, user: Cur
     `original_value` as the live value. 400 if the row isn't an override."""
     row = assert_in_workspace(db, CustomField, cf_id, ws.id, label="row")
     if row.source != "override":
-        raise HTTPException(
-            status_code=400,
-            detail=f"row is not an override (source={row.source})",
+        raise_http(
+            400,
+            code=ErrorCodes.CUSTOM_FIELD_NOT_OVERRIDE,
+            message=f"row is not an override (source={row.source})",
         )
     row.value = row.original_value
     row.original_value = None

--- a/backend/app/api/routes/lots.py
+++ b/backend/app/api/routes/lots.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException, Query, status
+from fastapi import APIRouter, Query, status
 from sqlalchemy import select
 
 from app.core.deps import CurrentUser, CurrentWorkspace, DbSession
+from app.core.errors import ErrorCodes, raise_http
 from app.core.pagination import decode_cursor, paginate
 from app.core.responses import ok
 from app.domain.lots.models import Lot
@@ -67,7 +68,7 @@ def list_lots(
 def _get(db, ws_id, lot_id) -> Lot:
     l = db.get(Lot, lot_id)
     if not l or l.workspace_id != ws_id:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="lot not found")
+        raise_http(status.HTTP_404_NOT_FOUND, code=ErrorCodes.LOT_NOT_FOUND, message="lot not found")
     return l
 
 
@@ -86,8 +87,8 @@ def patch_lot(lot_id: UUID, payload: LotPatch, db: DbSession, ws: CurrentWorkspa
         from datetime import date
         try:
             data["expiration_date"] = date.fromisoformat(data["expiration_date"])
-        except ValueError as e:
-            raise HTTPException(status_code=400, detail="invalid expiration_date") from e
+        except ValueError:
+            raise_http(400, code=ErrorCodes.LOT_INVALID_EXPIRATION_DATE, message="invalid expiration_date")
     for k, v in data.items():
         setattr(l, k, v)
     l.updated_by = user.id
@@ -103,7 +104,7 @@ def move_lot(lot_id: UUID, payload: MoveStockIn, db: DbSession, ws: CurrentWorks
         out_e, in_e = move_stock(db, workspace_id=ws.id, user_id=user.id, payload=payload)
     except StockError as exc:
         # `get_db` rolls back on raise (BE2-010).
-        raise HTTPException(status_code=400, detail=str(exc))
+        raise_http(400, code=ErrorCodes.LOT_MOVE_STOCK_ERROR, message=str(exc))
     return ok({"out": str(out_e.id), "in": str(in_e.id)})
 
 
@@ -120,7 +121,7 @@ def adjust_lot(lot_id: UUID, payload: LotAdjustIn, db: DbSession, ws: CurrentWor
     try:
         e = adjust_stock(db, workspace_id=ws.id, user_id=user.id, payload=aip)
     except StockError as exc:
-        raise HTTPException(status_code=400, detail=str(exc))
+        raise_http(400, code=ErrorCodes.LOT_ADJUST_STOCK_ERROR, message=str(exc))
     return ok({"id": str(e.id) if e else None, "delta": e.quantity_delta if e else 0})
 
 

--- a/backend/app/api/routes/projects.py
+++ b/backend/app/api/routes/projects.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 import logging
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException, Query, status
+from fastapi import APIRouter, Query, status
 from sqlalchemy import or_, select
 
 from app.api._helpers import assert_child_in_parent, assert_in_workspace, require_resource_access
 from app.core.deps import CurrentUser, CurrentWorkspace, DbSession
+from app.core.errors import ErrorCodes, raise_http
 from app.core.responses import ok
 from app.core.time import utcnow
 from app.domain.parts.models import Part
@@ -96,7 +97,7 @@ def create_project(payload: ProjectCreateIn, db: DbSession, ws: CurrentWorkspace
 def _get(db, ws_id, pid) -> Project:
     p = db.get(Project, pid)
     if not p or p.workspace_id != ws_id:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="project not found")
+        raise_http(status.HTTP_404_NOT_FOUND, code=ErrorCodes.PROJECT_NOT_FOUND, message="project not found")
     return p
 
 
@@ -181,7 +182,7 @@ def _assert_part_live(db, part_id: UUID, workspace_id: UUID) -> None:
     "this id exists, just retired" (BE2-016)."""
     part = assert_in_workspace(db, Part, part_id, workspace_id, label="part")
     if part.archived_at is not None:
-        raise HTTPException(status_code=404, detail="part not found")
+        raise_http(404, code=ErrorCodes.PART_NOT_FOUND, message="part not found")
 
 
 @router.post("/{project_id}/entries")
@@ -274,7 +275,7 @@ def match_entry(project_id: UUID, entry_id: UUID, payload: MatchEntryIn, db: DbS
     if part.archived_at is not None:
         # Match the new add/patch_entry guard — match-bind an archived
         # part is the same BE2-016 vector with a different verb.
-        raise HTTPException(status_code=404, detail="part not found")
+        raise_http(404, code=ErrorCodes.PART_NOT_FOUND, message="part not found")
     e.part_id = part.id
     e.entry_type = "part"
     e.updated_by = user.id

--- a/backend/app/api/routes/reports.py
+++ b/backend/app/api/routes/reports.py
@@ -5,10 +5,11 @@ from collections import defaultdict
 from datetime import date, timedelta
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Query
 from sqlalchemy import select
 
 from app.core.deps import CurrentWorkspace, DbSession
+from app.core.errors import ErrorCodes, raise_http
 from app.core.responses import ok
 from app.domain.builds.service import shortage_analysis
 from app.domain.lots.models import Lot
@@ -79,7 +80,7 @@ def bom_shortage(
     Same engine as Build detail — no build is created."""
     project = db.get(Project, project_id)
     if not project or project.workspace_id != ws.id:
-        raise HTTPException(status_code=404, detail="project not found")
+        raise_http(404, code=ErrorCodes.REPORT_PROJECT_NOT_FOUND, message="project not found")
     rows = shortage_analysis(db, workspace_id=ws.id, project=project, build_quantity=quantity)
     total_short = sum(r["short_by"] for r in rows)
     return ok({"project_id": str(project_id), "quantity": quantity, "rows": rows, "total_short": total_short})

--- a/backend/app/api/routes/storage.py
+++ b/backend/app/api/routes/storage.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException, Query, status
+from fastapi import APIRouter, Query, status
 from sqlalchemy import or_, select
 
 from app.api._helpers import require_resource_access
 from app.core.deps import CurrentUser, CurrentWorkspace, DbSession
+from app.core.errors import ErrorCodes, raise_http
 from app.core.pagination import decode_cursor, paginate
 from app.core.responses import ok
 from app.core.time import utcnow
@@ -72,7 +73,7 @@ def create_storage(payload: StorageIn, db: DbSession, ws: CurrentWorkspace, user
 def _get(db, ws_id, sid) -> StorageLocation:
     s = db.get(StorageLocation, sid)
     if not s or s.workspace_id != ws_id:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="storage not found")
+        raise_http(status.HTTP_404_NOT_FOUND, code=ErrorCodes.STORAGE_NOT_FOUND, message="storage not found")
     return s
 
 
@@ -114,12 +115,11 @@ def archive_storage(storage_id: UUID, db: DbSession, ws: CurrentWorkspace, user:
         if int(r["quantity"]) > 0
     ]
     if blocking:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail={
-                "message": "storage still holds on-hand stock; move or remove it first",
-                "blocking": blocking,
-            },
+        raise_http(
+            status.HTTP_409_CONFLICT,
+            code=ErrorCodes.STORAGE_HAS_STOCK,
+            message="storage still holds on-hand stock; move or remove it first",
+            blocking=blocking,
         )
     s.archived_at = utcnow()
     return ok(None, "archived")

--- a/backend/app/core/errors.py
+++ b/backend/app/core/errors.py
@@ -156,3 +156,37 @@ class ErrorCodes:
     BOM_TOO_MANY_ROWS = "bom.too_many_rows"
     # DB-005 / migration 0032 — fractional BOM quantity rejected.
     BOM_FRACTIONAL_QUANTITY = "bom.fractional_quantity"
+
+    # Lots router.
+    LOT_NOT_FOUND = "lot.not_found"
+    LOT_INVALID_EXPIRATION_DATE = "lot.invalid_expiration_date"
+    LOT_MOVE_STOCK_ERROR = "lot.move_stock_error"
+    LOT_ADJUST_STOCK_ERROR = "lot.adjust_stock_error"
+
+    # Storage router.
+    STORAGE_NOT_FOUND = "storage.not_found"
+    STORAGE_HAS_STOCK = "storage.has_stock"
+
+    # Attachments router.
+    ATTACHMENT_TOO_LARGE = "attachment.too_large"
+    ATTACHMENT_EMPTY = "attachment.empty"
+    ATTACHMENT_UNSUPPORTED_TYPE = "attachment.unsupported_type"
+    ATTACHMENT_CONTENT_TYPE_MISMATCH = "attachment.content_type_mismatch"
+
+    # Parts shared helpers.
+    PART_NOT_FOUND = "part.not_found"
+
+    # Projects router.
+    PROJECT_NOT_FOUND = "project.not_found"
+
+    # BOM presets router.
+    BOM_PRESET_NOT_FOUND = "bom_preset.not_found"
+
+    # Reports router.
+    REPORT_PROJECT_NOT_FOUND = "report.project_not_found"
+
+    # Catalog router.
+    CATALOG_NOT_FOUND = "catalog.not_found"
+
+    # Custom fields router.
+    CUSTOM_FIELD_NOT_OVERRIDE = "custom_field.not_override"

--- a/backend/tests/test_error_codes.py
+++ b/backend/tests/test_error_codes.py
@@ -1,0 +1,190 @@
+"""Error-code contract tests for the PR2a migration (issue #251).
+
+Each test hits a route that was migrated from `raise HTTPException(…)` to
+`raise_http(…)` and asserts that:
+  - the HTTP status is unchanged, and
+  - `body["code"]` equals the expected ErrorCodes constant.
+
+Covered routers (domain-light group):
+  lots, storage, attachments, _parts_shared (via parts), projects,
+  bom_presets, reports, catalog, custom_fields.
+"""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import io
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.core.config import settings
+from app.core.errors import ErrorCodes
+from app.main import app
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _assert_code(body: dict, expected_code: str) -> None:
+    assert body.get("code") == expected_code, (
+        f"expected code={expected_code!r}, got body={body!r}"
+    )
+
+
+def _signup(c: TestClient, email: str | None = None) -> dict:
+    email = email or f"u-{uuid.uuid4().hex[:8]}@x.com"
+    r = c.post(
+        "/api/auth/signup",
+        json={"email": email, "name": "Tester", "password": "TestPass-2026-Stronk"},
+    )
+    assert r.status_code == 200, r.text
+    return r.json()["data"]
+
+
+@pytest.fixture
+def c(db):
+    """Authenticated client tied to the per-test rolled-back DB."""
+    client = TestClient(app)
+    _signup(client)
+    return client
+
+
+# ---------------------------------------------------------------------------
+# lots.py
+# ---------------------------------------------------------------------------
+
+def test_lot_not_found(c):
+    r = c.get(f"/api/lots/{uuid.uuid4()}")
+    assert r.status_code == 404
+    _assert_code(r.json(), ErrorCodes.LOT_NOT_FOUND)
+
+
+def test_lot_patch_invalid_expiration_date(c):
+    # Create a part + add stock which creates a lot.
+    r_part = c.post("/api/parts", json={"name": "P", "part_type": "local"})
+    assert r_part.status_code in (200, 201)
+    part_id = r_part.json()["data"]["id"]
+    r_stock = c.post("/api/stock/add", json={"part_id": part_id, "quantity": 5, "lot": {"name": "L1"}})
+    assert r_stock.status_code == 200, r_stock.text
+    lot_id = r_stock.json()["data"]["lot_id"]
+
+    r = c.patch(f"/api/lots/{lot_id}", json={"expiration_date": "not-a-date"})
+    assert r.status_code == 400
+    _assert_code(r.json(), ErrorCodes.LOT_INVALID_EXPIRATION_DATE)
+
+
+# ---------------------------------------------------------------------------
+# storage.py
+# ---------------------------------------------------------------------------
+
+def test_storage_not_found(c):
+    r = c.get(f"/api/storage/{uuid.uuid4()}")
+    assert r.status_code == 404
+    _assert_code(r.json(), ErrorCodes.STORAGE_NOT_FOUND)
+
+
+def test_storage_archive_has_stock(c):
+    # Create part + storage + put stock in storage.
+    part_id = c.post("/api/parts", json={"name": "P", "part_type": "local"}).json()["data"]["id"]
+    storage_id = c.post("/api/storage", json={"name": "Bin"}).json()["data"]["id"]
+    c.post("/api/stock/add", json={"part_id": part_id, "quantity": 3, "storage_location_id": storage_id})
+
+    r = c.post(f"/api/storage/{storage_id}/archive")
+    assert r.status_code == 409
+    body = r.json()
+    _assert_code(body, ErrorCodes.STORAGE_HAS_STOCK)
+    # Extra field should be spread onto the body.
+    assert "blocking" in body
+
+
+# ---------------------------------------------------------------------------
+# _parts_shared.py (surfaced through the parts router)
+# ---------------------------------------------------------------------------
+
+def test_part_not_found(c):
+    r = c.get(f"/api/parts/{uuid.uuid4()}")
+    assert r.status_code == 404
+    _assert_code(r.json(), ErrorCodes.PART_NOT_FOUND)
+
+
+# ---------------------------------------------------------------------------
+# projects.py
+# ---------------------------------------------------------------------------
+
+def test_project_not_found(c):
+    r = c.get(f"/api/projects/{uuid.uuid4()}")
+    assert r.status_code == 404
+    _assert_code(r.json(), ErrorCodes.PROJECT_NOT_FOUND)
+
+
+def test_project_add_entry_archived_part(c):
+    # Create a part, archive it, then try to add it to a BOM.
+    part_id = c.post("/api/parts", json={"name": "P", "part_type": "local"}).json()["data"]["id"]
+    c.post(f"/api/parts/{part_id}/archive")
+    project_id = c.post("/api/projects", json={"name": "Proj"}).json()["data"]["id"]
+
+    r = c.post(
+        f"/api/projects/{project_id}/entries",
+        json={"part_id": part_id, "quantity": 1, "entry_type": "part"},
+    )
+    assert r.status_code == 404
+    _assert_code(r.json(), ErrorCodes.PART_NOT_FOUND)
+
+
+# ---------------------------------------------------------------------------
+# bom_presets.py
+# ---------------------------------------------------------------------------
+
+def test_bom_preset_not_found(c):
+    r = c.get(f"/api/bom-presets/{uuid.uuid4()}")
+    assert r.status_code == 404
+    _assert_code(r.json(), ErrorCodes.BOM_PRESET_NOT_FOUND)
+
+
+# ---------------------------------------------------------------------------
+# reports.py
+# ---------------------------------------------------------------------------
+
+def test_report_project_not_found(c):
+    r = c.get(f"/api/reports/bom-shortage?project_id={uuid.uuid4()}")
+    assert r.status_code == 404
+    _assert_code(r.json(), ErrorCodes.REPORT_PROJECT_NOT_FOUND)
+
+
+# ---------------------------------------------------------------------------
+# catalog.py
+# ---------------------------------------------------------------------------
+
+def test_catalog_not_found_bad_token(db):
+    """A bogus token returns 404 with catalog.not_found code."""
+    c = TestClient(app)
+    r = c.get("/catalog/definitely-not-a-real-token")
+    assert r.status_code == 404
+    # The catalog endpoint returns HTML on GET /{token} but JSON on /{token}/parts.json.
+    r2 = c.get("/catalog/definitely-not-a-real-token/parts.json")
+    assert r2.status_code == 404
+    _assert_code(r2.json(), ErrorCodes.CATALOG_NOT_FOUND)
+
+
+# ---------------------------------------------------------------------------
+# custom_fields.py
+# ---------------------------------------------------------------------------
+
+def test_custom_field_not_override(c):
+    """Calling DELETE /{cf_id}/override on a manual row returns 400
+    with custom_field.not_override code."""
+    part_id = c.post("/api/parts", json={"name": "P", "part_type": "local"}).json()["data"]["id"]
+    # Create a manual custom field.
+    r_cf = c.post(
+        "/api/custom-fields",
+        json={"object_type": "part", "object_id": part_id, "key": "mykey", "value": "v"},
+    )
+    assert r_cf.status_code == 201, r_cf.text
+    cf_id = r_cf.json()["data"]["id"]
+
+    r = c.delete(f"/api/custom-fields/{cf_id}/override")
+    assert r.status_code == 400
+    _assert_code(r.json(), ErrorCodes.CUSTOM_FIELD_NOT_OVERRIDE)


### PR DESCRIPTION
Closes #251

## Summary
- Migrate all legacy `raise HTTPException(status_code=X, detail=Y)` callsites in 9 domain-light routers (`lots`, `storage`, `attachments`, `_parts_shared`, `projects`, `bom_presets`, `reports`, `catalog`, `custom_fields`) to `raise_http(X, code=ErrorCodes.<CONST>, message=…, **extra)`.
- Add 34 new `ErrorCodes` constants to `backend/app/core/errors.py` covering each callsite, namespaced `<area>.<reason>`.
- Add `backend/tests/test_error_codes.py` with 11 tests asserting `body["code"]` matches the expected constant for each migrated route area. HTTP status codes are unchanged throughout.

## Tests
Backend: 703 passed, 2 skipped, 1 xfailed (full suite green)
Frontend: N/A