### PR TITLE
docs: add PR template and CONTRIBUTING.md to prevent step-1/N orphan pattern (#258)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+## Summary
+
+<!-- 1–3 bullet points describing what this PR does and why -->
+
+## Test plan
+
+- [ ] Relevant backend tests pass (`pytest`)
+- [ ] Frontend builds without errors (`npm run build`)
+- [ ] Manual smoke test performed (describe below if relevant)
+
+## Multi-step issues
+
+- [ ] If this PR is labelled "step 1/N", "PR 1 of N", or "part 1", either:
+  - a follow-up issue is filed and linked below (`Refs #N`), **or**
+  - the PR title uses `Refs #N` instead of `Closes #N` (so the issue stays open)
+
+Follow-up issue(s): <!-- e.g. Refs #123 -->
+
+## Breaking changes
+
+- [ ] No breaking changes
+- [ ] Breaking change — describe migration path below
+
+<!-- Breaking change details if applicable -->
+
+---
+
+🤖 Generated with [Claude Code](https://claude.ai/claude-code)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,6 +173,10 @@ them, that's the bug.
   without the token produce no `.map` files, so the Docker build cache is
   clean. The `find -name '*.map' -delete` in `web/Dockerfile.prod` remains
   as belt-and-braces for edge-case local builds.
+- **"Step 1 of N" PRs must not close the parent issue.** Using `Closes #N`
+  on a partial PR auto-closes the issue the moment the PR merges, leaving the
+  remaining steps with no tracking. Use `Refs #N` instead, or file a follow-up
+  issue and link it. Full rule in `CONTRIBUTING.md` (multi-step issues rule).
 
 ## Frontend conventions worth preserving
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing
+
+## Filing an issue
+
+- Search existing issues first to avoid duplicates.
+- Use a clear title. If the fix will need multiple PRs, say so upfront (e.g. "Step 1 of 2: …") and describe all planned steps in the body.
+- Attach labels (`area:`, `complexity:`, `priority:`) if you have triage access; otherwise leave it for maintainers.
+
+## Opening a pull request
+
+1. Branch from `main`. Use the naming pattern `fix/issue-NNN-short-description` or `feat/issue-NNN-short-description`.
+2. Fill in the PR template (`.github/PULL_REQUEST_TEMPLATE.md`). The test plan and multi-step checkbox are mandatory.
+3. Run `pytest` (backend) and `npm run build` (frontend) before marking the PR ready for review.
+4. Add screenshots for any visible UI changes.
+5. Link the issue: use `Closes #N` if this PR fully resolves it, or `Refs #N` if further work remains.
+
+## Multi-step issues rule
+
+When a PR title or description contains "step 1", "PR 1 of", or "part 1" (case-insensitive), you **must** do one of the following before the PR is merged:
+
+- **Option A** — File a follow-up issue for the remaining steps and include `Refs #N` (the follow-up issue) in the PR description. The original issue stays open until all steps land.
+- **Option B** — Use `Refs #N` (the original issue) instead of `Closes #N` in the PR body so the issue is not auto-closed.
+
+Do **not** use `Closes #N` on a step-1 PR unless all remaining steps are also included in that PR. Auto-closing an issue after only the first step lands leaves the work permanently orphaned with no visible signal.
+
+## Closes vs Refs
+
+| Keyword | Effect on the issue |
+|---------|---------------------|
+| `Closes #N` | Issue is closed automatically when the PR merges |
+| `Fixes #N` | Same as Closes |
+| `Refs #N` | Issue is linked but stays open |
+
+Use `Refs #N` whenever the issue requires more than one PR to fully resolve.


### PR DESCRIPTION
Closes #258

## Summary

- Add `.github/PULL_REQUEST_TEMPLATE.md` with a multi-step checklist requiring authors to confirm follow-up issues are filed or `Refs #N` is used instead of `Closes #N`
- Add `CONTRIBUTING.md` with issue-filing guidance, PR workflow, the multi-step issues rule, and a `Closes` vs `Refs` reference table
- Add a bullet to `CLAUDE.md` under "Things that have bitten us" pointing at the rule in `CONTRIBUTING.md`

## Tests

Backend: N/A
Frontend: N/A