### PR TITLE
ci: gate deploy on line-count-budget job (#303)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -488,12 +488,13 @@ jobs:
   # SEC2-016 hole that issue #282 closes).
   #
   # Current gates, in dependency order:
-  #   - lockfile-drift   (SEC2-016) — pyproject ↔ uv.lock ↔ requirements.lock
-  #   - pip-audit        (SEC2-016) — HIGH/CRITICAL CVEs in the pinned set
-  #   - backend-tests                — pytest + alembic
-  #   - web-build                    — tsc -b + vite build (+ sourcemap upload)
-  #   - prod-validate                — docker compose config sanity check
-  #   - playwright-e2e               — full-stack smoke
+  #   - lockfile-drift    (SEC2-016)   — pyproject ↔ uv.lock ↔ requirements.lock
+  #   - pip-audit         (SEC2-016)   — HIGH/CRITICAL CVEs in the pinned set
+  #   - line-count-budget (CQ-002/003) — per-file line-count caps
+  #   - backend-tests                  — pytest + alembic
+  #   - web-build                      — tsc -b + vite build (+ sourcemap upload)
+  #   - prod-validate                  — docker compose config sanity check
+  #   - playwright-e2e                 — full-stack smoke
   #
   # If you add a new pre-deploy gate (lint, secrets-scan, SBOM, smoke, …), add
   # it here too, even if it already chains transitively through some other job.
@@ -501,7 +502,7 @@ jobs:
     # Only redeploy on green main pushes. PRs and feature branches just run
     # the test/validate/security jobs above.
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: [lockfile-drift, pip-audit, backend-tests, web-build, prod-validate, playwright-e2e]
+    needs: [lockfile-drift, pip-audit, line-count-budget, backend-tests, web-build, prod-validate, playwright-e2e]
     runs-on: ubuntu-latest
     # Environment association. Today this just scopes any environment-level
     # secrets we add later; if a "Required reviewers" protection rule is


### PR DESCRIPTION
## Summary

- The `line-count-budget` job (added by #278) hard-fails when monitored files exceed their per-file caps, but it was never added to the `deploy: needs:` array. So a budget overage on a push to `main` failed the budget job in isolation while `deploy` still proceeded — gate was decorative, not load-bearing.
- This PR adds `line-count-budget` to `deploy: needs:` and updates the inline comment that enumerates the gate inventory. Same one-word fix #292 applied for #282.

## Diff

```diff
   # Current gates, in dependency order:
-  #   - lockfile-drift   (SEC2-016) — pyproject ↔ uv.lock ↔ requirements.lock
-  #   - pip-audit        (SEC2-016) — HIGH/CRITICAL CVEs in the pinned set
-  #   - backend-tests                — pytest + alembic
+  #   - lockfile-drift    (SEC2-016)   — pyproject ↔ uv.lock ↔ requirements.lock
+  #   - pip-audit         (SEC2-016)   — HIGH/CRITICAL CVEs in the pinned set
+  #   - line-count-budget (CQ-002/003) — per-file line-count caps
+  #   - backend-tests                  — pytest + alembic
   ...
-    needs: [lockfile-drift, pip-audit, backend-tests, web-build, prod-validate, playwright-e2e]
+    needs: [lockfile-drift, pip-audit, line-count-budget, backend-tests, web-build, prod-validate, playwright-e2e]
```

## Test plan

- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`).
- [ ] After merge, observe the next push-to-main run: `deploy` lists `line-count-budget` as a prerequisite in the Actions dependency graph.
- [ ] Optional manual verification: push a branch that intentionally inflates a monitored file beyond its cap and confirm `deploy` shows blocked rather than running.

Closes #303

🤖 Generated with [Claude Code](https://claude.com/claude-code)