### PR TITLE
fix(stock): enforce storage constraints on orders.receive and builds.consume output

### DIFF
--- a/backend/app/api/routes/builds.py
+++ b/backend/app/api/routes/builds.py
@@ -21,6 +21,7 @@ from app.domain.builds.service import (
 )
 from app.domain.projects.models import Project
 from app.domain.stock.models import StockEntry
+from app.domain.stock.service import StockConflictError
 
 router = APIRouter()
 
@@ -165,6 +166,19 @@ def consume_build(
     try:
         result = consume(
             db, workspace_id=ws.id, user_id=user.id, build=b, project=project, payload=payload
+        )
+    except StockConflictError as exc:
+        # BE-004 follow-up (#280): the build sub-assembly output is a
+        # producer write into the chosen output storage; if that storage
+        # is constrained the violation surfaces as a structured 409 with
+        # the same body shape as /api/stock/add.
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "message": str(exc),
+                "constraint": exc.constraint,
+                "storage_location_id": str(exc.storage_location_id),
+            },
         )
     except BuildError as exc:
         # `get_db` rolls back on raise (BE2-010), so dropping the

--- a/backend/app/api/routes/orders.py
+++ b/backend/app/api/routes/orders.py
@@ -22,6 +22,7 @@ from app.domain.orders.schemas import (
 from app.domain.orders.service import OrderError, receive
 from app.domain.parts.models import Part
 from app.domain.stock.models import StockEntry
+from app.domain.stock.service import StockConflictError
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -295,6 +296,18 @@ def receive_order(order_id: UUID, payload: ReceiveIn, db: DbSession, ws: Current
     o = _get_order(db, ws.id, order_id)
     try:
         result = receive(db, workspace_id=ws.id, user_id=user.id, order=o, payload=payload)
+    except StockConflictError as exc:
+        # BE-004 follow-up (#280): receive lines into a constrained
+        # destination must surface a structured 409 with the same body
+        # shape as /api/stock/add so existing client-side handlers work.
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "message": str(exc),
+                "constraint": exc.constraint,
+                "storage_location_id": str(exc.storage_location_id),
+            },
+        )
     except OrderError as exc:
         # Re-raise as a 4xx — `get_db` rolls back automatically when
         # the route raises (BE2-010), so we don't need an explicit

--- a/backend/app/domain/builds/service.py
+++ b/backend/app/domain/builds/service.py
@@ -23,7 +23,11 @@ from app.domain.lots.models import Lot
 from app.domain.parts.models import Part, PartMetaMember, PartSubstitute
 from app.domain.projects.models import Project, ProjectEntry
 from app.domain.stock.models import StockEntry
-from app.domain.stock.service import current_quantity, lock_parts_for_stock_write
+from app.domain.stock.service import (
+    current_quantity,
+    enforce_storage_constraints,
+    lock_parts_for_stock_write,
+)
 from app.domain.storage.models import StorageLocation
 
 
