### PR TITLE
fix(db): add trigger to enforce parts.default_storage_location_id workspace (#254)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,11 +86,13 @@ them, that's the bug.
   `domain/stock/service.py::current_quantity` or roll-ups built on it.
   Never compute "current stock" by joining or aggregating outside that
   service.
-- **Workspace isolation is enforced in code, not the DB.** Every query in
-  every service filters by `ws.id`, and every cross-table FK lookup is
-  followed by a `workspace_id` equality check. There is no row-level
-  security. New endpoints must replicate this; pin it with a test in
-  `tests/test_workspace_isolation.py` style.
+- **Workspace isolation is enforced in code, not the DB** — except
+  `parts.default_storage_location_id`, which is additionally enforced by a
+  Postgres BEFORE trigger (`parts_default_storage_workspace_check`, migration
+  0036). Every query in every service filters by `ws.id`, and every
+  cross-table FK lookup is followed by a `workspace_id` equality check. There
+  is no row-level security. New endpoints must replicate this; pin it with a
+  test in `tests/test_workspace_isolation.py` style.
 - **API envelope.** Every response is `{ data, status }` — never a bare
   payload. Server-side use `responses.ok()` / `responses.err()`.
   Client-side `lib/api.ts` unwraps `data` and throws `ApiError(status,

--- a/backend/alembic/versions/0036_parts_default_storage_ws_trigger.py
+++ b/backend/alembic/versions/0036_parts_default_storage_ws_trigger.py
@@ -1,0 +1,55 @@
+"""Add BEFORE trigger to enforce parts.default_storage_location_id workspace.
+
+Revision ID: 0036
+Revises: 0035
+Create Date: 2026-05-02
+
+DB-015 Phase 2 / issue #254.
+
+The service layer already rejects cross-workspace default_storage_location_id
+assignments. This migration adds a Postgres BEFORE trigger that provides the
+same guarantee at the database level, so that direct SQL (e.g. migrations,
+admin queries) cannot silently produce an inconsistent row.
+
+ERRCODE 23514 (check_violation) is raised so that SQLAlchemy surfaces it as
+an IntegrityError — the same family as CHECK constraint failures.
+"""
+
+from alembic import op
+
+revision = "0036"
+down_revision = "0035"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+    CREATE OR REPLACE FUNCTION check_default_storage_workspace() RETURNS trigger AS $$
+    BEGIN
+      IF NEW.default_storage_location_id IS NOT NULL THEN
+        PERFORM 1 FROM storage_locations
+        WHERE id = NEW.default_storage_location_id
+          AND workspace_id = NEW.workspace_id;
+        IF NOT FOUND THEN
+          RAISE EXCEPTION 'parts.default_storage_location_id (%) not in workspace (%)',
+            NEW.default_storage_location_id, NEW.workspace_id
+            USING ERRCODE = '23514';
+        END IF;
+      END IF;
+      RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql;
+    """)
+    op.execute("""
+    CREATE TRIGGER parts_default_storage_workspace_check
+      BEFORE INSERT OR UPDATE OF default_storage_location_id, workspace_id
+      ON parts
+      FOR EACH ROW
+      EXECUTE FUNCTION check_default_storage_workspace();
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP TRIGGER IF EXISTS parts_default_storage_workspace_check ON parts;")
+    op.execute("DROP FUNCTION IF EXISTS check_default_storage_workspace();")

--- a/backend/tests/test_workspace_isolation.py
+++ b/backend/tests/test_workspace_isolation.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import uuid
 
+import pytest
 from fastapi.testclient import TestClient
 
 from app.main import app
@@ -389,28 +390,24 @@ def test_no_cross_workspace_default_storage_in_existing_rows():
     )
 
 
-def test_raw_update_can_smuggle_cross_workspace_default_storage_xfail():
-    """DB-015 / Phase 2 marker. The service layer enforces workspace
-    isolation on `parts.default_storage_location_id`; the database
-    does not. A direct SQL UPDATE bypasses the guard today.
-
-    Marked xfail. When the Phase 2 trigger lands (per-row enforcement
-    of `parts.workspace_id = (SELECT workspace_id FROM
-    storage_locations WHERE id = NEW.default_storage_location_id)`),
-    flip this to a regular assertion: the raw UPDATE must raise an
-    IntegrityError instead of silently persisting."""
-    import pytest as _pytest
+def test_raw_update_cannot_smuggle_cross_workspace_default_storage():
+    """DB-015 Phase 2 (migration 0036). The BEFORE trigger
+    `parts_default_storage_workspace_check` must reject a direct SQL UPDATE
+    that points default_storage_location_id at a storage_location in a
+    different workspace."""
     from sqlalchemy import text
+    from sqlalchemy.exc import DBAPIError, IntegrityError, ProgrammingError
+
     from app.infra.db import SessionLocal
 
     a, b = _two_workspaces()
     storage_a = _create_storage(a, "A-bin")
     part_b = _create_part(b, "B-part")
 
-    # Direct SQL: bypass the route layer entirely. Today this succeeds —
-    # the Phase 2 trigger would make it fail.
+    # Direct SQL: bypass the route layer entirely.  The trigger must fire
+    # and raise an error (ERRCODE 23514 → IntegrityError in SQLAlchemy).
     with SessionLocal() as s:
-        try:
+        with pytest.raises((IntegrityError, ProgrammingError, DBAPIError)):
             s.execute(
                 text(
                     "UPDATE parts SET default_storage_location_id = :sid "
@@ -419,27 +416,87 @@ def test_raw_update_can_smuggle_cross_workspace_default_storage_xfail():
                 {"sid": storage_a, "pid": part_b},
             )
             s.commit()
-            updated = s.execute(
-                text(
-                    "SELECT default_storage_location_id FROM parts "
-                    "WHERE id = :pid"
-                ),
-                {"pid": part_b},
-            ).scalar()
-            persisted_cross_ws = str(updated) == storage_a
-        except Exception:
-            persisted_cross_ws = False
-            s.rollback()
 
-    if persisted_cross_ws:
-        _pytest.xfail(
-            "DB-015 Phase 2 not landed: raw UPDATE bypasses workspace "
-            "guard. Flip this to a regular assertion when the trigger "
-            "migration ships."
+
+def test_raw_update_same_workspace_default_storage_succeeds():
+    """Positive path for migration 0036: a raw SQL UPDATE that sets
+    default_storage_location_id to a storage_location in the *same*
+    workspace must be accepted by the trigger."""
+    from sqlalchemy import text
+
+    from app.infra.db import SessionLocal
+
+    a, _ = _two_workspaces()
+    storage_a = _create_storage(a, "A-bin")
+    part_a = _create_part(a, "A-part")
+
+    with SessionLocal() as s:
+        s.execute(
+            text(
+                "UPDATE parts SET default_storage_location_id = :sid "
+                "WHERE id = :pid"
+            ),
+            {"sid": storage_a, "pid": part_a},
         )
-    else:
-        # Already fixed (trigger present) — perfect.
-        assert True
+        s.commit()
+
+        result = s.execute(
+            text("SELECT default_storage_location_id FROM parts WHERE id = :pid"),
+            {"pid": part_a},
+        ).scalar()
+
+    assert str(result) == storage_a, (
+        "same-workspace UPDATE should persist; trigger incorrectly rejected it"
+    )
+
+
+def test_raw_insert_cross_workspace_default_storage_rejected():
+    """DB-015 Phase 2 (migration 0036). The BEFORE trigger must also fire on
+    INSERT, preventing a cross-workspace default_storage_location_id from
+    ever being written via a direct SQL INSERT."""
+    import uuid
+
+    from sqlalchemy import text
+    from sqlalchemy.exc import DBAPIError, IntegrityError, ProgrammingError
+
+    from app.infra.db import SessionLocal
+
+    a, b = _two_workspaces()
+    storage_a = _create_storage(a, "A-bin")
+
+    # We need the workspace_id for workspace B.
+    with SessionLocal() as s:
+        ws_b_id = s.execute(
+            text("SELECT workspace_id FROM parts WHERE workspace_id != :wsa LIMIT 1"),
+            {"wsa": storage_a[:36]},  # narrow to any workspace that isn't A
+        ).scalar()
+        # Fall back: look up via a workspace that owns storage_a
+        ws_a_id = s.execute(
+            text("SELECT workspace_id FROM storage_locations WHERE id = :sid"),
+            {"sid": storage_a},
+        ).scalar()
+
+    # Find workspace B's actual id via a separate query
+    with SessionLocal() as s:
+        ws_b_id = s.execute(
+            text(
+                "SELECT id FROM workspaces WHERE id != :wsa LIMIT 1"
+            ),
+            {"wsa": ws_a_id},
+        ).scalar()
+
+    new_part_id = str(uuid.uuid4())
+    with SessionLocal() as s:
+        with pytest.raises((IntegrityError, ProgrammingError, DBAPIError)):
+            s.execute(
+                text(
+                    "INSERT INTO parts (id, workspace_id, name, part_type, "
+                    "default_storage_location_id, created_at, updated_at) "
+                    "VALUES (:id, :ws, 'injected', 'local', :sid, NOW(), NOW())"
+                ),
+                {"id": new_part_id, "ws": ws_b_id, "sid": storage_a},
+            )
+            s.commit()
 
 
 def test_parts_bulk_import_rejects_foreign_storage():

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -148,6 +148,13 @@ database — the protection is the consistent code pattern. The
 `tests/test_workspace_isolation.py` test pins this contract for the
 parts router; new endpoints should add equivalent coverage.
 
+**Exception — DB-level trigger:** `parts.default_storage_location_id`
+is additionally protected by a Postgres BEFORE trigger
+(`parts_default_storage_workspace_check`, added in migration 0036).
+The trigger raises ERRCODE 23514 (check_violation) if the referenced
+`storage_locations` row belongs to a different workspace, so that
+even direct SQL bypasses the service-layer guard.
+
 `get_current_workspace()` reads the workspace from the
 `X-Workspace-Id` header or the `stockmgr_workspace` cookie, validates
 membership, and falls back to the user's first active membership.


### PR DESCRIPTION
Closes #254

## Summary
- Add Alembic migration 0036: BEFORE trigger (`parts_default_storage_workspace_check`) on `parts` that rejects any INSERT or UPDATE where `default_storage_location_id` references a `storage_locations` row in a different workspace (raises ERRCODE 23514 → `IntegrityError` in SQLAlchemy)
- Flip the xfail test `test_raw_update_can_smuggle_cross_workspace_default_storage_xfail` to a regular assertion expecting `(IntegrityError, ProgrammingError, DBAPIError)`
- Add positive same-workspace UPDATE test (`test_raw_update_same_workspace_default_storage_succeeds`) and raw-INSERT cross-workspace test (`test_raw_insert_cross_workspace_default_storage_rejected`)
- Update `docs/ARCHITECTURE.md` to document the DB-level trigger exception to the "code-only enforcement" rule
- Update `CLAUDE.md` hard invariant to note the trigger on `parts.default_storage_location_id` (migration 0036)

## Tests
Backend: 696 passed, 2 skipped — all new tests pass

Frontend: N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)