### PR TITLE
fix(security): stream provider asset downloads to enforce size cap (#285)

### DIFF
--- a/backend/app/domain/parts/services/assets.py
+++ b/backend/app/domain/parts/services/assets.py
@@ -33,6 +33,7 @@ import ipaddress
 import logging
 import os
 import socket
+from dataclasses import dataclass
 from urllib.parse import urlparse
 
 import httpx
@@ -44,6 +45,24 @@ log = logging.getLogger(__name__)
 
 _TIMEOUT_SEC = 10.0
 _MAX_BYTES = 10 * 1024 * 1024  # 10 MB ceiling — datasheet PDFs are usually 1-3 MB
+_CHUNK_SIZE = 64 * 1024  # 64 KB — streaming read granularity for the size-cap guard
+
+
+@dataclass
+class _AssetResponse:
+    """Result of `_http_get` after size-capped streaming.
+
+    `body` is `None` when the download was aborted because either the
+    `Content-Length` header or the running stream total exceeded
+    `_MAX_BYTES`. Returning the headers + status separately lets the
+    caller distinguish "oversize" from "non-200" / "empty" without
+    holding any oversized bytes in memory.
+    """
+
+    status_code: int
+    headers: dict[str, str]
+    body: bytes | None
+
 
 # Content-Type → file extension. Falls through to URL-suffix inference
 # for anything that doesn't match. SVG is intentionally absent — see
@@ -117,8 +136,8 @@ def _ext_from_url(url: str) -> str | None:
     return ext if 1 <= len(ext) <= 5 and ext.isalnum() else None
 
 
-def _ext_from_response(resp: httpx.Response, url: str) -> str:
-    ct = (resp.headers.get("content-type") or "").split(";", 1)[0].strip().lower()
+def _ext_from_response(headers: dict[str, str], url: str) -> str:
+    ct = (headers.get("content-type") or "").split(";", 1)[0].strip().lower()
     if ct == "image/svg+xml":
         # Explicit refusal — the file lands as `.bin` and the serve
         # route forces an `attachment` disposition for non-images.
@@ -157,16 +176,59 @@ def _host_is_allowed(host: str) -> bool:
     return ip.is_global
 
 
-def _http_get(url: str) -> httpx.Response:
-    """Network seam — patched by tests.
+def _http_get(url: str) -> _AssetResponse:
+    """Network seam — patched by tests. Streams the response body and
+    aborts as soon as the running byte total exceeds `_MAX_BYTES`,
+    so a hostile multi-GB body can never be fully buffered into memory
+    before the size cap fires (security #285).
 
     `follow_redirects=False` is load-bearing: a 30x upstream is treated
     as a refusal (returns the redirect itself, which the caller rejects
     because `status_code != 200`). Auto-following would void the host
     allow-list since the Location: header could point anywhere.
+
+    The returned `_AssetResponse.body` is `None` when the download was
+    aborted because of the size cap (either Content-Length pre-check or
+    mid-stream chunk-counter); the caller treats that the same as any
+    other refusal and returns `None` to its caller.
     """
     with httpx.Client(timeout=_TIMEOUT_SEC, follow_redirects=False) as client:
-        return client.get(url)
+        with client.stream("GET", url) as resp:
+            headers = dict(resp.headers)
+            status = resp.status_code
+
+            # Belt-and-braces: many CDNs send Content-Length, so we can
+            # short-circuit oversize responses without reading the body.
+            # Treated as advisory — a missing or malformed value falls
+            # through to the chunk-counting guard below.
+            cl = headers.get("content-length")
+            if cl is not None:
+                try:
+                    if int(cl) > _MAX_BYTES:
+                        log.warning(
+                            "provider asset rejected: Content-Length %s > %d (%s)",
+                            cl,
+                            _MAX_BYTES,
+                            url,
+                        )
+                        return _AssetResponse(status, headers, None)
+                except ValueError:
+                    pass
+
+            chunks: list[bytes] = []
+            total = 0
+            for chunk in resp.iter_bytes(chunk_size=_CHUNK_SIZE):
+                total += len(chunk)
+                if total > _MAX_BYTES:
+                    log.warning(
+                        "provider asset rejected: streamed body exceeded %d bytes (%s)",
+                        _MAX_BYTES,
+                        url,
+                    )
+                    return _AssetResponse(status, headers, None)
+                chunks.append(chunk)
+
+            return _AssetResponse(status, headers, b"".join(chunks))
 
 
 def fetch_provider_asset(url: str, workspace_id: str, kind: str) -> str | None:
@@ -202,11 +264,15 @@ def fetch_provider_asset(url: str, workspace_id: str, kind: str) -> str | None:
     # `_http_get` docstring).
     if resp.status_code != 200:
         return None
-    body = resp.content
-    if not body or len(body) > _MAX_BYTES:
+    # `body is None` signals the streaming guard aborted because the
+    # response exceeded `_MAX_BYTES` (see `_http_get`). The size cap is
+    # already enforced upstream; the caller just maps it to the same
+    # "refusal" path as any other failure.
+    body = resp.body
+    if not body:
         return None
 
-    ext = _ext_from_response(resp, url)
+    ext = _ext_from_response(resp.headers, url)
 
     # Magic-byte validation (SEC2-012). Skip check for opaque .bin fallback —
     # those already carry a forced-download Content-Disposition when served.

--- a/backend/tests/test_assets.py
+++ b/backend/tests/test_assets.py
@@ -27,12 +27,22 @@ def ws_id() -> str:
 _PNG_BODY = b"\x89PNG\r\n\x1a\n" + b"image-bytes"
 
 
-def _resp(status_code: int = 200, body: bytes = _PNG_BODY, content_type: str = "image/png") -> MagicMock:
-    r = MagicMock()
-    r.status_code = status_code
-    r.content = body
-    r.headers = {"content-type": content_type}
-    return r
+def _resp(
+    status_code: int = 200,
+    body: bytes | None = _PNG_BODY,
+    content_type: str = "image/png",
+) -> assets._AssetResponse:
+    """Mimic the streaming-aware `_http_get` return value (#285).
+
+    `body=None` simulates the streaming guard aborting because the response
+    exceeded `_MAX_BYTES`; the helper sets that on `_AssetResponse.body`
+    rather than handing the full buffer back to the caller.
+    """
+    return assets._AssetResponse(
+        status_code=status_code,
+        headers={"content-type": content_type},
+        body=body,
+    )
 
 
 def test_fetch_writes_to_uploads_and_returns_local_path(monkeypatch, ws_id, tmp_path):
@@ -75,11 +85,125 @@ def test_fetch_returns_none_on_404(monkeypatch, ws_id, tmp_path):
 
 
 def test_fetch_returns_none_on_oversize(monkeypatch, ws_id, tmp_path):
+    """`_http_get` signals oversize via `body=None` (#285) — the caller maps
+    that to the same refusal as a 4xx / network error."""
     monkeypatch.setattr(settings(), "UPLOAD_DIR", str(tmp_path), raising=False)
     monkeypatch.setattr(assets, "_host_is_allowed", lambda _h: True)
-    huge = b"x" * (assets._MAX_BYTES + 1)
-    monkeypatch.setattr(assets, "_http_get", lambda url: _resp(body=huge))
+    monkeypatch.setattr(assets, "_http_get", lambda url: _resp(body=None))
     assert assets.fetch_provider_asset("https://example.com/huge.png", ws_id, "image") is None
+
+
+def test_http_get_streams_and_aborts_when_exceeds_max_bytes(monkeypatch, tmp_path):
+    """`_http_get` must abort mid-stream as soon as the running byte total
+    crosses `_MAX_BYTES` — never accumulating the full hostile body in
+    memory (#285). We assert the iterator was abandoned before the third
+    chunk by counting how many chunks the fake yielded."""
+    from unittest.mock import patch
+
+    chunks_consumed: list[int] = []
+
+    # Three chunks: the third would push the total well past the cap.
+    # The streaming loop must bail out after the second chunk and never
+    # ask the iterator for the third.
+    chunk_a = b"a" * (assets._MAX_BYTES // 2)
+    chunk_b = b"b" * (assets._MAX_BYTES // 2 + 1)  # pushes over the cap
+    chunk_c = b"c" * 1024  # must never be read
+
+    def fake_iter_bytes(chunk_size=65536):
+        for chunk in (chunk_a, chunk_b, chunk_c):
+            chunks_consumed.append(len(chunk))
+            yield chunk
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.headers = {"content-type": "image/png"}
+    mock_resp.iter_bytes = fake_iter_bytes
+
+    mock_stream = MagicMock()
+    mock_stream.__enter__ = lambda s: mock_resp
+    mock_stream.__exit__ = MagicMock(return_value=False)
+
+    mock_client = MagicMock()
+    mock_client.stream.return_value = mock_stream
+    mock_client.__enter__ = lambda s: mock_client
+    mock_client.__exit__ = MagicMock(return_value=False)
+
+    with patch("app.domain.parts.services.assets.httpx.Client", return_value=mock_client):
+        out = assets._http_get("https://media.digikey.com/huge.png")
+
+    assert out.body is None, "oversize stream must signal refusal via body=None"
+    assert out.status_code == 200
+    # The fake yielded two chunks and was then abandoned — the third chunk
+    # (which would have been read by a non-streaming buffer) was never
+    # accumulated.
+    assert chunks_consumed == [len(chunk_a), len(chunk_b)], (
+        f"streaming guard read past the cap: {chunks_consumed!r}"
+    )
+
+
+def test_http_get_aborts_on_content_length_pre_check(monkeypatch, tmp_path):
+    """Many CDNs send Content-Length; a value > `_MAX_BYTES` must short-
+    circuit before any chunk is read at all (#285)."""
+    from unittest.mock import patch
+
+    chunks_read: list[bool] = []
+
+    def fake_iter_bytes(chunk_size=65536):  # pragma: no cover - must not be called
+        chunks_read.append(True)
+        yield b"x"
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.headers = {
+        "content-type": "image/png",
+        "content-length": str(assets._MAX_BYTES + 1),
+    }
+    mock_resp.iter_bytes = fake_iter_bytes
+
+    mock_stream = MagicMock()
+    mock_stream.__enter__ = lambda s: mock_resp
+    mock_stream.__exit__ = MagicMock(return_value=False)
+
+    mock_client = MagicMock()
+    mock_client.stream.return_value = mock_stream
+    mock_client.__enter__ = lambda s: mock_client
+    mock_client.__exit__ = MagicMock(return_value=False)
+
+    with patch("app.domain.parts.services.assets.httpx.Client", return_value=mock_client):
+        out = assets._http_get("https://media.digikey.com/fat.png")
+
+    assert out.body is None
+    assert chunks_read == [], "Content-Length pre-check must abort before iter_bytes"
+
+
+def test_http_get_ignores_malformed_content_length(monkeypatch, tmp_path):
+    """A junk Content-Length (e.g. `'banana'`) must not crash — fall through
+    to the chunk-counting guard."""
+    from unittest.mock import patch
+
+    body = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
+
+    def fake_iter_bytes(chunk_size=65536):
+        yield body
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.headers = {"content-type": "image/png", "content-length": "banana"}
+    mock_resp.iter_bytes = fake_iter_bytes
+
+    mock_stream = MagicMock()
+    mock_stream.__enter__ = lambda s: mock_resp
+    mock_stream.__exit__ = MagicMock(return_value=False)
+
+    mock_client = MagicMock()
+    mock_client.stream.return_value = mock_stream
+    mock_client.__enter__ = lambda s: mock_client
+    mock_client.__exit__ = MagicMock(return_value=False)
+
+    with patch("app.domain.parts.services.assets.httpx.Client", return_value=mock_client):
+        out = assets._http_get("https://media.digikey.com/ok.png")
+
+    assert out.body == body
 
 
 def test_fetch_returns_none_on_network_error(monkeypatch, ws_id, tmp_path):

--- a/backend/tests/test_provider_assets.py
+++ b/backend/tests/test_provider_assets.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 import hashlib
 import os
 import uuid
-from unittest.mock import MagicMock
 
 import pytest
 from fastapi.testclient import TestClient
@@ -31,12 +30,17 @@ from app.main import app
 _PNG_BODY = b"\x89PNG\r\n\x1a\n" + b"image-bytes"
 
 
-def _resp(status_code: int = 200, body: bytes = _PNG_BODY, content_type: str = "image/png") -> MagicMock:
-    r = MagicMock()
-    r.status_code = status_code
-    r.content = body
-    r.headers = {"content-type": content_type}
-    return r
+def _resp(
+    status_code: int = 200,
+    body: bytes | None = _PNG_BODY,
+    content_type: str = "image/png",
+) -> assets._AssetResponse:
+    """Match the streaming-aware `_http_get` return type (#285)."""
+    return assets._AssetResponse(
+        status_code=status_code,
+        headers={"content-type": content_type},
+        body=body,
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The `_MAX_BYTES = 10 MB` ceiling on provider image / datasheet downloads in `backend/app/domain/parts/services/assets.py` was enforced on `len(resp.content)` **after** `httpx.Client.get()` had already buffered the full response into memory. A hostile or compromised provider CDN could ship a multi-GB body and OOM the backend long before the rejection fired.

This PR rewrites `_http_get` to stream the body via `httpx.Client.stream()` and abort as soon as the running chunk total exceeds `_MAX_BYTES`, so an oversize hostile body is never fully accumulated.

## Changes

- `backend/app/domain/parts/services/assets.py`
  - Add `_AssetResponse(status_code, headers, body)` dataclass; `body=None` signals an oversize abort.
  - Rewrite `_http_get` to use `client.stream("GET", url)` with chunked reads (64 KB) and a running-total guard that bails out immediately past `_MAX_BYTES`.
  - Belt-and-braces: short-circuit on a declared `Content-Length > _MAX_BYTES` before reading any body bytes (treated as advisory — a missing or malformed header falls through to the chunk-counting guard).
  - Update `fetch_provider_asset` call-site: read `resp.body` (and treat `None` as a refusal) instead of `resp.content`. The redundant `len(body) > _MAX_BYTES` post-check is removed because the cap is now enforced upstream.
  - `_ext_from_response` now takes a `headers: dict` instead of an `httpx.Response`.
- `backend/tests/test_assets.py`, `backend/tests/test_provider_assets.py`
  - Update `_resp` helpers to return `_AssetResponse` instead of a `MagicMock` shaped like `httpx.Response`.
  - Update `test_fetch_returns_none_on_oversize` to set `body=None` (the new oversize signal).
  - Add three streaming-path tests:
    - `test_http_get_streams_and_aborts_when_exceeds_max_bytes` — asserts `_http_get` abandons the iterator after the 2nd chunk and never reads the 3rd (which would have crossed the cap by ~1 KB).
    - `test_http_get_aborts_on_content_length_pre_check` — asserts a `Content-Length: _MAX_BYTES+1` short-circuits before `iter_bytes` is called at all.
    - `test_http_get_ignores_malformed_content_length` — asserts a junk `Content-Length` value (`"banana"`) doesn't crash and the body is still read.

## Invariants preserved

- Magic-byte validation from #246 (strict: sniffed must equal declared) — unchanged and still applied to the streamed body.
- Host allow-list + DNS-resolves-to-public-IP SSRF guard (SEC2-006) — unchanged.
- `follow_redirects=False` — unchanged.
- No `verify=False` on httpx clients.
- Content-addressed storage path `{UPLOAD_DIR}/parts/{ws_id}/{sha}.{ext}` — unchanged.
- API envelope, workspace isolation — not touched.

## Test plan

- [x] `pytest tests/test_provider_assets.py tests/test_assets.py -q` — 35 passed locally (Postgres-backed).
- [x] `lint-delta` — no new ruff violations (baseline 159 -> 155, 4 fixed since baseline; nothing added).
- [x] Manual scenarios covered by the new tests:
  - Stream that crosses the cap mid-download → aborts; body=None.
  - `Content-Length` header that declares oversize → short-circuit, no body read.
  - Malformed `Content-Length` → falls through to chunk guard.
- [ ] Production smoke after merge: confirm a normal Mouser/DigiKey image still downloads and gets content-addressed under `/uploads/parts/{ws}/{sha}.png`.

Closes #285