### PR TITLE
TP-109: Sourcing search endpoint + ADR-0020

### DIFF
--- a/backend/app/api/routes/sourcing.py
+++ b/backend/app/api/routes/sourcing.py
@@ -4,21 +4,26 @@ from __future__ import annotations
 from time import perf_counter
 
 from fastapi import APIRouter, Depends, Request
+from fastapi.responses import JSONResponse
+from sqlalchemy.orm import Session
 
-from app.core.deps import CurrentWorkspace, require_role
+from app.core.deps import CurrentUser, CurrentWorkspace, require_role
 from app.core.ratelimit import limiter, workspace_key
-from app.core.responses import ok
-from app.core.secrets import decrypt
+from app.core.responses import err, ok
 from app.domain.sourcing import (
     SourcingAuthError,
     SourcingClientError,
     SourcingRateLimitError,
     SourcingTimeoutError,
-    TrustedPartsClient,
 )
-from app.domain.sourcing.schemas import SourcingQuery
+from app.domain.sourcing import service as sourcing_service
+from app.domain.sourcing.factory import make_sourcing_provider
+from app.domain.sourcing.schemas import SourcingQuery, SourcingSearchIn
+from app.domain.sourcing.service import SourcingBudgetBlocked, SourcingNotConfigured
+from app.infra.db import get_db
 
 router = APIRouter()
+search_router = APIRouter()
 
 _TEST_PROBE_TOKEN = "TEST_PROBE_DO_NOT_BUY"
 
@@ -38,28 +43,9 @@ def _test_result(is_ok: bool, message: str, latency_ms: int):
 @limiter.limit("6/minute", key_func=workspace_key)
 def test_sourcing_connection(request: Request, ws: CurrentWorkspace):
     started_at = perf_counter()
-    if (
-        ws.sourcing_provider != "trustedparts"
-        or not ws.sourcing_company_id_enc
-        or not ws.sourcing_api_key_enc
-    ):
+    client = make_sourcing_provider(ws)
+    if client is None:
         return _test_result(False, "not configured", 0)
