### PR TITLE
fix(tests): default conftest DATABASE_URL to 127.0.0.1 for host pytest

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,13 +45,26 @@ cd web && npm test                                                           # v
 ```
 
 Outside Docker, the backend test suite needs a real Postgres (no SQLite
-fallback — schema uses `UUID`, `ARRAY`, `Numeric`):
+fallback — schema uses `UUID`, `ARRAY`, `Numeric`). `tests/conftest.py`
+defaults `DATABASE_URL` to
+`postgresql+psycopg://stockmgr:stockmgr@127.0.0.1:5432/stockmgr_test`, so
+with a local Postgres listening on `127.0.0.1:5432` and the `stockmgr` user
+(password `stockmgr`, `CREATEDB` privilege) you can simply run:
+
+```bash
+cd backend && python -m pytest -q
+```
+
+The test DB (`stockmgr_test`) is auto-created by conftest if it doesn't
+exist. For a non-default host/port/credentials, set `TEST_DATABASE_URL`:
 
 ```bash
 TEST_DATABASE_URL=postgresql+psycopg://stockmgr:stockmgr@127.0.0.1:5432/stockmgr_test \
   python -m pytest -q
 ```
 
+Note: the dev compose file does not publish Postgres to the host, so host
+pytest needs a separately installed local Postgres (not the Docker one).
 `tests/conftest.py` drops + recreates the public schema between tests.
 
 ### Build / lint

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -14,8 +14,17 @@ from sqlalchemy.orm import Session, sessionmaker
 # This exercises the explicit-DATABASE_URL-override branch in
 # Settings._assemble_database_url (INFRA2-005): when DATABASE_URL is
 # supplied directly it is used as-is and the POSTGRES_* parts are ignored.
+#
+# The fallback default points at 127.0.0.1 so host-side `pytest` works
+# against a local Postgres without any environment override (issue #306).
+# In-container runs (`docker compose exec backend pytest`) are unaffected:
+# Compose injects DATABASE_URL=...@db:5432/... before Python starts, so
+# `setdefault` is a no-op and the docker hostname is preserved. Operators
+# with non-standard local Postgres setups can still set TEST_DATABASE_URL
+# (or DATABASE_URL) explicitly and that takes precedence.
 os.environ.setdefault(
-    "DATABASE_URL", os.environ.get("TEST_DATABASE_URL", "postgresql+psycopg://stockmgr:stockmgr@db:5432/stockmgr_test")
+    "DATABASE_URL",
+    os.environ.get("TEST_DATABASE_URL", "postgresql+psycopg://stockmgr:stockmgr@127.0.0.1:5432/stockmgr_test"),
 )
 os.environ.setdefault("SESSION_SECRET", "test-secret")
 os.environ.setdefault("UPLOAD_DIR", "/tmp/stockmgr-test-uploads")

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -63,7 +63,11 @@ def _migration_db_url() -> str:
         "DATABASE_URL",
         os.environ.get(
             "TEST_DATABASE_URL",
-            "postgresql+psycopg://stockmgr:stockmgr@db:5432/stockmgr_test",
+            # Fallback mirrors conftest.py default (issue #306) — host-side
+            # 127.0.0.1, not the docker-network `db` hostname. In practice
+            # conftest sets DATABASE_URL before this runs, so the fallback
+            # is rarely hit, but it stays consistent.
+            "postgresql+psycopg://stockmgr:stockmgr@127.0.0.1:5432/stockmgr_test",
         ),
     )
     head, db_name = base.rsplit("/", 1)


### PR DESCRIPTION
## Summary

- `backend/tests/conftest.py` defaulted `DATABASE_URL` to the docker-network hostname `db:5432`, which only resolves inside the compose network. Host-side `pytest` failed at DNS resolution before any test ran unless the operator already knew to export `TEST_DATABASE_URL`.
- This PR flips the fallback to `127.0.0.1:5432` so a stock local Postgres setup (user/password `stockmgr`/`stockmgr`, `CREATEDB` privilege) just works with `cd backend && python -m pytest -q`.
- In-container runs are unchanged: `docker-compose.dev.yml` injects `DATABASE_URL=...@db:5432/...` for the `backend` service before Python starts, so `os.environ.setdefault` is a no-op and the docker hostname is preserved.
- The same now-dead-but-consistent fallback in `tests/test_migrations.py` is updated to match.
- `CLAUDE.md` "Tests" section documents the zero-config host flow plus the `TEST_DATABASE_URL` override path for non-default setups.

## Test plan

- [x] Verify `127.0.0.1` resolves and is reachable on the dev host.
- [x] Confirm `os.environ.setdefault` no-ops when `DATABASE_URL` is pre-set (in-container path preserved verbatim).
- [x] Confirm `TEST_DATABASE_URL` override still wins over the new default.
- [ ] CI: backend `pytest` passes against the CI Postgres (no DNS regression in-container).

Closes #306

Generated with [Claude Code](https://claude.com/claude-code)