### PR TITLE
Add Umami analytics snippet

### DIFF
--- a/deploy/.env.prod.example
+++ b/deploy/.env.prod.example
@@ -109,6 +109,27 @@ SENTRY_TRACES_SAMPLE_RATE=0.0
 VITE_SENTRY_DSN=
 VITE_SENTRY_TRACES_SAMPLE_RATE=0.0
 
+# ---- Umami (self-hosted analytics, optional) ----
+# Loader IIFE in web/index.html only injects the tracker when BOTH of
+# these are non-empty at build time. Empty → no script tag, no network
+# call, no DOM mutation.
+#
+# - Self-hosted, no cookies, respects DNT.
+# - Website ID is the UUID Umami generates per site (Umami → Settings →
+#   Websites → click the site → "Website ID" field).
+# - Script URL is your Umami instance's tracking script URL,
+#   e.g. https://stats.example.com/script.js.
+#
+# Both are baked into the SPA bundle at build time and visible in the
+# browser DevTools — they're identifiers, not secrets. Treat the website
+# ID like a Sentry DSN.
+#
+# Rotation: regenerate the site in Umami → update VITE_UMAMI_WEBSITE_ID
+# → redeploy. The old site keeps any historical pageviews; new pageviews
+# go to the new ID. See docs/runbooks/analytics-umami.md.
+VITE_UMAMI_WEBSITE_ID=
+VITE_UMAMI_SCRIPT_URL=
+
 # ---- Email / SMTP (issue #281) ----
 # Email verification on signup is forced ON in prod (config.py validator
 # `_default_email_verification_in_prod`). The backend now ALSO refuses to

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -179,6 +179,9 @@ services:
         VITE_SENTRY_DSN: ${VITE_SENTRY_DSN:-}
         VITE_SENTRY_TRACES_SAMPLE_RATE: ${VITE_SENTRY_TRACES_SAMPLE_RATE:-0.0}
         VITE_APP_VERSION: ${SENTRY_RELEASE:-}
+        # Umami self-hosted analytics. Both empty → no tracker injected.
+        VITE_UMAMI_WEBSITE_ID: ${VITE_UMAMI_WEBSITE_ID:-}
+        VITE_UMAMI_SCRIPT_URL: ${VITE_UMAMI_SCRIPT_URL:-}
     restart: unless-stopped
     mem_limit: 256m
     cpus: "0.5"

