### PR TITLE
fix(security): refuse to boot prod without SMTP; never log verification link

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -74,14 +74,19 @@ class Settings(BaseSettings):
     # Email / SMTP for the email-verification flow (SEC2-014).
     # In dev (APP_ENV != "prod") the mail backend writes to stdout so the
     # verification link surfaces in container logs without an SMTP server.
-    # In prod all four SMTP_* vars must be set.
+    # In prod the model_validator below rejects any of SMTP_HOST / SMTP_USER /
+    # SMTP_PASSWORD / MAIL_FROM / APP_BASE_URL being empty (or APP_BASE_URL
+    # being the dev default), so a misconfigured deploy fails fast at boot
+    # instead of silently falling through to the stdout backend and writing
+    # the verification link to container logs (issue #281).
     SMTP_HOST: str = ""
     SMTP_PORT: int = 587
     SMTP_USER: str = ""
     SMTP_PASSWORD: str = ""
     MAIL_FROM: str = "noreply@stockmanager.local"
     # Public-facing base URL for generating verification links.
-    # In dev the default mirrors the Vite dev server.
+    # In dev the default mirrors the Vite dev server; the prod validator
+    # rejects this default (links must be on the public hostname).
     APP_BASE_URL: str = "http://localhost:5173"
     # Enable the two-step email-verification flow on signup (SEC2-014).
     # Defaults to True in prod, False elsewhere so the test suite can
@@ -153,6 +158,32 @@ class Settings(BaseSettings):
                 "Generate one with: "
                 'python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"'
             )
+        return self
+
+    @model_validator(mode="after")
+    def _require_smtp_in_prod(self) -> "Settings":
+        # Issue #281: in prod the email-verification flow is forced on
+        # (see _default_email_verification_in_prod above), but if any of
+        # the SMTP creds are missing the mail backend silently fell
+        # through to stdout, leaking the verification link into
+        # `docker compose logs backend`. Fail closed at import so a
+        # misconfigured deploy never gets the chance to mint a single
+        # token. The error message lists the missing variable names only
+        # — never the values — so it is safe to paste into a bug report.
+        if self.APP_ENV == "prod":
+            missing: list[str] = []
+            for name in ("SMTP_HOST", "SMTP_USER", "SMTP_PASSWORD", "MAIL_FROM"):
+                if not getattr(self, name):
+                    missing.append(name)
+            if not self.APP_BASE_URL or self.APP_BASE_URL == "http://localhost:5173":
+                missing.append("APP_BASE_URL")
+            if missing:
+                raise ValueError(
+                    "Email verification is mandatory when APP_ENV=prod, but the "
+                    "following required variables are missing or set to a dev "
+                    f"default: {', '.join(missing)}. Set them in .env.prod "
+                    "before deploying — see deploy/.env.prod.example."
+                )
         return self
 
 

--- a/backend/app/core/mail.py
+++ b/backend/app/core/mail.py
@@ -2,12 +2,17 @@
 
 Two backends are available:
 
