### PR TITLE
TP-101: Add migration 0037 for workspace sourcing columns

### DIFF
--- a/backend/alembic/versions/0037_workspace_sourcing_provider.py
+++ b/backend/alembic/versions/0037_workspace_sourcing_provider.py
@@ -1,0 +1,69 @@
+"""Add workspace sourcing provider settings.
+
+Revision ID: 0037
+Revises: 0036
+Create Date: 2026-05-08
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+from alembic import op
+
+revision = "0037"
+down_revision = "0036"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "workspaces",
+        sa.Column(
+            "sourcing_provider",
+            sa.String(length=40),
+            nullable=False,
+            server_default="none",
+        ),
+    )
+    op.add_column(
+        "workspaces",
+        sa.Column("sourcing_company_id_enc", sa.String(length=1024), nullable=True),
+    )
+    op.add_column(
+        "workspaces",
+        sa.Column("sourcing_api_key_enc", sa.String(length=1024), nullable=True),
+    )
+    op.add_column(
+        "workspaces",
+        sa.Column("sourcing_country_code", sa.String(length=2), nullable=True),
+    )
+    op.add_column(
+        "workspaces",
+        sa.Column("sourcing_currency_code", sa.String(length=3), nullable=True),
+    )
+    op.add_column(
+        "workspaces",
+        sa.Column("sourcing_preferred_distributors", JSONB, nullable=True),
+    )
+    op.add_column(
+        "workspaces",
+        sa.Column(
+            "sourcing_use_cached_for_dashboards",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.true(),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("workspaces", "sourcing_use_cached_for_dashboards")
+    op.drop_column("workspaces", "sourcing_preferred_distributors")
+    op.drop_column("workspaces", "sourcing_currency_code")
+    op.drop_column("workspaces", "sourcing_country_code")
+    op.drop_column("workspaces", "sourcing_api_key_enc")
+    op.drop_column("workspaces", "sourcing_company_id_enc")
+    op.drop_column("workspaces", "sourcing_provider")

--- a/backend/app/api/routes/workspaces.py
+++ b/backend/app/api/routes/workspaces.py
@@ -124,6 +124,16 @@ def _serialize_workspace(ws: Workspace, new_token: str | None = None) -> dict:
         # Never echo the API key/secret. Just say whether each is set.
         "has_parts_provider_api_key": bool(ws.parts_provider_api_key),
         "has_parts_provider_api_secret": bool(ws.parts_provider_api_secret),
+        "sourcing_provider": ws.sourcing_provider or "none",
+        "sourcing_country_code": ws.sourcing_country_code,
+        "sourcing_currency_code": ws.sourcing_currency_code,
+        "sourcing_preferred_distributors": ws.sourcing_preferred_distributors,
+        "sourcing_use_cached_for_dashboards": bool(
+            ws.sourcing_use_cached_for_dashboards
+        ),
+        # Sourcing credentials follow the encrypted-at-rest parts-provider pattern.
+        "has_sourcing_company_id": bool(ws.sourcing_company_id_enc),
+        "has_sourcing_api_key": bool(ws.sourcing_api_key_enc),
         "scanner": ws.scanner or "zxing",
         # Same secret-handling pattern as the parts-provider key.
         "has_scanner_license_key": bool(ws.scanner_license_key),

--- a/backend/app/domain/workspaces/models.py
+++ b/backend/app/domain/workspaces/models.py
@@ -4,7 +4,7 @@ import uuid
 
 import sqlalchemy as sa
 from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Index, String, UniqueConstraint, text
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.dialects.postgresql import JSONB, UUID
 
 from app.core.time import utcnow
 from app.infra.db import Base
@@ -45,6 +45,23 @@ class Workspace(Base):
     parts_provider_api_key = Column(String(1024), nullable=True)
     # DigiKey needs a second credential (client_secret). Mouser leaves this NULL.
     parts_provider_api_secret = Column(String(1024), nullable=True)
+    sourcing_provider = Column(
+        String(40),
+        nullable=False,
+        default="none",
+        server_default="none",
+    )
+    sourcing_company_id_enc = Column(String(1024), nullable=True)
+    sourcing_api_key_enc = Column(String(1024), nullable=True)
+    sourcing_country_code = Column(String(2), nullable=True)
+    sourcing_currency_code = Column(String(3), nullable=True)
+    sourcing_preferred_distributors = Column(JSONB, nullable=True)
+    sourcing_use_cached_for_dashboards = Column(
+        Boolean,
+        nullable=False,
+        default=True,
+        server_default=sa.true(),
+    )
     # Which client-side decoder the scanner pages mount. 'zxing' is the
     # royalty-free default; 'scandit' is opt-in and consumes scanner_license_key.
     scanner = Column(String(40), nullable=False, default="zxing")  # zxing | scandit

--- a/backend/tests/test_workspace_settings.py
+++ b/backend/tests/test_workspace_settings.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from app.domain.workspaces.models import Workspace
+
+
+def test_workspace_get_includes_sourcing_defaults(authed_client):
+    r = authed_client.get("/api/workspaces/current")
+    assert r.status_code == 200, r.text
+
+    body = r.json()["data"]
+    assert body["sourcing_provider"] == "none"
+    assert body["sourcing_country_code"] is None
+    assert body["sourcing_currency_code"] is None
+    assert body["sourcing_preferred_distributors"] is None
+    assert body["sourcing_use_cached_for_dashboards"] is True
+    assert body["has_sourcing_company_id"] is False
+    assert body["has_sourcing_api_key"] is False
+
+
+def test_workspace_get_never_returns_sourcing_secrets(authed_client, db):
+    cur = authed_client.get("/api/workspaces/current").json()["data"]
+    ws = db.get(Workspace, UUID(cur["id"]))
+    ws.sourcing_company_id_enc = "ciphertext-company-id"
+    ws.sourcing_api_key_enc = "ciphertext-api-key"
+    db.flush()
+
+    r = authed_client.get("/api/workspaces/current")
+    assert r.status_code == 200, r.text
+    body = r.json()["data"]
+
+    assert body["has_sourcing_company_id"] is True
+    assert body["has_sourcing_api_key"] is True
+    assert "sourcing_company_id" not in body
+    assert "sourcing_api_key" not in body
+    assert "sourcing_company_id_enc" not in body
+    assert "sourcing_api_key_enc" not in body
+    assert "plaintext-company-id" not in r.text
+    assert "plaintext-api-key" not in r.text
+    assert "ciphertext-company-id" not in r.text
+    assert "ciphertext-api-key" not in r.text
+
+
+def test_workspace_serializer_shape_unchanged_for_existing_fields(authed_client):
+    r = authed_client.get("/api/workspaces/current")
+    assert r.status_code == 200, r.text
+
+    body = r.json()["data"]
+    assert {
+        "id",
+        "name",
+        "kind",
+        "currency_default",
+        "lot_control_enabled",
+        "serial_tracking_enabled",
+        "catalog_enabled",
+        "catalog_token_set",
+        "parts_provider",
+        "has_parts_provider_api_key",
+        "has_parts_provider_api_secret",
+        "scanner",
+        "has_scanner_license_key",
+    }.issubset(body)

--- a/docs/domain/providers.md
+++ b/docs/domain/providers.md
@@ -18,6 +18,22 @@ Provider state lives on the `Workspace` row (`backend/app/domain/workspaces/mode
 
 Encryption envelope: `app.core.secrets.encrypt` / `decrypt`. Plaintext never appears in a column. Read paths call `decrypt(ws.parts_provider_api_key)` immediately before passing to the provider.
 
+## Workspace sourcing settings
+
+TrustedParts sourcing state also lives on the `Workspace` row (`backend/app/domain/workspaces/models.py:48-64`). It is separate from catalog-provider credentials because it drives availability, quoting, and dashboard refresh behaviour rather than one-off MPN enrichment.
+
+| Column | Notes |
+|---|---|
+| `sourcing_provider` | `none` until a sourcing provider integration is configured. DB default `none`. |
+| `sourcing_company_id_enc` | Encrypted sourcing account/company identifier. Exposed only as `has_sourcing_company_id` on `GET /api/workspaces/current`. |
+| `sourcing_api_key_enc` | Encrypted sourcing API key. Exposed only as `has_sourcing_api_key` on `GET /api/workspaces/current`. |
+| `sourcing_country_code` | Optional ISO 3166-1 alpha-2 country code for provider locale. |
+| `sourcing_currency_code` | Optional ISO 4217 currency code for sourcing responses. |
+| `sourcing_preferred_distributors` | Optional JSONB preference payload for distributor ordering/filtering. |
+| `sourcing_use_cached_for_dashboards` | Dashboard refreshes may use cached sourcing data. DB default `true`. |
+
+The workspace serializer (`backend/app/api/routes/workspaces.py:118-136`) returns only non-secret sourcing fields and boolean masks. It never serializes plaintext or ciphertext for the encrypted sourcing credential columns.
+
 ## Provider factory
 
 `backend/app/domain/parts/providers/base.py::make_provider(name, api_key, api_secret=None)` (`backend/app/domain/parts/providers/base.py:44-65`):


### PR DESCRIPTION
Adds migration 0037 to extend workspaces with the TrustedParts sourcing provider fields: provider, encrypted company/API credential slots, locale/currency, preferred distributors JSONB, and dashboard cache default. The Workspace model now declares those columns, GET /api/workspaces/current returns only non-secret sourcing fields plus has_sourcing_company_id/has_sourcing_api_key masks, and docs describe the new workspace sourcing settings.

Validation run:

```
DATABASE_URL=postgresql+psycopg://stockmgr:stockmgr@127.0.0.1:5432/stockmgr_test uv run --extra dev alembic upgrade head
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
```

```
DATABASE_URL=postgresql+psycopg://stockmgr:stockmgr@127.0.0.1:5432/stockmgr_test uv run --extra dev alembic downgrade -1
INFO  [alembic.runtime.migration] Running downgrade 0037 -> 0036, Add workspace sourcing provider settings.

DATABASE_URL=postgresql+psycopg://stockmgr:stockmgr@127.0.0.1:5432/stockmgr_test uv run --extra dev alembic upgrade head
INFO  [alembic.runtime.migration] Running upgrade 0036 -> 0037, Add workspace sourcing provider settings.
```

```
UV_LINK_MODE=copy uv run --extra dev pytest -k workspace_settings
4 passed, 756 deselected, 1 warning in 4.72s
```

```
UV_LINK_MODE=copy uv run --extra dev ruff check tests/test_workspace_settings.py
All checks passed!
```

```
WORK_DIR=. LINT_CMD="cd backend && UV_LINK_MODE=copy uv run --extra dev ruff check app --output-format=concise" BASELINE_FILE=".ruff-baseline.txt" scripts/lint-delta.sh
lint-delta: no new violations (baseline: 159, current: 154, fixed since baseline: 5)
```

Unavailable validation:

- Docker validation commands from the issue could not run in this environment because `docker` is not installed (`/bin/bash: docker: command not found`).
- The first host Alembic attempt inherited the compose-only `db` hostname and failed name resolution; rerunning with the local test DATABASE_URL passed upgrade/downgrade/upgrade as shown above.
- Raw host `ruff check` reports existing repository baseline violations; the project lint-delta gate passed with no new app violations.

Refs #321