### PR TITLE
TP-107: Workspace Sourcing settings card

### DIFF
--- a/docs/frontend/workspace-settings.md
+++ b/docs/frontend/workspace-settings.md
@@ -1,0 +1,23 @@
+# Workspace Settings
+
+Audience: engineer
+
+Frontend notes for `/settings/workspace` cards that edit workspace-scoped configuration.
+
+## Sourcing Provider
+
+The Workspace page mounts `SourcingCard` below the parts data provider card.
+Source: `web/src/routes/settings/Workspace.tsx:655`.
+
+The card edits TrustedParts sourcing preferences with provider, masked CompanyId
+and API key inputs, country, currency, preferred distributors, and dashboard
+cache preference. Save calls `api.patch("/workspaces/current", body)` and
+invalidates the workspace-current query; test connection calls
+`api.post("/workspaces/current/sourcing/test", {})`.
+Source: `web/src/routes/settings/SourcingCard.tsx:85-134`.
+
+Credential values are never read back from the API. The UI clears typed
+credential fields after save and displays only the `Configured ✓` pill when
+`has_sourcing_company_id && has_sourcing_api_key` is true.
+Source: `web/src/routes/settings/SourcingCard.tsx:70-82`,
+`web/src/routes/settings/SourcingCard.tsx:137-147`.

