### PR TITLE
fix(api): honour ?limit=N on legacy bare-list /api/parts (#286)

### DIFF
--- a/backend/app/api/routes/parts_core.py
+++ b/backend/app/api/routes/parts_core.py
@@ -67,10 +67,13 @@ def list_parts(
 
     Two response shapes — keyed off the request, NOT the route:
 
-      - Default (no ``cursor``, no ``paged=true``): bare list of parts.
-        Preserves the pre-cursor public API so the many lookup-style
-        consumers (BOM dropdowns, OrderDetail, ScanImport's MPN dup check,
-        …) keep working without per-call migration.
+      - Default (no ``cursor``, no ``paged=true``): bare list of parts,
+        respecting ``limit`` (default 50, max 200). Preserves the
+        pre-cursor public API so the many lookup-style consumers (BOM
+        dropdowns, OrderDetail, ScanImport's MPN dup check, …) keep
+        working without per-call migration. Callers that need more than
+        the default 50 must pass ``?limit=N`` explicitly (capped at 200).
+        For workspaces larger than 200 parts use the cursor-paged path.
 
       - Cursor opt-in (``?cursor=…`` OR ``?paged=true``): paged envelope
         ``{items: [...], next_cursor: str | null}``.
@@ -78,6 +81,9 @@ def list_parts(
         the next page.  ``next_cursor`` is null when no further pages
         exist. The ``cursor`` is an HMAC-signed blob — tampering returns
         400.
+
+    The ``limit`` query param is honoured in both modes; ``paged=true``
+    only changes the response envelope shape (adds ``next_cursor``).
 
     Every query is scoped to the current workspace (CLAUDE.md invariant).
     """
@@ -112,9 +118,14 @@ def list_parts(
     else:
         # Legacy bare-list shape — keep the same ORDER BY (name, id) the
         # paged path uses so two consumers viewing the same workspace in
-        # the same instant agree on row order.
+        # the same instant agree on row order. ``limit`` is honoured here
+        # too (issue #286) — previously it was silently ignored on this
+        # branch and a workspace with 50k parts would ship the entire
+        # catalog over the wire.
         parts = list(
-            db.execute(stmt.order_by(Part.name.asc(), Part.id.asc())).scalars()
+            db.execute(
+                stmt.order_by(Part.name.asc(), Part.id.asc()).limit(limit)
+            ).scalars()
         )
         next_cursor = None
 

--- a/backend/tests/test_pagination.py
+++ b/backend/tests/test_pagination.py
@@ -202,6 +202,38 @@ def test_legacy_bare_list_default_shape():
         assert "name" in item
 
 
+def test_legacy_bare_list_respects_limit():
+    """Issue #286: GET /api/parts?limit=N must respect ``limit`` even on
+    the legacy bare-list path (previously the limit was silently ignored
+    when neither ``cursor`` nor ``paged=true`` was set, so a workspace
+    with 50k parts shipped the entire catalog over the wire)."""
+    client, _ = _signup_and_get_client()
+    _create_parts_batch(client, 100)
+
+    r = client.get("/api/parts?limit=10")
+    assert r.status_code == 200
+    body = r.json()
+    # Envelope is {data, status} where status is a {category, message} object.
+    assert body["status"]["category"] == "ok"
+    data = body["data"]
+    assert isinstance(data, list)
+    assert len(data) == 10, f"Expected 10 items, got {len(data)}"
+
+
+def test_legacy_bare_list_default_limit_is_50():
+    """Issue #286 — pin the default ``limit`` (50) for the bare-list path.
+    A workspace with more than 50 parts must not receive everything when
+    no ``limit`` is supplied; callers that need the full catalog must
+    pass ``?limit=200`` explicitly."""
+    client, _ = _signup_and_get_client()
+    _create_parts_batch(client, 100)
+
+    r = client.get("/api/parts")
+    assert r.status_code == 200
+    data = r.json()["data"]
+    assert len(data) == 50, f"Expected 50 items (default limit), got {len(data)}"
+
+
 # ---------------------------------------------------------------------------
 # Workspace isolation: a cursor from workspace A must not work in workspace B
 # ---------------------------------------------------------------------------

--- a/web/src/routes/builds/BuildDetail.tsx
+++ b/web/src/routes/builds/BuildDetail.tsx
@@ -38,7 +38,7 @@ export default function BuildDetail() {
     queryFn: () => api.get<ProjectEntry[]>(`/projects/${projectId}/entries`),
     enabled: !!projectId,
   });
-  const { data: parts } = useQuery({ queryKey: useWsKey("parts"), queryFn: () => api.get<Part[]>("/parts") });
+  const { data: parts } = useQuery({ queryKey: useWsKey("parts"), queryFn: () => api.get<Part[]>("/parts?limit=200") });
   const { data: storage } = useQuery({ queryKey: useWsKey("storage"), queryFn: () => api.get<StorageLocation[]>("/storage") });
 
   // consumption plan: project_entry_id → list of consume rows

--- a/web/src/routes/lots/LotDetail.tsx
+++ b/web/src/routes/lots/LotDetail.tsx
@@ -12,7 +12,7 @@ import type { Lot, Part, StockEntry, StorageLocation } from "@/types";
 export function LotLayout() {
   const { lotId } = useParams<{ lotId: string }>();
   const { data, isError, error } = useQuery({ queryKey: useWsKey("lot", lotId), queryFn: () => api.get<Lot>(`/lots/${lotId}`), enabled: !!lotId });
-  const { data: parts } = useQuery({ queryKey: useWsKey("parts"), queryFn: () => api.get<Part[]>("/parts") });
+  const { data: parts } = useQuery({ queryKey: useWsKey("parts"), queryFn: () => api.get<Part[]>("/parts?limit=200") });
   if (isError) return <div className="text-red-600 text-sm p-4">Failed to load lot. {error instanceof ApiError ? error.userMessage : ""}</div>;
   if (!data) return <div className="text-muted">Loading…</div>;
   const part = parts?.find(p => p.id === data.part_id);

--- a/web/src/routes/orders/OrderDetail.tsx
+++ b/web/src/routes/orders/OrderDetail.tsx
@@ -47,7 +47,7 @@ export default function OrderDetail() {
     queryFn: () => api.get<DetailOut>(`/orders/${orderId}`),
     enabled: !!orderId,
   });
-  const { data: parts } = useQuery({ queryKey: useWsKey("parts"), queryFn: () => api.get<Part[]>("/parts") });
+  const { data: parts } = useQuery({ queryKey: useWsKey("parts"), queryFn: () => api.get<Part[]>("/parts?limit=200") });
   const { data: storage } = useQuery({ queryKey: useWsKey("storage"), queryFn: () => api.get<StorageLocation[]>("/storage") });
 
   const partsById = new Map(parts?.map(p => [p.id, p]) ?? []);

--- a/web/src/routes/parts/LotsList.tsx
+++ b/web/src/routes/parts/LotsList.tsx
@@ -13,7 +13,7 @@ import QueryStateBoundary from "@/components/QueryStateBoundary";
 export default function LotsList() {
   const query = useQuery({ queryKey: useWsKey("lots"), queryFn: () => api.get<Lot[]>("/lots") });
   const { data } = query;
-  const { data: parts } = useQuery({ queryKey: useWsKey("parts"), queryFn: () => api.get<Part[]>("/parts") });
+  const { data: parts } = useQuery({ queryKey: useWsKey("parts"), queryFn: () => api.get<Part[]>("/parts?limit=200") });
   const partName = new Map(parts?.map(p => [p.id, p.name]) ?? []);
   const nav = useNavigate();
 

--- a/web/src/routes/parts/StockHistory.tsx
+++ b/web/src/routes/parts/StockHistory.tsx
@@ -15,7 +15,7 @@ export default function StockHistory() {
   const { data } = historyQuery;
   // The parts/storage queries hydrate name maps for the table cells; missing
   // them just falls back to UUIDs in the column, so they stay bare.
-  const { data: parts } = useQuery({ queryKey: useWsKey("parts"), queryFn: () => api.get<Part[]>("/parts") });
+  const { data: parts } = useQuery({ queryKey: useWsKey("parts"), queryFn: () => api.get<Part[]>("/parts?limit=200") });
   const { data: storage } = useQuery({ queryKey: useWsKey("storage"), queryFn: () => api.get<StorageLocation[]>("/storage") });
   const partName = new Map(parts?.map(p => [p.id, p.name]) ?? []);
   const sName = new Map(storage?.map(s => [s.id, s.name]) ?? []);

--- a/web/src/routes/parts/detail/PartMembers.tsx
+++ b/web/src/routes/parts/detail/PartMembers.tsx
@@ -18,7 +18,7 @@ export default function PartMembers() {
     queryFn: () => api.get<Member[]>(`/parts/${partId}/members`),
   });
   const { data: members } = membersQuery;
-  const { data: parts } = useQuery({ queryKey: useWsKey("parts"), queryFn: () => api.get<Part[]>("/parts") });
+  const { data: parts } = useQuery({ queryKey: useWsKey("parts"), queryFn: () => api.get<Part[]>("/parts?limit=200") });
   const partsById = new Map(parts?.map(p => [p.id, p]) ?? []);
 
   const [pick, setPick] = useState("");

--- a/web/src/routes/parts/detail/PartSubstitutes.tsx
+++ b/web/src/routes/parts/detail/PartSubstitutes.tsx
@@ -15,7 +15,7 @@ export default function PartSubstitutes() {
   const { workspaceId } = useAuth();
   const subsQuery = useQuery({ queryKey: useWsKey("part", partId, "subs"), queryFn: () => api.get<Sub[]>(`/parts/${partId}/substitutes`) });
   const { data: subs } = subsQuery;
-  const { data: parts } = useQuery({ queryKey: useWsKey("parts"), queryFn: () => api.get<Part[]>("/parts") });
+  const { data: parts } = useQuery({ queryKey: useWsKey("parts"), queryFn: () => api.get<Part[]>("/parts?limit=200") });
   const partsById = new Map(parts?.map(p => [p.id, p]) ?? []);
   const [pick, setPick] = useState("");
 

--- a/web/src/routes/projects/detail/ProjectBOM.tsx
+++ b/web/src/routes/projects/detail/ProjectBOM.tsx
@@ -19,7 +19,7 @@ export default function ProjectBOM() {
     queryFn: () => api.get<ProjectEntry[]>(`/projects/${projectId}/entries`),
   });
   const { data: entries } = entriesQuery;
-  const { data: parts } = useQuery({ queryKey: useWsKey("parts"), queryFn: () => api.get<Part[]>("/parts") });
+  const { data: parts } = useQuery({ queryKey: useWsKey("parts"), queryFn: () => api.get<Part[]>("/parts?limit=200") });
   const partsById = new Map(parts?.map(p => [p.id, p]) ?? []);
 
   const [matching, setMatching] = useState<{ entryId: string; pick: string } | null>(null);

--- a/web/src/routes/storage/StorageDetail.tsx
+++ b/web/src/routes/storage/StorageDetail.tsx
@@ -67,7 +67,7 @@ export function StorageInfo() {
     queryKey: storagePartsKey,
     queryFn: () => api.get<{ part_id: string; lot_id: string | null; quantity: number }[]>(`/storage/${storageId}/parts`),
   });
-  const { data: parts } = useQuery({ queryKey: partsKey, queryFn: () => api.get<Part[]>("/parts") });
+  const { data: parts } = useQuery({ queryKey: partsKey, queryFn: () => api.get<Part[]>("/parts?limit=200") });
   // Derived data — safe to compute even when rows/parts are undefined.
   // Hoisted above the `isError` early-return so the hook count stays
   // stable across renders (Rules of Hooks — see #284).
@@ -103,7 +103,7 @@ export function StorageHistory() {
     queryFn: () => api.get<StockEntry[]>(`/storage/${storageId}/history?limit=200`),
   });
   const { data } = historyQuery;
-  const { data: parts } = useQuery({ queryKey: useWsKey("parts"), queryFn: () => api.get<Part[]>("/parts") });
+  const { data: parts } = useQuery({ queryKey: useWsKey("parts"), queryFn: () => api.get<Part[]>("/parts?limit=200") });
   const partName = new Map(parts?.map(p => [p.id, p.name]) ?? []);
   return (
     <QueryStateBoundary query={historyQuery} resourceLabel="storage history">


### PR DESCRIPTION
## Summary

- The bare-list path of `GET /api/parts` (no `cursor`, no `paged=true`) silently ignored the `limit` query param and returned the entire workspace catalog — a 50k-part workspace shipped 50k rows of JSON on every dropdown hydration.
- Apply `.limit(limit)` to the bare-list query (default 50, max 200 — the FastAPI `Query(default=50, le=200)` cap already exists). Docstring updated to spell out the contract: `limit` is honoured in both modes; `paged=true` only changes the envelope shape.
- 10 lookup-style frontend callers used to fetch `/parts` with no params and rely on the implicit "everything" behaviour. Each now passes `?limit=200` to preserve the working dropdown size for the current user base.

## Files

- `backend/app/api/routes/parts_core.py` — apply `.limit(limit)` on the legacy branch + docstring.
- `backend/tests/test_pagination.py` — two new tests:
  - `test_legacy_bare_list_respects_limit` — 100 parts, `?limit=10` → 10 items.
  - `test_legacy_bare_list_default_limit_is_50` — 100 parts, no param → 50 items (pins the default).
- 10 frontend callers: `ProjectBOM`, `BuildDetail`, `OrderDetail`, `StorageDetail` (×2), `LotDetail`, `LotsList`, `StockHistory`, `PartSubstitutes`, `PartMembers` — each now passes `?limit=200`.

## Test plan

- [x] `pytest tests/test_pagination.py` — 13 passed (the two new cases + the existing 11).
- [x] Full backend suite — 733 passed, 2 skipped.
- [ ] Spot-check that BOM / Build / Order / Storage / Lot / Substitute pickers still populate after merge in a workspace with <200 parts (no behavioural change for that range).
- [ ] Frontend `tsc -b` + `vite build` (CI).

Closes #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)