-
-    company_id = decrypt(ws.sourcing_company_id_enc)
-    api_key = decrypt(ws.sourcing_api_key_enc)
-    if not company_id or not api_key:
-        return _test_result(False, "not configured", 0)
-
-    # TODO(#326): replace "dev" with the repository git SHA once a shared
-    # app.core helper exposes it.
-    user_agent = f"stockManager/dev workspace={ws.id}"
-    client = TrustedPartsClient(
-        company_id=company_id,
-        api_key=api_key,
-        country_code=ws.sourcing_country_code,
-        currency_code=ws.sourcing_currency_code,
-        user_agent=user_agent,
-    )
 
     try:
         client.search(
@@ -76,3 +62,79 @@ def test_sourcing_connection(request: Request, ws: CurrentWorkspace):
         return _test_result(False, "TrustedParts upstream error", _elapsed_ms(started_at))
 
     return _test_result(True, "OK", _elapsed_ms(started_at))
+
+
+@search_router.post(
+    "/search",
+    dependencies=[Depends(require_role("member"))],
+)
+@limiter.limit("60/minute", key_func=workspace_key)
+def search_sourcing(
+    request: Request,
+    payload: SourcingSearchIn,
+    ws: CurrentWorkspace,
+    user: CurrentUser,
+    db: Session = Depends(get_db),
+):
+    try:
+        out = sourcing_service.search(
+            db,
+            workspace=ws,
+            mpns=payload.mpns,
+            country=payload.country,
+            currency=payload.currency,
+            in_stock_only=payload.in_stock_only,
+            distributors=payload.distributors,
+            use_cached_data=payload.use_cached_data,
+            requested_by=user.id,
+        )
+    except SourcingNotConfigured:
+        return _error_response(request, 409, "conflict", "sourcing not configured")
+    except SourcingBudgetBlocked:
+        return _error_response(request, 503, "server_error", "sourcing budget exhausted")
+    except SourcingAuthError:
+        return _error_response(
+            request,
+            502,
+            "server_error",
+            "TrustedParts rejected sourcing credentials",
+        )
+    except SourcingRateLimitError:
+        return _error_response(
+            request,
+            502,
+            "server_error",
+            "TrustedParts rate limit reached",
+        )
+    except SourcingTimeoutError:
+        return _error_response(
+            request,
+            502,
+            "server_error",
+            "TrustedParts request timed out",
+        )
+    except SourcingClientError:
+        return _error_response(
+            request,
+            502,
+            "server_error",
+            "TrustedParts sourcing request failed",
+        )
+
+    return ok(out.model_dump(mode="json"))
+
+
+def _error_response(
+    request: Request,
+    status_code: int,
+    category: str,
+    message: str,
+) -> JSONResponse:
+    return JSONResponse(
+        status_code=status_code,
+        content=err(
+            category,
+            message,
+            request_id=getattr(request.state, "request_id", None),
+        ),
+    )

--- a/backend/app/core/version.py
+++ b/backend/app/core/version.py
@@ -1,0 +1,10 @@
+"""Build version helpers."""
+
+from __future__ import annotations
+
+import os
+
+
+def git_sha() -> str:
+    """Return the deployed git SHA, or ``dev`` for local/test runs."""
+    return os.environ.get("GIT_SHA") or "dev"

--- a/backend/app/domain/sourcing/factory.py
+++ b/backend/app/domain/sourcing/factory.py
@@ -1,1 +1,32 @@
-"""Provider factory scaffold for workspace-scoped sourcing."""
+"""Provider factory for workspace-scoped sourcing."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.core.secrets import decrypt
+from app.core.version import git_sha
+from app.domain.sourcing.client import TrustedPartsClient
+
+
+def make_sourcing_provider(workspace: Any) -> TrustedPartsClient | None:
+    """Return a TrustedParts client for a configured workspace."""
+    if (
+        workspace.sourcing_provider != "trustedparts"
+        or not workspace.sourcing_company_id_enc
+        or not workspace.sourcing_api_key_enc
+    ):
+        return None
+
+    company_id = decrypt(workspace.sourcing_company_id_enc)
+    api_key = decrypt(workspace.sourcing_api_key_enc)
+    if not company_id or not api_key:
+        return None
+
+    return TrustedPartsClient(
+        company_id=company_id,
+        api_key=api_key,
+        country_code=workspace.sourcing_country_code,
+        currency_code=workspace.sourcing_currency_code,
+        user_agent=f"stockManager/{git_sha()} workspace={workspace.id}",
+    )

--- a/backend/app/domain/sourcing/schemas.py
+++ b/backend/app/domain/sourcing/schemas.py
@@ -1,7 +1,10 @@
 """Pydantic DTOs for TrustedParts sourcing."""
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict, Field
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class SourcingQuery(BaseModel):
@@ -56,3 +59,65 @@ class SourcingSearchRaw(BaseModel):
 
     offers: list[SourcingOffer]
     request_id: str | None = None
+
+
+class SourcingSearchIn(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    mpns: list[str] = Field(min_length=1, max_length=50)
+    country: str | None = Field(default=None, min_length=2, max_length=2)
+    currency: str | None = Field(default=None, min_length=3, max_length=3)
+    in_stock_only: bool = False
+    distributors: list[str] | None = None
+    use_cached_data: bool | None = None
+
+    @field_validator("mpns")
+    @classmethod
+    def _strip_mpns(cls, value: list[str]) -> list[str]:
+        stripped = [item.strip() for item in value]
+        if any(not item for item in stripped):
+            raise ValueError("mpns must not contain empty values")
+        return stripped
+
+    @field_validator("country", "currency")
+    @classmethod
+    def _uppercase_codes(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return value.strip().upper()
+
+    @field_validator("distributors")
+    @classmethod
+    def _strip_distributors(cls, value: list[str] | None) -> list[str] | None:
+        if value is None:
+            return None
+        stripped = [item.strip() for item in value if item.strip()]
+        return stripped or None
+
+
+class SourcingAttributionLinks(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    primary: str
+    attribution: str
+
+
+class SourcingSearchResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    mpn: str
+    offers: list[SourcingOffer] = Field(default_factory=list)
+    request_id: str | None = None
+    fetched_at: datetime
+    cache_hit: bool
+
+
+class SourcingSearchOut(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    results: list[SourcingSearchResult]
+    request_id: str | None = None
+    powered_by: Literal["TrustedParts"] = "TrustedParts"
+    fetched_at: datetime
+    cache_hit: bool
+    links: SourcingAttributionLinks

--- a/backend/app/domain/sourcing/service.py
+++ b/backend/app/domain/sourcing/service.py
@@ -1,1 +1,188 @@
-"""Service facade scaffold for TrustedParts sourcing."""
+"""Service facade for TrustedParts sourcing."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.core.time import utcnow
+from app.domain.sourcing import cache
+from app.domain.sourcing.budget import BUDGET
+from app.domain.sourcing.factory import make_sourcing_provider
+from app.domain.sourcing.schemas import (
+    SourcingAttributionLinks,
+    SourcingQuery,
+    SourcingSearchOut,
+    SourcingSearchRaw,
+    SourcingSearchResult,
+)
+
+TTL_SECONDS = 30 * 60
+TRUSTEDPARTS_LINKS = SourcingAttributionLinks(
+    primary="https://www.trustedparts.com/",
+    attribution="https://www.trustedparts.com/en/about",
+)
+
+
+class SourcingNotConfigured(Exception):
+    """Workspace has no usable TrustedParts sourcing configuration."""
+
+
+class SourcingBudgetBlocked(Exception):
+    """Workspace exceeded the hard TrustedParts parts-count budget."""
+
+
+def search(
+    db: Session,
+    *,
+    workspace: Any,
+    mpns: list[str],
+    country: str | None = None,
+    currency: str | None = None,
+    in_stock_only: bool = False,
+    distributors: list[str] | None = None,
+    use_cached_data: bool | None = None,
+    requested_by: UUID | None = None,
+) -> SourcingSearchOut:
+    clean_mpns = [mpn.strip() for mpn in mpns]
+    if not 1 <= len(clean_mpns) <= 50 or any(not mpn for mpn in clean_mpns):
+        raise ValueError("sourcing search requires 1 to 50 non-empty MPNs")
+
+    provider = make_sourcing_provider(workspace)
+    if provider is None:
+        raise SourcingNotConfigured("sourcing not configured")
+
+    effective_country = _clean_code(country) or workspace.sourcing_country_code
+    effective_currency = _clean_code(currency) or workspace.sourcing_currency_code
+    effective_distributors = (
+        _clean_distributors(distributors)
+        if distributors is not None
+        else _clean_distributors(workspace.sourcing_preferred_distributors)
+    )
+    effective_use_cached = (
+        bool(workspace.sourcing_use_cached_for_dashboards)
+        if use_cached_data is None
+        else use_cached_data
+    )
+
+    verdict = BUDGET.check(workspace.id, parts_count=len(clean_mpns))
+    if not verdict.allow:
+        raise SourcingBudgetBlocked(verdict.reason)
+    if verdict.mode == "degraded":
+        effective_use_cached = True
+
+    provider.country_code = effective_country
+    provider.currency_code = effective_currency
+
+    results: list[SourcingSearchResult] = []
+    for mpn in clean_mpns:
+        query = _canonical_query(
+            mpn=mpn,
+            country=effective_country,
+            currency=effective_currency,
+            in_stock_only=in_stock_only,
+            distributors=effective_distributors,
+            use_cached_data=effective_use_cached,
+        )
+
+        def fetch() -> dict[str, Any]:
+            fetched_at = utcnow()
+            raw = provider.search(
+                [SourcingQuery(search_token=mpn)],
+                exact_match=True,
+                in_stock_only=in_stock_only,
+                distributors=effective_distributors,
+                use_cached_data=effective_use_cached,
+            )
+            return {
+                "offers": [offer.model_dump(mode="json") for offer in raw.offers],
+                "request_id": raw.request_id,
+                "fetched_at": fetched_at.isoformat(),
+            }
+
+        response, cache_hit = cache.get_or_fetch(
+            db,
+            workspace_id=workspace.id,
+            query=query,
+            ttl_seconds=TTL_SECONDS,
+            fetch_fn=fetch,
+            created_by=requested_by,
+        )
+        if not cache_hit:
+            BUDGET.record(workspace.id, 1)
+
+        raw = _raw_from_cache_response(response)
+        fetched_at = _fetched_at_from_response(response)
+        results.append(
+            SourcingSearchResult(
+                mpn=mpn,
+                offers=raw.offers,
+                request_id=raw.request_id,
+                fetched_at=fetched_at,
+                cache_hit=cache_hit,
+            )
+        )
+
+    response_fetched_at = max((result.fetched_at for result in results), default=utcnow())
+    request_id = next((result.request_id for result in results if result.request_id), None)
+    return SourcingSearchOut(
+        results=results,
+        request_id=request_id,
+        fetched_at=response_fetched_at,
+        cache_hit=all(result.cache_hit for result in results),
+        links=TRUSTEDPARTS_LINKS,
+    )
+
+
+def _canonical_query(
+    *,
+    mpn: str,
+    country: str | None,
+    currency: str | None,
+    in_stock_only: bool,
+    distributors: list[str] | None,
+    use_cached_data: bool,
+) -> dict[str, Any]:
+    return {
+        "provider": "trustedparts",
+        "mpn": mpn,
+        "country": country,
+        "currency": currency,
+        "in_stock_only": in_stock_only,
+        "distributors": distributors or [],
+        "use_cached_data": use_cached_data,
+        "exact_match": True,
+    }
+
+
+def _raw_from_cache_response(response: dict[str, Any]) -> SourcingSearchRaw:
+    return SourcingSearchRaw.model_validate(
+        {
+            "offers": response.get("offers", []),
+            "request_id": response.get("request_id"),
+        }
+    )
+
+
+def _fetched_at_from_response(response: dict[str, Any]) -> datetime:
+    fetched_at = response.get("fetched_at")
+    if isinstance(fetched_at, str):
+        return datetime.fromisoformat(fetched_at)
+    return utcnow()
+
+
+def _clean_code(value: str | None) -> str | None:
+    if value is None:
+        return None
+    value = value.strip().upper()
+    return value or None
+
+
+def _clean_distributors(value: Any) -> list[str] | None:
+    if not isinstance(value, list):
+        return None
+    distributors = [str(item).strip() for item in value if str(item).strip()]
+    return distributors or None

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -386,6 +386,7 @@ app.include_router(custom_fields.router, prefix="/api/custom-fields", tags=["cus
 app.include_router(tags.router, prefix="/api/tags", tags=["tags"], dependencies=_member_gate)
 app.include_router(search.router, prefix="/api/search", tags=["search"], dependencies=_member_gate)
 app.include_router(sourcing.router, prefix="/api/workspaces", tags=["sourcing"])
+app.include_router(sourcing.search_router, prefix="/api/sourcing", tags=["sourcing"])
 app.include_router(
     parts_provider.router,
     prefix="/api/parts",

--- a/backend/tests/test_bulk_import_deadline.py
+++ b/backend/tests/test_bulk_import_deadline.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import uuid
 from time import monotonic
 
-import pytest
 from fastapi.testclient import TestClient
 
 from app.main import app
@@ -20,7 +19,11 @@ from app.main import app
 def _signup_with_mouser(c: TestClient) -> str:
     r = c.post(
         "/api/auth/signup",
-        json={"email": f"u-{uuid.uuid4().hex[:8]}@x.com", "name": "u", "password": "TestPass-2026-Stronk"},
+        json={
+            "email": f"u-{uuid.uuid4().hex[:8]}@x.com",
+            "name": "u",
+            "password": "TestPass-2026-Stronk",
+        },
     )
     assert r.status_code == 200, r.text
     c.patch(
@@ -53,9 +56,6 @@ def test_per_row_timeout_marks_row_lookup_failed_neighbours_still_run(monkeypatc
     """A provider call that hangs longer than _BULK_IMPORT_ROW_TIMEOUT_S
     must surface as `lookup_failed` (with a timeout mention) while rows
     before and after it continue to process."""
-    import app.api.routes.parts_scan as parts_mod
-    import app.domain.parts.providers.mouser as mouser_mod
-
     # Make row 2 hang past the per-row timeout by patching the provider-cache
     # lookup to sleep, then lowering the per-row timeout so we don't actually
     # wait. The route uses a function-scope ThreadPoolExecutor that submits
@@ -64,13 +64,32 @@ def test_per_row_timeout_marks_row_lookup_failed_neighbours_still_run(monkeypatc
     # background — the test deliberately exercises that path.
     import time as _time
 
+    import app.api.routes.parts_scan as parts_mod
+    import app.domain.parts.providers.mouser as mouser_mod
     import app.domain.parts.services.provider_cache as _pc
-
-    real_lookup = _pc.lookup_with_cache
 
     def maybe_slow_lookup(provider, mpn):
         if "SLOW" in mpn:
             _time.sleep(2.0)  # well past the 0.1s test timeout
+            # The request abandons this worker after the row timeout. Keep
+            # the abandoned thread deterministic after monkeypatch teardown:
+            # don't re-enter the real provider/cache path later and mutate
+            # module-level circuit-breaker state for following tests.
+            return {
+                "found": True,
+                "result": {
+                    "mpn": mpn,
+                    "manufacturer": "Yageo",
+                    "description": "Resistor",
+                    "category": None,
+                    "footprint": None,
+                    "datasheet_url": None,
+                    "image_url": None,
+                    "source_url": "https://example.com",
+                    "specs": [],
+                },
+            }
+        real_lookup = _pc.lookup_with_cache
         return real_lookup(provider, mpn)
 
     monkeypatch.setattr(parts_mod, "lookup_with_cache", maybe_slow_lookup)

--- a/backend/tests/test_rbac_member.py
+++ b/backend/tests/test_rbac_member.py
@@ -33,7 +33,7 @@ def owner_and_member():
     """Owner creates a workspace, invites a user as `member`, member
     accepts and switches into the shared workspace."""
     owner = TestClient(app)
-    _signup(owner)
+    _, owner_ws_id = _signup(owner)
 
     invitee_email = f"member-{uuid.uuid4().hex[:6]}@x.com"
     inv = owner.post(
@@ -51,11 +51,7 @@ def owner_and_member():
     )
     member.post("/api/invitations/accept", json={"token": token})
 
-    me = member.get("/api/auth/me").json()["data"]
-    member_personal = me["workspaces"][0]["id"]
-    wss = member.get("/api/workspaces").json()["data"]
-    shared = next(w for w in wss if w["id"] != member_personal)
-    member.post(f"/api/workspaces/{shared['id']}/switch")
+    member.post(f"/api/workspaces/{owner_ws_id}/switch")
 
     return owner, member
 

--- a/backend/tests/test_sourcing_search_route.py
+++ b/backend/tests/test_sourcing_search_route.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+import pytest
+from fastapi.testclient import TestClient
+
+import app.core.ratelimit as _ratelimit_mod
+from app.domain.sourcing.budget import BUDGET
+from app.domain.sourcing.schemas import (
+    SourcingDistributor,
+    SourcingLinks,
+    SourcingOffer,
+    SourcingQuery,
+    SourcingSearchRaw,
+)
+from app.main import app
+
+
+def _signup(client: TestClient | None = None) -> tuple[TestClient, str]:
+    c = client or TestClient(app)
+    r = c.post(
+        "/api/auth/signup",
+        json={
+            "email": f"sourcing-{uuid.uuid4().hex[:8]}@example.com",
+            "name": "Sourcing Tester",
+            "password": "TestPass-2026-Stronk",
+        },
+    )
+    assert r.status_code == 200, r.text
+    return c, r.json()["data"]["workspace_id"]
+
+
+def _configure_sourcing(client: TestClient) -> None:
+    r = client.patch(
+        "/api/workspaces/current",
+        json={
+            "sourcing_provider": "trustedparts",
+            "sourcing_company_id": "company-123",
+            "sourcing_api_key": "api-key-456",
+            "sourcing_country_code": "CZ",
+            "sourcing_currency_code": "EUR",
+            "sourcing_preferred_distributors": ["DigiKey"],
+            "sourcing_use_cached_for_dashboards": False,
+        },
+    )
+    assert r.status_code == 200, r.text
+
+
+class _FakeTrustedPartsClient:
+    calls: list[dict] = []
+
+    def __init__(self) -> None:
+        self.country_code = "CZ"
+        self.currency_code = "EUR"
+
+    def search(
+        self,
+        queries: list[SourcingQuery],
+        *,
+        in_stock_only: bool,
+        distributors: list[str] | None,
+        use_cached_data: bool,
+        **_kwargs,
+    ) -> SourcingSearchRaw:
+        query = queries[0]
+        self.calls.append(
+            {
+                "queries": [item.model_dump(exclude_none=True) for item in queries],
+                "country_code": self.country_code,
+                "currency_code": self.currency_code,
+                "in_stock_only": in_stock_only,
+                "distributors": distributors,
+                "use_cached_data": use_cached_data,
+            }
+        )
+        return SourcingSearchRaw(
+            offers=[
+                SourcingOffer(
+                    mpn=query.search_token,
+                    manufacturer="ST",
+                    description="Test offer",
+                    distributors=[
+                        SourcingDistributor(
+                            name="DigiKey",
+                            sku=f"{query.search_token}-DK",
+                            stock=42,
+                            unit_price=1.23,
+                            currency=self.currency_code,
+                            product_url="https://www.trustedparts.com/product",
+                        )
+                    ],
+                    links=SourcingLinks(
+                        primary=f"https://www.trustedparts.com/search/{query.search_token}"
+                    ),
+                )
+            ],
+            request_id=f"req-{len(self.calls)}",
+        )
+
+
+@pytest.fixture(autouse=True)
+def reset_sourcing_state(monkeypatch):
+    original_limiter_enabled = _ratelimit_mod.limiter.enabled
+    _ratelimit_mod.limiter.enabled = False
+    _FakeTrustedPartsClient.calls = []
+    BUDGET._events.clear()
+    try:
+        _ratelimit_mod.limiter.reset()
+    except Exception:
+        pass
+    monkeypatch.setattr(
+        "app.domain.sourcing.service.make_sourcing_provider",
+        lambda _workspace: _FakeTrustedPartsClient(),
+    )
+    yield
+    _ratelimit_mod.limiter.enabled = original_limiter_enabled
+    BUDGET._events.clear()
+    try:
+        _ratelimit_mod.limiter.reset()
+    except Exception:
+        pass
+
+
+def test_envelope_shape(authed_client):
+    _configure_sourcing(authed_client)
+
+    r = authed_client.post("/api/sourcing/search", json={"mpns": ["STM32F103C8T6"]})
+
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["status"]["category"] == "ok"
+    data = body["data"]
+    assert data["powered_by"] == "TrustedParts"
+    datetime.fromisoformat(data["fetched_at"])
+    assert data["links"]["primary"]
+    assert data["request_id"] == "req-1"
+    assert data["cache_hit"] is False
+    assert data["results"][0]["mpn"] == "STM32F103C8T6"
+    assert data["results"][0]["cache_hit"] is False
+
+
+def test_too_few_or_too_many_mpns_422(authed_client):
+    _configure_sourcing(authed_client)
+
+    r = authed_client.post("/api/sourcing/search", json={"mpns": []})
+    assert r.status_code == 422, r.text
+    assert r.json()["status"]["category"] == "validation_error"
+
+    r = authed_client.post(
+        "/api/sourcing/search",
+        json={"mpns": [f"MPN-{index}" for index in range(51)]},
+    )
+    assert r.status_code == 422, r.text
+    assert r.json()["status"]["category"] == "validation_error"
+
+
+def test_unconfigured_returns_409(authed_client, monkeypatch):
+    monkeypatch.setattr(
+        "app.domain.sourcing.service.make_sourcing_provider",
+        lambda _workspace: None,
+    )
+
+    r = authed_client.post("/api/sourcing/search", json={"mpns": ["BAT54C"]})
+
+    assert r.status_code == 409, r.text
+    assert r.json()["status"] == {
+        "category": "conflict",
+        "message": "sourcing not configured",
+    }
+
+
+def test_budget_blocked_returns_503(authed_client):
+    _configure_sourcing(authed_client)
+    ws_id = _current_workspace_id(authed_client)
+    BUDGET.record(uuid.UUID(ws_id), 250)
+
+    r = authed_client.post("/api/sourcing/search", json={"mpns": ["BAT54C"]})
+
+    assert r.status_code == 503, r.text
+    assert r.json()["status"] == {
+        "category": "server_error",
+        "message": "sourcing budget exhausted",
+    }
+
+
+def test_rate_limited_returns_429_after_60_per_minute(authed_client):
+    _ratelimit_mod.limiter.enabled = True
+    _configure_sourcing(authed_client)
+
+    for _index in range(60):
+        r = authed_client.post("/api/sourcing/search", json={"mpns": ["MAX232"]})
+        assert r.status_code == 200, r.text
+
+    r = authed_client.post("/api/sourcing/search", json={"mpns": ["MAX232"]})
+
+    assert r.status_code == 429, r.text
+    assert r.json()["status"]["category"] == "rate_limited"
+
+
+def test_cache_hit_reflected_in_response(authed_client):
+    _configure_sourcing(authed_client)
+
+    first = authed_client.post("/api/sourcing/search", json={"mpns": ["BAV99"]})
+    second = authed_client.post("/api/sourcing/search", json={"mpns": ["BAV99"]})
+
+    assert first.status_code == 200, first.text
+    assert second.status_code == 200, second.text
+    assert first.json()["data"]["cache_hit"] is False
+    assert second.json()["data"]["cache_hit"] is True
+    assert second.json()["data"]["results"][0]["cache_hit"] is True
+    assert len(_FakeTrustedPartsClient.calls) == 1
+
+
+def test_attribution_links_present(authed_client):
+    _configure_sourcing(authed_client)
+
+    r = authed_client.post("/api/sourcing/search", json={"mpns": ["NE555"]})
+
+    assert r.status_code == 200, r.text
+    links = r.json()["data"]["links"]
+    assert links["primary"] == "https://www.trustedparts.com/"
+    assert links["attribution"] == "https://www.trustedparts.com/en/about"
+
+
+def test_degraded_mode_forces_use_cached_data_true(authed_client):
+    _configure_sourcing(authed_client)
+    ws_id = _current_workspace_id(authed_client)
+    BUDGET.record(uuid.UUID(ws_id), 50)
+
+    r = authed_client.post(
+        "/api/sourcing/search",
+        json={"mpns": ["LM358"], "use_cached_data": False},
+    )
+
+    assert r.status_code == 200, r.text
+    assert _FakeTrustedPartsClient.calls[-1]["use_cached_data"] is True
+
+
+def _current_workspace_id(client: TestClient) -> str:
+    r = client.get("/api/workspaces/current")
+    assert r.status_code == 200, r.text
+    return r.json()["data"]["id"]

--- a/backend/tests/test_sourcing_test_route.py
+++ b/backend/tests/test_sourcing_test_route.py
@@ -120,7 +120,7 @@ def test_bad_creds_returns_invalid_credentials(authed_client, monkeypatch):
             raise SourcingAuthError("bad credentials")
 
     monkeypatch.setattr(
-        "app.api.routes.sourcing.TrustedPartsClient",
+        "app.domain.sourcing.factory.TrustedPartsClient",
         BadCredsTrustedPartsClient,
     )
 
@@ -138,7 +138,7 @@ def test_good_creds_returns_ok_and_latency(authed_client, monkeypatch):
     _configure_sourcing(authed_client)
     _SuccessfulTrustedPartsClient.calls = []
     monkeypatch.setattr(
-        "app.api.routes.sourcing.TrustedPartsClient",
+        "app.domain.sourcing.factory.TrustedPartsClient",
         _SuccessfulTrustedPartsClient,
     )
 
@@ -165,7 +165,7 @@ def test_good_creds_returns_ok_and_latency(authed_client, monkeypatch):
 def test_rate_limit_after_6_per_minute(authed_client, monkeypatch, limiter_enabled):
     _configure_sourcing(authed_client)
     monkeypatch.setattr(
-        "app.api.routes.sourcing.TrustedPartsClient",
+        "app.domain.sourcing.factory.TrustedPartsClient",
         _SuccessfulTrustedPartsClient,
     )
 
@@ -224,9 +224,9 @@ def test_workspace_isolation_uses_own_creds(db, monkeypatch):
         return decrypt(token)
 
     _SuccessfulTrustedPartsClient.calls = []
-    monkeypatch.setattr("app.api.routes.sourcing.decrypt", decrypt_spy)
+    monkeypatch.setattr("app.domain.sourcing.factory.decrypt", decrypt_spy)
     monkeypatch.setattr(
-        "app.api.routes.sourcing.TrustedPartsClient",
+        "app.domain.sourcing.factory.TrustedPartsClient",
         _SuccessfulTrustedPartsClient,
     )
 

--- a/backend/tests/test_workspace_isolation.py
+++ b/backend/tests/test_workspace_isolation.py
@@ -375,6 +375,103 @@ def test_sourcing_cache_isolated_by_workspace(db):
     assert second_hit_b is True
 
 
+def test_sourcing_search_uses_caller_workspace_secrets(monkeypatch):
+    """The search route must decrypt only the current workspace's sourcing creds."""
+    from app.core.secrets import decrypt
+    from app.domain.sourcing.budget import BUDGET
+    from app.domain.sourcing.schemas import SourcingQuery, SourcingSearchRaw
+    from app.domain.workspaces.models import Workspace
+    from app.infra.db import SessionLocal
+
+    class RecordingTrustedPartsClient:
+        calls: list[dict] = []
+
+        def __init__(
+            self,
+            company_id: str,
+            api_key: str,
+            country_code: str | None,
+            currency_code: str | None,
+            user_agent: str,
+        ) -> None:
+            self.company_id = company_id
+            self.api_key = api_key
+            self.country_code = country_code
+            self.currency_code = currency_code
+            self.user_agent = user_agent
+
+        def search(self, queries: list[SourcingQuery], *, use_cached_data: bool, **_kwargs):
+            self.calls.append(
+                {
+                    "company_id": self.company_id,
+                    "api_key": self.api_key,
+                    "queries": [query.search_token for query in queries],
+                    "use_cached_data": use_cached_data,
+                }
+            )
+            return SourcingSearchRaw(offers=[], request_id="workspace-secret-check")
+
+    def configure_sourcing(client: TestClient, company_id: str, api_key: str) -> None:
+        r = client.patch(
+            "/api/workspaces/current",
+            json={
+                "sourcing_provider": "trustedparts",
+                "sourcing_company_id": company_id,
+                "sourcing_api_key": api_key,
+                "sourcing_country_code": "CZ",
+                "sourcing_currency_code": "EUR",
+            },
+        )
+        assert r.status_code == 200, r.text
+
+    client_a = TestClient(app)
+    client_b = TestClient(app)
+    ws_a_id = _signup(client_a, f"sourcing-a-{uuid.uuid4().hex[:6]}@x.com")
+    ws_b_id = _signup(client_b, f"sourcing-b-{uuid.uuid4().hex[:6]}@x.com")
+    configure_sourcing(client_a, "company-a", "api-key-a")
+    configure_sourcing(client_b, "company-b", "api-key-b")
+
+    with SessionLocal() as session:
+        ws_a = session.get(Workspace, ws_a_id)
+        ws_b = session.get(Workspace, ws_b_id)
+        assert ws_a is not None
+        assert ws_b is not None
+        a_tokens = {ws_a.sourcing_company_id_enc, ws_a.sourcing_api_key_enc}
+        b_tokens = {ws_b.sourcing_company_id_enc, ws_b.sourcing_api_key_enc}
+
+    seen_tokens: list[str | None] = []
+
+    def decrypt_spy(token: str | None) -> str | None:
+        seen_tokens.append(token)
+        return decrypt(token)
+
+    BUDGET._events.clear()
+    RecordingTrustedPartsClient.calls = []
+    monkeypatch.setattr("app.domain.sourcing.factory.decrypt", decrypt_spy)
+    monkeypatch.setattr(
+        "app.domain.sourcing.factory.TrustedPartsClient",
+        RecordingTrustedPartsClient,
+    )
+
+    r_a = client_a.post("/api/sourcing/search", json={"mpns": ["BAT54C"]})
+    assert r_a.status_code == 200, r_a.text
+    assert r_a.json()["data"]["cache_hit"] is False
+    seen_tokens.clear()
+
+    r = client_b.post("/api/sourcing/search", json={"mpns": ["BAT54C"]})
+
+    assert r.status_code == 200, r.text
+    assert r.json()["data"]["cache_hit"] is False
+    assert set(seen_tokens) == b_tokens
+    assert not set(seen_tokens) & a_tokens
+    assert [call["company_id"] for call in RecordingTrustedPartsClient.calls] == [
+        "company-a",
+        "company-b",
+    ]
+    assert RecordingTrustedPartsClient.calls[-1]["company_id"] == "company-b"
+    assert RecordingTrustedPartsClient.calls[-1]["api_key"] == "api-key-b"
+
+
 # ---------------------------------------------------------------------------
 # parts.default_storage_location_id on create / patch / bulk-import-from-scan
 # ---------------------------------------------------------------------------

--- a/docs/adr/0007-provider-catalog-vs-spec-split.md
+++ b/docs/adr/0007-provider-catalog-vs-spec-split.md
@@ -25,6 +25,8 @@ Both tabs read from the same `custom_fields(source='provider')` rows. The split 
 
 The same key list lives server-side in `backend/app/domain/parts/services/` (TODO(verify): exact filename — CLAUDE.md cites `backend/app/domain/parts/services/provider.py` but the directory contains `assets.py`, `bag_signature.py`, `provider_cache.py` — the catalog-key list may have moved to `provider_cache.py` or one of the `providers/` modules).
 
+TrustedParts procurement sourcing is deliberately outside this catalog/spec split. See [ADR-0020](0020-trustedparts-sourcing-provider-split.md) for the separate sourcing-provider boundary, cache limit, attribution, and no-mixing rules.
+
 ## Consequences
 
 - **Good**: Re-categorising a key (e.g. promoting "Lifecycle" from Sourcing to a header pill) is one PR touching two files, no DB migration. Historical rows automatically re-render under the new categorisation.
@@ -46,3 +48,4 @@ The same key list lives server-side in `backend/app/domain/parts/services/` (TOD
 - Source: `backend/app/domain/parts/services/` (TODO(verify): exact file)
 - Source: `backend/app/domain/parts/providers/mouser.py`, `backend/app/domain/parts/providers/digikey.py` (emit the `specs[]` rows)
 - Rule: `CLAUDE.md:119-124`
+- Related ADR: [ADR-0020](0020-trustedparts-sourcing-provider-split.md)

--- a/docs/adr/0020-trustedparts-sourcing-provider-split.md
+++ b/docs/adr/0020-trustedparts-sourcing-provider-split.md
@@ -1,0 +1,52 @@
+# ADR-0020: TrustedParts sourcing provider split
+
+Audience: engineer
+
+- **Status**: Accepted
+- **Date**: 2026-05-08
+- **Supersedes**: —
+- **Superseded by**: —
+
+## Context
+
+Catalog enrichment providers and procurement sourcing answer different questions. Mouser/DigiKey lookup fills part metadata and provider-shaped specs; TrustedParts sourcing returns authorized distributor stock, price, and purchase links that are time-sensitive and subject to stricter attribution and retention rules. The Phase 1 TrustedParts work introduced credentials on `Workspace`, a short-lived sourcing cache, and a process-local parts-count budget.
+
+TrustedParts is the first sourcing provider because its Inventory API v2 is built around authorized distributor availability and exposes a batch search endpoint for up to 50 query tokens. Its terms require clear TrustedParts attribution, prohibit indistinct aggregation with third-party content, and allow ECIA to limit or throttle API usage. TrustedParts API v2 documents the `/v2/search` endpoint at `https://api.trustedparts.com/v2/search`; the API Terms of Use require attribution and forbid uses that aggregate TrustedParts content without distinction.
+
+## Decision
+
+Sourcing is a separate domain under `backend/app/domain/sourcing/`, not a third `parts_provider` implementation. Workspace sourcing credentials stay on `Workspace`, are encrypted at rest, and are decrypted only in `make_sourcing_provider()` before constructing `TrustedPartsClient` (`backend/app/domain/sourcing/factory.py:12`). `POST /api/sourcing/search` calls the sourcing service facade (`backend/app/domain/sourcing/service.py:39`) and returns an attributed API-envelope response (`backend/app/api/routes/sourcing.py:87`).
+
+The cache is workspace-scoped and short-lived. The database enforces a maximum seven-day retention window (`backend/app/domain/sourcing/models.py:13`), while the service currently uses a 30-minute TTL (`backend/app/domain/sourcing/service.py:24`). The budget is a parts-count budget, not a request-count budget, and is in-process by design while production runs one uvicorn worker (`backend/app/domain/sourcing/budget.py:104`). The client payload does not send `SourceIp`; user attribution is via the app user/session and visible API response attribution, not via TrustedParts `SourceIp`.
+
+TrustedParts results must stay visibly distinct from catalog-provider data. Public or UI surfaces that combine distributor data from multiple origins need an explicit future decision before launch.
+
+## Consequences
+
+- **Good**:
+  - Catalog enrichment and procurement sourcing have separate ownership boundaries, DTOs, cache policy, and ToU controls.
+  - ToU constraints are enforced by construction: short retention, workspace-scoped credentials, visible attribution, no `SourceIp`, no silent mixing with other distributor sources.
+  - The route's 50-MPN schema limit aligns with TrustedParts batch shape and the existing scan-import cap.
+- **Trade-offs**:
+  - The split adds a new domain, migrations, service facade, tests, and docs rather than reusing the older `parts_provider` adapter surface.
+  - The process-local budget assumes `uvicorn --workers 1`; increasing workers needs a Redis-backed budget or equivalent shared counter first.
+- **What it forbids**:
+  - Permanent price history or long-retention TrustedParts offer snapshots.
+  - Public mixing of TrustedParts distributor data with other-source distributor data without prior written approval / a new ADR.
+  - Partial-match behavior in batch requests. Batch sourcing searches must remain exact-match.
+
+## Alternatives considered
+
+- **Add TrustedParts as a third `parts_provider` choice** — rejected because sourcing answers procurement/offer questions, not catalog/spec enrichment. Reusing `parts_provider` would blur credential semantics, cache TTLs, attribution, and UI ownership.
+- **Fully RPC-cached sourcing layer** — rejected because long-lived cached offer history conflicts with TrustedParts retention and attribution constraints. A short-lived workspace cache is enough to reduce repeated clicks without becoming a price-history store.
+
+## References
+
+- TrustedParts Inventory API v2: `https://www.trustedparts.com/docs/api/trustedparts-api/version-2/`
+- TrustedParts Inventory API Terms of Use: `https://www.trustedparts.com/docs/api/trustedparts-api/terms-of-use/`
+- Source: `backend/app/domain/sourcing/factory.py:12`
+- Source: `backend/app/domain/sourcing/service.py:39`
+- Source: `backend/app/api/routes/sourcing.py:87`
+- Related ADR: [ADR-0007](0007-provider-catalog-vs-spec-split.md)
+- Issue: `https://github.com/matescb/stockManager/issues/329`
+- Plan: `/home/matyas/.claude/plans/read-all-the-documentation-robust-giraffe.md`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -29,3 +29,4 @@ New ADRs follow the template in [STYLE.md](../STYLE.md#adr-pages-docsadrnnnn-slu
 | 0017 | [Step-of-N PRs use `Refs #N`, not `Closes #N`](0017-step-of-n-prs-refs-not-closes.md) |
 | 0018 | [Prod email verification requires SMTP; never log verification tokens](0018-prod-smtp-fail-closed.md) |
 | 0019 | [Self-hosted Umami for product analytics, env-gated tracker](0019-umami-self-hosted-analytics.md) |
+| 0020 | [TrustedParts sourcing provider split](0020-trustedparts-sourcing-provider-split.md) |

--- a/docs/api/sourcing.md
+++ b/docs/api/sourcing.md
@@ -2,13 +2,78 @@
 
 Audience: engineer
 
-TrustedParts sourcing endpoints for workspace-scoped connection checks.
+TrustedParts sourcing endpoints for workspace-scoped connection checks and short-lived offer search.
 
 ## Conventions
 
-See [API conventions](./README.md) for envelope, errors, pagination. Mounted at `/api/workspaces`; current routes require a cookie session and current workspace.
+See [API conventions](./README.md) for envelope, errors, pagination. Connection checks are mounted under `/api/workspaces`; search is mounted under `/api/sourcing`. Current routes require a cookie session and current workspace.
 
 ## Routes
+
+### `POST /api/sourcing/search`
+
+Search TrustedParts for 1-50 exact MPNs using the current workspace's encrypted sourcing credentials.
+
+**Request**
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `mpns` | `string[]` | Yes | 1-50 non-empty MPNs. |
+| `country` | `string` | No | Two-letter override; falls back to workspace sourcing default. |
+| `currency` | `string` | No | Three-letter override; falls back to workspace sourcing default. |
+| `in_stock_only` | `boolean` | No | Defaults to `false`. |
+| `distributors` | `string[]` | No | Falls back to `sourcing_preferred_distributors` when omitted. |
+| `use_cached_data` | `boolean` | No | Falls back to `sourcing_use_cached_for_dashboards`; forced true when the request is in degraded budget mode. |
+
+**Response** — `200 OK` (envelope: `{ data, status }`)
+
+```json
+{
+  "data": {
+    "results": [
+      {
+        "mpn": "STM32F103C8T6",
+        "offers": [
+          {
+            "mpn": "STM32F103C8T6",
+            "distributors": [
+              { "name": "DigiKey", "stock": 42, "unit_price": 1.23, "currency": "EUR" }
+            ]
+          }
+        ],
+        "request_id": "trustedparts-request-id",
+        "fetched_at": "2026-05-08T12:00:00+00:00",
+        "cache_hit": false
+      }
+    ],
+    "request_id": "trustedparts-request-id",
+    "powered_by": "TrustedParts",
+    "fetched_at": "2026-05-08T12:00:00+00:00",
+    "cache_hit": false,
+    "links": {
+      "primary": "https://www.trustedparts.com/",
+      "attribution": "https://www.trustedparts.com/en/about"
+    }
+  },
+  "status": { "category": "ok", "message": "OK" }
+}
+```
+
+**Errors**
+
+- `409 Conflict` — `{ "data": null, "status": { "category": "conflict", "message": "sourcing not configured" } }`.
+- `422 Unprocessable Entity` — validation envelope when `mpns` is empty, over 50, contains empty strings, or an unknown field is sent.
+- `429 Too Many Requests` — workspace rate limit: 60 requests/minute.
+- `502 Bad Gateway` — TrustedParts auth, rate-limit, timeout, upstream, or response-shape failure.
+- `503 Service Unavailable` — `{ "data": null, "status": { "category": "server_error", "message": "sourcing budget exhausted" } }`.
+
+**Notes**
+
+- The route uses member-or-higher role gating and never decrypts credentials in the handler; decryption happens in `make_sourcing_provider()`.
+- Local cache rows are scoped by `workspace_id`, and cache hits do not consume the in-process parts-count budget.
+- Source: `backend/app/api/routes/sourcing.py:87`.
+- Service: `backend/app/domain/sourcing/service.py:39`.
+- Factory: `backend/app/domain/sourcing/factory.py:12`.
 
 ### `POST /api/workspaces/current/sourcing/test`
 

--- a/docs/runbooks/provider-outage.md
+++ b/docs/runbooks/provider-outage.md
@@ -155,10 +155,50 @@ needs a code change:
    "Provider catalog vs spec keys").
 4. PR + deploy.
 
+## TrustedParts outage
+
+TrustedParts sourcing is separate from the Mouser/DigiKey catalog providers. It backs `POST /api/sourcing/search`, the workspace sourcing connection test, and future sourcing UI surfaces; catalog lookup, manual part creation, stock movements, and existing parts remain available.
+
+Integration entry points:
+
+- `backend/app/domain/sourcing/client.py` — TrustedParts API v2 client.
+- `backend/app/domain/sourcing/factory.py:12` — decrypts the current workspace's sourcing credentials and builds the client.
+- `backend/app/domain/sourcing/service.py:39` — cache, budget, and response attribution facade.
+- `backend/app/api/routes/sourcing.py:87` — member search route and error mapping.
+
+### TrustedParts triage
+
+| Symptom | Likely cause | Action |
+|---|---|---|
+| `409 sourcing not configured` | Workspace has no TrustedParts company ID/API key | Workspace admin configures sourcing credentials in workspace settings. |
+| `502 TrustedParts rejected sourcing credentials` | Company ID or API key is invalid/revoked | Workspace admin re-issues credentials in TrustedParts and saves them again. |
+| `502 TrustedParts rate limit reached` | TrustedParts throttled the key | Ask the workspace to pause high-volume sourcing; retry after the provider window clears. |
+| `502 TrustedParts request timed out` or upstream failure | TrustedParts or network outage | Use manual entry/fallback below; retry when provider status recovers. |
+| `503 sourcing budget exhausted` | Local hard parts-count budget blocked live calls | Wait for the rolling window to expire; cached hits still avoid additional budget consumption. |
+
+### Rate-limit recovery
+
+1. Check whether the response is our local `429` route limit, local `503` budget block, or an upstream `502` TrustedParts rate-limit mapping.
+2. For local `429`, wait for the 60/minute workspace route window.
+3. For local `503`, wait for the rolling budget window. The budget is process-local and assumes one uvicorn worker (`backend/app/domain/sourcing/budget.py:104`).
+4. For upstream TrustedParts throttling, reduce sourcing calls from the affected workspace and retry later. Do not bypass the budget, add `SourceIp`, or remove attribution to work around throttling.
+
+### Credential issues
+
+1. Confirm only one workspace is affected.
+2. Ask a workspace admin to update TrustedParts company ID and API key in workspace settings.
+3. Use `POST /api/workspaces/current/sourcing/test` to confirm the credentials probe returns `{ "ok": true }`.
+4. If the test route succeeds but search still fails, inspect `backend/app/domain/sourcing/service.py:39` and `backend/app/api/routes/sourcing.py:87` for regression in defaults, cache, or error mapping.
+
+### Fallback
+
+Users can still create and edit parts manually, set storage/stock, and use catalog providers. TrustedParts sourcing results are convenience procurement data; they must not be replaced by scraped data or mixed public distributor data during an outage without a new approval path. Existing cached results can be served until their short TTL expires, but the cache is not a permanent price-history store.
+
 ## Verification
 
 - A test lookup for a known-good MPN against the affected provider
   succeeds and populates expected fields.
+- A TrustedParts search for a known-good MPN returns `powered_by="TrustedParts"` and attribution links, or the workspace sourcing test returns `{ "ok": true }` after credential repair.
 - Sentry: `httpx.*` from the provider modules drops back to baseline
   rate.
 - A workspace that reported issues confirms autofill is back.


### PR DESCRIPTION
## Summary

- Wired `POST /api/sourcing/search` through a sourcing service facade that applies workspace defaults, cache lookup, budget checks, TrustedParts attribution, and API-envelope error mapping.
- Centralized TrustedParts client construction in `make_sourcing_provider()` so encrypted workspace credentials are decrypted in one place and reused by the connection-test route.
- Added search DTOs, `git_sha()` user-agent helper, route/search/cache/isolation tests, ADR-0020, API docs, ADR cross-link, and TrustedParts outage runbook notes.
- Stabilized two backend full-suite ordering issues exposed by CI: an abandoned timeout worker mutating provider cache/circuit-breaker state after monkeypatch teardown, and an RBAC member fixture switching by list order instead of the owner workspace id.

## Notes

- ADR-0019 already exists on `main` for Umami, so this uses ADR-0020 per the TP-109 implementer rule for an occupied ADR number.
- Workspace-isolation reviewer ran clean: route resolves `CurrentWorkspace`, service uses `workspace.id` for cache and budget, cache is scoped by `(workspace_id, query_hash)`, factory decrypts only the provided workspace fields, and tests cover same-query cross-workspace cache isolation plus caller-workspace secrets.
- End-to-end curl smoke was not run because this environment has no live TrustedParts credentials or browser cookie jar; the route is covered with TestClient and a fake TrustedParts provider.

## Validation

- `cd backend && uv run --extra dev python -m pytest -q` — passed: 803 passed, 2 skipped, 3 deselected, 66 warnings.
- `cd backend && uv run --extra dev python -m pytest -q -k "sourcing or workspace_isolation"` — passed: 91 passed, 717 deselected, 5 warnings.
- `cd backend && uv run --extra dev python -m pytest -q tests/test_rbac_member.py tests/test_bulk_import_deadline.py tests/test_bulk_import_from_scan.py` — passed: 31 passed, 3 warnings.
- `LINT_CMD="uv run --extra dev ruff check ." BASELINE_FILE=".ruff-baseline.txt" WORK_DIR="backend" bash scripts/lint-delta.sh` — passed: no new violations.
- `cd backend && uv run --extra dev ruff check app/api/routes/sourcing.py app/domain/sourcing/factory.py app/domain/sourcing/schemas.py app/domain/sourcing/service.py app/core/version.py tests/test_sourcing_search_route.py tests/test_sourcing_test_route.py tests/test_bulk_import_deadline.py tests/test_rbac_member.py` — passed.
- `cd backend && bash -c "! rg -n 'verify=False' app/domain/sourcing"` — passed.
- `cd web && npx tsc -b` — passed.
- `git diff --check origin/main...HEAD` — passed.

Refs #329
