### PR TITLE
TP-108: Sourcing request budget tracker

### DIFF
--- a/backend/app/domain/sourcing/budget.py
+++ b/backend/app/domain/sourcing/budget.py
@@ -1,1 +1,110 @@
-"""Request budget tracking scaffold for TrustedParts sourcing."""
+"""Per-workspace TrustedParts request budget tracking."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Callable, Literal
+from uuid import UUID
+
+
+@dataclass(frozen=True)
+class BudgetVerdict:
+    allow: bool
+    mode: Literal["live", "degraded", "blocked"]
+    reason: str
+
+
+# Soft thresholds: (rolling window seconds, parts searched in window).
+SOFT_LIMITS = [(10, 50), (60, 150), (3600, 2000), (86400, 15000)]
+
+# Hard thresholds: (rolling window seconds, parts searched in window).
+HARD_LIMITS = [(10, 250), (60, 1000), (3600, 25000), (86400, 250000)]
+
+_WINDOWS = tuple(window_seconds for window_seconds, _limit in HARD_LIMITS)
+
+
+class BudgetTracker:
+    """In-process rolling-window parts-count budget per workspace."""
+
+    def __init__(self, *, clock: Callable[[], float] | None = None) -> None:
+        self._clock = clock or time.monotonic
+        self._events: dict[tuple[UUID, int], list[tuple[float, int]]] = {}
+
+    def record(self, workspace_id: UUID, parts_count: int) -> None:
+        self._validate_parts_count(parts_count)
+        now = self._clock()
+        for window_seconds in _WINDOWS:
+            self._events.setdefault((workspace_id, window_seconds), []).append((now, parts_count))
+        self._prune(workspace_id)
+
+    def check(self, workspace_id: UUID, parts_count: int) -> BudgetVerdict:
+        self._validate_parts_count(parts_count)
+        self._prune(workspace_id)
+
+        for window_seconds, limit in HARD_LIMITS:
+            if self._window_total(workspace_id, window_seconds) + parts_count > limit:
+                return BudgetVerdict(
+                    allow=False,
+                    mode="blocked",
+                    reason=f"hard limit exceeded for {self._window_label(window_seconds)} window",
+                )
+
+        for window_seconds, limit in SOFT_LIMITS:
+            if self._window_total(workspace_id, window_seconds) + parts_count > limit:
+                return BudgetVerdict(
+                    allow=True,
+                    mode="degraded",
+                    reason=f"soft limit exceeded for {self._window_label(window_seconds)} window",
+                )
+
+        return BudgetVerdict(
+            allow=True,
+            mode="live",
+            reason="within TrustedParts parts-count budget",
+        )
+
+    def _prune(self, workspace_id: UUID) -> None:
+        now = self._clock()
+        for window_seconds in _WINDOWS:
+            key = (workspace_id, window_seconds)
+            events = self._events.get(key)
+            if events is None:
+                continue
+
+            keep_after = now - window_seconds
+            fresh_events = [
+                (timestamp, count) for timestamp, count in events if timestamp >= keep_after
+            ]
+            if fresh_events:
+                self._events[key] = fresh_events
+            else:
+                self._events.pop(key, None)
+
+    def _window_total(self, workspace_id: UUID, window_seconds: int) -> int:
+        events = self._events.get((workspace_id, window_seconds), [])
+        return sum(count for _timestamp, count in events)
+
+    @staticmethod
+    def _validate_parts_count(parts_count: int) -> None:
+        if parts_count <= 0:
+            raise ValueError("parts_count must be positive")
+
+    @staticmethod
+    def _window_label(window_seconds: int) -> str:
+        if window_seconds < 60:
+            return f"{window_seconds}s"
+        if window_seconds < 3600:
+            return f"{window_seconds // 60}m"
+        if window_seconds < 86400:
+            return f"{window_seconds // 3600}h"
+        return f"{window_seconds // 86400}d"
+
+
+BUDGET = BudgetTracker()
+"""Process-local budget singleton.
+
+Production currently runs uvicorn with ``--workers 1``, so the in-memory
+budget is shared by all requests in that process. If workers increase, a
+future Redis ADR must replace this per-process store.
+"""

--- a/backend/tests/test_sourcing_budget.py
+++ b/backend/tests/test_sourcing_budget.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import importlib
+from uuid import uuid4
+
+from app.domain.sourcing import budget as budget_module
+from app.domain.sourcing.budget import BUDGET, BudgetTracker, BudgetVerdict
+
+
+class FakeClock:
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def test_below_soft_returns_live():
+    tracker = BudgetTracker(clock=FakeClock())
+    ws = uuid4()
+
+    verdict = tracker.check(ws, 50)
+
+    assert verdict == BudgetVerdict(
+        allow=True,
+        mode="live",
+        reason="within TrustedParts parts-count budget",
+    )
+
+
+def test_above_soft_below_hard_returns_degraded():
+    tracker = BudgetTracker(clock=FakeClock())
+    ws = uuid4()
+    tracker.record(ws, 50)
+
+    verdict = tracker.check(ws, 1)
+
+    assert verdict.allow is True
+    assert verdict.mode == "degraded"
+    assert verdict.reason == "soft limit exceeded for 10s window"
+
+
+def test_above_hard_returns_blocked():
+    tracker = BudgetTracker(clock=FakeClock())
+    ws = uuid4()
+    tracker.record(ws, 250)
+
+    verdict = tracker.check(ws, 1)
+
+    assert verdict.allow is False
+    assert verdict.mode == "blocked"
+    assert verdict.reason == "hard limit exceeded for 10s window"
+
+
+def test_counter_increments_by_parts_count_not_one():
+    bulk_tracker = BudgetTracker(clock=FakeClock())
+    repeated_tracker = BudgetTracker(clock=FakeClock())
+    ws = uuid4()
+
+    bulk_tracker.record(ws, 50)
+    for _index in range(50):
+        repeated_tracker.record(ws, 1)
+
+    assert bulk_tracker.check(ws, 1).mode == repeated_tracker.check(ws, 1).mode == "degraded"
+    assert bulk_tracker.check(ws, 201).mode == repeated_tracker.check(ws, 201).mode == "blocked"
+
+
+def test_window_expiry_with_fake_clock():
+    clock = FakeClock()
+    tracker = BudgetTracker(clock=clock)
+    ws = uuid4()
+    tracker.record(ws, 50)
+    clock.advance(10.1)
+
+    tracker._prune(ws)
+
+    assert tracker.check(ws, 1).mode == "live"
+
+
+def test_two_workspaces_independent():
+    tracker = BudgetTracker(clock=FakeClock())
+    loaded_ws = uuid4()
+    quiet_ws = uuid4()
+    tracker.record(loaded_ws, 250)
+
+    assert tracker.check(loaded_ws, 1).mode == "blocked"
+    assert tracker.check(quiet_ws, 50).mode == "live"
+
+
+def test_singleton_identity():
+    reimported = importlib.import_module("app.domain.sourcing.budget")
+
+    assert BUDGET is budget_module.BUDGET
+    assert BUDGET is reimported.BUDGET


### PR DESCRIPTION
## Summary
- Added the TrustedParts sourcing budget tracker with BudgetVerdict, soft/hard rolling-window limits, injectable monotonic clock, pruning, and module-level BUDGET singleton.
- Tracks per-workspace counters by parts_count across 10s, 1m, 1h, and 24h windows; workspace budgets are independent.
- Added focused tests for live, degraded, blocked, parts_count accounting, window expiry, workspace independence, and singleton identity.

## Validation
- `docker compose -f docker-compose.dev.yml exec backend pytest -k sourcing_budget` - not run: Docker is unavailable in this environment (`docker: command not found`).
- `docker compose -f docker-compose.dev.yml exec backend ruff check` - not run: Docker is unavailable in this environment (`docker: command not found`).
- `uv run --extra dev pytest -k sourcing_budget` - passed: 7 passed, 771 deselected, 1 warning in 1.77s.
- `uv run --extra dev ruff check app/domain/sourcing/budget.py tests/test_sourcing_budget.py` - passed: All checks passed.
- `uv run --extra dev ruff check` - failed on existing repo-wide lint baseline outside this change: 341 errors reported, beginning with alembic/env.py import ordering and pre-existing E501/F401/E741 findings in unrelated files.

Counters explicitly increment by `parts_count`, not by HTTP request count or by 1; `record(ws, 50)` consumes the same window budget as 50 calls to `record(ws, 1)`.

Refs #328