### PR TITLE
fix(auth): preserve query string + hash on RedirectIfAuthed deep-link bounce

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense, type ReactNode } from "react";
-import { Navigate, Outlet, Route, Routes, useLocation } from "react-router-dom";
+import { Navigate, Outlet, Route, Routes, useLocation, type Location } from "react-router-dom";
 import { AuthProvider, useAuth } from "@/lib/auth";
 import AppShell from "@/components/layout/AppShell";
 import { ConfirmDialogProvider } from "@/components/ConfirmDialog";
@@ -143,11 +143,17 @@ function RedirectIfAuthed({ children }: { children: React.ReactNode }) {
   if (loading) return null;
   if (me) {
     const from = (location.state as { from?: Location } | null)?.from;
-    const target =
-      from && from.pathname !== "/login" && from.pathname !== "/signup"
-        ? from.pathname
-        : "/parts";
-    return <Navigate to={target} replace />;
+    // Preserve search + hash so deep-links like /parts/scan-import?storage_id=abc
+    // or /parts/abc?tab=specs#anchor survive the auth round-trip (#304).
+    if (from && from.pathname !== "/login" && from.pathname !== "/signup") {
+      return (
+        <Navigate
+          to={{ pathname: from.pathname, search: from.search, hash: from.hash }}
+          replace
+        />
+      );
+    }
+    return <Navigate to="/parts" replace />;
   }
   return <>{children}</>;
 }

--- a/web/src/routes/auth/__tests__/RedirectIfAuthed.dom.test.tsx
+++ b/web/src/routes/auth/__tests__/RedirectIfAuthed.dom.test.tsx
@@ -1,11 +1,13 @@
 /**
- * Tests for the RedirectIfAuthed guard (FE2-019).
+ * Tests for the RedirectIfAuthed guard (FE2-019, #304).
  *
  * Pinned behaviours:
  *  1. me=null  → the child form renders (unauthenticated user may use /login).
  *  2. me=user  → redirects to /parts (default fallback).
  *  3. loading=true → renders nothing (null placeholder, no form flash).
  *  4. me=user + state.from=/orders/abc → redirects to /orders/abc (deep-link).
+ *  5. me=user + state.from with search/hash → preserves query string + fragment
+ *     across the auth bounce (#304).
  *
  * The component is defined in App.tsx as a module-scoped function; we
  * exercise it by mounting a minimal Router tree that mirrors the real
@@ -13,7 +15,14 @@
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, cleanup } from "@testing-library/react";
-import { MemoryRouter, Route, Routes, Navigate, useLocation } from "react-router-dom";
+import {
+  MemoryRouter,
+  Route,
+  Routes,
+  Navigate,
+  useLocation,
+  type Location,
+} from "react-router-dom";
 import { useAuth } from "@/lib/auth";
 
 // ---------------------------------------------------------------------------
@@ -37,14 +46,31 @@ function RedirectIfAuthed({ children }: { children: React.ReactNode }) {
   const location = useLocation();
   if (loading) return null;
   if (me) {
-    const from = (location.state as { from?: { pathname: string } } | null)?.from;
-    const target =
-      from && from.pathname !== "/login" && from.pathname !== "/signup"
-        ? from.pathname
-        : "/parts";
-    return <Navigate to={target} replace />;
+    const from = (location.state as { from?: Location } | null)?.from;
+    if (from && from.pathname !== "/login" && from.pathname !== "/signup") {
+      return (
+        <Navigate
+          to={{ pathname: from.pathname, search: from.search, hash: from.hash }}
+          replace
+        />
+      );
+    }
+    return <Navigate to="/parts" replace />;
   }
   return <>{children}</>;
+}
+
+// Spy component used to assert the post-redirect Location's search + hash
+// (MemoryRouter doesn't update window.location, so we read it via useLocation).
+function LocationSpy() {
+  const loc = useLocation();
+  return (
+    <div>
+      <div data-testid="spy-pathname">{loc.pathname}</div>
+      <div data-testid="spy-search">{loc.search}</div>
+      <div data-testid="spy-hash">{loc.hash}</div>
+    </div>
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -71,6 +97,15 @@ function renderAt(
         />
         <Route path="/parts" element={<div>parts-page</div>} />
         <Route path="/orders/abc" element={<div>orders-abc</div>} />
+        <Route
+          path="/parts/scan-import"
+          element={
+            <>
+              <div>scan-import-page</div>
+              <LocationSpy />
+            </>
+          }
+        />
         <Route path="/signup" element={<div>signup-form</div>} />
       </Routes>
     </MemoryRouter>,
@@ -117,5 +152,28 @@ describe("RedirectIfAuthed", () => {
     // state.from pointing at /login itself must not loop — fall back to /parts.
     renderAt("/login", { from: { pathname: "/login" } }, { me: fakeUser, loading: false });
     expect(screen.getByText("parts-page")).toBeDefined();
+  });
+
+  it("me=user + state.from with search+hash: preserves query string and fragment (#304)", () => {
+    const fakeUser = { user: { id: "u1", email: "u@test.com" }, workspaces: [] };
+    // Supply a Location-shaped object including search + hash. The fixed
+    // RedirectIfAuthed must propagate all three to the Navigate target.
+    renderAt(
+      "/login",
+      {
+        from: {
+          pathname: "/parts/scan-import",
+          search: "?storage_id=abc&tab=queue",
+          hash: "#row-7",
+          state: null,
+          key: "test",
+        },
+      },
+      { me: fakeUser, loading: false },
+    );
+    expect(screen.getByText("scan-import-page")).toBeDefined();
+    expect(screen.getByTestId("spy-pathname").textContent).toBe("/parts/scan-import");
+    expect(screen.getByTestId("spy-search").textContent).toBe("?storage_id=abc&tab=queue");
+    expect(screen.getByTestId("spy-hash").textContent).toBe("#row-7");
   });
 });


### PR DESCRIPTION
## Summary

- `RedirectIfAuthed` in `web/src/App.tsx` was sending already-authed users to `from.pathname` only, dropping `search` and `hash`. Deep links like `/parts/scan-import?storage_id=abc&tab=queue` or `/parts/abc?tab=specs#anchor` silently lost intent on the auth round-trip.
- Pass the full `Partial<Path>` (`pathname` + `search` + `hash`) to `<Navigate to={…}>`. Also imports `Location` as a type from `react-router-dom` (the old code accidentally relied on the global DOM `Location` because both share `pathname`).
- The complementary code paths (`Gate`, `authBus` 401 handler, `Login.tsx`, `Signup.tsx`) already preserved the full Location — no change needed there.

## Test plan

- [x] `npm test` — 238 pass / 3 skipped, including the existing 5 `RedirectIfAuthed` tests and the new `state.from with search+hash` test that asserts query string and fragment survive the redirect.
- [x] `npm run build` — `tsc -b` clean, vite build succeeds.
- [ ] Manual smoke: log out, paste `/parts/scan-import?storage_id=abc&tab=queue` into the address bar, log in, confirm the URL after redirect still has `?storage_id=abc&tab=queue`.
- [ ] Manual smoke: same with `#row-7` fragment.

Closes #304

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>