### PR TITLE
fix(ci): fail lint-delta when linter command crashes

### DIFF
--- a/scripts/lint-delta.sh
+++ b/scripts/lint-delta.sh
@@ -33,7 +33,35 @@ trap 'rm -f "$CUR_RAW" "$KEYED_CUR" "$KEYED_BASE"' EXIT
 
 # Capture raw linter output (with line:col) so we can show humans where
 # the new violations live.
-(cd "$WORK_DIR" && eval "$LINT_CMD") 2>&1 \
+#
+# We must distinguish "linter ran cleanly with N violations" from
+# "linter crashed / was missing / misconfigured". The former is exit 0
+# (no findings) or exit 1 (findings); anything else (127 command not
+# found, 126 not executable, signal death, ruff/eslint internal error)
+# is a configuration error and must fail the gate, not be swallowed.
+# Previously the pipeline ended in `|| true`, which masked all of
+# these and let CI go green while no linting actually happened (#302).
+RAW_OUTPUT=""
+RAW_RC=0
+RAW_OUTPUT=$(cd "$WORK_DIR" && eval "$LINT_CMD" 2>&1) || RAW_RC=$?
+case "$RAW_RC" in
+  0|1) ;;
+  *)
+    echo "ERROR: linter command exited with status $RAW_RC (configuration error, not a violation)" >&2
+    echo "  LINT_CMD: $LINT_CMD" >&2
+    echo "  WORK_DIR: $WORK_DIR" >&2
+    echo "  output:" >&2
+    printf '%s\n' "$RAW_OUTPUT" | sed 's/^/    /' >&2
+    exit 2
+    ;;
+esac
+
+# Filter the captured output down to lines that look like
+# "<file>:<line>:<col>: ...". An empty result is fine (zero violations
+# from a clean linter run); the `|| true` here is intentional because
+# `grep` exits 1 when no lines match — that is not a configuration
+# error, unlike the linter exit code handled above.
+printf '%s\n' "$RAW_OUTPUT" \
   | grep -E '^[^[:space:]].+:[0-9]+:[0-9]+:' \
   | sed "s|^$(pwd)/||g" \
   > "$CUR_RAW" || true


### PR DESCRIPTION
## Summary

`scripts/lint-delta.sh` previously ended its linter-invocation pipeline in `|| true`, which swallowed every non-zero exit from `eval "$LINT_CMD"` — including exit 127 (command not found), 126 (not executable), and signal death. When the linter failed to start, `CUR_RAW` was empty, the computed delta was zero, and the script exited clean. CI looked green while no linting actually ran.

This PR distinguishes "linter ran cleanly with N violations" (exit 0 or 1, both expected from ruff/eslint) from "linter crashed or was misconfigured" (any other exit code). On a configuration error we print a diagnostic and exit 2 so the CI step fails loudly. The `|| true` is preserved only on the subsequent `grep | sed` filter step, where `grep`'s exit 1 legitimately means "no violation lines matched" and is not a configuration error.

Carried over from PR #300, which kept the original `|| true` while making other fixes.

## Test plan

- [x] Normal run against current `.ruff-baseline.txt` still passes:
  ```
  $ cd backend && LINT_CMD="ruff check app --output-format=concise" \
      BASELINE_FILE="../.ruff-baseline.txt" WORK_DIR="." \
      bash ../scripts/lint-delta.sh
  lint-delta: no new violations (baseline: 159, current: 154, fixed since baseline: 5)
  exit: 0
  ```
- [x] Command-not-found exits 2 with a diagnostic (was: silently 0):
  ```
  $ LINT_CMD='definitely-not-a-real-linter-command' \
      BASELINE_FILE=.ruff-baseline.txt WORK_DIR=. bash scripts/lint-delta.sh
  ERROR: linter command exited with status 127 (configuration error, not a violation)
    LINT_CMD: definitely-not-a-real-linter-command
    WORK_DIR: .
    output:
      scripts/lint-delta.sh: line 46: definitely-not-a-real-linter-command: command not found
  exit: 2
  ```
- [x] Valid no-output linter (`true`) still exits 0:
  ```
  $ LINT_CMD='true' BASELINE_FILE=.ruff-baseline.txt WORK_DIR=. bash scripts/lint-delta.sh
  lint-delta: no new violations (baseline: 159, current: 0, fixed since baseline: 159)
  exit: 0
  ```
- [ ] CI green on this PR (both `backend-tests` ruff gate and `web-build` eslint gate still call the script with the same env-var contract — no `ci.yml` change needed).

Closes #302

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>