### PR TITLE
TP-103: Scaffold sourcing domain module

### DIFF
--- a/backend/app/domain/sourcing/README.md
+++ b/backend/app/domain/sourcing/README.md
@@ -1,0 +1,28 @@
+# sourcing
+
+Audience: engineer
+
+TrustedParts sourcing domain scaffold for live authorized-distributor offers.
+
+## Purpose
+
+This module will own TrustedParts sourcing, separate from catalog enrichment providers under `backend/app/domain/parts/providers/`.
+
+## Boundary
+
+- Workspace-scoped credentials and lookups.
+- Live authorized-distributor offers, not persisted catalog specs.
+- Cache entries capped at 7 days.
+- Parts-count request budget tracking.
+
+## Files
+
+| File | Planned role |
+|---|---|
+| `client.py`, `schemas.py`, `models.py` | Client, DTOs, models |
+| `cache.py`, `budget.py` | Cache helpers, request budget tracker |
+| `service.py`, `factory.py` | Route facade, workspace-scoped provider construction |
+
+## See also
+
+- [ADR-0019 — TrustedParts sourcing provider split](../../../../docs/adr/0019-trustedparts-sourcing-provider-split.md)

--- a/backend/app/domain/sourcing/__init__.py
+++ b/backend/app/domain/sourcing/__init__.py
@@ -1,0 +1,1 @@
+"""TrustedParts sourcing domain package scaffold."""

--- a/backend/app/domain/sourcing/budget.py
+++ b/backend/app/domain/sourcing/budget.py
@@ -1,0 +1,1 @@
+"""Request budget tracking scaffold for TrustedParts sourcing."""

--- a/backend/app/domain/sourcing/cache.py
+++ b/backend/app/domain/sourcing/cache.py
@@ -1,0 +1,1 @@
+"""Cache helper scaffold for TrustedParts sourcing offers."""

--- a/backend/app/domain/sourcing/client.py
+++ b/backend/app/domain/sourcing/client.py
@@ -1,0 +1,1 @@
+"""TrustedParts client scaffold for live sourcing lookups."""

--- a/backend/app/domain/sourcing/factory.py
+++ b/backend/app/domain/sourcing/factory.py
@@ -1,0 +1,1 @@
+"""Provider factory scaffold for workspace-scoped sourcing."""

--- a/backend/app/domain/sourcing/models.py
+++ b/backend/app/domain/sourcing/models.py
@@ -1,0 +1,1 @@
+"""SQLAlchemy model scaffold for TrustedParts sourcing."""

--- a/backend/app/domain/sourcing/schemas.py
+++ b/backend/app/domain/sourcing/schemas.py
@@ -1,0 +1,1 @@
+"""Pydantic DTO scaffold for TrustedParts sourcing."""

--- a/backend/app/domain/sourcing/service.py
+++ b/backend/app/domain/sourcing/service.py
@@ -1,0 +1,1 @@
+"""Service facade scaffold for TrustedParts sourcing."""


### PR DESCRIPTION
## Summary
- Scaffolded `backend/app/domain/sourcing/` with module-docstring-only Python files.
- Added a short sourcing README covering purpose, boundary, file roles, and the forward ADR-0019 link.

## Validation
```text
$ docker compose -f docker-compose.dev.yml exec backend python -c "from app.domain import sourcing"
/bin/bash: line 1: docker: command not found

$ docker compose -f docker-compose.dev.yml exec backend ruff check
/bin/bash: line 1: docker: command not found

$ python3 -c "import sys; print(sys.version); from app.domain import sourcing"  # from backend/
3.12.3 (main, Mar 23 2026, 19:04:32) [GCC 13.3.0]

$ ruff check app/domain/sourcing  # from backend/
All checks passed!

$ ruff check  # from backend/
Found 341 errors in pre-existing files outside backend/app/domain/sourcing.
```

Refs #323
