### PR TITLE
fix(ci): make lint-delta gate line-number-tolerant

### DIFF
--- a/scripts/lint-delta.sh
+++ b/scripts/lint-delta.sh
@@ -4,10 +4,13 @@
 # Usage:
 #   LINT_CMD="<command>"  BASELINE_FILE="<path>"  bash scripts/lint-delta.sh
 #
-# The linter output is filtered to lines that look like lint diagnostics
-# (i.e. lines matching <file>:<line>:<col>: …) and compared against the
-# checked-in baseline. Exit 1 iff there are new violations not in the
-# baseline.
+# Comparison is line-number-tolerant. We collapse <line>:<col> away on
+# both sides and compare multiset counts of (file, rule, message)
+# triples — a triple is "new" only when its current count exceeds its
+# baseline count. Pure line-shifts (an insert above an existing
+# baselined entry that bumps every entry below by N) don't trip the
+# gate, which is what bit every PR rebased onto main while the baseline
+# pinned exact line numbers.
 #
 # To regenerate a baseline after intentional cleanup:
 #   See "Updating lint baselines" in docs/development.md
@@ -23,28 +26,59 @@ if [ ! -f "$BASELINE_FILE" ]; then
   exit 1
 fi
 
-TMPFILE=$(mktemp)
-trap 'rm -f "$TMPFILE"' EXIT
+CUR_RAW=$(mktemp)
+KEYED_CUR=$(mktemp)
+KEYED_BASE=$(mktemp)
+trap 'rm -f "$CUR_RAW" "$KEYED_CUR" "$KEYED_BASE"' EXIT
 
-# Run linter; capture output; ignore its exit code (we decide pass/fail)
+# Capture raw linter output (with line:col) so we can show humans where
+# the new violations live.
 (cd "$WORK_DIR" && eval "$LINT_CMD") 2>&1 \
   | grep -E '^[^[:space:]].+:[0-9]+:[0-9]+:' \
   | sed "s|^$(pwd)/||g" \
-  | sort > "$TMPFILE" || true
+  > "$CUR_RAW" || true
 
-# Find lines present in current output but NOT in baseline
-NEW_VIOLATIONS=$(comm -23 "$TMPFILE" <(sort "$BASELINE_FILE"))
+# Collapse helper: <file>:<line>:<col>: <rule> <msg>  ->  <file>: <rule> <msg>
+collapse_re='s|:[0-9]+:[0-9]+: |: |'
+
+# Tab-separated current file: <collapsed-key>\t<raw-line>
+awk -v re="$collapse_re" '
+  { key=$0; sub(/:[0-9]+:[0-9]+: /, ": ", key); print key "\t" $0 }
+' "$CUR_RAW" | sort > "$KEYED_CUR"
+
+# Baseline allowance per collapsed key: <key>\t<count>
+sed -E "$collapse_re" "$BASELINE_FILE" | sort | uniq -c \
+  | awk '{ n=$1; $1=""; sub(/^ /,""); print $0 "\t" n }' > "$KEYED_BASE"
+
+# For each collapsed key in current, accumulate seen[key]; emit raw line
+# (with line:col) when seen[key] exceeds baseline allowance.
+NEW_VIOLATIONS=$(
+  awk -F'\t' '
+    NR==FNR { allow[$1] = $2+0; next }
+    {
+      key = $1; raw = $2
+      seen[key]++
+      if (seen[key] > allow[key]) print raw
+    }
+  ' "$KEYED_BASE" "$KEYED_CUR"
+)
 
 if [ -n "$NEW_VIOLATIONS" ]; then
   echo ""
-  echo "=== NEW lint violations (not in baseline $BASELINE_FILE) ==="
+  echo "=== NEW lint violations (not absorbed by baseline $BASELINE_FILE) ==="
   echo "$NEW_VIOLATIONS"
+  echo ""
+  echo "Comparison is line-number-tolerant: a violation only counts as new"
+  echo "when its (file, rule, message) triple appears more times than the"
+  echo "baseline allows. Pure line-shifts don't trip this gate."
   echo ""
   echo "Fix the new violations, or update the baseline if they are intentional:"
   echo "  See docs/development.md — 'Updating lint baselines'"
   exit 1
 fi
 
-FIXED=$(comm -23 <(sort "$BASELINE_FILE") "$TMPFILE" | wc -l | tr -d ' ')
-CURRENT=$(wc -l < "$TMPFILE" | tr -d ' ')
-echo "lint-delta: no new violations (baseline: $(wc -l < "$BASELINE_FILE" | tr -d ' '), current: $CURRENT, fixed since baseline: $FIXED)"
+BASE_TOTAL=$(wc -l < "$BASELINE_FILE" | tr -d ' ')
+CUR_TOTAL=$(wc -l < "$CUR_RAW" | tr -d ' ')
+FIXED=$((BASE_TOTAL - CUR_TOTAL))
+[ "$FIXED" -lt 0 ] && FIXED=0
+echo "lint-delta: no new violations (baseline: $BASE_TOTAL, current: $CUR_TOTAL, fixed since baseline: $FIXED)"


### PR DESCRIPTION
## Summary

The `lint-delta` gate (`scripts/lint-delta.sh`, introduced by PR #266) compared linter output against the baseline by exact `<file>:<line>:<col>` match via `comm -23`. Any line inserted above an existing baselined entry shifted every entry below by one — and the script registered each shifted entry as a "new" violation.

This bit every backend PR rebased onto the line-count-budget commit:
- **PR #296** (#279 datetime imports) — old script: 8 false positives. New script: passes.
- **PR #297** (#281 SMTP fail-closed) — old script: 1 false positive in `config.py`. New script: passes.
- **PR #298** (#286 parts limit) — old script: 7 false positives in `parts_core.py`. New script: passes.
- **PR #299** (#280 storage constraints) — old script: 11 false positives. New script surfaces **1 genuine** new `E501` in `stock/service.py:419` (the `enforce_storage_constraints` rename pushed an existing line from 100 → 108 cols).

## How it works now

Comparison is line-number-tolerant. We collapse `:line:col` away and compare multiset counts of `(file, rule, message)` triples — a triple is "new" only when its current count exceeds its baseline count. Pure line-shifts are absorbed; genuine new violations are still surfaced with the raw `:line:col` so authors can locate them.

```
$ LINT_CMD=... BASELINE_FILE=... bash scripts/lint-delta.sh
=== NEW lint violations (not absorbed by baseline .ruff-baseline.txt) ===
app/domain/stock/service.py:419:101: E501 Line too long (108 > 100)
```

## Test plan

- [x] Run against `main` baseline → no false positives, prints "no new violations (baseline: 159, current: 159, fixed since baseline: 0)".
- [x] Run against PR #296's branch state → passes (was failing).
- [x] Run against PR #299's branch state → fails on the 1 genuine new `E501` in `stock/service.py:419` (correctly identified, not buried in 10 false positives).
- [x] No baseline file changes — the existing `.ruff-baseline.txt` and `.eslint-baseline.txt` still work as-is.