### PR TITLE
fix(fe): sweep remaining useQuery callsites for error handling (#245)

### DIFF
--- a/web/src/components/AttachmentsPanel.tsx
+++ b/web/src/components/AttachmentsPanel.tsx
@@ -5,6 +5,7 @@ import { Trash2, Download, UploadCloud, Paperclip } from "lucide-react";
 import { api, ApiError } from "@/lib/api";
 import { useWsKey } from "@/lib/queryKeys";
 import { useConfirm } from "@/components/ConfirmDialog";
+import { InlineQueryError } from "@/components/QueryStateBoundary";
 import { formatDateTime } from "@/lib/format";
 
 type Attachment = {
@@ -123,11 +124,12 @@ export default function AttachmentsPanel({ objectType, objectId, canWrite }: Pro
   const confirm = useConfirm();
   const qc = useQueryClient();
   const queryKey = useWsKey("attachments", objectType, objectId);
-  const { data, isLoading } = useQuery({
+  const attachmentsQuery = useQuery({
     queryKey,
     queryFn: () =>
       api.get<Attachment[]>(`/attachments/by-object/${objectType}/${objectId}`),
   });
+  const { data, isLoading, isError } = attachmentsQuery;
 
   const [file, setFile] = useState<File | null>(null);
   const [fileType, setFileType] = useState<FileType>("other");
@@ -272,7 +274,9 @@ export default function AttachmentsPanel({ objectType, objectId, canWrite }: Pro
         </div>
       )}
 
-      {isLoading ? (
+      {isError ? (
+        <InlineQueryError query={attachmentsQuery} label="attachments" />
+      ) : isLoading ? (
         <div className="text-muted text-sm">Loading…</div>
       ) : !data || data.length === 0 ? (
         <div className="text-muted text-sm">No attachments yet.</div>

--- a/web/src/components/CommandPalette.tsx
+++ b/web/src/components/CommandPalette.tsx
@@ -15,6 +15,7 @@ import {
 } from "lucide-react";
 import { api } from "@/lib/api";
 import { useWsKey } from "@/lib/queryKeys";
+import { InlineQueryError } from "@/components/QueryStateBoundary";
 
 type SearchData = {
   parts: { id: string; name: string; mpn: string | null }[];
@@ -45,12 +46,13 @@ export default function CommandPalette() {
     };
   }, []);
 
-  const { data: results } = useQuery({
+  const searchQuery = useQuery({
     queryKey: useWsKey("cp-search", q),
     queryFn: () => api.get<SearchData>(`/search?q=${encodeURIComponent(q)}`),
     enabled: open && q.trim().length >= 2,
     staleTime: 30_000,
   });
+  const { data: results } = searchQuery;
 
   function go(href: string) {
     setOpen(false);
@@ -66,6 +68,11 @@ export default function CommandPalette() {
         placeholder="Type to search or jump…"
       />
       <Command.List>
+        {searchQuery.isError && (
+          <div className="p-2">
+            <InlineQueryError query={searchQuery} label="search results" />
+          </div>
+        )}
         <Command.Empty>
           {q.trim().length >= 2 ? "No matches." : "Start typing to search…"}
         </Command.Empty>

--- a/web/src/components/QueryStateBoundary.tsx
+++ b/web/src/components/QueryStateBoundary.tsx
@@ -16,12 +16,22 @@ import { ApiError } from "@/lib/api";
  * banner for 401 because the redirect is happening anyway and a
  * flash of "couldn't load" would confuse the user mid-bounce.
  */
-type QueryLike = {
+export type QueryLike = {
   isError: boolean;
   error: unknown;
   refetch: () => unknown;
   isFetching: boolean;
 };
+
+function is401(err: unknown): boolean {
+  return err instanceof ApiError && err.status === 401;
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof ApiError) return err.userMessage;
+  if (err instanceof Error) return err.message;
+  return "Unknown error";
+}
 
 export default function QueryStateBoundary({
   query,
@@ -32,15 +42,13 @@ export default function QueryStateBoundary({
   resourceLabel: string;
   children: ReactNode;
 }) {
-  const is401 = query.error instanceof ApiError && query.error.status === 401;
-  if (query.isError && !is401) {
-    const msg = query.error instanceof Error ? query.error.message : "Unknown error";
+  if (query.isError && !is401(query.error)) {
     return (
       <div className="card p-4 flex items-start gap-3 text-sm">
         <AlertTriangle size={18} className="text-warning shrink-0 mt-0.5" />
         <div className="flex-1">
           <div className="font-medium text-text">Couldn't load {resourceLabel}.</div>
-          <div className="text-muted mt-0.5">{msg}</div>
+          <div className="text-muted mt-0.5">{errorMessage(query.error)}</div>
         </div>
         <button
           type="button"
@@ -54,4 +62,47 @@ export default function QueryStateBoundary({
     );
   }
   return <>{children}</>;
+}
+
+/**
+ * Inline error pill for panels that mix an action surface with a query
+ * (e.g. AttachmentsPanel, PartSettings, BuildCreate). Unlike
+ * `QueryStateBoundary`, this does NOT short-circuit the surrounding
+ * subtree — it only renders in place of the data block, leaving
+ * whatever action UI surrounds it interactive.
+ *
+ * Returns `null` when the query has no error or when the error is a
+ * 401 (handled by the global auth bus in main.tsx — same rule as
+ * `QueryStateBoundary`).
+ */
+export function InlineQueryError({
+  query,
+  label,
+  className,
+}: {
+  query: QueryLike;
+  label: string;
+  className?: string;
+}) {
+  if (!query.isError || is401(query.error)) return null;
+  return (
+    <div
+      role="alert"
+      className={`card p-2 text-sm flex items-center gap-2 border-danger/40 ${className ?? ""}`}
+    >
+      <AlertTriangle size={14} className="text-danger shrink-0" />
+      <span className="flex-1">
+        <span className="font-medium">Couldn't load {label}.</span>{" "}
+        <span className="text-muted">{errorMessage(query.error)}</span>
+      </span>
+      <button
+        type="button"
+        className="btn text-xs"
+        disabled={query.isFetching}
+        onClick={() => query.refetch()}
+      >
+        {query.isFetching ? "Retrying…" : "Retry"}
+      </button>
+    </div>
+  );
 }

--- a/web/src/components/__dom__/AttachmentsPanel.dom.test.tsx
+++ b/web/src/components/__dom__/AttachmentsPanel.dom.test.tsx
@@ -1,0 +1,159 @@
+/**
+ * DOM tests for AttachmentsPanel error handling (#245 round 2).
+ *
+ * Pinned regression: pre-fix, a failed attachments fetch (5xx) rendered
+ * the "No attachments yet." empty state, indistinguishable from a real
+ * empty list (the symptom called out in issue #245). The fix routes the
+ * error branch through `InlineQueryError`; the upload affordance must
+ * stay interactive while the list region shows the pill so the user can
+ * still attempt to upload (the data fetch may be flaky for unrelated
+ * reasons that don't block writes).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+// `useWsKey` reads `useAuth()` at render time. Stub it so the test
+// doesn't need the full AuthProvider stack (which itself pulls
+// react-router + Sentry).
+vi.mock("@/lib/auth", () => ({
+  useAuth: () => ({
+    me: null,
+    loading: false,
+    refresh: () => Promise.resolve(),
+    logout: () => Promise.resolve(),
+    workspaceId: "ws-test",
+    switchWorkspace: () => Promise.resolve(),
+  }),
+}));
+
+// ConfirmDialog uses portals — stub `useConfirm` to a no-op so render
+// stays stable.
+vi.mock("@/components/ConfirmDialog", () => ({
+  useConfirm: () => () => Promise.resolve(false),
+}));
+
+import { api, ApiError } from "@/lib/api";
+import AttachmentsPanel from "../AttachmentsPanel";
+
+beforeEach(() => {
+  cleanup();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function makeClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+}
+
+function Wrapper({ children, client }: { children: React.ReactNode; client: QueryClient }) {
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe("AttachmentsPanel — error handling", () => {
+  it("renders the inline error pill on a 5xx (not the empty state)", async () => {
+    vi.spyOn(api, "get").mockRejectedValueOnce(
+      new ApiError(
+        503,
+        { data: null, status: { category: "server_error", message: "Backend down" } },
+        "Backend down",
+      ),
+    );
+    const client = makeClient();
+
+    render(
+      <Wrapper client={client}>
+        <AttachmentsPanel objectType="part" objectId="part-1" canWrite={true} />
+      </Wrapper>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeDefined();
+    });
+
+    // The empty-state copy must NOT be present — that's the regression.
+    expect(screen.queryByText(/no attachments yet/i)).toBeNull();
+    // The error pill should mention "attachments" so the user knows
+    // what failed.
+    expect(screen.getByRole("alert").textContent?.toLowerCase()).toContain("attachments");
+    // A retry affordance is present.
+    expect(screen.getByRole("button", { name: /retry/i })).toBeDefined();
+  });
+
+  it("keeps the upload controls in the DOM while the list region shows the pill", async () => {
+    vi.spyOn(api, "get").mockRejectedValueOnce(
+      new ApiError(
+        500,
+        { data: null, status: { category: "server_error", message: "Boom" } },
+        "Boom",
+      ),
+    );
+    const client = makeClient();
+
+    render(
+      <Wrapper client={client}>
+        <AttachmentsPanel objectType="part" objectId="part-1" canWrite={true} />
+      </Wrapper>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeDefined();
+    });
+
+    // Upload affordance still rendered: the file input, the type
+    // dropdown, and the Upload button are all present so the user can
+    // still attempt a write while the read failed.
+    expect(screen.getByLabelText(/^file$/i)).toBeDefined();
+    expect(screen.getByLabelText(/^type$/i)).toBeDefined();
+    expect(screen.getByRole("button", { name: /upload/i })).toBeDefined();
+  });
+
+  it("shows the empty state (no error pill) when the list is genuinely empty", async () => {
+    vi.spyOn(api, "get").mockResolvedValueOnce([]);
+    const client = makeClient();
+
+    render(
+      <Wrapper client={client}>
+        <AttachmentsPanel objectType="part" objectId="part-1" canWrite={true} />
+      </Wrapper>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/no attachments yet/i)).toBeDefined();
+    });
+    // Crucially, no alert role is rendered — empty list is NOT an error.
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("does not render the pill on a 401 (auth bus handles redirect)", async () => {
+    vi.spyOn(api, "get").mockRejectedValueOnce(
+      new ApiError(
+        401,
+        { data: null, status: { category: "unauthenticated", message: "Session expired" } },
+        "Session expired",
+      ),
+    );
+    const client = makeClient();
+
+    render(
+      <Wrapper client={client}>
+        <AttachmentsPanel objectType="part" objectId="part-1" canWrite={true} />
+      </Wrapper>,
+    );
+
+    // Wait for the query to settle (it errored, so isError=true). The
+    // pill suppresses 401 because the global QueryCache.onError fires
+    // the auth bus and redirects to /login — flashing "couldn't load"
+    // mid-bounce would confuse the user.
+    await waitFor(() => {
+      // The query has settled into the error branch — the empty state
+      // copy is gone, but the alert is suppressed.
+      expect(screen.queryByText(/loading…/i)).toBeNull();
+    });
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+});

--- a/web/src/components/__dom__/QueryStateBoundary.dom.test.tsx
+++ b/web/src/components/__dom__/QueryStateBoundary.dom.test.tsx
@@ -1,0 +1,169 @@
+/**
+ * DOM tests for QueryStateBoundary + InlineQueryError (#245 round 2).
+ *
+ * Pinned behaviours:
+ *  - Renders children when `isError=false`
+ *  - Renders error card on a non-401 error
+ *  - Renders children (no error card) on 401 — the global auth bus is
+ *    already redirecting, a flash of "couldn't load" mid-bounce would
+ *    confuse the user (CLAUDE.md: 401 is handled centrally)
+ *  - Retry triggers `query.refetch()`
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { ApiError } from "@/lib/api";
+import QueryStateBoundary, { InlineQueryError, type QueryLike } from "../QueryStateBoundary";
+
+beforeEach(() => {
+  cleanup();
+});
+
+function makeQuery(overrides: Partial<QueryLike> = {}): QueryLike {
+  return {
+    isError: false,
+    error: null,
+    refetch: () => undefined,
+    isFetching: false,
+    ...overrides,
+  };
+}
+
+describe("QueryStateBoundary", () => {
+  it("renders children when the query has no error", () => {
+    render(
+      <QueryStateBoundary query={makeQuery()} resourceLabel="parts">
+        <div>visible content</div>
+      </QueryStateBoundary>,
+    );
+    expect(screen.getByText("visible content")).toBeDefined();
+  });
+
+  it("renders the error card when the query errored (non-401)", () => {
+    const q = makeQuery({
+      isError: true,
+      error: new ApiError(
+        500,
+        { data: null, status: { category: "server_error", message: "boom" } },
+        "boom",
+      ),
+    });
+    render(
+      <QueryStateBoundary query={q} resourceLabel="parts">
+        <div>hidden content</div>
+      </QueryStateBoundary>,
+    );
+    expect(screen.queryByText("hidden content")).toBeNull();
+    expect(screen.getByText(/couldn't load parts/i)).toBeDefined();
+    expect(screen.getByRole("button", { name: /retry/i })).toBeDefined();
+  });
+
+  it("falls through to children on a 401 (global auth bus handles redirect)", () => {
+    const q = makeQuery({
+      isError: true,
+      error: new ApiError(
+        401,
+        { data: null, status: { category: "unauthenticated", message: "expired" } },
+        "expired",
+      ),
+    });
+    render(
+      <QueryStateBoundary query={q} resourceLabel="parts">
+        <div>still visible</div>
+      </QueryStateBoundary>,
+    );
+    expect(screen.getByText("still visible")).toBeDefined();
+    expect(screen.queryByText(/couldn't load/i)).toBeNull();
+  });
+
+  it("Retry button calls query.refetch()", () => {
+    const refetch = vi.fn();
+    const q = makeQuery({
+      isError: true,
+      error: new Error("boom"),
+      refetch,
+    });
+    render(
+      <QueryStateBoundary query={q} resourceLabel="parts">
+        <div />
+      </QueryStateBoundary>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /retry/i }));
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables Retry while isFetching", () => {
+    const q = makeQuery({
+      isError: true,
+      error: new Error("boom"),
+      isFetching: true,
+    });
+    render(
+      <QueryStateBoundary query={q} resourceLabel="parts">
+        <div />
+      </QueryStateBoundary>,
+    );
+    const btn = screen.getByRole("button", { name: /retrying…/i }) as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+  });
+});
+
+describe("InlineQueryError", () => {
+  it("renders nothing when isError=false", () => {
+    const { container } = render(
+      <InlineQueryError query={makeQuery()} label="storage locations" />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the pill on a non-401 error", () => {
+    const q = makeQuery({
+      isError: true,
+      error: new ApiError(
+        500,
+        { data: null, status: { category: "server_error", message: "boom" } },
+        "boom",
+      ),
+    });
+    render(<InlineQueryError query={q} label="storage locations" />);
+    const alert = screen.getByRole("alert");
+    expect(alert).toBeDefined();
+    expect(alert.textContent?.toLowerCase()).toContain("storage locations");
+    expect(screen.getByRole("button", { name: /retry/i })).toBeDefined();
+  });
+
+  it("renders nothing on a 401 (global auth bus handles redirect)", () => {
+    const q = makeQuery({
+      isError: true,
+      error: new ApiError(
+        401,
+        { data: null, status: { category: "unauthenticated", message: "expired" } },
+        "expired",
+      ),
+    });
+    const { container } = render(<InlineQueryError query={q} label="storage" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("Retry button calls query.refetch()", () => {
+    const refetch = vi.fn();
+    const q = makeQuery({
+      isError: true,
+      error: new Error("boom"),
+      refetch,
+    });
+    render(<InlineQueryError query={q} label="storage" />);
+    fireEvent.click(screen.getByRole("button", { name: /retry/i }));
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables Retry while isFetching", () => {
+    const q = makeQuery({
+      isError: true,
+      error: new Error("boom"),
+      isFetching: true,
+    });
+    render(<InlineQueryError query={q} label="storage" />);
+    const btn = screen.getByRole("button", { name: /retrying…/i }) as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+  });
+});

--- a/web/src/components/scanner/Scanner.tsx
+++ b/web/src/components/scanner/Scanner.tsx
@@ -2,6 +2,7 @@ import { lazy, Suspense } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api";
 import { useWsKey } from "@/lib/queryKeys";
+import { InlineQueryError } from "@/components/QueryStateBoundary";
 
 type WsScanner = {
   scanner: "zxing" | "scandit";
@@ -40,11 +41,19 @@ const ScanditScanner = lazy(() => import("./ScanditScanner"));
 export default function Scanner({ onScan, className, symbologies }: Props) {
   // Same query key as Settings → Workspace, so the cache is shared across
   // scanner mounts and the settings page.
-  const { data: ws, isLoading } = useQuery({
+  const wsQuery = useQuery({
     queryKey: useWsKey("ws", "current"),
     queryFn: () => api.get<WsScanner>("/workspaces/current"),
   });
+  const { data: ws, isLoading, isError } = wsQuery;
 
+  if (isError) {
+    return (
+      <div className={className}>
+        <InlineQueryError query={wsQuery} label="scanner config" />
+      </div>
+    );
+  }
   if (isLoading || !ws) {
     return <div className={className}>Loading scanner…</div>;
   }

--- a/web/src/routes/builds/BuildCreate.tsx
+++ b/web/src/routes/builds/BuildCreate.tsx
@@ -4,6 +4,7 @@ import { useQuery } from "@tanstack/react-query";
 import { api, ApiError } from "@/lib/api";
 import { useApiMutation } from "@/lib/mutations";
 import { useWsKey } from "@/lib/queryKeys";
+import { InlineQueryError } from "@/components/QueryStateBoundary";
 import type { Build, Project } from "@/types";
 
 type BuildCreatePayload = {
@@ -16,10 +17,11 @@ type BuildCreatePayload = {
 export default function BuildCreate() {
   const nav = useNavigate();
   const [params] = useSearchParams();
-  const { data: projects } = useQuery({
+  const projectsQuery = useQuery({
     queryKey: useWsKey("projects"),
     queryFn: () => api.get<Project[]>("/projects"),
   });
+  const { data: projects } = projectsQuery;
   const [name, setName] = useState("");
   const [projectId, setProjectId] = useState(params.get("project_id") ?? "");
   const [qty, setQty] = useState(1);
@@ -54,6 +56,7 @@ export default function BuildCreate() {
     <form onSubmit={submit} className="card p-4 max-w-2xl space-y-3">
       <h3 className="text-md font-semibold">New build</h3>
       {err && <div className="text-danger text-sm">{err}</div>}
+      <InlineQueryError query={projectsQuery} label="projects" />
       <div>
         <label className="label" htmlFor="build-create-name">Name *</label>
         <input id="build-create-name" className="input" required value={name} onChange={e => setName(e.target.value)} placeholder="BUILD-2026-001" />

--- a/web/src/routes/parts/PartCreate.tsx
+++ b/web/src/routes/parts/PartCreate.tsx
@@ -6,6 +6,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useWsKey } from "@/lib/queryKeys";
 import type { MpnLookupResult, ProviderSpec, StorageLocation } from "@/types";
 import MpnLookup from "@/components/MpnLookup";
+import { InlineQueryError } from "@/components/QueryStateBoundary";
 
 /**
  * Mirror of `backend/app/api/routes/_parts_shared.py::PartIn`.
@@ -58,7 +59,8 @@ export default function PartCreate() {
   // an inline banner instead of silently swallowing the error. The part
   // is valid — just missing provider-side fields — so we never DELETE it.
   const [refreshFailed, setRefreshFailed] = useState<{ partId: string } | null>(null);
-  const { data: storage } = useQuery({ queryKey: useWsKey("storage"), queryFn: () => api.get<StorageLocation[]>("/storage") });
+  const storageQuery = useQuery({ queryKey: useWsKey("storage"), queryFn: () => api.get<StorageLocation[]>("/storage") });
+  const { data: storage } = storageQuery;
 
   // FE2-006: gate concurrent submits via mutationKey so a double-click
   // on Create can't post two parts; the 409 conflict-link branch stays
@@ -264,6 +266,7 @@ export default function PartCreate() {
       </label>
       <div>
         <label className="label" htmlFor="part-create-default-storage">Default storage location</label>
+        <InlineQueryError query={storageQuery} label="storage locations" className="mb-2" />
         <select id="part-create-default-storage" className="input" value={form.default_storage_location_id} onChange={e => set("default_storage_location_id", e.target.value)}>
           <option value="">— none —</option>
           {storage?.filter(s => !s.archived_at).map(s => <option key={s.id} value={s.id}>{s.name}</option>)}

--- a/web/src/routes/parts/ScanImport.tsx
+++ b/web/src/routes/parts/ScanImport.tsx
@@ -18,6 +18,7 @@ import { type ImportResponse, type LookupState, type Row } from "./ScanImport/ty
 import ScanImportSession from "./ScanImport/ScanImportSession";
 import ScanImportQueue from "./ScanImport/ScanImportQueue";
 import ScanImportActions from "./ScanImport/ScanImportActions";
+import { InlineQueryError } from "@/components/QueryStateBoundary";
 
 export default function ScanImport() {
   const nav = useNavigate();
@@ -81,10 +82,11 @@ export default function ScanImport() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchParams]);
 
-  const { data: storages } = useQuery({
+  const storagesQuery = useQuery({
     queryKey: useWsKey("storage"),
     queryFn: () => api.get<StorageLocation[]>("/storage"),
   });
+  const { data: storages } = storagesQuery;
 
   const handleRow = useCallback(
     (row: Row) => setRows(prev => [...prev, row]),
@@ -172,6 +174,7 @@ export default function ScanImport() {
           onLookupUpdate={handleLookupUpdate}
         />
         <div className="card p-3 flex flex-col">
+          <InlineQueryError query={storagesQuery} label="storage locations" className="mb-2" />
           <ScanImportActions
             rowCount={rows.length}
             importableCount={importable.length}

--- a/web/src/routes/parts/StockHistory.tsx
+++ b/web/src/routes/parts/StockHistory.tsx
@@ -7,10 +7,14 @@ import type { Part, StockEntry, StorageLocation } from "@/types";
 import { DataTable } from "@/components/DataTable";
 import EmptyState from "@/components/EmptyState";
 import PartsTopNav from "@/components/PartsTopNav";
+import QueryStateBoundary from "@/components/QueryStateBoundary";
 import { Link } from "react-router-dom";
 
 export default function StockHistory() {
-  const { data } = useQuery({ queryKey: useWsKey("stock-history"), queryFn: () => api.get<StockEntry[]>("/stock/history?limit=500") });
+  const historyQuery = useQuery({ queryKey: useWsKey("stock-history"), queryFn: () => api.get<StockEntry[]>("/stock/history?limit=500") });
+  const { data } = historyQuery;
+  // The parts/storage queries hydrate name maps for the table cells; missing
+  // them just falls back to UUIDs in the column, so they stay bare.
   const { data: parts } = useQuery({ queryKey: useWsKey("parts"), queryFn: () => api.get<Part[]>("/parts") });
   const { data: storage } = useQuery({ queryKey: useWsKey("storage"), queryFn: () => api.get<StorageLocation[]>("/storage") });
   const partName = new Map(parts?.map(p => [p.id, p.name]) ?? []);
@@ -18,6 +22,7 @@ export default function StockHistory() {
   return (
     <div>
       <PartsTopNav />
+      <QueryStateBoundary query={historyQuery} resourceLabel="stock history">
       <DataTable
         rows={data ?? []}
         rowKey={r => r.id}
@@ -39,6 +44,7 @@ export default function StockHistory() {
           { key: "comments", header: "Comments", accessor: r => r.comments ?? "" },
         ]}
       />
+      </QueryStateBoundary>
     </div>
   );
 }

--- a/web/src/routes/parts/detail/PartAddStock.tsx
+++ b/web/src/routes/parts/detail/PartAddStock.tsx
@@ -5,6 +5,7 @@ import { api, ApiError } from "@/lib/api";
 import { useApiMutation } from "@/lib/mutations";
 import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
 import { useAuth } from "@/lib/auth";
+import { InlineQueryError } from "@/components/QueryStateBoundary";
 import type { StorageLocation } from "@/types";
 
 /**
@@ -32,7 +33,8 @@ export default function PartAddStock() {
   const nav = useNavigate();
   const qc = useQueryClient();
   const { workspaceId } = useAuth();
-  const { data: storage } = useQuery({ queryKey: useWsKey("storage"), queryFn: () => api.get<StorageLocation[]>("/storage") });
+  const storageQuery = useQuery({ queryKey: useWsKey("storage"), queryFn: () => api.get<StorageLocation[]>("/storage") });
+  const { data: storage } = storageQuery;
   const [qty, setQty] = useState<number>(0);
   const [location, setLocation] = useState("");
   const [priceMode, setPriceMode] = useState<"none" | "per_component" | "entire_lot">("none");
@@ -87,6 +89,7 @@ export default function PartAddStock() {
     <form onSubmit={submit} className="card p-4 max-w-2xl space-y-3">
       <h3 className="text-md font-semibold">Add stock</h3>
       {err && <div className="text-danger text-sm">{err}</div>}
+      <InlineQueryError query={storageQuery} label="storage locations" />
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
         <div>
           <label className="label" htmlFor="add-stock-qty">Quantity *</label>

--- a/web/src/routes/parts/detail/PartInfo.tsx
+++ b/web/src/routes/parts/detail/PartInfo.tsx
@@ -6,6 +6,7 @@ import { ExternalLink, FileText, Loader2, RefreshCw } from "lucide-react";
 import { api, ApiError } from "@/lib/api";
 import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
 import { useAuth } from "@/lib/auth";
+import { InlineQueryError } from "@/components/QueryStateBoundary";
 import type { CustomFieldRow, Part } from "@/types";
 
 const PROVIDER_LABEL: Record<string, string> = {
@@ -53,11 +54,12 @@ export default function PartInfo() {
   const { part } = useOutletContext<{ part: Part }>();
   const qc = useQueryClient();
   const { workspaceId } = useAuth();
-  const { data: cf } = useQuery({
+  const cfQuery = useQuery({
     queryKey: useWsKey("part", part.id, "custom-fields"),
     queryFn: () =>
       api.get<CustomFieldRow[]>(`/custom-fields/by-object/part/${part.id}`),
   });
+  const { data: cf } = cfQuery;
   const lookupBy = (k: string) => cf?.find(r => r.key === k)?.value || null;
   // Image now lives in the layout header (passed in via Part.image_url);
   // the only Media-card affordance that still belongs on this page is the
@@ -99,6 +101,11 @@ export default function PartInfo() {
 
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+      {cfQuery.isError && (
+        <div className="col-span-2">
+          <InlineQueryError query={cfQuery} label="custom fields" />
+        </div>
+      )}
       {linked && (
         <div className="card p-3 col-span-2 flex items-center gap-3 text-sm">
           <RefreshCw size={14} className="text-accent shrink-0" />

--- a/web/src/routes/parts/detail/PartMoveStock.tsx
+++ b/web/src/routes/parts/detail/PartMoveStock.tsx
@@ -5,6 +5,7 @@ import { api, ApiError } from "@/lib/api";
 import { useApiMutation } from "@/lib/mutations";
 import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
 import { useAuth } from "@/lib/auth";
+import { InlineQueryError } from "@/components/QueryStateBoundary";
 import type { StorageLocation } from "@/types";
 
 type StockRow = {
@@ -34,18 +35,21 @@ export default function PartMoveStock() {
   const nav = useNavigate();
   const qc = useQueryClient();
   const { workspaceId } = useAuth();
-  const { data: storage } = useQuery({
+  const storageQuery = useQuery({
     queryKey: useWsKey("storage"),
     queryFn: () => api.get<StorageLocation[]>("/storage"),
   });
-  const { data: stock } = useQuery({
+  const stockQuery = useQuery({
     queryKey: useWsKey("part", partId, "stock"),
     queryFn: () => api.get<StockResp>(`/parts/${partId}/stock`),
   });
-  const { data: lots } = useQuery({
+  const lotsQuery = useQuery({
     queryKey: useWsKey("part", partId, "lots"),
     queryFn: () => api.get<Lot[]>(`/parts/${partId}/lots`),
   });
+  const { data: storage } = storageQuery;
+  const { data: stock } = stockQuery;
+  const { data: lots } = lotsQuery;
 
   const [sourceKey, setSourceKey] = useState("");
   const [dest, setDest] = useState("");
@@ -128,6 +132,9 @@ export default function PartMoveStock() {
     <form onSubmit={submit} className="card p-4 max-w-2xl space-y-3">
       <h3 className="text-md font-semibold">Move stock</h3>
       {err && <div className="text-danger text-sm">{err}</div>}
+      <InlineQueryError query={stockQuery} label="current stock" />
+      <InlineQueryError query={storageQuery} label="storage locations" />
+      <InlineQueryError query={lotsQuery} label="lots" />
       <div>
         <label className="label" htmlFor="move-stock-from">From *</label>
         {sources.length === 0 ? (

--- a/web/src/routes/parts/detail/PartRemoveStock.tsx
+++ b/web/src/routes/parts/detail/PartRemoveStock.tsx
@@ -5,6 +5,7 @@ import { api, ApiError } from "@/lib/api";
 import { useApiMutation } from "@/lib/mutations";
 import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
 import { useAuth } from "@/lib/auth";
+import { InlineQueryError } from "@/components/QueryStateBoundary";
 import type { StorageLocation } from "@/types";
 
 /**
@@ -38,18 +39,21 @@ export default function PartRemoveStock() {
   const nav = useNavigate();
   const qc = useQueryClient();
   const { workspaceId } = useAuth();
-  const { data: storage } = useQuery({
+  const storageQuery = useQuery({
     queryKey: useWsKey("storage"),
     queryFn: () => api.get<StorageLocation[]>("/storage"),
   });
-  const { data: stock } = useQuery({
+  const stockQuery = useQuery({
     queryKey: useWsKey("part", partId, "stock"),
     queryFn: () => api.get<StockResp>(`/parts/${partId}/stock`),
   });
-  const { data: lots } = useQuery({
+  const lotsQuery = useQuery({
     queryKey: useWsKey("part", partId, "lots"),
     queryFn: () => api.get<Lot[]>(`/parts/${partId}/lots`),
   });
+  const { data: storage } = storageQuery;
+  const { data: stock } = stockQuery;
+  const { data: lots } = lotsQuery;
 
   const [sourceKey, setSourceKey] = useState("");
   const [qty, setQty] = useState<number>(0);
@@ -128,6 +132,9 @@ export default function PartRemoveStock() {
     <form onSubmit={submit} className="card p-4 max-w-2xl space-y-3">
       <h3 className="text-md font-semibold">Remove stock</h3>
       {err && <div className="text-danger text-sm">{err}</div>}
+      <InlineQueryError query={stockQuery} label="current stock" />
+      <InlineQueryError query={storageQuery} label="storage locations" />
+      <InlineQueryError query={lotsQuery} label="lots" />
       <div>
         <label className="label" htmlFor="remove-stock-source">Source *</label>
         {sources.length === 0 ? (

--- a/web/src/routes/parts/detail/PartSettings.tsx
+++ b/web/src/routes/parts/detail/PartSettings.tsx
@@ -5,6 +5,7 @@ import { api, ApiError } from "@/lib/api";
 import { useApiMutation } from "@/lib/mutations";
 import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
 import { useAuth } from "@/lib/auth";
+import { InlineQueryError } from "@/components/QueryStateBoundary";
 import type { Part, StorageLocation } from "@/types";
 
 type PartPatch = {
@@ -22,7 +23,8 @@ export default function PartSettings() {
   const { partId } = useParams();
   const qc = useQueryClient();
   const { workspaceId } = useAuth();
-  const { data: storage } = useQuery({ queryKey: useWsKey("storage"), queryFn: () => api.get<StorageLocation[]>("/storage") });
+  const storageQuery = useQuery({ queryKey: useWsKey("storage"), queryFn: () => api.get<StorageLocation[]>("/storage") });
+  const { data: storage } = storageQuery;
   const [low, setLow] = useState(part.low_stock_report_quantity?.toString() ?? "");
   const [attrPct, setAttrPct] = useState(String(part.attrition_percentage));
   const [attrMin, setAttrMin] = useState(String(part.attrition_min_quantity));
@@ -82,6 +84,7 @@ export default function PartSettings() {
       </div>
       <div>
         <label className="label" htmlFor="ps-default-storage">Default storage location</label>
+        <InlineQueryError query={storageQuery} label="storage locations" className="mb-2" />
         <select id="ps-default-storage" className="input" value={defStorage} onChange={e => setDefStorage(e.target.value)}>
           <option value="">— none —</option>
           {storage?.filter(s => !s.archived_at).map(s => <option key={s.id} value={s.id}>{s.name}</option>)}

--- a/web/src/routes/projects/detail/ProjectImport.tsx
+++ b/web/src/routes/projects/detail/ProjectImport.tsx
@@ -7,6 +7,7 @@ import { useApiMutation } from "@/lib/mutations";
 import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
 import { useAuth } from "@/lib/auth";
 import { useConfirm, usePrompt } from "@/components/ConfirmDialog";
+import { InlineQueryError } from "@/components/QueryStateBoundary";
 
 // Must match server cap in backend/app/domain/projects/bom_import.py
 // (_MAX_DECODED_BYTES = 4_000_000). Using 4 * 1000 * 1000 — decimal MB —
@@ -143,10 +144,11 @@ export default function ProjectImport() {
       setErr(e instanceof ApiError ? e.userMessage : "Import failed");
     },
   });
-  const { data: presets, refetch: refetchPresets } = useQuery({
+  const presetsQuery = useQuery({
     queryKey: useWsKey("bom-presets"),
     queryFn: () => api.get<Preset[]>("/bom-presets"),
   });
+  const { data: presets, refetch: refetchPresets } = presetsQuery;
 
   function applyPreset(p: Preset) {
     if (p.config.separator) setSeparator(p.config.separator);
@@ -279,6 +281,7 @@ export default function ProjectImport() {
     <div className="space-y-4">
       <StepIndicator step={step} />
       {err && <div className="card p-3 text-danger text-sm">{err}</div>}
+      <InlineQueryError query={presetsQuery} label="BOM presets" />
       {step === "upload" && (
         <div className="card p-4 space-y-3 max-w-xl">
           <h3 className="text-md font-semibold">Step 1 — upload CSV/TSV</h3>

--- a/web/src/routes/settings/Workspace.tsx
+++ b/web/src/routes/settings/Workspace.tsx
@@ -6,6 +6,7 @@ import { useAuth } from "@/lib/auth";
 import { useApiMutation } from "@/lib/mutations";
 import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
 import { useConfirm } from "@/components/ConfirmDialog";
+import { InlineQueryError } from "@/components/QueryStateBoundary";
 
 type Ws = {
   id: string;
@@ -62,19 +63,23 @@ export default function WorkspaceSettings() {
   const confirm = useConfirm();
   const { me, workspaceId, refresh, switchWorkspace } = useAuth();
   const qc = useQueryClient();
-  const { data: cur } = useQuery({ queryKey: useWsKey("ws", "current"), queryFn: () => api.get<Ws>("/workspaces/current") });
-  const { data: members, refetch: refetchMembers } = useQuery({
+  const curQuery = useQuery({ queryKey: useWsKey("ws", "current"), queryFn: () => api.get<Ws>("/workspaces/current") });
+  const membersQuery = useQuery({
     queryKey: useWsKey("ws", "members"),
     queryFn: () => api.get<Member[]>("/workspaces/members"),
   });
-  const { data: invites, refetch: refetchInvites } = useQuery({
+  const invitesQuery = useQuery({
     queryKey: useWsKey("ws", "invitations"),
     queryFn: () => api.get<Invitation[]>("/invitations"),
   });
-  const { data: catalogTokens, refetch: refetchCatalogTokens } = useQuery({
+  const catalogTokensQuery = useQuery({
     queryKey: useWsKey("ws", "catalog-tokens"),
     queryFn: () => api.get<CatalogToken[]>("/workspaces/current/catalog/tokens"),
   });
+  const { data: cur } = curQuery;
+  const { data: members, refetch: refetchMembers } = membersQuery;
+  const { data: invites, refetch: refetchInvites } = invitesQuery;
+  const { data: catalogTokens, refetch: refetchCatalogTokens } = catalogTokensQuery;
   const [newTokenLabel, setNewTokenLabel] = useState("");
   const [newlyCreatedToken, setNewlyCreatedToken] = useState<string | null>(null);
 
@@ -256,6 +261,12 @@ export default function WorkspaceSettings() {
     <div className="max-w-3xl">
       <h1 className="text-xl font-semibold mb-4">Workspace</h1>
       {err && <div className="card p-3 text-danger text-sm mb-3">{err}</div>}
+      <div className="space-y-2 mb-3">
+        <InlineQueryError query={curQuery} label="workspace settings" />
+        <InlineQueryError query={membersQuery} label="members" />
+        <InlineQueryError query={invitesQuery} label="invitations" />
+        <InlineQueryError query={catalogTokensQuery} label="catalog tokens" />
+      </div>
       {cur && (
         <div className="card p-4 mb-4 space-y-3 text-sm">
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">


### PR DESCRIPTION
## Summary

Round-2 follow-up to #262. The closing PR added `isError` guards to 14 detail-panel sites but missed the file the original issue cited (`AttachmentsPanel.tsx`) plus ~14 other `useQuery` sites with no error handling. This PR finishes the sweep.

`QueryStateBoundary.tsx` gains a new named export `InlineQueryError` that shares the same `QueryLike` type and 401 short-circuit. The boundary short-circuits the whole subtree (right for list pages, wrong for panels that mix an action surface with a query).

## Files migrated

### Inline pill (`InlineQueryError`) — keeps action UI live
- `web/src/components/AttachmentsPanel.tsx` ← the symptom file from the original issue. Previously conflated 5xx with the "no attachments" empty state. Now a 503 renders a distinct alert pill while upload controls stay interactive (regression test added).
- `web/src/components/CommandPalette.tsx`
- `web/src/components/scanner/Scanner.tsx` — main `/workspaces/current` query. Previously rendered "Loading scanner…" forever on error. The inner `ScanditScannerWithKey` already had an explicit error branch and was left as is.
- `web/src/routes/parts/PartCreate.tsx` (storage picker)
- `web/src/routes/parts/ScanImport.tsx` (storage picker)
- `web/src/routes/parts/detail/PartInfo.tsx` (custom-fields fetch)
- `web/src/routes/parts/detail/PartSettings.tsx` (storage picker)
- `web/src/routes/parts/detail/PartAddStock.tsx` (storage picker)
- `web/src/routes/parts/detail/PartMoveStock.tsx` (stock/storage/lots)
- `web/src/routes/parts/detail/PartRemoveStock.tsx` (stock/storage/lots)
- `web/src/routes/builds/BuildCreate.tsx` (projects picker)
- `web/src/routes/projects/detail/ProjectImport.tsx` (BOM presets)
- `web/src/routes/settings/Workspace.tsx` (cur/members/invites/catalog tokens — 4 pills above the body)

### Subtree boundary (`QueryStateBoundary`)
- `web/src/routes/parts/StockHistory.tsx` (wraps the DataTable)

### Intentionally left bare
- `StockHistory.tsx`'s `parts` and `storage` map-hydration queries — they only feed name lookups for the table cells; missing them falls back to UUIDs in the rendered column. Comment added in source.
- Round-1 plan claimed `Scanner.tsx` had its own status surface and could be skipped. Re-checked: the main `useQuery` only handled `isLoading || !ws`, so an error state silently rendered "Loading scanner…" forever. Migrated.

## Audit

```
grep -rEln "useQuery\(" web/src --include="*.tsx" \
  | while read f; do grep -q "isError\|QueryStateBoundary\|InlineQueryError" "$f" || echo "$f"; done
```

Returns empty.

## Tests

- `web/src/components/__dom__/AttachmentsPanel.dom.test.tsx` — RTL test with a stubbed `api.get` throwing `ApiError(503)`. Asserts: error pill renders, empty-state copy does NOT, upload controls stay in the DOM, empty list shows empty-state without a pill, 401 suppresses the pill (auth bus handles redirect).
- `web/src/components/__dom__/QueryStateBoundary.dom.test.tsx` — covers both `QueryStateBoundary` and `InlineQueryError`: renders children when no error, renders alert on non-401, falls through on 401, Retry triggers refetch, isFetching disables Retry.

## Test plan

- [x] `cd web && npm run build` — `tsc -b` zero errors, vite build green
- [x] `cd web && npm test` — 236 passed, 3 skipped (pre-existing)
- [x] Audit grep returns empty
- [ ] Stop the backend, open a part with attachments — error pill appears, upload controls remain interactive
- [ ] Stop the backend, reload `/parts/<id>/info` — custom-fields pill appears at the top of the grid

Closes #245