### PR TITLE
TP-201: GET /api/parts/{id}/sourcing endpoint

### DIFF
--- a/backend/app/api/routes/sourcing.py
+++ b/backend/app/api/routes/sourcing.py
@@ -2,14 +2,17 @@
 from __future__ import annotations
 
 from time import perf_counter
+from uuid import UUID
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, Query, Request
 from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
 
+from app.api._helpers import assert_in_workspace
 from app.core.deps import CurrentUser, CurrentWorkspace, require_role
 from app.core.ratelimit import limiter, workspace_key
 from app.core.responses import err, ok
+from app.domain.parts.models import Part
 from app.domain.sourcing import (
     SourcingAuthError,
     SourcingClientError,
@@ -24,8 +27,10 @@ from app.infra.db import get_db
 
 router = APIRouter()
 search_router = APIRouter()
+parts_router = APIRouter()
 
 _TEST_PROBE_TOKEN = "TEST_PROBE_DO_NOT_BUY"
+_PART_SOURCING_TTL_SECONDS = 1800
 
 
 def _elapsed_ms(started_at: float) -> int:
@@ -122,6 +127,97 @@ def search_sourcing(
         )
 
     return ok(out.model_dump(mode="json"))
+
+
+@parts_router.get(
+    "/{part_id}/sourcing",
+    dependencies=[Depends(require_role("member"))],
+)
+@limiter.limit("60/minute", key_func=workspace_key)
+def get_part_sourcing(
+    request: Request,
+    part_id: UUID,
+    ws: CurrentWorkspace,
+    user: CurrentUser,
+    country: str | None = Query(default=None, min_length=2, max_length=2),
+    currency: str | None = Query(default=None, min_length=3, max_length=3),
+    in_stock_only: bool = False,
+    distributors: list[str] | None = Query(default=None),
+    db: Session = Depends(get_db),
+):
+    part = assert_in_workspace(db, Part, part_id, ws.id, label="part")
+    mpn = (part.mpn or "").strip()
+    if not mpn:
+        return ok({"offers": [], "reason": "no_mpn", "cache_hit": None})
+
+    try:
+        out = sourcing_service.search(
+            db,
+            workspace=ws,
+            mpns=[mpn],
+            country=country,
+            currency=currency,
+            in_stock_only=in_stock_only,
+            distributors=_clean_query_distributors(distributors),
+            use_cached_data=ws.sourcing_use_cached_for_dashboards,
+            ttl_seconds=_PART_SOURCING_TTL_SECONDS,
+            requested_by=user.id,
+        )
+    except SourcingNotConfigured:
+        return _error_response(request, 409, "conflict", "sourcing not configured")
+    except SourcingBudgetBlocked:
+        return _error_response(request, 503, "server_error", "sourcing budget exhausted")
+    except SourcingAuthError:
+        return _error_response(
+            request,
+            502,
+            "server_error",
+            "TrustedParts rejected sourcing credentials",
+        )
+    except SourcingRateLimitError:
+        return _error_response(
+            request,
+            502,
+            "server_error",
+            "TrustedParts rate limit reached",
+        )
+    except SourcingTimeoutError:
+        return _error_response(
+            request,
+            502,
+            "server_error",
+            "TrustedParts request timed out",
+        )
+    except SourcingClientError:
+        return _error_response(
+            request,
+            502,
+            "server_error",
+            "TrustedParts sourcing request failed",
+        )
+
+    result = out.results[0]
+    return ok(
+        {
+            "mpn": result.mpn,
+            "offers": [offer.model_dump(mode="json") for offer in result.offers],
+            "request_id": result.request_id,
+            "powered_by": out.powered_by,
+            "fetched_at": result.fetched_at.isoformat(),
+            "cache_hit": result.cache_hit,
+            "links": out.links.model_dump(mode="json"),
+            "reason": "ok",
+        }
+    )
+
+
+def _clean_query_distributors(value: list[str] | None) -> list[str] | None:
+    if value is None:
+        return None
+    cleaned: list[str] = []
+    for item in value:
+        cleaned.extend(part.strip() for part in item.split(",") if part.strip())
+    return cleaned or None
 
 
 def _error_response(

--- a/backend/app/domain/sourcing/service.py
+++ b/backend/app/domain/sourcing/service.py
@@ -69,6 +69,7 @@ def search(
     in_stock_only: bool = False,
     distributors: list[str] | None = None,
     use_cached_data: bool | None = None,
+    ttl_seconds: int = TTL_SECONDS,
     requested_by: UUID | None = None,
 ) -> SourcingSearchOut:
     clean_mpns = [mpn.strip() for mpn in mpns]
@@ -131,7 +132,7 @@ def search(
             db,
             workspace_id=workspace.id,
             query=query,
-            ttl_seconds=TTL_SECONDS,
+            ttl_seconds=ttl_seconds,
             fetch_fn=fetch,
             created_by=requested_by,
         )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -388,6 +388,12 @@ app.include_router(search.router, prefix="/api/search", tags=["search"], depende
 app.include_router(sourcing.router, prefix="/api/workspaces", tags=["sourcing"])
 app.include_router(sourcing.search_router, prefix="/api/sourcing", tags=["sourcing"])
 app.include_router(
+    sourcing.parts_router,
+    prefix="/api/parts",
+    tags=["sourcing"],
+    dependencies=_member_gate,
+)
+app.include_router(
     parts_provider.router,
     prefix="/api/parts",
     tags=["parts_provider"],

--- a/backend/tests/test_parts_routing.py
+++ b/backend/tests/test_parts_routing.py
@@ -15,7 +15,6 @@ from fastapi.routing import APIRoute
 
 from app.main import app
 
-
 # (method, path) tuples expected to be mounted under /api/parts.
 EXPECTED_PARTS_ROUTES: set[tuple[str, str]] = {
     # Assets
@@ -31,6 +30,7 @@ EXPECTED_PARTS_ROUTES: set[tuple[str, str]] = {
     ("GET", "/api/parts/{part_id}/stock"),
     ("GET", "/api/parts/{part_id}/lots"),
     ("GET", "/api/parts/{part_id}/activity"),
+    ("GET", "/api/parts/{part_id}/sourcing"),
     # Substitutes
     ("POST", "/api/parts/{part_id}/substitutes"),
     ("GET", "/api/parts/{part_id}/substitutes"),

--- a/backend/tests/test_sourcing_part_route.py
+++ b/backend/tests/test_sourcing_part_route.py
@@ -1,0 +1,270 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+import pytest
+from fastapi.testclient import TestClient
+
+import app.core.ratelimit as _ratelimit_mod
+from app.domain.sourcing.budget import BUDGET
+from app.domain.sourcing.schemas import (
+    SourcingDistributor,
+    SourcingLinks,
+    SourcingOffer,
+    SourcingQuery,
+    SourcingSearchRaw,
+)
+from app.main import app
+from tests._factories import create_part, signup_user
+
+
+def _configure_sourcing(client: TestClient, *, use_cached: bool = False) -> None:
+    r = client.patch(
+        "/api/workspaces/current",
+        json={
+            "sourcing_provider": "trustedparts",
+            "sourcing_company_id": "company-123",
+            "sourcing_api_key": "api-key-456",
+            "sourcing_country_code": "CZ",
+            "sourcing_currency_code": "EUR",
+            "sourcing_preferred_distributors": ["DigiKey"],
+            "sourcing_use_cached_for_dashboards": use_cached,
+        },
+    )
+    assert r.status_code == 200, r.text
+
+
+def _current_workspace_id(client: TestClient) -> str:
+    r = client.get("/api/workspaces/current")
+    assert r.status_code == 200, r.text
+    return r.json()["data"]["id"]
+
+
+class _FakeTrustedPartsClient:
+    calls: list[dict] = []
+
+    def __init__(self) -> None:
+        self.country_code = "CZ"
+        self.currency_code = "EUR"
+
+    def search(
+        self,
+        queries: list[SourcingQuery],
+        *,
+        in_stock_only: bool,
+        distributors: list[str] | None,
+        use_cached_data: bool,
+        **_kwargs,
+    ) -> SourcingSearchRaw:
+        query = queries[0]
+        self.calls.append(
+            {
+                "queries": [item.model_dump(exclude_none=True) for item in queries],
+                "country_code": self.country_code,
+                "currency_code": self.currency_code,
+                "in_stock_only": in_stock_only,
+                "distributors": distributors,
+                "use_cached_data": use_cached_data,
+            }
+        )
+        return SourcingSearchRaw(
+            offers=[
+                SourcingOffer(
+                    mpn=query.search_token,
+                    manufacturer="ST",
+                    description="Test offer",
+                    distributors=[
+                        SourcingDistributor(
+                            name="DigiKey",
+                            sku=f"{query.search_token}-DK",
+                            stock=42,
+                            unit_price=1.23,
+                            currency=self.currency_code,
+                            product_url="https://www.trustedparts.com/product",
+                        )
+                    ],
+                    links=SourcingLinks(
+                        primary=f"https://www.trustedparts.com/search/{query.search_token}"
+                    ),
+                )
+            ],
+            request_id=f"req-{len(self.calls)}",
+        )
+
+
+@pytest.fixture(autouse=True)
+def reset_sourcing_state(monkeypatch):
+    original_limiter_enabled = _ratelimit_mod.limiter.enabled
+    _ratelimit_mod.limiter.enabled = False
+    _FakeTrustedPartsClient.calls = []
+    BUDGET._events.clear()
+    try:
+        _ratelimit_mod.limiter.reset()
+    except Exception:
+        pass
+    monkeypatch.setattr(
+        "app.domain.sourcing.service.make_sourcing_provider",
+        lambda _workspace: _FakeTrustedPartsClient(),
+    )
+    yield
+    _ratelimit_mod.limiter.enabled = original_limiter_enabled
+    BUDGET._events.clear()
+    try:
+        _ratelimit_mod.limiter.reset()
+    except Exception:
+        pass
+
+
+def test_part_with_mpn_returns_offers(authed_client, monkeypatch):
+    _configure_sourcing(authed_client)
+    part_id = create_part(authed_client, name="STM32", mpn="STM32F103C8T6")
+    ttl_values: list[int] = []
+
+    from app.domain.sourcing import cache as sourcing_cache
+
+    original_get_or_fetch = sourcing_cache.get_or_fetch
+
+    def spy_get_or_fetch(*args, **kwargs):
+        ttl_values.append(kwargs["ttl_seconds"])
+        return original_get_or_fetch(*args, **kwargs)
+
+    monkeypatch.setattr(sourcing_cache, "get_or_fetch", spy_get_or_fetch)
+
+    r = authed_client.get(
+        f"/api/parts/{part_id}/sourcing",
+        params={
+            "country": "de",
+            "currency": "eur",
+            "in_stock_only": "true",
+            "distributors": "DigiKey,Mouser",
+        },
+    )
+
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["status"]["category"] == "ok"
+    data = body["data"]
+    assert data["mpn"] == "STM32F103C8T6"
+    assert data["powered_by"] == "TrustedParts"
+    datetime.fromisoformat(data["fetched_at"])
+    assert data["cache_hit"] is False
+    assert data["reason"] == "ok"
+    assert data["links"]["primary"] == "https://www.trustedparts.com/"
+    assert data["offers"][0]["distributors"][0]["name"] == "DigiKey"
+    assert ttl_values == [1800]
+    assert _FakeTrustedPartsClient.calls == [
+        {
+            "queries": [{"search_token": "STM32F103C8T6"}],
+            "country_code": "DE",
+            "currency_code": "EUR",
+            "in_stock_only": True,
+            "distributors": ["DigiKey", "Mouser"],
+            "use_cached_data": False,
+        }
+    ]
+
+
+def test_part_without_mpn_returns_no_mpn_reason_and_skips_network(authed_client):
+    part_id = create_part(authed_client, name="Manual part")
+
+    r = authed_client.get(f"/api/parts/{part_id}/sourcing")
+
+    assert r.status_code == 200, r.text
+    assert r.json()["data"] == {
+        "offers": [],
+        "reason": "no_mpn",
+        "cache_hit": None,
+    }
+    assert _FakeTrustedPartsClient.calls == []
+
+
+def test_foreign_part_returns_404_envelope(authed_client):
+    foreign_client = TestClient(app)
+    signup_user(foreign_client)
+    foreign_part_id = create_part(foreign_client, name="Foreign", mpn="BAT54C")
+
+    r = authed_client.get(f"/api/parts/{foreign_part_id}/sourcing")
+
+    assert r.status_code == 404, r.text
+    body = r.json()
+    assert body["data"] is None
+    assert body["status"]["category"] == "not_found"
+
+
+def test_unconfigured_returns_409(authed_client, monkeypatch):
+    monkeypatch.setattr(
+        "app.domain.sourcing.service.make_sourcing_provider",
+        lambda _workspace: None,
+    )
+    part_id = create_part(authed_client, name="BAT54", mpn="BAT54C")
+
+    r = authed_client.get(f"/api/parts/{part_id}/sourcing")
+
+    assert r.status_code == 409, r.text
+    assert r.json()["status"] == {
+        "category": "conflict",
+        "message": "sourcing not configured",
+    }
+
+
+def test_budget_blocked_returns_503(authed_client):
+    _configure_sourcing(authed_client)
+    part_id = create_part(authed_client, name="BAT54", mpn="BAT54C")
+    BUDGET.record(uuid.UUID(_current_workspace_id(authed_client)), 250)
+
+    r = authed_client.get(f"/api/parts/{part_id}/sourcing")
+
+    assert r.status_code == 503, r.text
+    assert r.json()["status"] == {
+        "category": "server_error",
+        "message": "sourcing budget exhausted",
+    }
+
+
+def test_rate_limit_after_60_per_minute(authed_client):
+    _ratelimit_mod.limiter.enabled = True
+    _configure_sourcing(authed_client)
+    part_id = create_part(authed_client, name="MAX232", mpn="MAX232")
+
+    for _index in range(60):
+        r = authed_client.get(f"/api/parts/{part_id}/sourcing")
+        assert r.status_code == 200, r.text
+
+    r = authed_client.get(f"/api/parts/{part_id}/sourcing")
+
+    assert r.status_code == 429, r.text
+    assert r.json()["status"]["category"] == "rate_limited"
+
+
+def test_cache_hit_on_second_call(authed_client):
+    _configure_sourcing(authed_client)
+    part_id = create_part(authed_client, name="BAV99", mpn="BAV99")
+
+    first = authed_client.get(f"/api/parts/{part_id}/sourcing")
+    second = authed_client.get(f"/api/parts/{part_id}/sourcing")
+
+    assert first.status_code == 200, first.text
+    assert second.status_code == 200, second.text
+    assert first.json()["data"]["cache_hit"] is False
+    assert second.json()["data"]["cache_hit"] is True
+    assert len(_FakeTrustedPartsClient.calls) == 1
+
+
+def test_workspace_isolation_two_parts_same_mpn(authed_client):
+    _configure_sourcing(authed_client)
+    part_a = create_part(authed_client, name="A BAV99", mpn="BAV99")
+
+    client_b = TestClient(app)
+    signup_user(client_b)
+    _configure_sourcing(client_b)
+    part_b = create_part(client_b, name="B BAV99", mpn="BAV99")
+
+    first = authed_client.get(f"/api/parts/{part_a}/sourcing")
+    second = client_b.get(f"/api/parts/{part_b}/sourcing")
+
+    assert first.status_code == 200, first.text
+    assert second.status_code == 200, second.text
+    assert first.json()["data"]["cache_hit"] is False
+    assert second.json()["data"]["cache_hit"] is False
+    assert len(_FakeTrustedPartsClient.calls) == 2

--- a/docs/api/sourcing.md
+++ b/docs/api/sourcing.md
@@ -2,13 +2,82 @@
 
 Audience: engineer
 
-TrustedParts sourcing endpoints for workspace-scoped connection checks and short-lived offer search.
+TrustedParts sourcing endpoints for workspace-scoped connection checks, short-lived offer search, and part-detail sourcing reads.
 
 ## Conventions
 
-See [API conventions](./README.md) for envelope, errors, pagination. Connection checks are mounted under `/api/workspaces`; search is mounted under `/api/sourcing`. Current routes require a cookie session and current workspace.
+See [API conventions](./README.md) for envelope, errors, pagination. Connection checks are mounted under `/api/workspaces`; search is mounted under `/api/sourcing`; part reads are mounted under `/api/parts`. Current routes require a cookie session and current workspace.
 
 ## Routes
+
+### `GET /api/parts/{part_id}/sourcing`
+
+Return cached TrustedParts offers for one part's MPN.
+
+**Request**
+
+Path: `part_id` is a part UUID in the current workspace.
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `country` | `string` | No | Two-letter override; falls back to workspace sourcing default. |
+| `currency` | `string` | No | Three-letter override; falls back to workspace sourcing default. |
+| `in_stock_only` | `boolean` | No | Defaults to `false`. |
+| `distributors` | `string[]` | No | Repeatable query param; comma-separated values are also accepted. Falls back to `sourcing_preferred_distributors` when omitted. |
+
+**Response** — `200 OK` (envelope: `{ data, status }`)
+
+```json
+{
+  "data": {
+    "mpn": "STM32F103C8T6",
+    "offers": [
+      {
+        "mpn": "STM32F103C8T6",
+        "distributors": [
+          { "name": "DigiKey", "stock": 42, "unit_price": 1.23, "currency": "EUR" }
+        ]
+      }
+    ],
+    "request_id": "trustedparts-request-id",
+    "powered_by": "TrustedParts",
+    "fetched_at": "2026-05-08T12:00:00+00:00",
+    "cache_hit": false,
+    "links": {
+      "primary": "https://www.trustedparts.com/",
+      "attribution": "https://www.trustedparts.com/en/about"
+    },
+    "reason": "ok"
+  },
+  "status": { "category": "ok", "message": "OK" }
+}
+```
+
+Parts without an MPN return a successful no-network response.
+
+```json
+{
+  "data": { "offers": [], "reason": "no_mpn", "cache_hit": null },
+  "status": { "category": "ok", "message": "OK" }
+}
+```
+
+**Errors**
+
+- `404 Not Found` — `part_id` is missing or belongs to another workspace.
+- `409 Conflict` — `{ "data": null, "status": { "category": "conflict", "message": "sourcing not configured" } }`.
+- `422 Unprocessable Entity` — validation envelope for malformed UUID or invalid query parameter lengths.
+- `429 Too Many Requests` — workspace rate limit: 60 requests/minute.
+- `502 Bad Gateway` — TrustedParts auth, rate-limit, timeout, upstream, or response-shape failure.
+- `503 Service Unavailable` — `{ "data": null, "status": { "category": "server_error", "message": "sourcing budget exhausted" } }`.
+
+**Notes**
+
+- The route validates `part_id` with `assert_in_workspace()` before reading the part MPN.
+- The local cache is scoped by `workspace_id`; the part-detail route calls sourcing search with `ttl_seconds=1800`.
+- The route uses member-or-higher role gating and maps the same sourcing exceptions as `POST /api/sourcing/search`.
+- Source: `backend/app/api/routes/sourcing.py:132-220`.
+- Service: `backend/app/domain/sourcing/service.py:62-138`.
 
 ### `POST /api/sourcing/search`
 


### PR DESCRIPTION
## Summary
- Added `GET /api/parts/{part_id}/sourcing` with member+ access, `assert_in_workspace` part lookup, workspace rate limit, no-MPN fast path, and TrustedParts exception mapping.
- Added explicit `ttl_seconds=1800` support through `sourcing_service.search` and wired the part route under `/api/parts`.
- Added focused route tests and documented the new endpoint in `docs/api/sourcing.md`.

## Validation
- `docker compose -f docker-compose.dev.yml exec backend pytest -k "sourcing_part_route or workspace_isolation"` could not run: `docker` is not installed in this environment.
- `cd backend && uv run --extra dev python -m pytest -k "sourcing_part_route or workspace_isolation"`: `52 passed, 773 deselected, 2 warnings in 22.11s`.
- `cd backend && uv run --extra dev python -m pytest tests/test_sourcing_part_route.py`: `8 passed, 1 warning in 4.65s`.
- `docker compose -f docker-compose.dev.yml exec backend ruff check` could not run: `docker` is not installed in this environment.
- `cd backend && uv run --extra dev ruff check`: repository baseline findings remain (`339 errors`), so this raw command is not clean on current main.
- `cd backend && WORK_DIR=. LINT_CMD="uv run --extra dev ruff check app --output-format=concise" BASELINE_FILE="../.ruff-baseline.txt" bash ../scripts/lint-delta.sh`: `lint-delta: no new violations (baseline: 159, current: 154, fixed since baseline: 5)`.
- `cd backend && uv run --extra dev ruff check app/api/routes/sourcing.py app/domain/sourcing/service.py tests/test_sourcing_part_route.py`: `All checks passed!`.

## Workspace Isolation
- The route resolves caller-supplied `part_id` with `assert_in_workspace(db, Part, part_id, ws.id, label="part")`.
- Added `test_foreign_part_returns_404_envelope` and `test_workspace_isolation_two_parts_same_mpn`; the targeted `workspace_isolation` selection passed.

## Deviations
- Docker validation was not feasible because `docker` is unavailable here; local `uv` equivalents were run instead.
- `sourcing_service.search` needed a small `ttl_seconds` parameter hook so the route can pass the issue-required explicit `1800` value.

Refs #344