### PR TITLE
TP-102: Add sourcing credentials to workspace settings PATCH/GET

### DIFF
--- a/backend/alembic/versions/0037_workspace_sourcing_provider.py
+++ b/backend/alembic/versions/0037_workspace_sourcing_provider.py
@@ -1,0 +1,69 @@
+"""Add workspace sourcing provider settings.
+
+Revision ID: 0037
+Revises: 0036
+Create Date: 2026-05-08
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+from alembic import op
+
+revision = "0037"
+down_revision = "0036"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "workspaces",
+        sa.Column(
+            "sourcing_provider",
+            sa.String(length=40),
+            nullable=False,
+            server_default="none",
+        ),
+    )
+    op.add_column(
+        "workspaces",
+        sa.Column("sourcing_company_id_enc", sa.String(length=1024), nullable=True),
+    )
+    op.add_column(
+        "workspaces",
+        sa.Column("sourcing_api_key_enc", sa.String(length=1024), nullable=True),
+    )
+    op.add_column(
+        "workspaces",
+        sa.Column("sourcing_country_code", sa.String(length=2), nullable=True),
+    )
+    op.add_column(
+        "workspaces",
+        sa.Column("sourcing_currency_code", sa.String(length=3), nullable=True),
+    )
+    op.add_column(
+        "workspaces",
+        sa.Column("sourcing_preferred_distributors", JSONB, nullable=True),
+    )
+    op.add_column(
+        "workspaces",
+        sa.Column(
+            "sourcing_use_cached_for_dashboards",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.true(),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("workspaces", "sourcing_use_cached_for_dashboards")
+    op.drop_column("workspaces", "sourcing_preferred_distributors")
+    op.drop_column("workspaces", "sourcing_currency_code")
+    op.drop_column("workspaces", "sourcing_country_code")
+    op.drop_column("workspaces", "sourcing_api_key_enc")
+    op.drop_column("workspaces", "sourcing_company_id_enc")
+    op.drop_column("workspaces", "sourcing_provider")

--- a/backend/app/api/routes/workspaces.py
+++ b/backend/app/api/routes/workspaces.py
@@ -124,6 +124,16 @@ def _serialize_workspace(ws: Workspace, new_token: str | None = None) -> dict:
         # Never echo the API key/secret. Just say whether each is set.
         "has_parts_provider_api_key": bool(ws.parts_provider_api_key),
         "has_parts_provider_api_secret": bool(ws.parts_provider_api_secret),
+        "sourcing_provider": ws.sourcing_provider or "none",
+        "sourcing_country_code": ws.sourcing_country_code,
+        "sourcing_currency_code": ws.sourcing_currency_code,
+        "sourcing_preferred_distributors": ws.sourcing_preferred_distributors,
+        "sourcing_use_cached_for_dashboards": bool(
+            ws.sourcing_use_cached_for_dashboards
+        ),
+        # Sourcing credentials follow the encrypted-at-rest parts-provider pattern.
+        "has_sourcing_company_id": bool(ws.sourcing_company_id_enc),
+        "has_sourcing_api_key": bool(ws.sourcing_api_key_enc),
         "scanner": ws.scanner or "zxing",
         # Same secret-handling pattern as the parts-provider key.
         "has_scanner_license_key": bool(ws.scanner_license_key),

--- a/backend/app/api/routes/workspaces.py
+++ b/backend/app/api/routes/workspaces.py
@@ -34,6 +34,14 @@ router = APIRouter()
 _OWNED_ORG_WORKSPACE_CAP = 5
 
 
+def _encrypt_patch_credential(value: str | None) -> str | None:
+    if value is None:
+        return None
+    if not value.strip():
+        return None
+    return encrypt(value)
+
+
 @router.get("")
 def list_workspaces(user: CurrentUser, db: DbSession):
     memberships = (
@@ -178,10 +186,9 @@ def patch_current(payload: WorkspacePatch, db: DbSession, ws: CurrentWorkspace, 
     # log — only the field names.
     _credential_fields_changed: list[str] = []
 
-    # parts_provider_api_key / _api_secret need special handling so ''
-    # actually clears (rather than being stored as an empty string).
-    # All three credentials are encrypted at rest via app.core.secrets
-    # (Sec HIGH-9). Empty string still clears (encrypt('') → None).
+    # Credential fields need special handling so empty input clears
+    # rather than storing an empty string. They are encrypted at rest via
+    # app.core.secrets (Sec HIGH-9).
     if "parts_provider_api_key" in data:
         new_key = data.pop("parts_provider_api_key")
         ws.parts_provider_api_key = encrypt(new_key) if new_key else None
@@ -194,6 +201,14 @@ def patch_current(payload: WorkspacePatch, db: DbSession, ws: CurrentWorkspace, 
         new_license = data.pop("scanner_license_key")
         ws.scanner_license_key = encrypt(new_license) if new_license else None
         _credential_fields_changed.append("scanner_license_key")
+    if "sourcing_company_id" in data:
+        new_company_id = data.pop("sourcing_company_id")
+        ws.sourcing_company_id_enc = _encrypt_patch_credential(new_company_id)
+        _credential_fields_changed.append("sourcing_company_id")
+    if "sourcing_api_key" in data:
+        new_api_key = data.pop("sourcing_api_key")
+        ws.sourcing_api_key_enc = _encrypt_patch_credential(new_api_key)
+        _credential_fields_changed.append("sourcing_api_key")
 
     for k, v in data.items():
         setattr(ws, k, v)

--- a/backend/app/domain/workspaces/models.py
+++ b/backend/app/domain/workspaces/models.py
@@ -4,7 +4,7 @@ import uuid
 
 import sqlalchemy as sa
 from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Index, String, UniqueConstraint, text
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.dialects.postgresql import JSONB, UUID
 
 from app.core.time import utcnow
 from app.infra.db import Base
@@ -45,6 +45,23 @@ class Workspace(Base):
     parts_provider_api_key = Column(String(1024), nullable=True)
     # DigiKey needs a second credential (client_secret). Mouser leaves this NULL.
     parts_provider_api_secret = Column(String(1024), nullable=True)
+    sourcing_provider = Column(
+        String(40),
+        nullable=False,
+        default="none",
+        server_default="none",
+    )
+    sourcing_company_id_enc = Column(String(1024), nullable=True)
+    sourcing_api_key_enc = Column(String(1024), nullable=True)
+    sourcing_country_code = Column(String(2), nullable=True)
+    sourcing_currency_code = Column(String(3), nullable=True)
+    sourcing_preferred_distributors = Column(JSONB, nullable=True)
+    sourcing_use_cached_for_dashboards = Column(
+        Boolean,
+        nullable=False,
+        default=True,
+        server_default=sa.true(),
+    )
     # Which client-side decoder the scanner pages mount. 'zxing' is the
     # royalty-free default; 'scandit' is opt-in and consumes scanner_license_key.
     scanner = Column(String(40), nullable=False, default="zxing")  # zxing | scandit

--- a/backend/app/domain/workspaces/schemas.py
+++ b/backend/app/domain/workspaces/schemas.py
@@ -52,6 +52,13 @@ class WorkspacePatch(BaseModel):
     scanner: Literal["zxing", "scandit"] | None = None
     # Same '' clears / non-empty replaces / None leaves alone semantics.
     scanner_license_key: str | None = None
+    sourcing_provider: Literal["none", "trustedparts"] | None = None
+    sourcing_company_id: str | None = Field(default=None, max_length=256)
+    sourcing_api_key: str | None = Field(default=None, max_length=256)
+    sourcing_country_code: str | None = Field(default=None, min_length=2, max_length=2)
+    sourcing_currency_code: str | None = Field(default=None, min_length=3, max_length=3)
+    sourcing_preferred_distributors: list[str] | None = None
+    sourcing_use_cached_for_dashboards: bool | None = None
 
 
 class CatalogTokenIn(BaseModel):

--- a/backend/tests/test_workspace_settings.py
+++ b/backend/tests/test_workspace_settings.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from app.domain.workspaces.models import Workspace
+
+
+def test_workspace_get_includes_sourcing_defaults(authed_client):
+    r = authed_client.get("/api/workspaces/current")
+    assert r.status_code == 200, r.text
+
+    body = r.json()["data"]
+    assert body["sourcing_provider"] == "none"
+    assert body["sourcing_country_code"] is None
+    assert body["sourcing_currency_code"] is None
+    assert body["sourcing_preferred_distributors"] is None
+    assert body["sourcing_use_cached_for_dashboards"] is True
+    assert body["has_sourcing_company_id"] is False
+    assert body["has_sourcing_api_key"] is False
+
+
+def test_workspace_get_never_returns_sourcing_secrets(authed_client, db):
+    cur = authed_client.get("/api/workspaces/current").json()["data"]
+    ws = db.get(Workspace, UUID(cur["id"]))
+    ws.sourcing_company_id_enc = "ciphertext-company-id"
+    ws.sourcing_api_key_enc = "ciphertext-api-key"
+    db.flush()
+
+    r = authed_client.get("/api/workspaces/current")
+    assert r.status_code == 200, r.text
+    body = r.json()["data"]
+
+    assert body["has_sourcing_company_id"] is True
+    assert body["has_sourcing_api_key"] is True
+    assert "sourcing_company_id" not in body
+    assert "sourcing_api_key" not in body
+    assert "sourcing_company_id_enc" not in body
+    assert "sourcing_api_key_enc" not in body
+    assert "plaintext-company-id" not in r.text
+    assert "plaintext-api-key" not in r.text
+    assert "ciphertext-company-id" not in r.text
+    assert "ciphertext-api-key" not in r.text
+
+
+def test_workspace_serializer_shape_unchanged_for_existing_fields(authed_client):
+    r = authed_client.get("/api/workspaces/current")
+    assert r.status_code == 200, r.text
+
+    body = r.json()["data"]
+    assert {
+        "id",
+        "name",
+        "kind",
+        "currency_default",
+        "lot_control_enabled",
+        "serial_tracking_enabled",
+        "catalog_enabled",
+        "catalog_token_set",
+        "parts_provider",
+        "has_parts_provider_api_key",
+        "has_parts_provider_api_secret",
+        "scanner",
+        "has_scanner_license_key",
+    }.issubset(body)

--- a/backend/tests/test_workspace_sourcing_settings.py
+++ b/backend/tests/test_workspace_sourcing_settings.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import select
+
+from app.core.secrets import decrypt
+from app.domain.audit.models import AuditLog
+from app.domain.workspaces.models import Workspace
+
+
+def _current_workspace_id(authed_client) -> UUID:
+    r = authed_client.get("/api/workspaces/current")
+    assert r.status_code == 200, r.text
+    return UUID(r.json()["data"]["id"])
+
+
+def test_set_sourcing_credentials_persists_ciphertext(authed_client, db):
+    company_id = "trustedparts-company-123"
+    api_key = "trustedparts-api-key-456"
+
+    r = authed_client.patch(
+        "/api/workspaces/current",
+        json={
+            "sourcing_provider": "trustedparts",
+            "sourcing_company_id": company_id,
+            "sourcing_api_key": api_key,
+            "sourcing_country_code": "CZ",
+            "sourcing_currency_code": "EUR",
+            "sourcing_preferred_distributors": ["DigiKey", "Mouser"],
+            "sourcing_use_cached_for_dashboards": False,
+        },
+    )
+    assert r.status_code == 200, r.text
+
+    ws = db.get(Workspace, _current_workspace_id(authed_client))
+    assert ws is not None
+    assert ws.sourcing_provider == "trustedparts"
+    assert ws.sourcing_country_code == "CZ"
+    assert ws.sourcing_currency_code == "EUR"
+    assert ws.sourcing_preferred_distributors == ["DigiKey", "Mouser"]
+    assert ws.sourcing_use_cached_for_dashboards is False
+    assert ws.sourcing_company_id_enc is not None
+    assert ws.sourcing_company_id_enc != company_id
+    assert decrypt(ws.sourcing_company_id_enc) == company_id
+    assert ws.sourcing_api_key_enc is not None
+    assert ws.sourcing_api_key_enc != api_key
+    assert decrypt(ws.sourcing_api_key_enc) == api_key
+
+
+def test_clear_sourcing_credential_with_empty_string(authed_client, db):
+    r = authed_client.patch(
+        "/api/workspaces/current",
+        json={
+            "sourcing_provider": "trustedparts",
+            "sourcing_company_id": "company-to-clear",
+            "sourcing_api_key": "api-key-to-clear",
+        },
+    )
+    assert r.status_code == 200, r.text
+
+    r = authed_client.patch(
+        "/api/workspaces/current",
+        json={"sourcing_company_id": "", "sourcing_api_key": "   "},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["data"]["has_sourcing_company_id"] is False
+    assert r.json()["data"]["has_sourcing_api_key"] is False
+
+    ws = db.get(Workspace, _current_workspace_id(authed_client))
+    assert ws is not None
+    assert ws.sourcing_company_id_enc is None
+    assert ws.sourcing_api_key_enc is None
+
+
+def test_invalid_sourcing_provider_returns_422_envelope(authed_client):
+    r = authed_client.patch(
+        "/api/workspaces/current",
+        json={"sourcing_provider": "bogus"},
+    )
+
+    assert r.status_code == 422
+    body = r.json()
+    assert body["data"] is None
+    assert body["status"]["category"] == "validation_error"
+    assert body["status"]["message"] == "validation failed"
+    assert any(
+        error["field"] == "body.sourcing_provider"
+        for error in body.get("errors", [])
+    )
+
+
+def test_audit_log_records_field_names_not_values(authed_client, db):
+    company_id = "audit-company-plaintext"
+    api_key = "audit-api-key-plaintext"
+
+    r = authed_client.patch(
+        "/api/workspaces/current",
+        json={
+            "sourcing_provider": "trustedparts",
+            "sourcing_company_id": company_id,
+            "sourcing_api_key": api_key,
+            "sourcing_country_code": "CZ",
+            "sourcing_currency_code": "EUR",
+        },
+    )
+    assert r.status_code == 200, r.text
+
+    rows = db.execute(
+        select(AuditLog)
+        .where(AuditLog.action == "workspace.credentials_rotated")
+        .order_by(AuditLog.created_at.desc())
+    ).scalars().all()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.comment == "fields=sourcing_company_id,sourcing_api_key"
+    row_text = str(
+        {
+            "action": row.action,
+            "target_type": row.target_type,
+            "target_ids": row.target_ids,
+            "comment": row.comment,
+        }
+    )
+    assert company_id not in row_text
+    assert api_key not in row_text
+
+
+def test_get_after_patch_masks_creds(authed_client):
+    company_id = "masked-company-id"
+    api_key = "masked-api-key"
+
+    r = authed_client.patch(
+        "/api/workspaces/current",
+        json={
+            "sourcing_provider": "trustedparts",
+            "sourcing_company_id": company_id,
+            "sourcing_api_key": api_key,
+        },
+    )
+    assert r.status_code == 200, r.text
+
+    r = authed_client.get("/api/workspaces/current")
+    assert r.status_code == 200, r.text
+    body = r.json()["data"]
+    assert body["sourcing_provider"] == "trustedparts"
+    assert body["has_sourcing_company_id"] is True
+    assert body["has_sourcing_api_key"] is True
+    assert "sourcing_company_id" not in body
+    assert "sourcing_api_key" not in body
+    assert "sourcing_company_id_enc" not in body
+    assert "sourcing_api_key_enc" not in body
+    assert company_id not in r.text
+    assert api_key not in r.text

--- a/docs/domain/providers.md
+++ b/docs/domain/providers.md
@@ -18,6 +18,22 @@ Provider state lives on the `Workspace` row (`backend/app/domain/workspaces/mode
 
 Encryption envelope: `app.core.secrets.encrypt` / `decrypt`. Plaintext never appears in a column. Read paths call `decrypt(ws.parts_provider_api_key)` immediately before passing to the provider.
 
+## Workspace sourcing settings
+
+TrustedParts sourcing state also lives on the `Workspace` row (`backend/app/domain/workspaces/models.py:48-64`). It is separate from catalog-provider credentials because it drives availability, quoting, and dashboard refresh behaviour rather than one-off MPN enrichment.
+
+| Column | Notes |
+|---|---|
+| `sourcing_provider` | `none` until a sourcing provider integration is configured. DB default `none`. |
+| `sourcing_company_id_enc` | Encrypted sourcing account/company identifier. Exposed only as `has_sourcing_company_id` on `GET /api/workspaces/current`. |
+| `sourcing_api_key_enc` | Encrypted sourcing API key. Exposed only as `has_sourcing_api_key` on `GET /api/workspaces/current`. |
+| `sourcing_country_code` | Optional ISO 3166-1 alpha-2 country code for provider locale. |
+| `sourcing_currency_code` | Optional ISO 4217 currency code for sourcing responses. |
+| `sourcing_preferred_distributors` | Optional JSONB preference payload for distributor ordering/filtering. |
+| `sourcing_use_cached_for_dashboards` | Dashboard refreshes may use cached sourcing data. DB default `true`. |
+
+The workspace serializer (`backend/app/api/routes/workspaces.py:118-136`) returns only non-secret sourcing fields and boolean masks. It never serializes plaintext or ciphertext for the encrypted sourcing credential columns.
+
 ## Provider factory
 
 `backend/app/domain/parts/providers/base.py::make_provider(name, api_key, api_secret=None)` (`backend/app/domain/parts/providers/base.py:44-65`):


### PR DESCRIPTION
Summary
- Extended PATCH /api/workspaces/current to accept TrustedParts sourcing settings and preferences.
- Encrypts sourcing_company_id and sourcing_api_key into the existing encrypted columns, with empty or whitespace-only strings clearing the credential.
- Added focused tests for ciphertext persistence, clearing, 422 envelope validation, masked GET responses, and audit logging field names only.

Validation
- `uv run --extra dev pytest -k "workspace_sourcing_settings or workspace_settings"`
  - 9 passed, 756 deselected, 2 warnings
- `uv run --extra dev pytest tests/test_parts_provider.py::test_workspace_patch_sets_and_masks_api_key tests/test_parts_provider.py::test_workspace_patch_empty_string_clears_key tests/test_parts_provider.py::test_workspace_patch_rejects_unknown_provider`
  - 3 passed, 2 warnings
- `uv run --extra dev ruff check app/domain/workspaces/schemas.py tests/test_workspace_sourcing_settings.py`
  - All checks passed
- `WORK_DIR=/mnt/data/WORK/stockManager-1/.codex/worktrees/tp-102-322/backend LINT_CMD="uv run --extra dev ruff check --output-format=concise app" BASELINE_FILE=/mnt/data/WORK/stockManager-1/.codex/worktrees/tp-102-322/.ruff-baseline.txt bash /mnt/data/WORK/stockManager-1/.codex/worktrees/tp-102-322/scripts/lint-delta.sh`
  - lint-delta: no new violations (baseline: 159, current: 154, fixed since baseline: 5)

Docker Validation
- Not run: `docker` is not installed in this environment, so the requested `docker compose -f docker-compose.dev.yml exec backend ...` commands were unavailable.

Audit Log Safety
- Tests assert the sourcing credential audit row is exactly `fields=sourcing_company_id,sourcing_api_key` and does not include plaintext credential values.

Refs #322