### PR TITLE
TP-204: Shared TrustedParts attribution components

### DIFF
--- a/docs/frontend/components.md
+++ b/docs/frontend/components.md
@@ -200,6 +200,19 @@ detail page (parts, storage, lots, projects, orders, builds). Slots:
   `tone` mapped to `text-text` / `text-danger` / `text-warning` /
   `text-success` (`:23-28`, `:71-83`)
 
+## TrustedParts Attribution
+
+`web/src/components/PoweredByTrustedParts.tsx:9-32` renders the visible,
+followable "Powered by TrustedParts" link with `target="_blank"` and
+`rel="noopener noreferrer"`; it intentionally omits `nofollow`
+(`:23-29`). Use `<PoweredByTrustedParts/>` on every TrustedParts-derived
+view; ToU compliance is enforced by review.
+
+`web/src/components/SourcingSourceLabel.tsx:10-29` renders the
+TrustedParts source pill with `aria-label="Source: TrustedParts"`
+(`:20-23`) so TrustedParts-derived distributor data stays visually and
+accessibly labelled.
+
 ## MpnLookup
 
 `web/src/components/MpnLookup.tsx`. Affordance attached to MPN inputs that

--- a/web/src/components/PoweredByTrustedParts.tsx
+++ b/web/src/components/PoweredByTrustedParts.tsx
@@ -1,0 +1,32 @@
+const DEFAULT_TRUSTEDPARTS_URL = "https://www.trustedparts.com";
+
+type Props = {
+  primaryUrl?: string;
+  size?: "sm" | "md";
+  className?: string;
+};
+
+export function PoweredByTrustedParts({
+  primaryUrl,
+  size = "sm",
+  className,
+}: Props) {
+  const classes = [
+    "pill",
+    "bg-accent/15",
+    "text-accent",
+    size === "md" ? "text-sm" : "",
+    className ?? "",
+  ].filter(Boolean).join(" ");
+
+  return (
+    <a
+      className={classes}
+      href={primaryUrl ?? DEFAULT_TRUSTEDPARTS_URL}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Powered by TrustedParts
+    </a>
+  );
+}

--- a/web/src/components/SourcingSourceLabel.tsx
+++ b/web/src/components/SourcingSourceLabel.tsx
@@ -1,0 +1,29 @@
+type Props = {
+  source: "trustedparts";
+  className?: string;
+};
+
+function unsupportedSource(source: never): never {
+  throw new Error(`Unsupported sourcing source: ${String(source)}`);
+}
+
+export function SourcingSourceLabel({ source, className }: Props) {
+  switch (source) {
+    case "trustedparts": {
+      const classes = [
+        "pill",
+        "bg-accent/15",
+        "text-accent",
+        className ?? "",
+      ].filter(Boolean).join(" ");
+
+      return (
+        <span className={classes} aria-label="Source: TrustedParts">
+          TrustedParts
+        </span>
+      );
+    }
+    default:
+      return unsupportedSource(source);
+  }
+}

--- a/web/src/components/__tests__/PoweredByTrustedParts.test.tsx
+++ b/web/src/components/__tests__/PoweredByTrustedParts.test.tsx
@@ -1,0 +1,47 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { PoweredByTrustedParts } from "../PoweredByTrustedParts";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("PoweredByTrustedParts", () => {
+  it("renders a followable link without rel='nofollow'", () => {
+    render(<PoweredByTrustedParts primaryUrl="https://example.com/trustedparts" />);
+
+    const link = screen.getByRole("link", { name: "Powered by TrustedParts" });
+
+    expect(link.getAttribute("href")).toBe("https://example.com/trustedparts");
+    expect(link.getAttribute("rel")).not.toContain("nofollow");
+  });
+
+  it("falls back to https://www.trustedparts.com when primaryUrl is undefined", () => {
+    render(<PoweredByTrustedParts />);
+
+    const link = screen.getByRole("link", { name: "Powered by TrustedParts" });
+
+    expect(link.getAttribute("href")).toBe("https://www.trustedparts.com");
+  });
+
+  it("opens in a new tab with rel='noopener noreferrer'", () => {
+    render(<PoweredByTrustedParts />);
+
+    const link = screen.getByRole("link", { name: "Powered by TrustedParts" });
+
+    expect(link.getAttribute("target")).toBe("_blank");
+    expect(link.getAttribute("rel")).toBe("noopener noreferrer");
+  });
+
+  it("respects the className prop", () => {
+    render(<PoweredByTrustedParts className="ml-2" />);
+
+    const link = screen.getByRole("link", { name: "Powered by TrustedParts" });
+
+    expect(link.className).toContain("pill");
+    expect(link.className).toContain("ml-2");
+  });
+});

--- a/web/src/components/__tests__/SourcingSourceLabel.test.tsx
+++ b/web/src/components/__tests__/SourcingSourceLabel.test.tsx
@@ -1,0 +1,40 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SourcingSourceLabel } from "../SourcingSourceLabel";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("SourcingSourceLabel", () => {
+  it("renders TrustedParts label for source='trustedparts'", () => {
+    render(<SourcingSourceLabel source="trustedparts" />);
+
+    const label = screen.getByText("TrustedParts");
+
+    expect(label.className).toContain("pill");
+  });
+
+  it("attaches aria-label for accessibility", () => {
+    render(<SourcingSourceLabel source="trustedparts" />);
+
+    const label = screen.getByLabelText("Source: TrustedParts");
+
+    expect(label.textContent).toBe("TrustedParts");
+  });
+
+  it("throws for an unknown source", () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      expect(() => {
+        render(<SourcingSourceLabel source={"mouser" as "trustedparts"} />);
+      }).toThrow("Unsupported sourcing source: mouser");
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Added `PoweredByTrustedParts` as a shared visible attribution link with the default TrustedParts URL, new-tab behavior, and className support.
- Added `SourcingSourceLabel` as the single-purpose accessible TrustedParts source pill.
- Documented that every TrustedParts-derived view must render `<PoweredByTrustedParts/>` for ToU review compliance.

## Validation
- `cd web && npm test -- PoweredByTrustedParts SourcingSourceLabel`
  - Passed: 2 files, 7 tests.
- `cd web && npx tsc -b`
  - Passed with no output.
- `cd web && npx eslint src/components/PoweredByTrustedParts.tsx src/components/SourcingSourceLabel.tsx src/components/__tests__/PoweredByTrustedParts.test.tsx src/components/__tests__/SourcingSourceLabel.test.tsx`
  - Passed with no output.
- `cd web && npm run lint`
  - Fails only on existing baseline entries already listed in `.eslint-baseline.txt` (`bagCode.ts` no-control-regex errors plus unrelated warnings in scanner/routes files).
- `git diff --check`
  - Passed.

## Compliance
- Confirmed `PoweredByTrustedParts` uses `rel="noopener noreferrer"` and does not include `nofollow`.
- Screenshot not captured: these are shared components without an isolated story/route to render in this headless context.

Refs #347
