### PR TITLE
TP-110: ADR for periodic-jobs scheduler (cache sweeper deploy gate)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,6 +230,9 @@ them, that's the bug.
   on a partial PR auto-closes the issue the moment the PR merges, leaving the
   remaining steps with no tracking. Use `Refs #N` instead, or file a follow-up
   issue and link it. Full rule in `CONTRIBUTING.md` (multi-step issues rule).
+- **Periodic jobs run through one scheduler path.** ADR-0021 chooses a
+  `backend-cron` sidecar + CLI entry point; don't add parallel APScheduler,
+  FastAPI lifespan, host cron, or systemd-timer jobs for app maintenance.
 
 ## Frontend conventions worth preserving
 

--- a/docs/adr/0020-trustedparts-sourcing-provider-split.md
+++ b/docs/adr/0020-trustedparts-sourcing-provider-split.md
@@ -17,7 +17,7 @@ TrustedParts is the first sourcing provider because its Inventory API v2 is buil
 
 Sourcing is a separate domain under `backend/app/domain/sourcing/`, not a third `parts_provider` implementation. Workspace sourcing credentials stay on `Workspace`, are encrypted at rest, and are decrypted only in `make_sourcing_provider()` before constructing `TrustedPartsClient` (`backend/app/domain/sourcing/factory.py:12`). `POST /api/sourcing/search` calls the sourcing service facade (`backend/app/domain/sourcing/service.py:39`) and returns an attributed API-envelope response (`backend/app/api/routes/sourcing.py:87`).
 
-The cache is workspace-scoped and short-lived. The database enforces a maximum seven-day retention window (`backend/app/domain/sourcing/models.py:13`), while the service currently uses a 30-minute TTL (`backend/app/domain/sourcing/service.py:24`). The budget is a parts-count budget, not a request-count budget, and is in-process by design while production runs one uvicorn worker (`backend/app/domain/sourcing/budget.py:104`). The client payload does not send `SourceIp`; user attribution is via the app user/session and visible API response attribution, not via TrustedParts `SourceIp`.
+The cache is workspace-scoped and short-lived. The database enforces a maximum seven-day retention window (`backend/app/domain/sourcing/models.py:13`), while the service currently uses a 30-minute TTL (`backend/app/domain/sourcing/service.py:24`). Expired-row cleanup is periodic-job infrastructure owned by ADR-0021. The budget is a parts-count budget, not a request-count budget, and is in-process by design while production runs one uvicorn worker (`backend/app/domain/sourcing/budget.py:104`). The client payload does not send `SourceIp`; user attribution is via the app user/session and visible API response attribution, not via TrustedParts `SourceIp`.
 
 TrustedParts results must stay visibly distinct from catalog-provider data. Public or UI surfaces that combine distributor data from multiple origins need an explicit future decision before launch.
 
@@ -48,5 +48,6 @@ TrustedParts results must stay visibly distinct from catalog-provider data. Publ
 - Source: `backend/app/domain/sourcing/service.py:39`
 - Source: `backend/app/api/routes/sourcing.py:87`
 - Related ADR: [ADR-0007](0007-provider-catalog-vs-spec-split.md)
+- Related ADR: [ADR-0021](0021-periodic-jobs-scheduler.md)
 - Issue: `https://github.com/matescb/stockManager/issues/329`
 - Plan: `/home/matyas/.claude/plans/read-all-the-documentation-robust-giraffe.md`

