### PR TITLE
fix(api): import datetime in builds + orders activity routes

### DIFF
--- a/backend/app/api/routes/builds.py
+++ b/backend/app/api/routes/builds.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime
 from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, Query, Request, status

--- a/backend/app/api/routes/orders.py
+++ b/backend/app/api/routes/orders.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import datetime
 from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, Query, Request, status

--- a/backend/tests/test_activity_cursor_builds_orders.py
+++ b/backend/tests/test_activity_cursor_builds_orders.py
@@ -1,0 +1,135 @@
+"""Regression test for issue #279.
+
+`builds.py` and `orders.py` both used `datetime.fromisoformat(...)` in their
+activity-cursor endpoints without importing `datetime`. The first request
+with a `?before_occurred_at=…` parameter would 500 with NameError. These
+tests exercise the cursor-parsing path end-to-end so the missing import is
+caught at runtime.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+from tests._factories import (
+    create_part as _create_part,
+    create_project_with_bom as _create_project_with_bom,
+    create_storage as _create_storage,
+    signup_user,
+)
+
+
+@pytest.fixture
+def authed():
+    c = TestClient(app)
+    signup_user(c)
+    return c
+
+
+def test_build_activity_cursor_param_accepted(authed):
+    """GET /api/builds/{id}/activity with a valid cursor returns 200, not 500."""
+    c = authed
+    p1 = _create_part(c, "R1k cursor")
+    storage = _create_storage(c, "S-cursor-build")
+    # Need a project with a BOM to create a build.
+    project_id = _create_project_with_bom(
+        c, "PCB-cursor", [{"part_id": p1, "quantity": 1}]
+    )
+    r = c.post(
+        "/api/builds",
+        json={"name": "B-cursor", "project_id": project_id, "quantity": 1},
+    )
+    assert r.status_code == 201, r.text
+    bid = r.json()["data"]["id"]
+
+    # Pass a valid cursor — without the datetime import this 500'd.
+    r = c.get(
+        f"/api/builds/{bid}/activity",
+        params={
+            "before_occurred_at": "2020-01-01T00:00:00",
+            "before_id": str(uuid.uuid4()),
+        },
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()["data"]
+    assert "events" in body
+    assert isinstance(body["events"], list)
+
+
+def test_build_activity_invalid_cursor_returns_422(authed):
+    """A malformed before_occurred_at returns 422, not 500."""
+    c = authed
+    p1 = _create_part(c, "R1k cursor-bad")
+    project_id = _create_project_with_bom(
+        c, "PCB-cursor-bad", [{"part_id": p1, "quantity": 1}]
+    )
+    r = c.post(
+        "/api/builds",
+        json={"name": "B-cursor-bad", "project_id": project_id, "quantity": 1},
+    )
+    assert r.status_code == 201, r.text
+    bid = r.json()["data"]["id"]
+
+    r = c.get(
+        f"/api/builds/{bid}/activity",
+        params={"before_occurred_at": "not-a-date"},
+    )
+    assert r.status_code == 422
+
+
+def test_order_activity_cursor_param_accepted(authed):
+    """GET /api/orders/{id}/activity with a valid cursor returns 200, not 500."""
+    c = authed
+    part_id = _create_part(c, "Cap cursor")
+    r = c.post(
+        "/api/orders",
+        json={
+            "name": "PO-cursor",
+            "currency": "USD",
+            "entries": [
+                {"part_id": part_id, "quantity_ordered": 1, "unit_price": "0.05"},
+            ],
+        },
+    )
+    assert r.status_code == 201, r.text
+    oid = r.json()["data"]["id"]
+
+    # Pass a valid cursor — without the datetime import this 500'd.
+    r = c.get(
+        f"/api/orders/{oid}/activity",
+        params={
+            "before_occurred_at": "2020-01-01T00:00:00",
+            "before_id": str(uuid.uuid4()),
+        },
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()["data"]
+    assert "events" in body
+    assert isinstance(body["events"], list)
+
+
+def test_order_activity_invalid_cursor_returns_422(authed):
+    """A malformed before_occurred_at returns 422, not 500."""
+    c = authed
+    part_id = _create_part(c, "Cap cursor-bad")
+    r = c.post(
+        "/api/orders",
+        json={
+            "name": "PO-cursor-bad",
+            "currency": "USD",
+            "entries": [
+                {"part_id": part_id, "quantity_ordered": 1, "unit_price": "0.05"},
+            ],
+        },
+    )
+    assert r.status_code == 201, r.text
+    oid = r.json()["data"]["id"]
+
+    r = c.get(
+        f"/api/orders/{oid}/activity",
+        params={"before_occurred_at": "not-a-date"},
+    )
+    assert r.status_code == 422


### PR DESCRIPTION
## Summary

Both `backend/app/api/routes/builds.py` and `backend/app/api/routes/orders.py` call `datetime.fromisoformat(before_occurred_at)` to parse the activity cursor query param, but neither file imports `datetime`. The first time a client passes `?before_occurred_at=…`, the call raises `NameError: name 'datetime' is not defined` and the endpoint returns 500.

The local-variable annotation `cursor_at: datetime | None` does not crash because both files have `from __future__ import annotations`, so the annotation is a string — only the runtime call was reachable.

This is exactly the class of bug `ruff --select F821` exists to catch (cross-ref #253 — lint gate currently non-blocking).

## Changes

- `backend/app/api/routes/builds.py`: add `from datetime import datetime`
- `backend/app/api/routes/orders.py`: add `from datetime import datetime`
- `backend/tests/test_activity_cursor_builds_orders.py`: new regression suite — 4 tests covering valid cursor (200) and malformed cursor (422) for both endpoints

## Test plan

- [x] `pytest tests/test_activity_cursor_builds_orders.py` — 4/4 pass
- [x] `pytest tests/test_builds.py tests/test_orders.py tests/test_activity_pagination.py` — 32/32 pass (no regressions)
- [x] `ruff check backend/app/api/routes/{builds,orders}.py --select F` — clean
- [x] Full backend suite — only pre-existing unrelated flakes (`test_pagination.py` / `test_parts_router_split.py` — both fail on schema-setup / route-registration unrelated to this change)

Closes #279