--- a/web/src/routes/settings/SourcingCard.tsx
+++ b/web/src/routes/settings/SourcingCard.tsx
@@ -1,0 +1,260 @@
+import { FormEvent, useEffect, useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { api, ApiError } from "@/lib/api";
+import { wsKeyOf } from "@/lib/queryKeys";
+
+export type SourcingWorkspace = {
+  id: string;
+  sourcing_provider: "none" | "trustedparts";
+  sourcing_country_code: string | null;
+  sourcing_currency_code: string | null;
+  sourcing_preferred_distributors: string[] | null;
+  sourcing_use_cached_for_dashboards: boolean;
+  has_sourcing_company_id: boolean;
+  has_sourcing_api_key: boolean;
+};
+
+type SourcingPatch = {
+  sourcing_provider: SourcingWorkspace["sourcing_provider"];
+  sourcing_country_code: string | null;
+  sourcing_currency_code: string | null;
+  sourcing_preferred_distributors: string[];
+  sourcing_use_cached_for_dashboards: boolean;
+  sourcing_company_id?: string;
+  sourcing_api_key?: string;
+};
+
+type SourcingTestResult = {
+  ok: boolean;
+  message: string;
+  latency_ms: number;
+};
+
+type TestBanner = SourcingTestResult & { text: string };
+
+function splitDistributors(value: string): string[] {
+  return value
+    .split(",")
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
+
+function testMessage(result: SourcingTestResult): string {
+  return `${result.message} (${result.latency_ms} ms)`;
+}
+
+export function SourcingCard({
+  workspace,
+  workspaceId,
+}: {
+  workspace: SourcingWorkspace;
+  workspaceId: string | null | undefined;
+}) {
+  const qc = useQueryClient();
+  const [provider, setProvider] = useState<SourcingWorkspace["sourcing_provider"]>(workspace.sourcing_provider);
+  const [companyId, setCompanyId] = useState("");
+  const [apiKey, setApiKey] = useState("");
+  const [companyIdTouched, setCompanyIdTouched] = useState(false);
+  const [apiKeyTouched, setApiKeyTouched] = useState(false);
+  const [country, setCountry] = useState(workspace.sourcing_country_code ?? "");
+  const [currency, setCurrency] = useState(workspace.sourcing_currency_code ?? "");
+  const [distributors, setDistributors] = useState(
+    (workspace.sourcing_preferred_distributors ?? []).join(", "),
+  );
+  const [useCache, setUseCache] = useState(workspace.sourcing_use_cached_for_dashboards);
+  const [hasCompanyId, setHasCompanyId] = useState(workspace.has_sourcing_company_id);
+  const [hasApiKey, setHasApiKey] = useState(workspace.has_sourcing_api_key);
+  const [testBanner, setTestBanner] = useState<TestBanner | null>(null);
+
+  useEffect(() => {
+    setProvider(workspace.sourcing_provider);
+    setCompanyId("");
+    setApiKey("");
+    setCompanyIdTouched(false);
+    setApiKeyTouched(false);
+    setCountry(workspace.sourcing_country_code ?? "");
+    setCurrency(workspace.sourcing_currency_code ?? "");
+    setDistributors((workspace.sourcing_preferred_distributors ?? []).join(", "));
+    setUseCache(workspace.sourcing_use_cached_for_dashboards);
+    setHasCompanyId(workspace.has_sourcing_company_id);
+    setHasApiKey(workspace.has_sourcing_api_key);
+    setTestBanner(null);
+  }, [workspace]);
+
+  const saveMutation = useMutation({
+    mutationKey: ["workspace", "sourcing", "save"],
+    mutationFn: (body: SourcingPatch) =>
+      api.patch<SourcingWorkspace, SourcingPatch>("/workspaces/current", body),
+    onSuccess: (saved, body) => {
+      qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "ws", "current") });
+      setCompanyId("");
+      setApiKey("");
+      setCompanyIdTouched(false);
+      setApiKeyTouched(false);
+      setHasCompanyId(saved.has_sourcing_company_id ?? Boolean(body.sourcing_company_id));
+      setHasApiKey(saved.has_sourcing_api_key ?? Boolean(body.sourcing_api_key));
+      toast.success("Sourcing settings saved.");
+    },
+    onError: (e) => {
+      toast.error(e instanceof ApiError ? e.userMessage : "Failed");
+    },
+  });
+
+  const testMutation = useMutation({
+    mutationKey: ["workspace", "sourcing", "test"],
+    mutationFn: () => api.post<SourcingTestResult>("/workspaces/current/sourcing/test", {}),
+    onSuccess: (result) => {
+      const text = testMessage(result);
+      setTestBanner({ ...result, text });
+      if (result.ok) {
+        toast.success(`Sourcing connection OK: ${text}`);
+      } else {
+        toast.error(`Sourcing connection failed: ${text}`);
+      }
+    },
+    onError: (e) => {
+      const text = e instanceof ApiError ? e.userMessage : "Failed";
+      setTestBanner({ ok: false, message: text, latency_ms: 0, text });
+      toast.error(text);
+    },
+  });
+
+  function submit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const body: SourcingPatch = {
+      sourcing_provider: provider,
+      sourcing_country_code: country.trim() ? country.trim().toUpperCase() : null,
+      sourcing_currency_code: currency.trim() ? currency.trim().toUpperCase() : null,
+      sourcing_preferred_distributors: splitDistributors(distributors),
+      sourcing_use_cached_for_dashboards: useCache,
+    };
+    if (companyIdTouched) body.sourcing_company_id = companyId;
+    if (apiKeyTouched) body.sourcing_api_key = apiKey;
+    saveMutation.mutate(body);
+  }
+
+  const configured = hasCompanyId && hasApiKey;
+
+  return (
+    <form className="card p-4 mb-4 space-y-3 text-sm" onSubmit={submit}>
+      <div className="flex items-center justify-between gap-3">
+        <h2 className="text-md font-semibold">Sourcing provider</h2>
+        {configured && (
+          <span className="pill bg-success/10 text-success" aria-label="Sourcing credentials configured">
+            Configured ✓
+          </span>
+        )}
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <div>
+          <label className="label" htmlFor="sourcing-provider">Provider</label>
+          <select
+            id="sourcing-provider"
+            className="input"
+            value={provider}
+            onChange={(e) => setProvider(e.target.value as SourcingWorkspace["sourcing_provider"])}
+          >
+            <option value="none">None</option>
+            <option value="trustedparts">TrustedParts</option>
+          </select>
+        </div>
+        <div>
+          <label className="label" htmlFor="sourcing-company-id">CompanyId</label>
+          <input
+            id="sourcing-company-id"
+            className="input font-mono text-xs"
+            type="password"
+            autoComplete="off"
+            value={companyId}
+            onChange={(e) => {
+              setCompanyIdTouched(true);
+              setCompanyId(e.target.value);
+            }}
+            placeholder={hasCompanyId ? "•••••••• (CompanyId set)" : "CompanyId"}
+          />
+        </div>
+        <div>
+          <label className="label" htmlFor="sourcing-api-key">API Key</label>
+          <input
+            id="sourcing-api-key"
+            className="input font-mono text-xs"
+            type="password"
+            autoComplete="off"
+            value={apiKey}
+            onChange={(e) => {
+              setApiKeyTouched(true);
+              setApiKey(e.target.value);
+            }}
+            placeholder={hasApiKey ? "•••••••• (API key set)" : "API key"}
+          />
+        </div>
+        <div>
+          <label className="label" htmlFor="sourcing-country">Country</label>
+          <input
+            id="sourcing-country"
+            className="input uppercase"
+            maxLength={2}
+            value={country}
+            onChange={(e) => setCountry(e.target.value.toUpperCase())}
+            placeholder="US"
+          />
+        </div>
+        <div>
+          <label className="label" htmlFor="sourcing-currency">Currency</label>
+          <input
+            id="sourcing-currency"
+            className="input uppercase"
+            maxLength={3}
+            value={currency}
+            onChange={(e) => setCurrency(e.target.value.toUpperCase())}
+            placeholder="USD"
+          />
+        </div>
+        <div>
+          <label className="label" htmlFor="sourcing-distributors">Preferred distributors</label>
+          <input
+            id="sourcing-distributors"
+            className="input"
+            value={distributors}
+            onChange={(e) => setDistributors(e.target.value)}
+            placeholder="DigiKey, Mouser"
+          />
+        </div>
+      </div>
+
+      <label className="flex items-center gap-2">
+        <input
+          type="checkbox"
+          checked={useCache}
+          onChange={(e) => setUseCache(e.target.checked)}
+        />
+        Use cached data for dashboards
+      </label>
+
+      {testBanner && (
+        <div
+          role={testBanner.ok ? "status" : "alert"}
+          className={testBanner.ok ? "text-xs text-success" : "text-xs text-danger"}
+        >
+          {testBanner.text}
+        </div>
+      )}
+
+      <div className="flex flex-wrap gap-2">
+        <button className="btn-primary" type="submit" disabled={saveMutation.isPending}>
+          Save
+        </button>
+        <button
+          className="btn"
+          type="button"
+          disabled={testMutation.isPending}
+          onClick={() => testMutation.mutate()}
+        >
+          Test connection
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/web/src/routes/settings/Workspace.tsx
+++ b/web/src/routes/settings/Workspace.tsx
@@ -7,6 +7,7 @@ import { useApiMutation } from "@/lib/mutations";
 import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
 import { useConfirm } from "@/components/ConfirmDialog";
 import { InlineQueryError } from "@/components/QueryStateBoundary";
+import { SourcingCard } from "./SourcingCard";
 
 type Ws = {
   id: string;
@@ -27,6 +28,13 @@ type Ws = {
   parts_provider: "none" | "mouser" | "digikey";
   has_parts_provider_api_key: boolean;
   has_parts_provider_api_secret: boolean;
+  sourcing_provider: "none" | "trustedparts";
+  sourcing_country_code: string | null;
+  sourcing_currency_code: string | null;
+  sourcing_preferred_distributors: string[] | null;
+  sourcing_use_cached_for_dashboards: boolean;
+  has_sourcing_company_id: boolean;
+  has_sourcing_api_key: boolean;
   scanner: "zxing" | "scandit";
   has_scanner_license_key: boolean;
 };
@@ -646,6 +654,8 @@ export default function WorkspaceSettings() {
           )}
         </div>
       )}