--- a/docs/adr/0021-periodic-jobs-scheduler.md
+++ b/docs/adr/0021-periodic-jobs-scheduler.md
@@ -1,0 +1,59 @@
+# ADR-0021: Periodic jobs run in a backend-cron sidecar
+
+Audience: engineer
+
+- **Status**: Accepted
+- **Date**: 2026-05-08
+- **Supersedes**: —
+- **Superseded by**: —
+
+## Context
+
+Phase 1 TrustedParts added a workspace-scoped sourcing cache with a seven-day database cap and a 30-minute service TTL. The database check prevents writes whose `expires_at` is more than seven days after `fetched_at`, but it does not delete expired rows. `sourcing.cache.sweep_expired()` exists for cleanup and is not called by any scheduler yet.
+
+The repo already has one ad hoc in-process periodic task: expired session purge is spawned from FastAPI lifespan in `backend/app/main.py:136` and controlled by `SESSION_PURGE_INTERVAL_SECONDS` in `backend/app/core/config.py:34`. That was acceptable as a single lightweight task, but adding every future periodic job to the request process would create hidden coupling to uvicorn lifecycle, graceful shutdown, and worker count.
+
+The next periodic jobs are:
+
+- `sourcing.cache.sweep_expired` for TrustedParts response retention.
+- Expired session purge, currently in FastAPI lifespan, when the shared runner exists.
+- Phase 5 alert evaluator (TP-503/504).
+- Future routine maintenance jobs that need database access but not an HTTP request.
+
+## Decision
+
+Periodic jobs run through a dedicated `backend-cron` sidecar container that invokes a shared backend CLI entry point, for example `python -m app.cli.run_job <job-name>`. The first implementation job is the sourcing cache sweeper. The sidecar uses the same backend image and database settings as `backend`, but it does not serve HTTP and does not run uvicorn.
+
+Each job must be registered in the CLI allow-list with a clear owner, cadence, and idempotency expectations. The sidecar owns scheduling; the FastAPI request process does not grow a second scheduler.
+
+## Consequences
+
+- **Good**:
+  - Periodic work does not block the request event loop or depend on ASGI lifespan timing.
+  - Future uvicorn worker changes cannot accidentally multiply periodic jobs.
+  - The CLI entry point is testable locally and can be run manually during incident response.
+  - Jobs share application code, config, logging, and database models without opening an HTTP-only maintenance endpoint.
+- **Trade-offs**:
+  - Production compose gains another long-running service and one more log stream.
+  - Local dev has to document how to run a job manually and how to run the sidecar when testing cadence.
+  - The scheduler implementation must handle overlap control for any job that might exceed its cadence.
+- **What it forbids**:
+  - Adding new periodic jobs directly to FastAPI lifespan, APScheduler, host cron, or systemd timers while `backend-cron` exists.
+  - Running the same job from multiple schedulers.
+  - Creating HTTP endpoints solely so a scheduler can trigger maintenance jobs.
+
+## Alternatives considered
+
+- **APScheduler in the FastAPI process** — rejected because it binds maintenance cadence to uvicorn lifecycle and can block or contend with the request process. The single-worker invariant in ADR-0012 avoids duplicate jobs today, but using it as a scheduler would make future worker changes riskier.
+- **`backend-cron` sidecar container** — accepted because it keeps scheduling inside Docker deployment, uses the same image and environment as the backend, and keeps periodic work outside the HTTP process.
+- **systemd timer on the VPS** — rejected because the job schedule would live outside the repo and compose stack. That makes review, local testing, and recovery harder, even though the current VPS already uses host cron for backups.
+
+## References
+
+- Source: `backend/app/domain/sourcing/cache.py:73`
+- Source: `backend/app/main.py:136`
+- Source: `backend/app/core/config.py:34`
+- Related ADR: [ADR-0012](0012-uvicorn-single-worker-slowapi.md)
+- Related ADR: [ADR-0020](0020-trustedparts-sourcing-provider-split.md)
+- Issue: `https://github.com/matescb/stockManager/issues/341`
+- Implementation issue: `https://github.com/matescb/stockManager/issues/356`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -30,3 +30,4 @@ New ADRs follow the template in [STYLE.md](../STYLE.md#adr-pages-docsadrnnnn-slu
 | 0018 | [Prod email verification requires SMTP; never log verification tokens](0018-prod-smtp-fail-closed.md) |
 | 0019 | [Self-hosted Umami for product analytics, env-gated tracker](0019-umami-self-hosted-analytics.md) |
 | 0020 | [TrustedParts sourcing provider split](0020-trustedparts-sourcing-provider-split.md) |
+| 0021 | [Periodic jobs run in a backend-cron sidecar](0021-periodic-jobs-scheduler.md) |


### PR DESCRIPTION
## Summary

- Added ADR-0021 selecting a `backend-cron` sidecar plus backend CLI entry point as the single periodic-job scheduler path.
- Cross-linked ADR-0020 to ADR-0021 for TrustedParts expired-cache cleanup ownership.
- Added ADR-0021 to the ADR index and added a CLAUDE.md guardrail warning against parallel scheduler paths.
- Filed implementation follow-up #356 for `backend-cron` + the first sourcing-cache sweeper job.

## Rationale

Chose Option B, `backend-cron` sidecar, because periodic work should not contend with the FastAPI request event loop or depend on uvicorn worker count. It stays inside the Docker deployment, reuses the backend image/config, and gives operators a CLI job path for manual recovery.

Jobs listed for this scheduler:

- TrustedParts sourcing cache sweep.
- Existing expired-session purge migration from the current FastAPI lifespan task.
- Phase 5 alert evaluator (TP-503/504).
- Future DB-backed routine maintenance jobs.

## Validation

- `git diff --check` — passed.
- `rg -n "ADR-0021|backend-cron|0021-periodic|issues/356" CLAUDE.md docs/adr` — confirmed cross-links and guardrail.

Refs #341
