### PR TITLE
refactor(be): extract inline Pydantic schemas to domain schemas.py modules (#252)

### DIFF
--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -6,7 +6,6 @@ from datetime import timedelta
 from uuid import UUID
 
 from fastapi import APIRouter, Request, Response, status
-from pydantic import BaseModel, ConfigDict, EmailStr, Field
 
 from app.core.auth import (
     WeakPasswordError,
@@ -29,6 +28,7 @@ from app.core.ratelimit import limiter
 from app.core.responses import Envelope, ok
 from app.core.time import utcnow
 from app.domain.users.models import PendingUser, User
+from app.domain.users.schemas import LoginIn, SignupIn, VerifyIn
 from app.domain.workspaces.models import Workspace, WorkspaceMember
 
 router = APIRouter()
@@ -63,34 +63,6 @@ def _hmac_token(plaintext: str) -> str:
     """
     key = settings().SESSION_SECRET.encode("utf-8")
     return _hmac.new(key, plaintext.encode("utf-8"), "sha256").hexdigest()
-
-
-# ---------------------------------------------------------------------------
-# Schemas
-# ---------------------------------------------------------------------------
-
-
-class SignupIn(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    email: EmailStr
-    name: str = Field(min_length=1, max_length=200)
-    password: str = Field(min_length=8, max_length=200)
-    workspace_name: str | None = None
-
-
-class LoginIn(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    email: EmailStr
-    password: str
-
-
-class VerifyIn(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    id: str
-    token: str
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/api/routes/bom_presets.py
+++ b/backend/app/api/routes/bom_presets.py
@@ -4,28 +4,14 @@ import json
 from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, Query, status
-from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import select
 
 from app.core.deps import CurrentUser, CurrentWorkspace, DbSession
 from app.core.responses import ok
 from app.domain.projects.models import BomImportPreset
+from app.domain.projects.schemas import PresetIn, PresetPatch
 
 router = APIRouter()
-
-
-class PresetIn(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    name: str = Field(min_length=1, max_length=200)
-    config: dict
-
-
-class PresetPatch(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    name: str | None = None
-    config: dict | None = None
 
 
 def _serialize(p: BomImportPreset) -> dict:

--- a/backend/app/api/routes/custom_fields.py
+++ b/backend/app/api/routes/custom_fields.py
@@ -3,24 +3,15 @@ from __future__ import annotations
 from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, status
-from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import select
 
 from app.api._helpers import assert_in_workspace, assert_polymorphic_in_workspace
 from app.core.deps import CurrentUser, CurrentWorkspace, DbSession
 from app.core.responses import ok
 from app.domain.custom_fields.models import CustomField
+from app.domain.custom_fields.schemas import CustomFieldIn
 
 router = APIRouter()
-
-
-class CustomFieldIn(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    object_type: str
-    object_id: UUID
-    key: str = Field(min_length=1, max_length=256)
-    value: str | None = Field(default=None, max_length=1024)
 
 
 def _serialize(r: CustomField) -> dict:

--- a/backend/app/api/routes/invitations.py
+++ b/backend/app/api/routes/invitations.py
@@ -3,11 +3,9 @@ from __future__ import annotations
 import hashlib
 import hmac as _hmac
 import secrets
-from typing import Literal
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Query, Request, status
-from pydantic import BaseModel, ConfigDict, EmailStr
 from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
 
@@ -25,6 +23,7 @@ from app.core.time import utcnow
 from app.domain.audit.service import log as _audit_log
 from app.domain.users.models import User
 from app.domain.workspaces.models import Workspace, WorkspaceInvitation, WorkspaceMember
+from app.domain.workspaces.schemas import AcceptIn, InviteIn
 
 router = APIRouter()
 
@@ -50,13 +49,6 @@ def _hmac_token(plaintext: str) -> str:
     """
     key = settings().SESSION_SECRET.encode("utf-8")
     return _hmac.new(key, plaintext.encode("utf-8"), "sha256").hexdigest()
-
-
-class InviteIn(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    email: EmailStr
-    role: Literal["admin", "member", "viewer"] = "member"
 
 
 def _serialize(inv: WorkspaceInvitation, *, plaintext_token: str | None = None) -> dict:
@@ -264,18 +256,6 @@ def revoke_invitation(invitation_id: UUID, db: DbSession, ws: CurrentWorkspace, 
 
 
 # ---- Public accept endpoint (does NOT require workspace membership) ------
-
-
-class AcceptIn(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    # SEC2-013: the token field now carries a composite value of the form
-    # "{invitation_id}:{plaintext_token}", produced by _serialize().  The
-    # accept handler splits on the first ":" to obtain the PK (for the
-    # DB lookup) and the plaintext (for HMAC comparison).  This keeps the
-    # frontend interface to a single opaque string while allowing a
-    # constant-time comparison path.
-    token: str
 
 
 # Token is 256-bit so brute-force is infeasible, but the endpoint is

--- a/backend/app/api/routes/lots.py
+++ b/backend/app/api/routes/lots.py
@@ -4,12 +4,12 @@ from datetime import datetime, timezone
 from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, Query, status
-from pydantic import BaseModel, ConfigDict
 from sqlalchemy import select
 
 from app.core.deps import CurrentUser, CurrentWorkspace, DbSession
 from app.core.responses import ok
 from app.domain.lots.models import Lot
+from app.domain.lots.schemas import LotAdjustIn, LotPatch
 from app.domain.stock.schemas import AdjustStockIn, MoveStockIn
 from app.domain.stock.service import (
     StockError,
@@ -76,16 +76,6 @@ def get_lot(lot_id: UUID, db: DbSession, ws: CurrentWorkspace):
     return ok(_serialize(l, quantity=q))
 
 
-class LotPatch(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    name: str | None = None
-    description: str | None = None
-    comments: str | None = None
-    expiration_date: str | None = None
-    serial_number: str | None = None
-
-
 @router.patch("/{lot_id}")
 def patch_lot(lot_id: UUID, payload: LotPatch, db: DbSession, ws: CurrentWorkspace, user: CurrentUser):
     l = _get(db, ws.id, lot_id)
@@ -113,14 +103,6 @@ def move_lot(lot_id: UUID, payload: MoveStockIn, db: DbSession, ws: CurrentWorks
         # `get_db` rolls back on raise (BE2-010).
         raise HTTPException(status_code=400, detail=str(exc))
     return ok({"out": str(out_e.id), "in": str(in_e.id)})
-
-
-class LotAdjustIn(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    actual_quantity: int
-    storage_location_id: UUID | None = None
-    comments: str | None = None
 
 
 @router.post("/{lot_id}/adjust-count")

--- a/backend/app/api/routes/parts_provider.py
+++ b/backend/app/api/routes/parts_provider.py
@@ -3,22 +3,16 @@ provider + API key and dispatches."""
 from __future__ import annotations
 
 from fastapi import APIRouter, Request
-from pydantic import BaseModel, ConfigDict, Field
 
 from app.core.deps import CurrentWorkspace
 from app.core.ratelimit import limiter, workspace_key
 from app.core.responses import ok
 from app.core.secrets import decrypt
 from app.domain.parts.providers import make_provider
+from app.domain.parts.schemas import LookupIn
 from app.domain.parts.services.provider_cache import lookup_with_cache
 
 router = APIRouter()
-
-
-class LookupIn(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    mpn: str = Field(min_length=1, max_length=200)
 
 
 @router.post("/lookup-mpn")

--- a/backend/app/api/routes/projects.py
+++ b/backend/app/api/routes/projects.py
@@ -4,7 +4,6 @@ import logging
 from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, Query, status
-from pydantic import BaseModel, ConfigDict
 from sqlalchemy import or_, select
 
 from app.api._helpers import assert_child_in_parent, assert_in_workspace, require_resource_access
@@ -19,6 +18,7 @@ from app.domain.projects.schemas import (
     BomEntryPatch,
     BomImportCommitIn,
     BomImportPreviewIn,
+    MatchEntryIn,
     ProjectCreateIn,
     ProjectPatchIn,
 )
@@ -264,12 +264,6 @@ def commit_bom(project_id: UUID, payload: BomImportCommitIn, db: DbSession, ws: 
     # the dep handle it.
     result = bom.commit(db, workspace_id=ws.id, user_id=user.id, project=project, payload=payload)
     return ok(result.model_dump())
-
-
-class MatchEntryIn(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    part_id: UUID
 
 
 @router.post("/{project_id}/entries/{entry_id}/match")

--- a/backend/app/api/routes/storage.py
+++ b/backend/app/api/routes/storage.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, Query, status
-from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import or_, select
 
 from app.api._helpers import require_resource_access
@@ -11,32 +10,13 @@ from app.core.deps import CurrentUser, CurrentWorkspace, DbSession
 from app.core.responses import ok
 from app.core.time import utcnow
 from app.domain.storage.models import StorageLocation
+from app.domain.storage.schemas import StorageIn, StoragePatch
 from app.domain.stock.service import (
     history_for_storage,
     stock_for_storage,
 )
 
 router = APIRouter()
-
-
-class StorageIn(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    name: str = Field(min_length=1, max_length=200)
-    description: str | None = None
-    single_part_only: bool = False
-    existing_parts_only: bool = False
-    is_full: bool = False
-
-
-class StoragePatch(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    name: str | None = None
-    description: str | None = None
-    single_part_only: bool | None = None
-    existing_parts_only: bool | None = None
-    is_full: bool | None = None
 
 
 def _serialize(s: StorageLocation) -> dict:

--- a/backend/app/api/routes/tags.py
+++ b/backend/app/api/routes/tags.py
@@ -3,22 +3,15 @@ from __future__ import annotations
 from uuid import UUID
 
 from fastapi import APIRouter, Query, status
-from pydantic import BaseModel, ConfigDict
 from sqlalchemy import select
 
 from app.api._helpers import assert_in_workspace, assert_polymorphic_in_workspace
 from app.core.deps import CurrentUser, CurrentWorkspace, DbSession
 from app.core.responses import ok
 from app.domain.tags.models import Tag, TagLink
+from app.domain.tags.schemas import TagIn, TagLinkIn
 
 router = APIRouter()
-
-
-class TagIn(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    name: str
-    color: str | None = None
 
 
 @router.get("")
@@ -44,14 +37,6 @@ def create(payload: TagIn, db: DbSession, ws: CurrentWorkspace, user: CurrentUse
     db.add(t)
     db.flush()
     return ok({"id": str(t.id), "name": t.name, "color": t.color})
-
-
-class TagLinkIn(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    tag_id: UUID
-    object_type: str
-    object_id: UUID
 
 
 @router.post("/links", status_code=status.HTTP_201_CREATED)

--- a/backend/app/api/routes/workspaces.py
+++ b/backend/app/api/routes/workspaces.py
@@ -4,11 +4,9 @@ import hashlib
 import hmac
 import secrets
 from datetime import datetime, timezone
-from typing import Literal
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Request, Response, status
-from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import select
 
 from app.core.config import settings
@@ -20,6 +18,7 @@ from app.core.secrets import decrypt, encrypt
 from app.domain.audit.service import log as _audit_log
 from app.domain.users.models import User
 from app.domain.workspaces.models import Workspace, WorkspaceCatalogToken, WorkspaceMember
+from app.domain.workspaces.schemas import CatalogTokenIn, MemberPatch, WorkspaceCreateIn, WorkspacePatch
 
 router = APIRouter()
 
@@ -28,13 +27,6 @@ router = APIRouter()
 # signup is `kind="personal"` and excluded so a user always has at
 # least one tenant. Everything beyond it (extra organisations) counts.
 _OWNED_ORG_WORKSPACE_CAP = 5
-
-
-class WorkspaceCreateIn(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    name: str = Field(min_length=1, max_length=200)
-    currency_default: str = "USD"
 
 
 @router.get("")
@@ -160,29 +152,6 @@ def current_scanner_license_key(ws: CurrentWorkspace):
     return ok({"license_key": decrypt(ws.scanner_license_key) or ""})
 
 
-class WorkspacePatch(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    name: str | None = Field(default=None, min_length=1, max_length=200)
-    currency_default: str | None = Field(default=None, min_length=3, max_length=3)
-    lot_control_enabled: bool | None = None
-    serial_tracking_enabled: bool | None = None
-    catalog_enabled: bool | None = None
-    # Write-only command flag: when true (and the catalog stays enabled), the
-    # route mints a fresh secrets.token_urlsafe(32) and stores it.
-    regenerate_catalog_token: bool | None = None
-    parts_provider: Literal["none", "mouser", "digikey"] | None = None
-    # Empty string clears the stored key; any other non-None value replaces it.
-    # None (omitted) leaves whatever's already stored alone.
-    parts_provider_api_key: str | None = None
-    # Same semantics as parts_provider_api_key. Used as DigiKey's
-    # client_secret; Mouser doesn't need it.
-    parts_provider_api_secret: str | None = None
-    scanner: Literal["zxing", "scandit"] | None = None
-    # Same '' clears / non-empty replaces / None leaves alone semantics.
-    scanner_license_key: str | None = None
-
-
 @router.patch("/current", dependencies=[Depends(require_role("admin"))])
 def patch_current(payload: WorkspacePatch, db: DbSession, ws: CurrentWorkspace, user: CurrentUser):
     data = payload.model_dump(exclude_unset=True)
@@ -275,12 +244,6 @@ def patch_current(payload: WorkspacePatch, db: DbSession, ws: CurrentWorkspace, 
 # ---------------------------------------------------------------------------
 # Catalog token CRUD (SEC2-019 / issue #77)
 # ---------------------------------------------------------------------------
-
-
-class CatalogTokenIn(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    label: str = Field(min_length=1, max_length=120)
 
 
 def _serialize_catalog_token(t: WorkspaceCatalogToken, plaintext: str | None = None) -> dict:
@@ -398,13 +361,6 @@ def list_members(db: DbSession, ws: CurrentWorkspace):
             for m, u in rows
         ]
     )
-
-
-class MemberPatch(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    role: Literal["owner", "admin", "member", "viewer"] | None = None
-    status: Literal["active", "disabled"] | None = None
 
 
 def _active_owner_count(db, ws_id):

--- a/backend/app/domain/custom_fields/schemas.py
+++ b/backend/app/domain/custom_fields/schemas.py
@@ -1,0 +1,28 @@
+"""Pydantic input schemas for the custom_fields domain (#252).
+
+Lifted out of `app/api/routes/custom_fields.py` so every domain has
+one canonical `domain/<x>/schemas.py`.
+
+Every input schema keeps `model_config = ConfigDict(extra="forbid")` —
+`tests/test_extra_forbid.py` regression-tests this and a silent drop
+would let unknown fields through.
+"""
+from __future__ import annotations
+
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+__all__ = [
+    "CustomFieldIn",
+]
+
+
+class CustomFieldIn(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    object_type: str
+    object_id: UUID
+    key: str = Field(min_length=1, max_length=256)
+    value: str | None = Field(default=None, max_length=1024)

--- a/backend/app/domain/lots/schemas.py
+++ b/backend/app/domain/lots/schemas.py
@@ -1,0 +1,38 @@
+"""Pydantic input schemas for the lots domain (#252).
+
+Lifted out of `app/api/routes/lots.py` so every domain has one
+canonical `domain/<x>/schemas.py`.
+
+Every input schema keeps `model_config = ConfigDict(extra="forbid")` —
+`tests/test_extra_forbid.py` regression-tests this and a silent drop
+would let unknown fields through.
+"""
+from __future__ import annotations
+
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+
+
+__all__ = [
+    "LotPatch",
+    "LotAdjustIn",
+]
+
+
+class LotPatch(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str | None = None
+    description: str | None = None
+    comments: str | None = None
+    expiration_date: str | None = None
+    serial_number: str | None = None
+
+
+class LotAdjustIn(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    actual_quantity: int
+    storage_location_id: UUID | None = None
+    comments: str | None = None

--- a/backend/app/domain/parts/schemas.py
+++ b/backend/app/domain/parts/schemas.py
@@ -31,6 +31,7 @@ __all__ = [
     "ScanImportRow",
     "ScanImportIn",
     "QuickRemoveBagIn",
+    "LookupIn",
 ]
 
 
@@ -154,3 +155,11 @@ class QuickRemoveBagIn(BaseModel):
     lot_id: UUID | None = None
     storage_location_id: UUID | None = None
     comments: str | None = Field(default=None, max_length=1000)
+
+
+# Provider lookup (#252 — lifted from app/api/routes/parts_provider.py)
+
+class LookupIn(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    mpn: str = Field(min_length=1, max_length=200)

--- a/backend/app/domain/projects/schemas.py
+++ b/backend/app/domain/projects/schemas.py
@@ -132,3 +132,27 @@ class BomImportCommitOut(BaseModel):
     inserted: int
     matched: int
     unmatched: int
+
+
+# BOM presets (#252 — lifted from app/api/routes/bom_presets.py)
+
+class PresetIn(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(min_length=1, max_length=200)
+    config: dict
+
+
+class PresetPatch(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str | None = None
+    config: dict | None = None
+
+
+# Project entry match (#252 — lifted from app/api/routes/projects.py)
+
+class MatchEntryIn(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    part_id: UUID

--- a/backend/app/domain/storage/schemas.py
+++ b/backend/app/domain/storage/schemas.py
@@ -1,0 +1,38 @@
+"""Pydantic input schemas for the storage domain (#252).
+
+Lifted out of `app/api/routes/storage.py` so every domain has one
+canonical `domain/<x>/schemas.py`.
+
+Every input schema keeps `model_config = ConfigDict(extra="forbid")` —
+`tests/test_extra_forbid.py` regression-tests this and a silent drop
+would let unknown fields through.
+"""
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+__all__ = [
+    "StorageIn",
+    "StoragePatch",
+]
+
+
+class StorageIn(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(min_length=1, max_length=200)
+    description: str | None = None
+    single_part_only: bool = False
+    existing_parts_only: bool = False
+    is_full: bool = False
+
+
+class StoragePatch(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str | None = None
+    description: str | None = None
+    single_part_only: bool | None = None
+    existing_parts_only: bool | None = None
+    is_full: bool | None = None

--- a/backend/app/domain/tags/schemas.py
+++ b/backend/app/domain/tags/schemas.py
@@ -1,0 +1,35 @@
+"""Pydantic input schemas for the tags domain (#252).
+
+Lifted out of `app/api/routes/tags.py` so every domain has one
+canonical `domain/<x>/schemas.py`.
+
+Every input schema keeps `model_config = ConfigDict(extra="forbid")` —
+`tests/test_extra_forbid.py` regression-tests this and a silent drop
+would let unknown fields through.
+"""
+from __future__ import annotations
+
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+
+
+__all__ = [
+    "TagIn",
+    "TagLinkIn",
+]
+
+
+class TagIn(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    color: str | None = None
+
+
+class TagLinkIn(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    tag_id: UUID
+    object_type: str
+    object_id: UUID

--- a/backend/app/domain/users/schemas.py
+++ b/backend/app/domain/users/schemas.py
@@ -1,0 +1,42 @@
+"""Pydantic input schemas for the users/auth domain (#252).
+
+Lifted out of `app/api/routes/auth.py` so every domain has one
+canonical `domain/<x>/schemas.py`.
+
+Every input schema keeps `model_config = ConfigDict(extra="forbid")` —
+`tests/test_extra_forbid.py` regression-tests this and a silent drop
+would let unknown fields through.
+"""
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, EmailStr, Field
+
+
+__all__ = [
+    "SignupIn",
+    "LoginIn",
+    "VerifyIn",
+]
+
+
+class SignupIn(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    email: EmailStr
+    name: str = Field(min_length=1, max_length=200)
+    password: str = Field(min_length=8, max_length=200)
+    workspace_name: str | None = None
+
+
+class LoginIn(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    email: EmailStr
+    password: str
+
+
+class VerifyIn(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    token: str

--- a/backend/app/domain/workspaces/schemas.py
+++ b/backend/app/domain/workspaces/schemas.py
@@ -1,0 +1,87 @@
+"""Pydantic input schemas for the workspaces domain (#252).
+
+Lifted out of `app/api/routes/workspaces.py` and
+`app/api/routes/invitations.py` so every domain has one canonical
+`domain/<x>/schemas.py`.
+
+Every input schema keeps `model_config = ConfigDict(extra="forbid")` —
+`tests/test_extra_forbid.py` regression-tests this and a silent drop
+would let unknown fields through.
+"""
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, EmailStr, Field
+
+
+__all__ = [
+    "WorkspaceCreateIn",
+    "WorkspacePatch",
+    "CatalogTokenIn",
+    "MemberPatch",
+    "InviteIn",
+    "AcceptIn",
+]
+
+
+class WorkspaceCreateIn(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(min_length=1, max_length=200)
+    currency_default: str = "USD"
+
+
+class WorkspacePatch(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str | None = Field(default=None, min_length=1, max_length=200)
+    currency_default: str | None = Field(default=None, min_length=3, max_length=3)
+    lot_control_enabled: bool | None = None
+    serial_tracking_enabled: bool | None = None
+    catalog_enabled: bool | None = None
+    # Write-only command flag: when true (and the catalog stays enabled), the
+    # route mints a fresh secrets.token_urlsafe(32) and stores it.
+    regenerate_catalog_token: bool | None = None
+    parts_provider: Literal["none", "mouser", "digikey"] | None = None
+    # Empty string clears the stored key; any other non-None value replaces it.
+    # None (omitted) leaves whatever's already stored alone.
+    parts_provider_api_key: str | None = None
+    # Same semantics as parts_provider_api_key. Used as DigiKey's
+    # client_secret; Mouser doesn't need it.
+    parts_provider_api_secret: str | None = None
+    scanner: Literal["zxing", "scandit"] | None = None
+    # Same '' clears / non-empty replaces / None leaves alone semantics.
+    scanner_license_key: str | None = None
+
+
+class CatalogTokenIn(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    label: str = Field(min_length=1, max_length=120)
+
+
+class MemberPatch(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    role: Literal["owner", "admin", "member", "viewer"] | None = None
+    status: Literal["active", "disabled"] | None = None
+
+
+class InviteIn(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    email: EmailStr
+    role: Literal["admin", "member", "viewer"] = "member"
+
+
+class AcceptIn(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    # SEC2-013: the token field now carries a composite value of the form
+    # "{invitation_id}:{plaintext_token}", produced by _serialize().  The
+    # accept handler splits on the first ":" to obtain the PK (for the
+    # DB lookup) and the plaintext (for HMAC comparison).  This keeps the
+    # frontend interface to a single opaque string while allowing a
+    # constant-time comparison path.
+    token: str


### PR DESCRIPTION
Closes #252

## Summary
- Extract 20 inline BaseModel classes from 10 routers to domain schemas.py files
- Creates 6 new domain schemas.py files: `users`, `workspaces`, `storage`, `lots`, `tags`, `custom_fields`
- Extends existing `parts/schemas.py` (adds `LookupIn`) and `projects/schemas.py` (adds `PresetIn`, `PresetPatch`, `MatchEntryIn`)
- Pure refactor — no field renames, no validator changes, no behaviour change

## Tests
Backend: 692 passed, 2 skipped, 1 xfailed

🤖 Generated with [Claude Code](https://claude.com/claude-code)