### PR TITLE
fix(backups): age-encrypt pre-deploy DB snapshots (#287)

### DIFF
--- a/deploy/.env.prod.example
+++ b/deploy/.env.prod.example
@@ -56,11 +56,17 @@ CORS_ORIGINS=https://parts.matescb.cz
 WORKSPACE_SECRETS_KEY=replace-me-with-fernet-key
 
 # ---- Backups ----
-# age recipient public key used to encrypt nightly backup artifacts.
-# The backup script (deploy/backup.sh) pipes pg_dump and uploads tarball
-# through age -r <key> before writing to disk.  The private key must be
-# escrowed off-VPS (e.g. a password manager or offline storage) — it is
-# never needed on the VPS itself (encryption-only).
+# age recipient public key used to encrypt every backup artifact written
+# on the VPS.  Both the nightly backup script (deploy/backup.sh) AND the
+# pre-deploy snapshot script (deploy/predeploy-dump.sh, run from the SSH
+# deploy step) pipe pg_dump and tarball output through `age -r <key>`
+# before it ever lands on disk.  The private key must be escrowed off-VPS
+# (e.g. a password manager or offline storage) — it is never needed on
+# the VPS itself (encryption-only).
+#
+# predeploy-dump.sh refuses to run if this is unset or still the
+# "age1..." placeholder, to avoid writing an unencrypted DB snapshot
+# (issue #287).
 #
 # Operator action required:
 #   1. Install age on the VPS:

--- a/deploy/predeploy-dump.sh
+++ b/deploy/predeploy-dump.sh
@@ -10,7 +10,13 @@
 # this script exits non-zero so the SSH deploy aborts and the existing
 # container keeps serving the old code.
 #
-# Output: /srv/backups/stockmanager/pre-deploy-${TS}-${SHA}.sql.gz
+# Output: /srv/backups/stockmanager/pre-deploy-${TS}-${SHA}.sql.gz.age
+#
+# Encryption: the dump is piped through `age -r $BACKUP_AGE_RECIPIENT`
+# before it ever lands on disk, mirroring the off-host nightlies in
+# `backup.sh`. The private key is escrowed off-VPS — see
+# docs/deployment.md#backups. Closes #287 (INFRA2-016 follow-up:
+# pre-deploy dumps were previously gzip-only, not encrypted at rest).
 #
 # Retention: separate from the nightly cron-driven backups in
 # `backup.sh`. Keep the last 14 pre-deploy dumps. Rationale: nightlies
@@ -36,13 +42,22 @@ mkdir -p "${BACKUP_DIR}"
 
 POSTGRES_USER="$(grep -E '^POSTGRES_USER=' "${ENV_FILE}" | cut -d= -f2-)"
 POSTGRES_DB="$(grep -E '^POSTGRES_DB=' "${ENV_FILE}" | cut -d= -f2-)"
+BACKUP_AGE_RECIPIENT="$(grep -E '^BACKUP_AGE_RECIPIENT=' "${ENV_FILE}" | cut -d= -f2-)"
 
 if [[ -z "${POSTGRES_USER}" || -z "${POSTGRES_DB}" ]]; then
     echo "ERROR: POSTGRES_USER / POSTGRES_DB missing from ${ENV_FILE}" >&2
     exit 1
 fi
 
-OUT="${BACKUP_DIR}/pre-deploy-${TS}-${SHA}.sql.gz"
+# Refuse to run if the age recipient is missing or still the placeholder
+# from .env.prod.example — an unencrypted dump on the VPS is exactly the
+# exposure this script is being hardened against (issue #287).
+if [[ -z "${BACKUP_AGE_RECIPIENT}" || "${BACKUP_AGE_RECIPIENT}" == "age1..." ]]; then
+    echo "ERROR: BACKUP_AGE_RECIPIENT not configured in ${ENV_FILE} — refusing to write unencrypted dump" >&2
+    exit 1
+fi
+
+OUT="${BACKUP_DIR}/pre-deploy-${TS}-${SHA}.sql.gz.age"
 
 echo "$(date -Iseconds)  pre-deploy dump  ${SHA}  ->  ${OUT}"
 
@@ -56,7 +71,8 @@ fi
 
 docker compose -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" exec -T db \
     pg_dump -U "${POSTGRES_USER}" "${POSTGRES_DB}" \
-    | gzip > "${OUT}.tmp"
+    | gzip \
+    | age -r "${BACKUP_AGE_RECIPIENT}" > "${OUT}.tmp"
 mv "${OUT}.tmp" "${OUT}"
 
 # pg_dump emits non-empty output even for an empty schema (header,
@@ -68,10 +84,12 @@ if [[ ! -s "${OUT}" ]]; then
     exit 1
 fi
 
-echo "$(date -Iseconds)  pre-deploy dump OK  $(du -h "${OUT}" | cut -f1)"
+echo "$(date -Iseconds)  pre-deploy dump OK (age-encrypted)  $(du -h "${OUT}" | cut -f1)"
 
 # Retention: keep the most recent N pre-deploy dumps. Sort by mtime
-# descending, skip the first N, delete the rest.
-ls -1t "${BACKUP_DIR}"/pre-deploy-*.sql.gz 2>/dev/null \
+# descending, skip the first N, delete the rest. NB: the glob is
+# .sql.gz.age — older plain-gzip dumps from before #287 are NOT matched
+# and must be cleaned up manually (one-shot; see docs/deployment.md).
+ls -1t "${BACKUP_DIR}"/pre-deploy-*.sql.gz.age 2>/dev/null \
     | tail -n +$((RETAIN_PREDEPLOY + 1)) \
     | xargs -r rm -v

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -465,9 +465,20 @@ sudo -u deploy docker compose -f docker-compose.prod.yml --env-file .env.prod \
 ```
 
 Note that **alembic migrations don't auto-roll-back**. If the bad commit
-included a destructive migration, restore from a `pg_dump` taken before the
-deploy (see [Backups](#backups)). Treat any irreversible migration as a
-release-management decision: take a dump first, ship in business hours.
+included a destructive migration, restore from the pre-deploy `pg_dump`
+written by [`deploy/predeploy-dump.sh`](../deploy/predeploy-dump.sh) (see
+[Backups](#backups) for layout). The pre-deploy dump is age-encrypted, so
+the restore pipeline is the same as for the nightlies — bring the private
+key onto the VPS temporarily, decrypt, restore, then `shred -u` the key:
+
+```bash
+sudo /srv/stockmanager/deploy/db-restore.sh /tmp/backup-key.txt \
+    /srv/backups/stockmanager/pre-deploy-<ts>-<sha>.sql.gz.age
+shred -u /tmp/backup-key.txt
+```
+
+Treat any irreversible migration as a release-management decision: take a
+dump first, ship in business hours.
 
 Always use `docker compose -f docker-compose.prod.yml` explicitly on the VPS —
 the repo no longer has a bare `docker-compose.yml` default, so muscle-memory
@@ -482,7 +493,7 @@ less error-prone:
 | Script | Purpose |
 |--------|---------|
 | `deploy/db-shell.sh` | Open an interactive `psql` session inside the running `db` container. Reads credentials from `.env.prod` so they never expand in the host shell. |
-| `deploy/db-restore.sh` | Decrypt and restore a `pg_dump` backup. Prompts for confirmation before overwriting. |
+| `deploy/db-restore.sh` | Decrypt and restore a `pg_dump` backup (works for both nightly `db-*.sql.gz.age` and pre-deploy `pre-deploy-*.sql.gz.age` files — same `age | gunzip | psql` pipeline). Prompts for confirmation before overwriting. |
 
 Both scripts are designed to be run as root from anywhere on the VPS:
 
@@ -646,12 +657,30 @@ to 14 daily / 8 weekly / 6 monthly.
 
 ```
 /srv/backups/stockmanager/                              # local, 7-day retention
-    db-2026-05-02.sql.gz.age
-    assets-2026-05-02.tar.gz.age
+    db-2026-05-02.sql.gz.age                            # nightly
+    assets-2026-05-02.tar.gz.age                        # nightly
+    pre-deploy-2026-05-03T1420-abc1234.sql.gz.age       # pre-deploy (deploy/predeploy-dump.sh)
 /mnt/nas-backups/stockmanager/                          # NAS, GFS retention
     daily/db-2026-05-02.sql.gz.age
     weekly/db-2026-05-03.sql.gz.age                     # Sundays
     monthly/db-2026-06-01.sql.gz.age                    # 1st of month
+```
+
+Pre-deploy dumps are written by [`deploy/predeploy-dump.sh`](../deploy/predeploy-dump.sh)
+from the SSH deploy step (after `git reset --hard origin/main`, before
+`docker compose up --build`). They use the same `pg_dump | gzip | age -r $RECIPIENT`
+pipeline as the nightlies — i.e., **no unencrypted SQL ever touches the VPS disk**
+(closes #287). The script refuses to run if `BACKUP_AGE_RECIPIENT` is unset or still
+the `age1...` placeholder. Retention is the last 14 pre-deploy dumps, separate from
+the nightly schedule.
+
+If you are upgrading past #287 and have legacy `pre-deploy-*.sql.gz` (no `.age`
+suffix) files on the VPS, the new retention loop will not delete them. After the
+first encrypted deploy lands cleanly, remove them by hand:
+
+```bash
+ls /srv/backups/stockmanager/pre-deploy-*.sql.gz   # confirm what's there
+rm /srv/backups/stockmanager/pre-deploy-*.sql.gz   # one-shot cleanup
 ```
 
 The local copy exists for fast restores and verification; the NAS copy is


### PR DESCRIPTION
## Summary

Pre-deploy `pg_dump` snapshots produced by `deploy/predeploy-dump.sh` were landing on the VPS as plain gzipped SQL (`/srv/backups/stockmanager/pre-deploy-*.sql.gz`) — INFRA2-016 only covered the off-host nightlies (#239), so this local copy stayed exposed to anyone with shell access or a leaked snapshot.

This PR mirrors the nightly pipeline by piping `pg_dump | gzip | age -r $BACKUP_AGE_RECIPIENT` so no unencrypted SQL ever touches disk.

- `deploy/predeploy-dump.sh` — read `BACKUP_AGE_RECIPIENT` from `.env.prod`, refuse to run if it is empty or still the `age1...` placeholder, pipe the dump through `age`, write to `*.sql.gz.age`, update the retention glob to match.
- `deploy/.env.prod.example` — clarify that `BACKUP_AGE_RECIPIENT` is now required by both `backup.sh` and `predeploy-dump.sh`. No new variable.
- `docs/deployment.md` — show the new `pre-deploy-*.sql.gz.age` artifact in the on-disk layout, document the one-shot cleanup of legacy plain-gzip dumps, and add a worked decrypt → restore example to the Rollback section.

The encryption key is the same `BACKUP_AGE_RECIPIENT` already in use for nightlies — sourced from `/srv/stockmanager/.env.prod` on the VPS at runtime (private key escrowed off-VPS, never on the host).

## Test plan

- [ ] `bash -n deploy/predeploy-dump.sh` passes (verified locally).
- [ ] On the VPS post-deploy, `file /srv/backups/stockmanager/pre-deploy-*.sql.gz.age` reports an age-encrypted file and `zcat` on it fails (binary).
- [ ] Restore drill: `sudo deploy/db-restore.sh /tmp/key.txt /srv/backups/stockmanager/pre-deploy-<ts>-<sha>.sql.gz.age` decrypts, gunzips, and restores cleanly into the running `db` container.
- [ ] After the first encrypted deploy lands, manually `rm /srv/backups/stockmanager/pre-deploy-*.sql.gz` (legacy plain-gzip files, not matched by the new retention glob).

Closes #287

🤖 Generated with [Claude Code](https://claude.com/claude-code)