--- a/docs/adr/0019-umami-self-hosted-analytics.md
+++ b/docs/adr/0019-umami-self-hosted-analytics.md
@@ -1,0 +1,59 @@
+# ADR-0019: Self-hosted Umami for product analytics, env-gated tracker
+
+Audience: engineer
+
+- **Status**: Accepted
+- **Date**: 2026-05-03
+- **Supersedes**: —
+- **Superseded by**: —
+
+## Context
+
+stockManager has Sentry for errors but no signal on what users actually do — which routes get traffic, where users drop off in the BOM/scan-import flows, which features are dead weight. Without that, the next round of refactor / cleanup decisions are guessing.
+
+Three alternatives considered:
+
+1. **No analytics.** Status quo. Wins on simplicity and zero data-handling burden. Loses on every product decision becoming an opinion rather than a measurement.
+2. **Plausible / Google Analytics (SaaS).** Hosted, cheap, well-known. GA4 is rejected on privacy posture (cookies, fingerprinting, US data). Plausible Cloud is acceptable but couples a small operational dependency to a paid third party for what is otherwise a hobby-scale deployment.
+3. **Self-hosted [Umami](https://umami.is).** Open source, no cookies, respects `Do-Not-Track`, no fingerprinting. Already running on a separate VPS at `https://stats.matescb.cz`. Adds one `<script>` tag to the SPA bundle, nothing on the backend.
+
+## Decision
+
+Use the existing self-hosted Umami instance.
+
+Wire the tracker as an **env-gated loader IIFE in `web/index.html`**:
+
+- Two new build args / env vars: `VITE_UMAMI_WEBSITE_ID`, `VITE_UMAMI_SCRIPT_URL`.
+- Both default to empty in `web/Dockerfile.prod`, `docker-compose.prod.yml`, `deploy/.env.prod.example`.
+- The IIFE only injects the `<script>` tag when both are non-empty.
+- Empty values are first-class: dev builds, CI builds, any prod deploy that omits the env produce a bundle that does nothing — no script tag, no network call, no DOM mutation.
+
+Both values are inlined into the SPA bundle and visible in the browser DevTools. They are **identifiers, not secrets**, and treated the same way the Sentry public DSN (`VITE_SENTRY_DSN`) is treated by ADR-0014.
+
+## Consequences
+
+**Good**
+
+- Zero new backend code, zero new Python deps.
+- Empty-env-disables pattern matches Sentry — one mental model for "frontend observability vendor inlined at build time".
+- Self-hosted means the user's pageviews never leave my infrastructure (Umami VPS is mine; stockManager VPS is mine; both EU). Defensible to anyone asking about GDPR.
+- Rotation is trivial: change UUID in `.env.prod`, redeploy. No code change.
+
+**Trade-offs**
+
+- The website ID UUID is in the bundle and visible to any visitor. Anyone can `curl` the tracker pretending to be the site. This is the same threat model as a Sentry public DSN — Umami treats it as identifier, not auth. If someone spams pageview pings, throttle at the Umami nginx layer.
+- Tracker is blocked by most ad-blockers (`*/script.js` heuristic). Acceptable — the cost of using a generic script name to avoid being singled out is that blockers still catch it. The data is "users who don't run an ad-blocker", not "all users". Calibrate aggregate numbers accordingly.
+- Adding a third observability target (after Sentry-backend and Sentry-frontend) is more env vars to forget. Mitigated by both Umami env vars being optional with safe-empty default — forgetting them in dev is harmless; forgetting them in prod is a missing-data signal, not a runtime fault.
+
+## Alternatives rejected
+
+- **GA4 / Google Tag Manager** — cookies, fingerprinting, US data, Google account dependency. Privacy posture incompatible with this project's user expectations.
+- **Plausible Cloud** — fine product but a paid SaaS dependency for a self-hosted-everything-else stack felt mismatched. If self-hosted Umami breaks, fall back here.
+- **Server-side analytics from request logs** — accurate but costly to build (would need a log shipper, an aggregation pipeline, and a UI). Umami gives all of that for one `<script>` tag.
+
+## References
+
+- Runbook: [`docs/runbooks/analytics-umami.md`](../runbooks/analytics-umami.md)
+- Phase: [`docs/phases/12-observability-sentry.md`](../phases/12-observability-sentry.md) — "Sister system: Umami"
+- Wiring: `web/index.html`, `web/Dockerfile.prod`, `docker-compose.prod.yml`, `deploy/.env.prod.example`
+- PR: #319

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -28,3 +28,4 @@ New ADRs follow the template in [STYLE.md](../STYLE.md#adr-pages-docsadrnnnn-slu
 | 0016 | [Sourcemaps emitted in CI only](0016-sourcemaps-ci-only.md) |
 | 0017 | [Step-of-N PRs use `Refs #N`, not `Closes #N`](0017-step-of-n-prs-refs-not-closes.md) |
 | 0018 | [Prod email verification requires SMTP; never log verification tokens](0018-prod-smtp-fail-closed.md) |
+| 0019 | [Self-hosted Umami for product analytics, env-gated tracker](0019-umami-self-hosted-analytics.md) |

--- a/docs/phases/12-observability-sentry.md
+++ b/docs/phases/12-observability-sentry.md
@@ -76,6 +76,20 @@ stack traces de-minify.
 - **Empty DSN → SDK no-op.** Dev environments stay quiet; no events,
   no network egress.
 
+## Sister system: Umami (product/usage signal)
+
+Sentry covers errors. Umami covers product/usage — pageviews and SPA
+route changes — with a self-hosted instance at `https://stats.matescb.cz`
+(separate VPS service from stockManager). Wiring is documented in
+[`docs/runbooks/analytics-umami.md`](../runbooks/analytics-umami.md) and
+the choice of self-hosted-Umami over Plausible / GA4 / no-analytics is
+in [`docs/adr/0019-umami-self-hosted-analytics.md`](../adr/0019-umami-self-hosted-analytics.md).
+
+Tracker is gated by `VITE_UMAMI_WEBSITE_ID` + `VITE_UMAMI_SCRIPT_URL`
+build env (per the same Vite-ARG-inlined pattern Sentry uses); both
+empty → no script tag, no network call. Privacy posture: no cookies,
+respects DNT, no PII.
+
 ## Things deferred
 
 - Server-side performance tracing sample rate tuning — currently

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -27,10 +27,12 @@ How to handle ops scenarios. Each runbook follows the template in [STYLE.md](../
 | [smtp-outage](smtp-outage.md) | SEV-2 | Signup verification + invitation emails fail; degraded paths |
 | [provider-outage](provider-outage.md) | SEV-2 | DigiKey or Mouser API unavailable; user-visible impact and mitigation |
 | [workspace-recovery](workspace-recovery.md) | SEV-2 | Restore a disabled workspace, audit a suspected isolation leak |
+| [analytics-umami](analytics-umami.md) | Routine / SEV-3 | Self-hosted Umami: rotate website ID, disable tracking, debug a missing pageview |
 
 ## Where dashboards live
 
 - **Sentry**: <project URL — TODO(verify): fill from `SENTRY_PROJECT` env in deploy job>
+- **Umami**: `https://stats.matescb.cz` (self-hosted, separate VPS service)
 - **UptimeRobot**: <monitor URL — TODO(verify)>
 - **GitHub Actions**: https://github.com/<org>/stockManager/actions
 - **VPS** (SSH): `ssh deploy@<vps-host>` — host in `docs/deployment.md`

--- a/docs/runbooks/analytics-umami.md
+++ b/docs/runbooks/analytics-umami.md
@@ -1,0 +1,121 @@
+# Umami analytics
+
+Audience: engineer / on-call
+
+Self-hosted [Umami](https://umami.is) running at `https://stats.matescb.cz`,
+tracking pageviews + SPA route changes for `parts.matescb.cz`. No cookies,
+respects `Do-Not-Track`, no PII collected.
+
+## How it's wired
+
+The tracker is a single client-side script injected by a small loader IIFE
+in [`web/index.html`](../../web/index.html). The IIFE only injects the
+script tag when **both** of these env vars are non-empty at build time:
+
+| Env var | Purpose | Example |
+|---|---|---|
+| `VITE_UMAMI_WEBSITE_ID` | Umami's per-site UUID | `5fdea605-7472-4437-8035-f8602d5bd627` |
+| `VITE_UMAMI_SCRIPT_URL` | Tracking script URL | `https://stats.matescb.cz/script.js` |
+
+Both are baked into the SPA bundle by Vite at build time
+(`web/Dockerfile.prod` ARG → ENV → Vite `%VITE_…%` substitution in
+`index.html`). They are **not secrets** — both values are visible in
+DevTools to anyone who loads the page. Umami treats the website ID as an
+identifier, not an auth token, the same way Sentry treats the public DSN.
+
+Empty values are first-class: dev builds, CI builds, and any prod deploy
+that omits these env vars produce a bundle that injects nothing — no
+script tag, no network call, no DOM mutation. The IIFE also bails when
+the placeholder string `%VITE_…` survives un-substituted (the dev server
+serves `index.html` without transformation).
+
+## Disable tracking
+
+```bash
+# In .env.prod on the VPS:
+VITE_UMAMI_WEBSITE_ID=
+VITE_UMAMI_SCRIPT_URL=
+```
+
+Then redeploy (or wait for the next auto-deploy on `main`). The next
+build inlines empty values, the IIFE no-ops, and no requests go to
+`stats.matescb.cz` from the SPA.
+
+## Rotate the website ID
+
+When: someone leaks the UUID publicly and you want a clean cut on which
+historical pageviews are theirs vs. yours, OR you migrate Umami to a new
+host.
+
+1. **Umami UI** → Settings → Websites → click the site → **Reset** (or
+   create a new site for the same domain). Copy the new UUID.
+2. **`.env.prod` on the VPS** → set `VITE_UMAMI_WEBSITE_ID=<new-uuid>`.
+3. **Redeploy** — `git push` to `main` triggers the auto-deploy, or
+   manually:
+
+   ```bash
+   ssh deploy@<vps-host>
+   cd /opt/stockmanager        # TODO(verify): exact path on VPS
+   docker compose -f docker-compose.prod.yml up -d --build web
+   ```
+
+4. **Verify** — load `https://parts.matescb.cz`, open DevTools → Network,
+   confirm a `script.js` request to `stats.matescb.cz`. Then check the
+   new site in Umami within ~10s for the first pageview.
+
+The old site keeps any historical pageviews. New pageviews go to the new
+ID. Plan for split data in any historical reports that span the cutover.
+
+## Debug a missing pageview
+
+Symptom: production site loads fine but Umami shows no new pageviews.
+
+1. **Browser DevTools → Network** on `parts.matescb.cz`. Filter for
+   `script.js`.
+   - **No request at all** → tracker not injected. Likely cause: build
+     env vars empty. Check `https://parts.matescb.cz/index.html` view
+     source — the loader IIFE should be present, and it should reference
+     the real UUID (not a `%VITE_…%` placeholder).
+   - **Request returns 404 / wrong URL** → `VITE_UMAMI_SCRIPT_URL` is
+     misconfigured.
+   - **Request returns 200 but no pageview pings** → the script loaded
+     but the website ID doesn't match a site in Umami. Check the
+     `data-website-id` attribute on the injected `<script>` tag against
+     the UUID in Umami → Settings → Websites.
+
+2. **Do-Not-Track**: Umami's official script honours the browser's DNT
+   header by design. If the missing pageview is yours, check
+   browser/extension DNT settings.
+
+3. **Ad-blockers**: many block `*/script.js` heuristically. Disable in
+   the browser, retry. (This is intentional on Umami's side — using a
+   common script name avoids singling out trackers, but blockers still
+   catch it. Acceptable trade-off for self-hosted analytics.)
+
+4. **Umami server**: check `https://stats.matescb.cz` is reachable; if
+   not, escalate to whoever runs the analytics VPS (separate from the
+   stockManager VPS — different incident).
+
+## Privacy posture
+
+- **No cookies set** by the Umami client script (Umami uses
+  fingerprint-free, server-side aggregation by IP+UA hash, rotated
+  daily).
+- **DNT respected** by the official `script.js`.
+- **No PII** collected — Umami records URL path, referrer, viewport,
+  language, country (from IP, then IP discarded), and event payloads
+  the app explicitly sends. The stockManager SPA does not call Umami's
+  custom-event API today, so the only data is pageview pings.
+- The privacy posture is documented in [`docs/user/privacy.md`]
+  (../user/privacy.md) for end users — keep both pages in sync if you
+  change what's collected.
+
+## Related
+
+- [`docs/phases/12-observability-sentry.md`](../phases/12-observability-sentry.md)
+  — Sentry (errors) is the other observability system; Umami is for
+  product/usage signal.
+- [`docs/runbooks/sentry-triage.md`](sentry-triage.md) — sister runbook
+  for the error side.
+- [`docs/adr/0019-umami-self-hosted-analytics.md`](../adr/0019-umami-self-hosted-analytics.md)
+  — why self-hosted Umami over Plausible / GA4 / no analytics.

--- a/web/Dockerfile.prod
+++ b/web/Dockerfile.prod
@@ -27,10 +27,17 @@ ARG VITE_SENTRY_TRACES_SAMPLE_RATE=0.0
 # Release identifier (git SHA) — used as Sentry's `release` tag so Sentry
 # groups issues per release.
 ARG VITE_APP_VERSION=
+# Umami (self-hosted analytics) — both must be set for the loader IIFE
+# in web/index.html to inject the tracker. Empty values disable tracking
+# entirely (no network call, no DOM mutation).
+ARG VITE_UMAMI_WEBSITE_ID=
+ARG VITE_UMAMI_SCRIPT_URL=
 
 ENV VITE_SENTRY_DSN=$VITE_SENTRY_DSN
 ENV VITE_SENTRY_TRACES_SAMPLE_RATE=$VITE_SENTRY_TRACES_SAMPLE_RATE
 ENV VITE_APP_VERSION=$VITE_APP_VERSION
+ENV VITE_UMAMI_WEBSITE_ID=$VITE_UMAMI_WEBSITE_ID
+ENV VITE_UMAMI_SCRIPT_URL=$VITE_UMAMI_SCRIPT_URL
 # SENTRY_AUTH_TOKEN / _ORG / _PROJECT are NOT passed here — source-map
 # upload is handled by the CI web-build job so the token never enters the
 # Docker layer cache (INFRA2-010).

--- a/web/index.html
+++ b/web/index.html
@@ -5,7 +5,27 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Crect width='16' height='16' rx='3' fill='%234ade80'/%3E%3Cpath d='M4 5h8M4 8h8M4 11h5' stroke='%230b0c0f' stroke-width='1.5' stroke-linecap='round'/%3E%3C/svg%3E" />
     <title>Parts Inventory & Production Manager</title>
-    <script defer src="https://stats.matescb.cz/script.js" data-website-id="5fdea605-7472-4437-8035-f8602d5bd627"></script>
+    <!--
+      Umami analytics (self-hosted, no cookies, respects DNT).
+      Loads only when both VITE_UMAMI_WEBSITE_ID and VITE_UMAMI_SCRIPT_URL
+      are set at build time (deploy/.env.prod.example documents both).
+      Dev builds ship empty values so the dev console isn't noisy.
+    -->
+    <script>
+      (function () {
+        var id = "%VITE_UMAMI_WEBSITE_ID%";
+        var src = "%VITE_UMAMI_SCRIPT_URL%";
+        // Vite substitutes empty string when the env var is unset; the
+        // raw `%VITE_…%` placeholder leaks through only on the dev
+        // server (which serves index.html untransformed). Skip both.
+        if (!id || !src || id.indexOf("%VITE_") === 0) return;
+        var s = document.createElement("script");
+        s.defer = true;
+        s.src = src;
+        s.setAttribute("data-website-id", id);
+        document.head.appendChild(s);
+      })();
+    </script>
   </head>
   <body class="bg-bg text-text font-sans">
     <div id="root"></div>

--- a/web/index.html
+++ b/web/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Crect width='16' height='16' rx='3' fill='%234ade80'/%3E%3Cpath d='M4 5h8M4 8h8M4 11h5' stroke='%230b0c0f' stroke-width='1.5' stroke-linecap='round'/%3E%3C/svg%3E" />
     <title>Parts Inventory & Production Manager</title>
+    <script defer src="https://stats.matescb.cz/script.js" data-website-id="5fdea605-7472-4437-8035-f8602d5bd627"></script>
   </head>
   <body class="bg-bg text-text font-sans">
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- Adds the self-hosted Umami tracking snippet to `web/index.html`
- Tracks pageviews and SPA route changes for `parts.matescb.cz`
- Loaded async with `defer`; no cookies, respects Do-Not-Track

## Test plan
- [ ] After merge & deploy, open `parts.matescb.cz` and confirm a request to `https://stats.matescb.cz/script.js` in DevTools → Network
- [ ] Verify the pageview shows up in https://stats.matescb.cz under the `parts.matescb.cz` site within ~10s
- [ ] Navigate between pages and confirm SPA route changes register as separate views

🤖 Generated with [Claude Code](https://claude.com/claude-code)