### PR TITLE
TP-106: Sourcing connection-test endpoint

### DIFF
--- a/backend/app/api/routes/sourcing.py
+++ b/backend/app/api/routes/sourcing.py
@@ -1,0 +1,78 @@
+"""Sourcing provider endpoints."""
+from __future__ import annotations
+
+from time import perf_counter
+
+from fastapi import APIRouter, Depends, Request
+
+from app.core.deps import CurrentWorkspace, require_role
+from app.core.ratelimit import limiter, workspace_key
+from app.core.responses import ok
+from app.core.secrets import decrypt
+from app.domain.sourcing import (
+    SourcingAuthError,
+    SourcingClientError,
+    SourcingRateLimitError,
+    SourcingTimeoutError,
+    TrustedPartsClient,
+)
+from app.domain.sourcing.schemas import SourcingQuery
+
+router = APIRouter()
+
+_TEST_PROBE_TOKEN = "TEST_PROBE_DO_NOT_BUY"
+
+
+def _elapsed_ms(started_at: float) -> int:
+    return max(1, int((perf_counter() - started_at) * 1000))
+
+
+def _test_result(is_ok: bool, message: str, latency_ms: int):
+    return ok({"ok": is_ok, "message": message, "latency_ms": latency_ms})
+
+
+@router.post(
+    "/current/sourcing/test",
+    dependencies=[Depends(require_role("admin"))],
+)
+@limiter.limit("6/minute", key_func=workspace_key)
+def test_sourcing_connection(request: Request, ws: CurrentWorkspace):
+    started_at = perf_counter()
+    if (
+        ws.sourcing_provider != "trustedparts"
+        or not ws.sourcing_company_id_enc
+        or not ws.sourcing_api_key_enc
+    ):
+        return _test_result(False, "not configured", 0)
+
+    company_id = decrypt(ws.sourcing_company_id_enc)
+    api_key = decrypt(ws.sourcing_api_key_enc)
+    if not company_id or not api_key:
+        return _test_result(False, "not configured", 0)
+
+    # TODO(#326): replace "dev" with the repository git SHA once a shared
+    # app.core helper exposes it.
+    user_agent = f"stockManager/dev workspace={ws.id}"
+    client = TrustedPartsClient(
+        company_id=company_id,
+        api_key=api_key,
+        country_code=ws.sourcing_country_code,
+        currency_code=ws.sourcing_currency_code,
+        user_agent=user_agent,
+    )
+
+    try:
+        client.search(
+            [SourcingQuery(search_token=_TEST_PROBE_TOKEN)],
+            use_cached_data=False,
+        )
+    except SourcingAuthError:
+        return _test_result(False, "invalid credentials", _elapsed_ms(started_at))
+    except SourcingRateLimitError:
+        return _test_result(False, "rate limited by TrustedParts", _elapsed_ms(started_at))
+    except SourcingTimeoutError:
+        return _test_result(False, "timeout reaching TrustedParts", _elapsed_ms(started_at))
+    except SourcingClientError:
+        return _test_result(False, "TrustedParts upstream error", _elapsed_ms(started_at))
+
+    return _test_result(True, "OK", _elapsed_ms(started_at))

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -117,6 +117,7 @@ from app.api.routes import (
     reports,
     search,
     sentry_tunnel,
+    sourcing,
     stock,
     storage,
     tags,
@@ -384,6 +385,7 @@ app.include_router(attachments.router, prefix="/api/attachments", tags=["attachm
 app.include_router(custom_fields.router, prefix="/api/custom-fields", tags=["custom_fields"], dependencies=_member_gate)
 app.include_router(tags.router, prefix="/api/tags", tags=["tags"], dependencies=_member_gate)
 app.include_router(search.router, prefix="/api/search", tags=["search"], dependencies=_member_gate)
+app.include_router(sourcing.router, prefix="/api/workspaces", tags=["sourcing"])
 app.include_router(
     parts_provider.router,
     prefix="/api/parts",

--- a/backend/tests/test_sourcing_test_route.py
+++ b/backend/tests/test_sourcing_test_route.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+
+import app.core.ratelimit as _ratelimit_mod
+from app.core.secrets import decrypt
+from app.domain.sourcing import SourcingAuthError
+from app.domain.sourcing.schemas import SourcingQuery
+from app.domain.workspaces.models import Workspace, WorkspaceMember
+from app.main import app
+
+
+def _signup(client: TestClient | None = None) -> tuple[TestClient, str]:
+    c = client or TestClient(app)
+    r = c.post(
+        "/api/auth/signup",
+        json={
+            "email": f"u-{uuid.uuid4().hex[:8]}@example.com",
+            "name": "Tester",
+            "password": "TestPass-2026-Stronk",
+        },
+    )
+    assert r.status_code == 200, r.text
+    return c, r.json()["data"]["workspace_id"]
+
+
+def _configure_sourcing(
+    client: TestClient,
+    *,
+    company_id: str = "company-123",
+    api_key: str = "api-key-456",
+) -> None:
+    r = client.patch(
+        "/api/workspaces/current",
+        json={
+            "sourcing_provider": "trustedparts",
+            "sourcing_company_id": company_id,
+            "sourcing_api_key": api_key,
+            "sourcing_country_code": "CZ",
+            "sourcing_currency_code": "EUR",
+        },
+    )
+    assert r.status_code == 200, r.text
+
+
+class _SuccessfulTrustedPartsClient:
+    calls: list[dict] = []
+
+    def __init__(
+        self,
+        company_id: str,
+        api_key: str,
+        country_code: str | None,
+        currency_code: str | None,
+        user_agent: str,
+    ) -> None:
+        self.company_id = company_id
+        self.api_key = api_key
+        self.country_code = country_code
+        self.currency_code = currency_code
+        self.user_agent = user_agent
+
+    def search(
+        self,
+        queries: list[SourcingQuery],
+        *,
+        use_cached_data: bool,
+        **_kwargs,
+    ):
+        assert all(isinstance(query, SourcingQuery) for query in queries)
+        self.calls.append(
+            {
+                "company_id": self.company_id,
+                "api_key": self.api_key,
+                "country_code": self.country_code,
+                "currency_code": self.currency_code,
+                "user_agent": self.user_agent,
+                "queries": [query.model_dump(exclude_none=True) for query in queries],
+                "use_cached_data": use_cached_data,
+            }
+        )
+        return object()
+
+
+@pytest.fixture(autouse=False)
+def limiter_enabled():
+    original = _ratelimit_mod.limiter.enabled
+    _ratelimit_mod.limiter.enabled = True
+    try:
+        _ratelimit_mod.limiter.reset()
+    except Exception:
+        pass
+    yield
+    _ratelimit_mod.limiter.enabled = original
+    try:
+        _ratelimit_mod.limiter.reset()
+    except Exception:
+        pass
+
+
+def test_unconfigured_returns_not_configured(authed_client):
+    r = authed_client.post("/api/workspaces/current/sourcing/test")
+
+    assert r.status_code == 200, r.text
+    assert r.json() == {
+        "data": {"ok": False, "message": "not configured", "latency_ms": 0},
+        "status": {"category": "ok", "message": "OK"},
+    }
+
+
+def test_bad_creds_returns_invalid_credentials(authed_client, monkeypatch):
+    _configure_sourcing(authed_client)
+
+    class BadCredsTrustedPartsClient(_SuccessfulTrustedPartsClient):
+        def search(self, queries: list[dict], *, use_cached_data: bool, **_kwargs):
+            raise SourcingAuthError("bad credentials")
+
+    monkeypatch.setattr(
+        "app.api.routes.sourcing.TrustedPartsClient",
+        BadCredsTrustedPartsClient,
+    )
+
+    r = authed_client.post("/api/workspaces/current/sourcing/test")
+
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["status"]["category"] == "ok"
+    assert body["data"]["ok"] is False
+    assert body["data"]["message"] == "invalid credentials"
+    assert body["data"]["latency_ms"] > 0
+
+
+def test_good_creds_returns_ok_and_latency(authed_client, monkeypatch):
+    _configure_sourcing(authed_client)
+    _SuccessfulTrustedPartsClient.calls = []
+    monkeypatch.setattr(
+        "app.api.routes.sourcing.TrustedPartsClient",
+        _SuccessfulTrustedPartsClient,
+    )
+
+    r = authed_client.post("/api/workspaces/current/sourcing/test")
+
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["data"]["ok"] is True
+    assert body["data"]["message"] == "OK"
+    assert body["data"]["latency_ms"] > 0
+    assert _SuccessfulTrustedPartsClient.calls == [
+        {
+            "company_id": "company-123",
+            "api_key": "api-key-456",
+            "country_code": "CZ",
+            "currency_code": "EUR",
+            "user_agent": f"stockManager/dev workspace={_current_workspace_id(authed_client)}",
+            "queries": [{"search_token": "TEST_PROBE_DO_NOT_BUY"}],
+            "use_cached_data": False,
+        }
+    ]
+
+
+def test_rate_limit_after_6_per_minute(authed_client, monkeypatch, limiter_enabled):
+    _configure_sourcing(authed_client)
+    monkeypatch.setattr(
+        "app.api.routes.sourcing.TrustedPartsClient",
+        _SuccessfulTrustedPartsClient,
+    )
+
+    for _ in range(6):
+        r = authed_client.post("/api/workspaces/current/sourcing/test")
+        assert r.status_code == 200, r.text
+
+    r = authed_client.post("/api/workspaces/current/sourcing/test")
+    assert r.status_code == 429, r.text
+    body = r.json()
+    assert body["data"] is None
+    assert body["status"]["category"] == "rate_limited"
+    assert body["retry_after_seconds"] > 0
+
+
+def test_non_admin_forbidden(authed_client, db):
+    ws_id = _current_workspace_id(authed_client)
+    membership = db.execute(
+        select(WorkspaceMember).where(WorkspaceMember.workspace_id == ws_id)
+    ).scalar_one()
+    membership.role = "member"
+    db.flush()
+
+    r = authed_client.post("/api/workspaces/current/sourcing/test")
+
+    assert r.status_code == 403, r.text
+    body = r.json()
+    assert body["data"] is None
+    assert body["status"]["category"] == "forbidden"
+
+
+def test_workspace_isolation_uses_own_creds(db, monkeypatch):
+    client_a, ws_a_id = _signup()
+    _configure_sourcing(
+        client_a,
+        company_id="company-a",
+        api_key="api-key-a",
+    )
+    client_b, ws_b_id = _signup()
+    _configure_sourcing(
+        client_b,
+        company_id="company-b",
+        api_key="api-key-b",
+    )
+
+    ws_a = db.get(Workspace, ws_a_id)
+    ws_b = db.get(Workspace, ws_b_id)
+    assert ws_a is not None
+    assert ws_b is not None
+    a_tokens = {ws_a.sourcing_company_id_enc, ws_a.sourcing_api_key_enc}
+    b_tokens = {ws_b.sourcing_company_id_enc, ws_b.sourcing_api_key_enc}
+    seen_tokens: list[str | None] = []
+
+    def decrypt_spy(token: str | None) -> str | None:
+        seen_tokens.append(token)
+        return decrypt(token)
+
+    _SuccessfulTrustedPartsClient.calls = []
+    monkeypatch.setattr("app.api.routes.sourcing.decrypt", decrypt_spy)
+    monkeypatch.setattr(
+        "app.api.routes.sourcing.TrustedPartsClient",
+        _SuccessfulTrustedPartsClient,
+    )
+
+    r = client_b.post("/api/workspaces/current/sourcing/test")
+
+    assert r.status_code == 200, r.text
+    assert r.json()["data"]["ok"] is True
+    assert set(seen_tokens) == b_tokens
+    assert not set(seen_tokens) & a_tokens
+    assert _SuccessfulTrustedPartsClient.calls[-1]["company_id"] == "company-b"
+    assert _SuccessfulTrustedPartsClient.calls[-1]["api_key"] == "api-key-b"
+
+
+def _current_workspace_id(client: TestClient) -> str:
+    r = client.get("/api/workspaces/current")
+    assert r.status_code == 200, r.text
+    return r.json()["data"]["id"]

--- a/docs/api/sourcing.md
+++ b/docs/api/sourcing.md
@@ -1,0 +1,49 @@
+# Sourcing API
+
+Audience: engineer
+
+TrustedParts sourcing endpoints for workspace-scoped connection checks.
+
+## Conventions
+
+See [API conventions](./README.md) for envelope, errors, pagination. Mounted at `/api/workspaces`; current routes require a cookie session and current workspace.
+
+## Routes
+
+### `POST /api/workspaces/current/sourcing/test`
+
+Probe the current workspace's TrustedParts credentials with a deterministic single-token search.
+
+**Request**
+
+No body.
+
+**Response** - `200 OK` (envelope: `{ data, status }`)
+
+```json
+{
+  "data": { "ok": true, "message": "OK", "latency_ms": 42 },
+  "status": { "category": "ok", "message": "OK" }
+}
+```
+
+When TrustedParts is not configured or rejects the probe, the HTTP status remains `200 OK` and `data.ok` is `false`.
+
+```json
+{
+  "data": { "ok": false, "message": "invalid credentials", "latency_ms": 7 },
+  "status": { "category": "ok", "message": "OK" }
+}
+```
+
+**Errors**
+
+- `403 Forbidden` - caller is not an admin of the current workspace.
+- `429 Too Many Requests` - more than six probes per minute for the workspace.
+
+**Notes**
+
+- The route decrypts only the current workspace's `sourcing_company_id_enc` and `sourcing_api_key_enc`, then passes plaintext directly to `TrustedPartsClient`; the plaintext credentials are not serialized or logged.
+- Probe token: `TEST_PROBE_DO_NOT_BUY`; called with `use_cached_data=false`.
+- Friendly failure messages: `not configured`, `invalid credentials`, `rate limited by TrustedParts`, `timeout reaching TrustedParts`, `TrustedParts upstream error`.
+- Source: `backend/app/api/routes/sourcing.py:33-78`.


### PR DESCRIPTION
## Summary
- Added `POST /api/workspaces/current/sourcing/test` for admin-only TrustedParts connection probes.
- Decrypts only the current workspace's sourcing credentials, sends deterministic `TEST_PROBE_DO_NOT_BUY` via `SourcingQuery`, and maps TrustedParts auth/rate-limit/timeout/client failures to friendly envelope responses.
- Mounted the sourcing router at `/api/workspaces`, documented the endpoint, and added route tests for success, bad credentials, unconfigured workspaces, rate limiting, non-admin access, and workspace credential isolation.

## Validation
- `uv run --extra dev python -m pytest -q tests/test_sourcing_test_route.py`
  - `6 passed, 1 warning in 2.75s`
- `uv run --extra dev ruff check app/api/routes/sourcing.py tests/test_sourcing_test_route.py`
  - `All checks passed!`
- `LINT_CMD='uv run --extra dev ruff check app --output-format=concise' BASELINE_FILE='.ruff-baseline.txt' WORK_DIR='backend' scripts/lint-delta.sh`
  - `lint-delta: no new violations (baseline: 159, current: 154, fixed since baseline: 5)`
- `git diff --check`
  - passed with no output
- Docker validation requested by the issue could not run on this host: `docker: command not found` for both `docker compose -f docker-compose.dev.yml exec backend pytest -q -k sourcing_test_route` and `docker compose -f docker-compose.dev.yml exec backend ruff check`.

## Workspace Isolation
- The route depends on `CurrentWorkspace` and only reads/decrypts credential columns from that resolved workspace.
- `test_workspace_isolation_uses_own_creds` configures separate TrustedParts credentials for workspaces A and B, calls as B, and asserts only B's encrypted values are decrypted and passed to the client.
- Manual workspace-isolation review is clean; no cross-workspace query or request-body workspace selector is introduced.

Refs #326
