### PR TITLE
TP-301: MPN dedup + ≤50 chunking helpers

### DIFF
--- a/backend/app/domain/sourcing/service.py
+++ b/backend/app/domain/sourcing/service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable, Sequence
 from datetime import datetime
 from typing import Any
 from uuid import UUID
@@ -33,6 +34,29 @@ class SourcingNotConfigured(Exception):
 
 class SourcingBudgetBlocked(Exception):
     """Workspace exceeded the hard TrustedParts parts-count budget."""
+
+
+def dedupe_mpns(mpns: Iterable[str | None]) -> list[str]:
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for mpn in mpns:
+        if mpn is None:
+            continue
+        clean_mpn = mpn.strip()
+        if not clean_mpn:
+            continue
+        key = clean_mpn.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(clean_mpn)
+    return deduped
+
+
+def chunk_mpns(mpns: Sequence[str], size: int = 50) -> list[list[str]]:
+    if size < 1 or size > 50:
+        raise ValueError("MPN chunk size must be between 1 and 50")
+    return [list(mpns[index : index + size]) for index in range(0, len(mpns), size)]
 
 
 def search(

--- a/backend/tests/test_sourcing_helpers.py
+++ b/backend/tests/test_sourcing_helpers.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import pytest
+
+from app.domain.sourcing.service import chunk_mpns, dedupe_mpns
+
+
+def test_dedupe_preserves_order_and_first_casing():
+    assert dedupe_mpns(["ABC", "abc", "  ABC  ", "DEF", "def", "Ghi"]) == [
+        "ABC",
+        "DEF",
+        "Ghi",
+    ]
+
+
+def test_dedupe_strips_whitespace():
+    assert dedupe_mpns(["  ABC  ", "\tDEF\n", " abc "]) == ["ABC", "DEF"]
+
+
+def test_dedupe_drops_empty_and_none():
+    assert dedupe_mpns([" ", "", None, "ABC"]) == ["ABC"]
+
+
+@pytest.mark.parametrize(
+    ("size", "expected"),
+    [
+        (1, [["1"], ["2"], ["3"], ["4"], ["5"], ["6"], ["7"], ["8"]]),
+        (7, [["1", "2", "3", "4", "5", "6", "7"], ["8"]]),
+        (50, [["1", "2", "3", "4", "5", "6", "7", "8"]]),
+    ],
+)
+def test_chunk_partitions_correctly_for_various_sizes(size: int, expected: list[list[str]]):
+    assert chunk_mpns(["1", "2", "3", "4", "5", "6", "7", "8"], size=size) == expected
+
+
+def test_chunk_rejects_size_zero():
+    with pytest.raises(ValueError):
+        chunk_mpns(["ABC"], size=0)
+
+
+def test_chunk_rejects_size_above_50():
+    with pytest.raises(ValueError):
+        chunk_mpns(["ABC"], size=51)
+
+
+def test_chunk_handles_empty_input():
+    assert chunk_mpns([], size=50) == []


### PR DESCRIPTION
## Summary
- Added pure `dedupe_mpns` and `chunk_mpns` helpers next to `service.search`.
- Added focused helper tests for whitespace stripping, empty/None dropping, first-seen dedupe behavior, chunk sizing, empty input, and invalid sizes.

## Validation
- `cd backend && uv run --extra dev python -m pytest -q tests/test_sourcing_helpers.py`
  - `9 passed, 1 warning in 1.24s`
- `cd backend && uv run --extra dev ruff check app/domain/sourcing/service.py tests/test_sourcing_helpers.py`
  - `All checks passed!`
- `LINT_CMD="uv run --extra dev ruff check ." BASELINE_FILE=".ruff-baseline.txt" WORK_DIR="backend" bash scripts/lint-delta.sh`
  - `lint-delta: no new violations (baseline: 159, current: 0, fixed since baseline: 159)`
- `git diff --check`
  - clean

## Case Folding
- `dedupe_mpns` strips whitespace and compares MPNs with `str.casefold()` while preserving the original casing of the first occurrence in the returned list.

## Scope
- No deviations from the backend sourcing-helper scope.

Refs #350