+
+      {cur && <SourcingCard workspace={cur} workspaceId={workspaceId} />}
 
       {cur && (
         <div className="card p-4 mb-4 space-y-3 text-sm">

--- a/web/src/routes/settings/__dom__/SourcingCard.dom.test.tsx
+++ b/web/src/routes/settings/__dom__/SourcingCard.dom.test.tsx
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { api } from "@/lib/api";
+import { SourcingCard, type SourcingWorkspace } from "../SourcingCard";
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const baseWorkspace: SourcingWorkspace = {
+  id: "ws-1",
+  sourcing_provider: "none",
+  sourcing_country_code: null,
+  sourcing_currency_code: null,
+  sourcing_preferred_distributors: null,
+  sourcing_use_cached_for_dashboards: true,
+  has_sourcing_company_id: false,
+  has_sourcing_api_key: false,
+};
+
+function renderCard(workspace: SourcingWorkspace = baseWorkspace) {
+  const client = new QueryClient({
+    defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+  });
+  const invalidateSpy = vi.spyOn(client, "invalidateQueries");
+  render(
+    <QueryClientProvider client={client}>
+      <SourcingCard workspace={workspace} workspaceId={workspace.id} />
+    </QueryClientProvider>,
+  );
+  return { client, invalidateSpy };
+}
+
+beforeEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+});
+
+describe("SourcingCard", () => {
+  it("renders empty form for unconfigured workspace", () => {
+    renderCard();
+
+    expect(screen.getByRole("heading", { name: "Sourcing provider" })).toBeDefined();
+    expect(screen.getByLabelText("Provider")).toBeDefined();
+    expect(screen.getByLabelText("CompanyId")).toBeDefined();
+    expect(screen.getByLabelText("API Key")).toBeDefined();
+    expect(screen.getByLabelText("Country")).toBeDefined();
+    expect(screen.getByLabelText("Currency")).toBeDefined();
+    expect(screen.getByLabelText("Preferred distributors")).toBeDefined();
+    expect(screen.getByLabelText("Use cached data for dashboards")).toBeDefined();
+    expect(screen.queryByText("Configured ✓")).toBeNull();
+  });
+
+  it("submits PATCH with the expected body shape on Save", async () => {
+    const user = userEvent.setup();
+    const patchSpy = vi.spyOn(api, "patch").mockResolvedValue({
+      ...baseWorkspace,
+      sourcing_provider: "trustedparts",
+      sourcing_country_code: "CZ",
+      sourcing_currency_code: "EUR",
+      sourcing_preferred_distributors: ["DigiKey", "Mouser"],
+      sourcing_use_cached_for_dashboards: false,
+      has_sourcing_company_id: true,
+      has_sourcing_api_key: true,
+    });
+    const { invalidateSpy } = renderCard();
+
+    await user.selectOptions(screen.getByLabelText("Provider"), "trustedparts");
+    await user.type(screen.getByLabelText("CompanyId"), "company-123");
+    await user.type(screen.getByLabelText("API Key"), "api-456");
+    await user.type(screen.getByLabelText("Country"), "cz");
+    await user.type(screen.getByLabelText("Currency"), "eur");
+    await user.type(screen.getByLabelText("Preferred distributors"), "DigiKey, Mouser");
+    await user.click(screen.getByLabelText("Use cached data for dashboards"));
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(patchSpy).toHaveBeenCalledWith("/workspaces/current", {
+        sourcing_provider: "trustedparts",
+        sourcing_country_code: "CZ",
+        sourcing_currency_code: "EUR",
+        sourcing_preferred_distributors: ["DigiKey", "Mouser"],
+        sourcing_use_cached_for_dashboards: false,
+        sourcing_company_id: "company-123",
+        sourcing_api_key: "api-456",
+      });
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["ws", "ws-1", "ws", "current"] });
+    expect(screen.getByText("Configured ✓")).toBeDefined();
+  });
+
+  it("surfaces test-connection result on success", async () => {
+    const user = userEvent.setup();
+    vi.spyOn(api, "post").mockResolvedValue({ ok: true, message: "OK", latency_ms: 12 });
+    renderCard();
+
+    await user.click(screen.getByRole("button", { name: "Test connection" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("status").textContent).toContain("OK (12 ms)");
+    });
+    expect(toast.success).toHaveBeenCalledWith("Sourcing connection OK: OK (12 ms)");
+  });
+
+  it("surfaces test-connection failure message on auth error", async () => {
+    const user = userEvent.setup();
+    vi.spyOn(api, "post").mockResolvedValue({
+      ok: false,
+      message: "invalid credentials",
+      latency_ms: 9,
+    });
+    renderCard();
+
+    await user.click(screen.getByRole("button", { name: "Test connection" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert").textContent).toContain("invalid credentials (9 ms)");
+    });
+    expect(toast.error).toHaveBeenCalledWith(
+      "Sourcing connection failed: invalid credentials (9 ms)",
+    );
+  });
+
+  it("does not display credential values, even when typed and saved", async () => {
+    const user = userEvent.setup();
+    vi.spyOn(api, "patch").mockResolvedValue({
+      ...baseWorkspace,
+      sourcing_provider: "trustedparts",
+      has_sourcing_company_id: true,
+      has_sourcing_api_key: true,
+    });
+    renderCard();
+
+    await user.type(screen.getByLabelText("CompanyId"), "secret-company-id");
+    await user.type(screen.getByLabelText("API Key"), "secret-api-key");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Configured ✓")).toBeDefined();
+    });
+    expect(screen.queryByDisplayValue("secret-company-id")).toBeNull();
+    expect(screen.queryByDisplayValue("secret-api-key")).toBeNull();
+    expect(screen.queryByText("secret-company-id")).toBeNull();
+    expect(screen.queryByText("secret-api-key")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Added a Workspace Settings Sourcing provider card for TrustedParts provider, masked CompanyId/API Key inputs, country/currency, preferred distributors, cache preference, Save, Test connection, and Configured pill state.
- Wired all HTTP through `web/src/lib/api.ts` with TanStack mutations and workspace-current query invalidation.
- Added focused RTL/Vitest coverage for rendering, PATCH body shape, test-connection success/failure, and credential non-display after save.
- Added frontend docs for the Workspace Settings sourcing card.

## Validation

- `cd web && npm ci` — passed; npm emitted Node 18 engine warnings for transitive packages requiring Node 20+ and reported existing audit findings.
- `cd web && npm test -- SourcingCard` — passed: 1 file, 5 tests.
- `cd web && npx tsc -b` — passed. Used this as the typecheck equivalent because `package.json` does not define `npm run typecheck`.
- `cd web && npm run lint` — failed on pre-existing, out-of-scope lint issues in `src/lib/bagCode.ts`, `src/components/scanner/ZxingScanner.tsx`, and other unrelated files.
- `cd web && npx eslint src/routes/settings/Workspace.tsx src/routes/settings/SourcingCard.tsx src/routes/settings/__dom__/SourcingCard.dom.test.tsx` — passed.
- `git diff --check` — passed.

Refs #327
