### PR TITLE
docs: document /api/health response shapes in deployment.md (#255)

### DIFF
--- a/backend/tests/test_deploy_doc_snippets.py
+++ b/backend/tests/test_deploy_doc_snippets.py
@@ -1,10 +1,12 @@
-"""Regression test: psql snippets in docs/deployment.md must expand
-$POSTGRES_USER / $POSTGRES_DB inside the container, not the host shell.
+"""Regression tests: docs/deployment.md content assertions.
 
-Any line in deployment.md that contains `psql -U "$POSTGRES_USER"` must be
-wrapped in a `sh -c '...'` invocation so the variable references are
-evaluated by the shell running inside the container, where those variables
-are actually set by the postgres image.
+1. psql snippets must expand $POSTGRES_USER / $POSTGRES_DB inside the
+   container, not the host shell. Any line that contains
+   `psql -U "$POSTGRES_USER"` must be wrapped in a `sh -c '...'` invocation.
+
+2. The Health endpoint section must document the two actual runtime checks
+   performed by `GET /api/health` (SELECT 1 DB probe + UPLOAD_DIR write
+   check) and must show both the 200 and 503 response shapes.
 """
 
 import pathlib
@@ -38,4 +40,59 @@ def test_psql_snippets_wrapped_in_sh_c() -> None:
         "outside of a sh -c wrapper. Variables expand on the host shell, not inside "
         "the container.\n"
         + "\n".join(violations)
+    )
+
+
+def test_health_endpoint_section_exists() -> None:
+    """docs/deployment.md must contain a ## Health endpoint section."""
+    assert DEPLOYMENT_MD.exists(), f"{DEPLOYMENT_MD} not found"
+    text = DEPLOYMENT_MD.read_text()
+    assert "## Health endpoint" in text, (
+        "docs/deployment.md is missing a '## Health endpoint' section. "
+        "Add it to document the /api/health response shapes."
+    )
+
+
+def test_health_endpoint_documents_select1() -> None:
+    """The Health endpoint section must mention the SELECT 1 DB probe."""
+    assert DEPLOYMENT_MD.exists(), f"{DEPLOYMENT_MD} not found"
+    text = DEPLOYMENT_MD.read_text()
+    assert "SELECT 1" in text, (
+        "docs/deployment.md does not mention 'SELECT 1'. "
+        "The health handler runs SELECT 1 via SQLAlchemy — document it."
+    )
+
+
+def test_health_endpoint_documents_upload_dir() -> None:
+    """The Health endpoint section must mention the UPLOAD_DIR write check."""
+    assert DEPLOYMENT_MD.exists(), f"{DEPLOYMENT_MD} not found"
+    text = DEPLOYMENT_MD.read_text()
+    assert "UPLOAD_DIR" in text, (
+        "docs/deployment.md does not mention 'UPLOAD_DIR'. "
+        "The health handler checks os.access(UPLOAD_DIR, os.W_OK) — document it."
+    )
+
+
+def test_health_endpoint_documents_503_shape() -> None:
+    """The Health endpoint section must document the 503 response body."""
+    assert DEPLOYMENT_MD.exists(), f"{DEPLOYMENT_MD} not found"
+    text = DEPLOYMENT_MD.read_text()
+    # The 503 response must show the envelope structure: data null + status category
+    assert '"data": null' in text or '"data":null' in text, (
+        "docs/deployment.md does not show '\"data\": null' in the 503 example. "
+        "The 503 response is envelope-wrapped with data: null."
+    )
+    assert "server_error" in text, (
+        "docs/deployment.md does not mention 'server_error' category. "
+        "503 responses use category 'server_error' in the envelope."
+    )
+
+
+def test_health_endpoint_documents_200_shape() -> None:
+    """The Health endpoint section must document the 200 response body."""
+    assert DEPLOYMENT_MD.exists(), f"{DEPLOYMENT_MD} not found"
+    text = DEPLOYMENT_MD.read_text()
+    assert '"status": "ok"' in text or '"status":"ok"' in text, (
+        "docs/deployment.md does not show '\"status\": \"ok\"' in the 200 example. "
+        "The 200 data payload contains {status: ok, db: ok, uploads: ok}."
     )

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -11,6 +11,7 @@ document covers:
 - [CI/CD details](#cicd-details) — secrets, jobs, gating.
 - [Operations](#operations) — logs, psql, alembic, env changes, rollback.
 - [Backups](#backups).
+- [Health endpoint](#health-endpoint) — response shapes for `GET /api/health`.
 
 The dev compose (`docker-compose.dev.yml`) is unsuitable for production: it ships
 uvicorn `--reload`, the Vite dev server, and will refuse to start without a
@@ -177,6 +178,8 @@ unless you're rebuilding the host, or migrating to a fresh VPS.
    sudo -u deploy docker compose -f docker-compose.prod.yml \
        --env-file .env.prod up -d --build
    curl -fsS http://127.0.0.1:8091/api/health
+   # 200 → {"data":{"status":"ok","db":"ok","uploads":"ok"},...}
+   # 503 → structured body; see ## Health endpoint below
    ```
 
 6. **Add the Apache vhost.**
@@ -187,6 +190,8 @@ unless you're rebuilding the host, or migrating to a fresh VPS.
    a2ensite parts.matescb.cz
    apache2ctl configtest && systemctl reload apache2
    curl -fsS -H "Host: parts.matescb.cz" http://127.0.0.1/api/health
+   # 200 → {"data":{"status":"ok","db":"ok","uploads":"ok"},...}
+   # 503 → structured body; see ## Health endpoint below
    ```
 
 7. **Issue the TLS cert.** Certbot edits the :80 vhost in place to add a
@@ -197,6 +202,8 @@ unless you're rebuilding the host, or migrating to a fresh VPS.
    certbot --apache -d parts.matescb.cz \
        --non-interactive --agree-tos -m matyas.skvor@gmail.com --redirect
    curl -fsS https://parts.matescb.cz/api/health
+   # 200 → {"data":{"status":"ok","db":"ok","uploads":"ok"},...}
+   # 503 → structured body; see ## Health endpoint below
    ```
 
    Renewal is automated by the certbot systemd timer that ships with the
@@ -533,6 +540,8 @@ sudo apache2ctl configtest && sudo systemctl reload apache2
 # 3. Verify: browsing the site shows the maintenance page;
 #    /api/health still returns 200.
 curl -s https://parts.matescb.cz/api/health
+# 200 → {"data":{"status":"ok","db":"ok","uploads":"ok"},...}
+# 503 → structured body; see ## Health endpoint below
 ```
 
 **Take a pre-migration snapshot**
@@ -571,6 +580,8 @@ sudo apache2ctl configtest && sudo systemctl reload apache2
 
 ```bash
 curl -s https://parts.matescb.cz/api/health
+# 200 → {"data":{"status":"ok","db":"ok","uploads":"ok"},...}
+# 503 → structured body; see ## Health endpoint below
 ```
 
 ### If you ever move TLS into the docker stack
@@ -783,12 +794,9 @@ Configure an external uptime check on [UptimeRobot](https://uptimerobot.com)
 | TLS expiry      | Enable if the plan includes it (catches cert renewal failure) |
 
 **What this catches:** host-down, TLS-broken, Apache-crashed,
-container-crashed (any of these stops the HTTP response returning 200).
-
-**What this does NOT catch:** DB unreachable while the process is alive.
-The `/api/health` endpoint is currently shallow — it only confirms the
-process responds. Deepening it (e.g. a test DB query) is tracked in
-INFRA2-002 (#95).
+container-crashed, DB unreachable, and uploads volume not writable (any of
+these causes `/api/health` to return 503). See [Health endpoint](#health-endpoint)
+for the full response shapes.
 
 **Credentials:** store the UptimeRobot login in the same secrets escrow
 as other SaaS credentials (see #95 — secret rotation runbook). Do not put
@@ -797,7 +805,74 @@ them in `.env.prod` or the repo.
 **Planned maintenance:** pause the monitor from the UptimeRobot dashboard
 before triggering a deploy that causes a longer-than-usual restart (e.g.
 a heavy migration). Resume it once `curl -fsS https://parts.matescb.cz/api/health`
-returns 200.
+returns 200 (200 body: `{"data":{"status":"ok","db":"ok","uploads":"ok"},...}`; 503
+returns a structured body — see [Health endpoint](#health-endpoint)).
+
+## Health endpoint
+
+`GET /api/health` is the single liveness + readiness probe for the stack.
+It runs two checks synchronously:
+
+1. **Database**: executes `SELECT 1` via the SQLAlchemy engine. Any exception
+   (connection refused, auth failure, timeout) marks the check failed and
+   surfaces the Python exception class name in the response.
+2. **Uploads volume**: calls `os.access(UPLOAD_DIR, os.W_OK)` to confirm the
+   volume is mounted and the process can write to it.
+
+Both checks must pass for a 200 response.
+
+### 200 — healthy
+
+```json
+{
+  "data": { "status": "ok", "db": "ok", "uploads": "ok" },
+  "status": { "category": "ok", "message": "OK" }
+}
+```
+
+### 503 — unhealthy
+
+The `detail` dict is spread by `core/responses.py::http_exception_handler`
+onto the standard `{data: null, status: {...}}` envelope. Example where the
+DB is unreachable:
+
+```json
+{
+  "data": null,
+  "status": {
+    "category": "server_error",
+    "message": "service unhealthy"
+  },
+  "db": "error: OperationalError",
+  "uploads": "ok"
+}
+```
+
+Example where the uploads volume is missing or read-only (DB is fine):
+
+```json
+{
+  "data": null,
+  "status": {
+    "category": "server_error",
+    "message": "service unhealthy"
+  },
+  "db": "ok",
+  "uploads": "not writable: /data/uploads"
+}
+```
+
+The `db` field is either `"ok"` or `"error: <ExceptionClassName>"`.
+The `uploads` field is either `"ok"` or `"not writable: <path>"`.
+
+### Callers
+
+| Caller | Notes |
+|--------|-------|
+| `docker-compose.prod.yml` healthcheck | Controls when the `web` container starts; determines `docker compose ps` status for the `backend` service. |
+| Post-deploy CI gate | `curl /api/health` retried in the deploy script so a failed migration, missing env var, or DB outage fails the deploy job rather than returning a green CI result on a broken prod. |
+| UptimeRobot external monitor | 5-minute interval; see [Monitoring](#monitoring). |
+| Manual smoke | Run `curl -fsS https://parts.matescb.cz/api/health` after any operator-driven change to confirm the stack is healthy. |
 
 ## Base image pinning (INFRA2-015)
 


### PR DESCRIPTION
Closes #255

## Summary
- Add `## Health endpoint` section to `docs/deployment.md` documenting the two runtime checks (`SELECT 1` via SQLAlchemy engine + `os.access(UPLOAD_DIR, os.W_OK)`), the 200 success body and 503 error body (both envelope-wrapped in `{data, status}`), and a callers table (docker-compose healthcheck, post-deploy CI gate, UptimeRobot, manual smoke)
- Fix stale "shallow" claim in the `## Monitoring` section — the endpoint has been deep since PR #29
- Annotate all 6 existing `curl .../api/health` lines in the doc with inline 200/503 shape hints
- Extend `backend/tests/test_deploy_doc_snippets.py` with 5 substring assertions that pin the new section content against the actual handler in `backend/app/main.py`

## Tests
Backend: 697 passed, 2 skipped, 1 xfailed (full suite green)
Frontend: N/A (doc-only change)