-* **StdoutBackend** (default in dev): writes the full email body to
-  stdout / the container log so the developer can copy-paste the
-  verification link without needing a real SMTP server.
+* **StdoutBackend** (default in dev): logs a single WARNING containing
+  the verification link so the developer can copy-paste it without
+  needing a real SMTP server. **Refuses to run when ``APP_ENV == "prod"``**
+  (issue #281): the verification link is a bearer credential and must
+  never be written to container logs in prod. The config validator
+  (`_require_smtp_in_prod`) is supposed to have failed closed at import
+  time; the runtime guard here is defence in depth.
 
-* **SmtpBackend**: sends via SMTP with STARTTLS.  Used when
-  ``APP_ENV == "prod"`` and ``SMTP_HOST`` is non-empty.
+* **SmtpBackend**: sends via SMTP with STARTTLS. Selected whenever
+  ``APP_ENV == "prod"``. The validator guarantees ``SMTP_HOST`` etc.
+  are populated.
 
 Call :func:`send_verification_email` from route code — it picks the
 right backend automatically based on the current settings.
@@ -19,6 +24,9 @@ Design notes:
 - No retry logic here.  A failure surfaces as a 500; the caller should
   not mint a ``PendingUser`` row before a successful send so no orphaned
   rows are left behind.
+- Issue #281: never log the message body. The dev backend logs only a
+  one-line WARNING with the link (intentional — the dev workflow needs
+  it visible) and the SMTP backend never logs the body at all.
 """
 from __future__ import annotations
 
@@ -64,29 +72,43 @@ def send_verification_email(*, to: str, verification_link: str) -> None:
 
     Picks the stdout backend in dev and the SMTP backend in prod.
     Raises on failure so the caller can abort the signup transaction.
+
+    Issue #281: the dispatch is on ``APP_ENV`` alone (not on
+    ``APP_ENV and SMTP_HOST``). A misconfigured prod that reached this
+    point would previously have fallen through to the stdout backend and
+    leaked the link into container logs. The config validator now fails
+    closed at import; this dispatch and the guard inside ``_send_stdout``
+    are defence in depth.
     """
     cfg = settings()
-    if cfg.APP_ENV == "prod" and cfg.SMTP_HOST:
+    if cfg.APP_ENV == "prod":
         _send_smtp(to=to, verification_link=verification_link)
     else:
         _send_stdout(to=to, verification_link=verification_link)
 
 
 def _send_stdout(*, to: str, verification_link: str) -> None:
-    """Dev backend: write the email to stdout / container logs."""
-    _log.info(
-        "MAIL (stdout backend) To: %s\nVerification link: %s",
+    """Dev backend: log a single WARNING with the verification link.
+
+    Refuses to run in prod (issue #281) — the verification link is a
+    bearer credential and must never be written to container logs. In
+    dev the link is logged at WARNING so it surfaces under the default
+    log level without needing the older `print` banner.
+    """
+    cfg = settings()
+    if cfg.APP_ENV == "prod":
+        # Belt-and-braces: the config validator should already have
+        # prevented boot, but if some future code path reaches here in
+        # prod, fail loud rather than leak.
+        raise RuntimeError(
+            "stdout mail backend refused in prod (issue #281): SMTP must "
+            "be configured. This indicates a misconfigured deploy that "
+            "bypassed the config validator."
+        )
+    _log.warning(
+        "dev mail backend (SMTP not configured): verification link for %s: %s",
         to,
         verification_link,
-    )
-    # Also print directly so it appears even when log level is WARNING.
-    print(
-        f"\n{'='*60}\n"
-        f"[DEV MAIL] Verification email\n"
-        f"To: {to}\n"
-        f"Link: {verification_link}\n"
-        f"{'='*60}\n",
-        flush=True,
     )
 
 

--- a/backend/tests/test_mail_prod_safety.py
+++ b/backend/tests/test_mail_prod_safety.py
@@ -1,0 +1,191 @@
+"""Prod safety for the email-verification mail backend (issue #281).
+
+Pins:
+  - Settings refuses to construct in prod when any required SMTP / mail
+    var is missing (`_require_smtp_in_prod` validator).
+  - Settings constructs cleanly in prod when all required values are
+    populated.
+  - Dev posture is preserved: empty SMTP env in dev is allowed.
+  - The stdout mail backend refuses to run in prod and produces no log
+    line containing the verification link (regression test for the leak).
+
+Modelled on the WORKSPACE_SECRETS_KEY trio in
+backend/tests/test_workspace_secrets.py:114-157 — same fail-closed-in-prod
+pattern, validated the same way.
+"""
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+
+def test_prod_with_empty_smtp_fails_closed(monkeypatch):
+    """A prod deploy that forgets any of SMTP_HOST / SMTP_USER /
+    SMTP_PASSWORD / MAIL_FROM / APP_BASE_URL must fail at import, not
+    silently fall through to the stdout backend (issue #281)."""
+    from cryptography.fernet import Fernet
+    from pydantic import ValidationError
+
+    from app.core.config import Settings
+
+    monkeypatch.setenv("APP_ENV", "prod")
+    monkeypatch.setenv("WORKSPACE_SECRETS_KEY", Fernet.generate_key().decode())
+    # Leave SMTP_HOST etc. empty.
+    for name in ("SMTP_HOST", "SMTP_USER", "SMTP_PASSWORD"):
+        monkeypatch.delenv(name, raising=False)
+
+    with pytest.raises(ValidationError) as exc_info:
+        Settings()
+    msg = str(exc_info.value)
+    assert "SMTP_HOST" in msg
+    # Sanity: error phrasing names variables, not values (prod-hygiene).
+    assert "Email verification" in msg
+
+
+def test_prod_with_dev_default_app_base_url_fails_closed(monkeypatch):
+    """APP_BASE_URL=http://localhost:5173 in prod is a misconfiguration:
+    verification links would point at a non-public dev URL. The validator
+    rejects the dev default explicitly."""
+    from cryptography.fernet import Fernet
+    from pydantic import ValidationError
+
+    from app.core.config import Settings
+
+    monkeypatch.setenv("APP_ENV", "prod")
+    monkeypatch.setenv("WORKSPACE_SECRETS_KEY", Fernet.generate_key().decode())
+    monkeypatch.setenv("SMTP_HOST", "smtp.example.com")
+    monkeypatch.setenv("SMTP_USER", "user")
+    monkeypatch.setenv("SMTP_PASSWORD", "pw")
+    monkeypatch.setenv("MAIL_FROM", "noreply@example.com")
+    monkeypatch.setenv("APP_BASE_URL", "http://localhost:5173")
+
+    with pytest.raises(ValidationError) as exc_info:
+        Settings()
+    assert "APP_BASE_URL" in str(exc_info.value)
+
+
+def test_prod_with_full_smtp_boots(monkeypatch):
+    """A complete prod config (real SMTP creds + public APP_BASE_URL)
+    constructs cleanly."""
+    from cryptography.fernet import Fernet
+
+    from app.core.config import Settings
+
+    monkeypatch.setenv("APP_ENV", "prod")
+    monkeypatch.setenv("WORKSPACE_SECRETS_KEY", Fernet.generate_key().decode())
+    monkeypatch.setenv("SMTP_HOST", "smtp.example.com")
+    monkeypatch.setenv("SMTP_USER", "user")
+    monkeypatch.setenv("SMTP_PASSWORD", "pw")
+    monkeypatch.setenv("MAIL_FROM", "noreply@example.com")
+    monkeypatch.setenv("APP_BASE_URL", "https://parts.example.com")
+
+    s = Settings()
+    assert s.APP_ENV == "prod"
+    assert s.SMTP_HOST == "smtp.example.com"
+    assert s.SIGNUP_REQUIRE_EMAIL_VERIFICATION is True
+
+
+def test_dev_with_empty_smtp_boots(monkeypatch):
+    """Dev posture is preserved — no SMTP env required, the stdout
+    backend handles delivery."""
+    from app.core.config import Settings
+
+    monkeypatch.setenv("APP_ENV", "dev")
+    for name in ("SMTP_HOST", "SMTP_USER", "SMTP_PASSWORD"):
+        monkeypatch.delenv(name, raising=False)
+
+    s = Settings()
+    assert s.APP_ENV == "dev"
+    assert s.SMTP_HOST == ""
+
+
+def test_send_verification_email_refuses_stdout_in_prod(monkeypatch, caplog, capsys):
+    """Defence in depth: if the validator is somehow bypassed and the
+    runtime ends up in prod with SMTP_HOST empty, the stdout backend
+    must raise rather than log the link.
+
+    Monkeypatch the cached settings instance directly to simulate a
+    misconfigured runtime (the validator would normally have prevented
+    boot)."""
+    from app.core import mail as mail_mod
+    from app.core.config import settings
+
+    cfg = settings()
+    monkeypatch.setattr(cfg, "APP_ENV", "prod")
+    monkeypatch.setattr(cfg, "SMTP_HOST", "")
+
+    link = "https://example.invalid/verify?id=PEND&token=SECRET-TOKEN-XYZ"
+
+    caplog.set_level(logging.DEBUG, logger="app.core.mail")
+    capsys.readouterr()  # drain anything pending
+
+    with pytest.raises(RuntimeError):
+        mail_mod._send_stdout(to="user@example.com", verification_link=link)
+
+    # Critical assertion: the link/token must not appear anywhere in
+    # captured logs or stdout. This is the regression test for the leak.
+    captured = capsys.readouterr()
+    assert "SECRET-TOKEN-XYZ" not in captured.out
+    assert "SECRET-TOKEN-XYZ" not in captured.err
+    for record in caplog.records:
+        assert "SECRET-TOKEN-XYZ" not in record.getMessage()
+
+
+def test_send_verification_email_dispatch_skips_stdout_in_prod(monkeypatch):
+    """The selector in send_verification_email goes to the SMTP backend
+    in prod regardless of whether SMTP_HOST is populated — the
+    `and cfg.SMTP_HOST` half of the old conjunct is gone, so an empty
+    SMTP_HOST in prod no longer falls through to stdout."""
+    from app.core import mail as mail_mod
+    from app.core.config import settings
+
+    cfg = settings()
+    monkeypatch.setattr(cfg, "APP_ENV", "prod")
+    monkeypatch.setattr(cfg, "SMTP_HOST", "")
+
+    called: dict[str, bool] = {"smtp": False, "stdout": False}
+
+    def _fake_smtp(*, to, verification_link):
+        called["smtp"] = True
+
+    def _fake_stdout(*, to, verification_link):
+        called["stdout"] = True
+
+    monkeypatch.setattr(mail_mod, "_send_smtp", _fake_smtp)
+    monkeypatch.setattr(mail_mod, "_send_stdout", _fake_stdout)
+
+    mail_mod.send_verification_email(
+        to="user@example.com",
+        verification_link="https://example.invalid/verify?id=A&token=B",
+    )
+    assert called["smtp"] is True
+    assert called["stdout"] is False
+
+
+def test_dev_stdout_backend_logs_warning_only(monkeypatch, caplog, capsys):
+    """In dev, the stdout backend logs a single WARNING (not the
+    multi-line print banner it used to). The link is still visible — the
+    dev workflow depends on it — but nothing is printed to stdout."""
+    from app.core import mail as mail_mod
+    from app.core.config import settings
+
+    cfg = settings()
+    monkeypatch.setattr(cfg, "APP_ENV", "dev")
+
+    link = "http://localhost:5173/verify?id=PEND&token=DEV-TOKEN-VISIBLE"
+
+    capsys.readouterr()
+    caplog.clear()
+    caplog.set_level(logging.WARNING, logger="app.core.mail")
+
+    mail_mod._send_stdout(to="user@example.com", verification_link=link)
+
+    captured = capsys.readouterr()
+    # No `print(...)` banner anymore — stdout/stderr should be empty.
+    assert captured.out == ""
+    # The WARNING must contain the link (dev workflow needs it).
+    assert any(
+        "DEV-TOKEN-VISIBLE" in r.getMessage() and r.levelno == logging.WARNING
+        for r in caplog.records
+    ), "dev stdout backend must log the verification link at WARNING"

--- a/backend/tests/test_workspace_secrets.py
+++ b/backend/tests/test_workspace_secrets.py
@@ -131,13 +131,22 @@ def test_prod_with_empty_workspace_secrets_key_fails_closed(monkeypatch):
 
 def test_prod_with_valid_workspace_secrets_key_boots(monkeypatch):
     """The other direction: a real Fernet key in prod must pass
-    validation cleanly."""
+    validation cleanly. Also populates the SMTP_* and APP_BASE_URL vars
+    required by the issue #281 fail-closed validator
+    (`_require_smtp_in_prod`) so this test exercises only the
+    workspace-secrets-key gate."""
     from cryptography.fernet import Fernet
 
     from app.core.config import Settings
 
     monkeypatch.setenv("APP_ENV", "prod")
     monkeypatch.setenv("WORKSPACE_SECRETS_KEY", Fernet.generate_key().decode())
+    # Required by `_require_smtp_in_prod` (issue #281).
+    monkeypatch.setenv("SMTP_HOST", "smtp.example.com")
+    monkeypatch.setenv("SMTP_USER", "user")
+    monkeypatch.setenv("SMTP_PASSWORD", "pw")
+    monkeypatch.setenv("MAIL_FROM", "noreply@example.com")
+    monkeypatch.setenv("APP_BASE_URL", "https://parts.example.com")
 
     s = Settings()
     assert s.APP_ENV == "prod"

--- a/deploy/.env.prod.example
+++ b/deploy/.env.prod.example
@@ -109,6 +109,27 @@ SENTRY_TRACES_SAMPLE_RATE=0.0
 VITE_SENTRY_DSN=
 VITE_SENTRY_TRACES_SAMPLE_RATE=0.0
 
+# ---- Email / SMTP (issue #281) ----
+# Email verification on signup is forced ON in prod (config.py validator
+# `_default_email_verification_in_prod`). The backend now ALSO refuses to
+# boot in prod when any of the required SMTP_* vars or APP_BASE_URL is
+# empty (or APP_BASE_URL is left at the dev default) — see the
+# `_require_smtp_in_prod` validator. This prevents the previous failure
+# mode where a misconfigured deploy silently fell through to a stdout
+# mail backend and wrote the verification link into container logs.
+#
+# Pick any SMTP relay you trust — Mailgun, SES, SMTP2GO, Postmark, etc.
+# The backend uses STARTTLS on port 587 by default.
+#
+# Required values (no defaults; an empty entry fails the deploy fast):
+SMTP_HOST=
+SMTP_USER=
+SMTP_PASSWORD=
+MAIL_FROM=noreply@parts.matescb.cz
+APP_BASE_URL=https://parts.matescb.cz
+# Optional (defaults to 587 — STARTTLS submission port):
+SMTP_PORT=587
+
 # ---- Sentry source-map upload (INFRA2-010) ----
 # SENTRY_AUTH_TOKEN, SENTRY_ORG, and SENTRY_PROJECT must NOT go here.
 # Source-map upload runs in the CI web-build job (push to main only) using

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -102,6 +102,19 @@ services:
       # also bakes this into the SPA bundle at build time (see web
       # service below).
       VITE_SENTRY_DSN: ${VITE_SENTRY_DSN:-}
+      # Email / SMTP for the email-verification flow (issue #281).
+      # No `:-` defaults on the required values (HOST/USER/PASSWORD/MAIL_FROM/
+      # APP_BASE_URL) — a missing entry in .env.prod becomes a Compose
+      # "variable is not set" warning, AND the backend's
+      # `_require_smtp_in_prod` validator hard-fails at import. Both are
+      # intentional: the silent-fallback failure mode (verification link
+      # written to container logs) is exactly what this issue removed.
+      SMTP_HOST: ${SMTP_HOST}
+      SMTP_PORT: ${SMTP_PORT:-587}
+      SMTP_USER: ${SMTP_USER}
+      SMTP_PASSWORD: ${SMTP_PASSWORD}
+      MAIL_FROM: ${MAIL_FROM}
+      APP_BASE_URL: ${APP_BASE_URL}
     volumes:
       - uploads:/data/uploads
     depends_on:


### PR DESCRIPTION
## Summary

- Add `_require_smtp_in_prod` Settings validator (mirrors the existing `_require_workspace_secrets_key_in_prod` pattern). Refuses to boot in prod when any of `SMTP_HOST` / `SMTP_USER` / `SMTP_PASSWORD` / `MAIL_FROM` / `APP_BASE_URL` is empty (or `APP_BASE_URL` is the dev default).
- Drop the `cfg.SMTP_HOST` half of the dispatch in `send_verification_email` so prod always selects the SMTP backend; the stdout backend now refuses to run in prod (defence in depth) and logs only a single WARNING in dev (no more multi-line `print` banner).
- Wire `SMTP_HOST` / `SMTP_PORT` / `SMTP_USER` / `SMTP_PASSWORD` / `MAIL_FROM` / `APP_BASE_URL` into the `docker-compose.prod.yml` backend env block (no `:-` defaults on required values, so a missing entry surfaces both as a Compose warning and as the new validator's hard fail). Document the new requirements in `deploy/.env.prod.example`.

## Why

Issue #281: prod email verification was forced on at signup, but the backend silently fell through to a stdout mail backend whenever any `SMTP_*` var was empty — writing the verification token URL into container logs where anyone with `docker logs` access could claim a fresh signup. Three-part remediation per the issue's implementation plan: fail closed in prod, wire the env, harden the dev fallback.

## Test plan

- [x] New `backend/tests/test_mail_prod_safety.py` (7 tests):
  - Validator rejects prod with empty SMTP and with the dev default `APP_BASE_URL`.
  - Validator boots prod cleanly with full SMTP + public `APP_BASE_URL`.
  - Dev posture preserved (empty SMTP env allowed).
  - `_send_stdout` raises `RuntimeError` in prod and produces no log/stdout containing the verification token (regression test for the leak).
  - `send_verification_email` selector goes to SMTP backend in prod regardless of `SMTP_HOST`.
  - Dev `_send_stdout` logs the link at WARNING and does not print to stdout.
- [x] Updated `test_prod_with_valid_workspace_secrets_key_boots` to also set the SMTP vars now required by the new validator.
- [x] `pytest -q` full backend suite: 738 passed, 2 skipped, 3 deselected.

## Deploy notes

Operator must add real values for `SMTP_HOST` / `SMTP_USER` / `SMTP_PASSWORD` / `MAIL_FROM` / `APP_BASE_URL` to `.env.prod` on the VPS before approving the production deploy environment in GitHub. The deploy will fail fast (backend container exits with `ValidationError`) if any required field is empty — that's the intended failure mode, not a regression. Verify with `docker compose -f docker-compose.prod.yml --env-file .env.prod config | grep SMTP` before approving.

Closes #281