@@ -441,6 +445,16 @@ def consume(
                 raise BuildError("output storage not in workspace")
             if storage.archived_at is not None or storage.is_full:
                 raise BuildError("output storage archived or full")
+            # BE-004 follow-up (#280): the build-output StockEntry is a
+            # producer write that must respect single_part_only /
+            # existing_parts_only. The per-(workspace, sub_part) advisory
+            # lock was already taken in the bundled lock call earlier in
+            # consume(); the helper additionally acquires the per-storage
+            # lock to close the cross-part race. StockConflictError is
+            # mapped to 409 in routes/builds.py.
+            enforce_storage_constraints(
+                db, workspace_id=workspace_id, storage=storage, part_id=sub_part.id
+            )
 
         output_lot = Lot(
             workspace_id=workspace_id,

--- a/backend/app/domain/orders/service.py
+++ b/backend/app/domain/orders/service.py
@@ -16,7 +16,7 @@ log = get_logger(__name__)
 from app.domain.orders.schemas import ReceiveIn
 from app.domain.parts.models import Part
 from app.domain.stock.models import StockEntry
-from app.domain.stock.service import lock_parts_for_stock_write
+from app.domain.stock.service import enforce_storage_constraints, lock_parts_for_stock_write
 from app.domain.storage.models import StorageLocation
 from app.domain.workspaces.models import Workspace
 
@@ -122,6 +122,16 @@ def receive(
                 raise OrderError("storage location is archived")
             if storage.is_full:
                 raise OrderError("storage location is marked full")
+            # BE-004 follow-up (#280): producer paths must enforce
+            # single_part_only / existing_parts_only on the destination,
+            # same as add_stock / move_stock. The per-part advisory lock
+            # was acquired above via lock_parts_for_stock_write; the helper
+            # additionally takes the per-storage lock for the cross-part
+            # race. Raised StockConflictError surfaces as a 409 in the
+            # route layer (mirror of routes/stock.py).
+            enforce_storage_constraints(
+                db, workspace_id=workspace_id, storage=storage, part_id=part.id
+            )
 
         currency = oe.currency or order.currency
         unit_price = oe.unit_price

--- a/backend/app/domain/stock/service.py
+++ b/backend/app/domain/stock/service.py
@@ -128,7 +128,7 @@ def _lock_for_storage_constraint(
     the storage lock without circular waits — there is no path that
     holds the storage lock while waiting for a per-part lock. (The
     multi-part helpers — ``builds.consume``, ``orders.receive`` — do
-    not pass a destination through ``_enforce_storage_constraints``,
+    not pass a destination through ``enforce_storage_constraints``,
     so they don't take a storage lock.)
     """
     db.execute(
@@ -327,7 +327,7 @@ def stock_for_storage(
     ]
 
 
-def _enforce_storage_constraints(
+def enforce_storage_constraints(
     db: Session,
     *,
     workspace_id: UUID,
@@ -337,10 +337,12 @@ def _enforce_storage_constraints(
     """Enforce single_part_only and existing_parts_only constraints using
     current stock (positive on-hand balances), not historical row counts.
 
-    Must be called inside the advisory lock for (workspace_id, part_id) —
-    every caller acquires that via ``_lock_for_stock_write`` first. We
-    additionally acquire the per-(workspace, storage) lock here so that
-    two concurrent writers targeting the *same destination* with
+    Public callers (``add_stock``, ``move_stock``, ``orders.receive``,
+    ``builds.consume``) all acquire the per-(workspace, part) advisory
+    lock via ``_lock_for_stock_write`` / ``lock_parts_for_stock_write``
+    before calling this helper — that lock must be held when this runs.
+    We additionally acquire the per-(workspace, storage) lock here so
+    that two concurrent writers targeting the *same destination* with
     *different parts* can't both pass the single_part_only /
     existing_parts_only check on a stale read and then both insert
     (cross-part race). The per-part lock alone only serialises same-part
@@ -348,10 +350,11 @@ def _enforce_storage_constraints(
     is fixed (part, then storage) to avoid AB/BA deadlocks with
     ``_lock_for_stock_write``.
 
-    Scope: ``add_stock`` and ``move_stock`` (the storage-constrained
-    paths). ``adjust_stock`` / ``remove_stock`` don't enter constrained
-    locations from outside, and the multi-part helpers don't pass a
-    destination through this function.
+    Scope: every producer path whose destination is a constrained
+    location — ``add_stock``, ``move_stock`` (destination side),
+    ``orders.receive`` (each receive line) and ``builds.consume``
+    (sub-assembly output). ``adjust_stock`` / ``remove_stock`` don't
+    enter constrained locations from outside.
 
     Raises StockConflictError on violation.
     """
@@ -413,7 +416,9 @@ def add_stock(
             raise StockError("storage location is archived")
         if storage.is_full:
             raise StockError("storage location is marked full")
-        _enforce_storage_constraints(db, workspace_id=workspace_id, storage=storage, part_id=payload.part_id)
+        enforce_storage_constraints(
+            db, workspace_id=workspace_id, storage=storage, part_id=payload.part_id
+        )
 
     # Mandatory default-storage check (spec §19.2). Previously the chain
     # short-circuited when `storage` was None — any row that simply omitted
@@ -586,7 +591,7 @@ def move_stock(
     if payload.quantity > available:
         raise StockError(f"insufficient stock at source (have {available}, want {payload.quantity})")
 
-    _enforce_storage_constraints(db, workspace_id=workspace_id, storage=dest, part_id=part.id)
+    enforce_storage_constraints(db, workspace_id=workspace_id, storage=dest, part_id=part.id)
 
     # Pre-assign UUIDs so the two StockEntry rows can reference each
     # other via `related_entry_id`. The actual write strategy is a

--- a/backend/tests/test_storage_constraints.py
+++ b/backend/tests/test_storage_constraints.py
@@ -390,3 +390,209 @@ def test_single_part_only_cross_part_race_blocked(c):
     # Exactly one succeeds, one is rejected with the structured 409.
     assert successes == 1, f"expected 1 success, got results={results}"
     assert conflicts == 1, f"expected 1 conflict, got results={results}"
+
+
+# ---------------------------------------------------------------------------
+# orders.receive — BE-004 follow-up (#280)
+#
+# `receive` writes a producer StockEntry just like add_stock; the same
+# storage-location constraints (single_part_only, existing_parts_only) must
+# fire. Pre-fix, `receive` skipped the helper entirely so a
+# /api/orders/{id}/receive could land stock into a constrained bin.
+# ---------------------------------------------------------------------------
+
+
+def _create_order(c: TestClient, part_id: str, qty: int = 5) -> tuple[str, str]:
+    """Create an order with a single entry for ``part_id``. Returns
+    ``(order_id, order_entry_id)``."""
+    r = c.post(
+        "/api/orders",
+        json={
+            "name": f"PO-{uuid.uuid4().hex[:6]}",
+            "currency": "USD",
+            "entries": [{"part_id": part_id, "quantity_ordered": qty}],
+        },
+    )
+    assert r.status_code in (200, 201), r.text
+    order_id = r.json()["data"]["id"]
+    detail = c.get(f"/api/orders/{order_id}").json()["data"]
+    entry_id = detail["entries"][0]["id"]
+    return order_id, entry_id
+
+
+def test_orders_receive_rejects_single_part_only_bin_holding_other_part(c):
+    """receive into a single_part_only bin already holding a different
+    part must 409 with the same {constraint, storage_location_id} body
+    that /api/stock/add returns."""
+    loc = _storage(c, "Recv-SPO", single_part_only=True)
+    part_a = _part(c, "RecvA")
+    part_b = _part(c, "RecvB")
+
+    # Seed part A in the constrained bin.
+    _add(c, part_a, 5, loc)
+
+    # Create an order for part B and try to receive into the same bin.
+    order_id, entry_id = _create_order(c, part_b, qty=3)
+    r = c.post(
+        f"/api/orders/{order_id}/receive",
+        json={
+            "lines": [
+                {"order_entry_id": entry_id, "quantity": 3, "storage_location_id": loc}
+            ]
+        },
+    )
+    assert r.status_code == 409, r.text
+    detail = r.json()
+    assert detail.get("constraint") == "single_part_only"
+    assert detail.get("storage_location_id") == loc
+
+
+def test_orders_receive_rejects_existing_parts_only_for_unstocked_part(c):
+    """receive into an existing_parts_only bin where the part has no
+    prior positive history must 409."""
+    loc = _storage(c, "Recv-EPO", existing_parts_only=True)
+    part = _part(c, "RecvNew")
+
+    order_id, entry_id = _create_order(c, part, qty=2)
+    r = c.post(
+        f"/api/orders/{order_id}/receive",
+        json={
+            "lines": [
+                {"order_entry_id": entry_id, "quantity": 2, "storage_location_id": loc}
+            ]
+        },
+    )
+    assert r.status_code == 409, r.text
+    detail = r.json()
+    assert detail.get("constraint") == "existing_parts_only"
+    assert detail.get("storage_location_id") == loc
+
+
+# ---------------------------------------------------------------------------
+# builds.consume — sub-assembly output — BE-004 follow-up (#280)
+#
+# When a project has `associated_subassembly_part_id` set, consume()
+# writes a producer StockEntry for the build output. That write must
+# also respect storage-location constraints.
+# ---------------------------------------------------------------------------
+
+
+def _make_build_with_output(
+    c: TestClient,
+    *,
+    sub_part_id: str,
+    bom_part_id: str,
+    bom_storage_id: str,
+    bom_qty: int = 10,
+) -> tuple[str, str]:
+    """Create a project + build configured for sub-assembly output.
+
+    Returns ``(build_id, project_entry_id)``. The caller posts to
+    /consume with the desired ``output_storage_location_id``.
+    """
+    r = c.post("/api/projects", json={"name": f"Proj-{uuid.uuid4().hex[:6]}"})
+    assert r.status_code in (200, 201), r.text
+    proj_id = r.json()["data"]["id"]
+
+    r = c.post(
+        f"/api/projects/{proj_id}/entries",
+        json={"part_id": bom_part_id, "quantity": bom_qty},
+    )
+    assert r.status_code in (200, 201), r.text
+    entry_id = r.json()["data"]["id"]
+
+    r = c.patch(
+        f"/api/projects/{proj_id}",
+        json={"associated_subassembly_part_id": sub_part_id},
+    )
+    assert r.status_code == 200, r.text
+
+    r = c.post(
+        "/api/builds",
+        json={"name": f"B-{uuid.uuid4().hex[:6]}", "project_id": proj_id, "quantity": 1},
+    )
+    assert r.status_code in (200, 201), r.text
+    build_id = r.json()["data"]["id"]
+    return build_id, entry_id
+
+
+def test_builds_consume_output_rejects_single_part_only_bin(c):
+    """The build output landed into a single_part_only bin already
+    holding another part must 409 — the producer write is now guarded
+    just like add_stock."""
+    storage_in = _storage(c, "Build-Inputs")
+    out_loc = _storage(c, "Build-Out-SPO", single_part_only=True)
+
+    bom_part = _part(c, "BOM-R")
+    sub_part = _part(c, "SUB")
+    blocker = _part(c, "Blocker")
+
+    # Seed plenty of BOM stock and pre-stock the constrained output bin
+    # with a different part so the constraint fires on the output write.
+    _add(c, bom_part, 100, storage_in)
+    _add(c, blocker, 1, out_loc)
+
+    build_id, entry_id = _make_build_with_output(
+        c,
+        sub_part_id=sub_part,
+        bom_part_id=bom_part,
+        bom_storage_id=storage_in,
+        bom_qty=10,
+    )
+
+    r = c.post(
+        f"/api/builds/{build_id}/consume",
+        json={
+            "output_storage_location_id": out_loc,
+            "lines": [
+                {
+                    "project_entry_id": entry_id,
+                    "part_id": bom_part,
+                    "quantity": 10,
+                    "storage_location_id": storage_in,
+                }
+            ],
+        },
+    )
+    assert r.status_code == 409, r.text
+    detail = r.json()
+    assert detail.get("constraint") == "single_part_only"
+    assert detail.get("storage_location_id") == out_loc
+
+
+def test_builds_consume_output_allows_unconstrained_bin_regression(c):
+    """Sanity: an unconstrained output bin still accepts the build
+    output. The new guard must not fire when the destination has no
+    storage-constraint flags set."""
+    storage_in = _storage(c, "Build-Inputs-Reg")
+    out_loc = _storage(c, "Build-Out-Plain")
+
+    bom_part = _part(c, "BOM-R-Reg")
+    sub_part = _part(c, "SUB-Reg")
+
+    _add(c, bom_part, 100, storage_in)
+
+    build_id, entry_id = _make_build_with_output(
+        c,
+        sub_part_id=sub_part,
+        bom_part_id=bom_part,
+        bom_storage_id=storage_in,
+        bom_qty=10,
+    )
+
+    r = c.post(
+        f"/api/builds/{build_id}/consume",
+        json={
+            "output_storage_location_id": out_loc,
+            "lines": [
+                {
+                    "project_entry_id": entry_id,
+                    "part_id": bom_part,
+                    "quantity": 10,
+                    "storage_location_id": storage_in,
+                }
+            ],
+        },
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["data"]["status"] == "complete"


### PR DESCRIPTION
## Summary

BE-004 (#35) added `single_part_only` / `existing_parts_only` enforcement via `_enforce_storage_constraints` in `backend/app/domain/stock/service.py`, but only `add_stock` and `move_stock`'s destination side called it. Two other producer paths wrote `StockEntry` rows directly and bypassed the guard:

- `orders.receive` (`domain/orders/service.py`) — a receive line could land stock into a `single_part_only` bin already holding another part, or into an `existing_parts_only` bin where the receiving part has no prior positive history.
- `builds.consume` sub-assembly output (`domain/builds/service.py`) — a build whose project has `associated_subassembly_part_id` could deposit the produce-side row into a constrained bin.

This PR (shape (a) from the issue):

- Renames `_enforce_storage_constraints` -> `enforce_storage_constraints` (public) in `domain/stock/service.py` and updates the existing two internal call-sites. No back-compat alias needed (no external callers existed).
- Calls `enforce_storage_constraints` from `orders.receive` (per receive line, after the storage workspace/archived/full checks) and from `builds.consume` (for the sub-assembly output, when an `output_storage_location_id` is supplied). Both call sites already hold the per-(workspace, part) advisory lock via `lock_parts_for_stock_write`, so the helper's nested per-(workspace, storage) lock composes without deadlock.
- Adds `except StockConflictError` arms in `routes/orders.py::receive_order` and `routes/builds.py::consume_build` mapping the violation to a structured 409 with the same `{message, constraint, storage_location_id}` body shape used by `/api/stock/add` (mirror of `routes/stock.py`). Frontend handlers that already parse this shape work unchanged.

Hard invariants preserved: workspace isolation (no new cross-table joins; helper queries are workspace-filtered), append-only ledger (no schema change), API envelope (`{data, status}` via `responses.ok` / detail-spread `HTTPException`).

## Test plan

- [x] `tests/test_storage_constraints.py` extended with four new cases (all green):
  - `test_orders_receive_rejects_single_part_only_bin_holding_other_part` — 409 with `constraint=single_part_only`.
  - `test_orders_receive_rejects_existing_parts_only_for_unstocked_part` — 409 with `constraint=existing_parts_only`.
  - `test_builds_consume_output_rejects_single_part_only_bin` — 409 on the build-output write.
  - `test_builds_consume_output_allows_unconstrained_bin_regression` — sanity that the new guard does not fire for plain bins.
- [x] `pytest tests/test_storage_constraints.py tests/test_orders.py tests/test_builds.py` -> 38 passed locally against Postgres.
- [ ] Manual smoke in dev: stock part A in a `single_part_only` bin, post `/api/orders/{id}/receive` for part B targeting the same bin -> expect 409 JSON body with `constraint`.

Closes #280
Refs #35

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>