### PR TITLE
TP-110a: Implement backend-cron scheduler + sourcing cache sweeper

### DIFF
--- a/backend/app/cli/__init__.py
+++ b/backend/app/cli/__init__.py
@@ -1,0 +1,1 @@
+"""Command-line entry points for backend maintenance jobs."""

--- a/backend/app/cli/run_job.py
+++ b/backend/app/cli/run_job.py
@@ -1,0 +1,120 @@
+"""Allow-listed backend maintenance job runner."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+
+from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+SessionFactory = Callable[[], Session]
+JobCallable = Callable[[Session], int]
+
+
+@dataclass(frozen=True)
+class JobSpec:
+    """Registered maintenance job metadata."""
+
+    name: str
+    owner: str
+    cadence: str
+    idempotency: str
+    run: JobCallable
+
+
+class UnknownJobError(ValueError):
+    """Raised when the requested job name is not registered."""
+
+
+def _default_session_factory() -> Session:
+    from app.infra.db import SessionLocal
+
+    return SessionLocal()
+
+
+def _run_sourcing_cache_sweep(db: Session) -> int:
+    from app.domain.sourcing.cache import sweep_expired_all_workspaces
+
+    return sweep_expired_all_workspaces(db)
+
+
+JOBS: dict[str, JobSpec] = {
+    "sourcing-cache-sweep": JobSpec(
+        name="sourcing-cache-sweep",
+        owner="backend/sourcing",
+        cadence="hourly",
+        idempotency="Deletes only rows whose expires_at is already in the past.",
+        run=_run_sourcing_cache_sweep,
+    )
+}
+
+
+def run_job(
+    job_name: str,
+    *,
+    jobs: Mapping[str, JobSpec] = JOBS,
+    session_factory: SessionFactory = _default_session_factory,
+) -> int:
+    """Run one registered job and return the job's affected-row count."""
+    job = jobs.get(job_name)
+    if job is None:
+        available = ", ".join(sorted(jobs)) or "(none)"
+        raise UnknownJobError(f"unknown job {job_name!r}; available jobs: {available}")
+
+    db = session_factory()
+    try:
+        affected = job.run(db)
+        db.commit()
+    except Exception:
+        db.rollback()
+        logger.exception("job=%s status=error", job.name)
+        raise
+    finally:
+        db.close()
+
+    logger.info(
+        "job=%s status=ok affected=%s cadence=%s owner=%s",
+        job.name,
+        affected,
+        job.cadence,
+        job.owner,
+    )
+    return affected
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run an allow-listed backend job.")
+    parser.add_argument("job_name", help="Registered job name, e.g. sourcing-cache-sweep")
+    return parser
+
+
+def main(
+    argv: list[str] | None = None,
+    *,
+    jobs: Mapping[str, JobSpec] = JOBS,
+    session_factory: SessionFactory = _default_session_factory,
+) -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    try:
+        args = _parser().parse_args(argv)
+    except SystemExit as exc:
+        return int(exc.code)
+
+    try:
+        run_job(args.job_name, jobs=jobs, session_factory=session_factory)
+    except UnknownJobError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/app/domain/sourcing/cache.py
+++ b/backend/app/domain/sourcing/cache.py
@@ -78,3 +78,20 @@ def sweep_expired(db: Session, *, workspace_id: UUID) -> int:
         .where(SourcingCache.expires_at < utcnow())
     )
     return result.rowcount or 0
+
+
+def sweep_expired_all_workspaces(db: Session) -> int:
+    """Delete expired rows by iterating through workspace-scoped sweeps."""
+    workspace_ids = (
+        db.execute(
+            select(SourcingCache.workspace_id)
+            .where(SourcingCache.expires_at < utcnow())
+            .distinct()
+        )
+        .scalars()
+        .all()
+    )
+    return sum(
+        sweep_expired(db, workspace_id=workspace_id)
+        for workspace_id in workspace_ids
+    )

--- a/backend/tests/test_ci_workflow.py
+++ b/backend/tests/test_ci_workflow.py
@@ -15,12 +15,12 @@ Also covers INFRA-003 / issue #44: asserts that the Sentry auth token is
 never exposed as a Docker build arg and that sourcemap upload happens
 in CI only.
 """
+
 from __future__ import annotations
 
 from pathlib import Path
 
 import yaml
-
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _CI_PATH = _REPO_ROOT / ".github" / "workflows" / "ci.yml"
@@ -136,6 +136,23 @@ def test_compose_prod_web_build_args_no_sentry_token():
         f"docker-compose.prod.yml web build.args contains sensitive Sentry "
         f"vars that must live only in GitHub Actions secrets: {leaked}"
     )
+
+
+def test_compose_prod_backend_cron_command_shape():
+    """backend-cron must stay on the shared CLI scheduler path."""
+    assert _COMPOSE_PROD_PATH.exists(), (
+        f"missing compose file at {_COMPOSE_PROD_PATH}"
+    )
+    data = yaml.safe_load(_COMPOSE_PROD_PATH.read_text())
+    cron = data["services"]["backend-cron"]
+    cmd = cron.get("command")
+
+    assert isinstance(cmd, list), (
+        "backend-cron.command must be a YAML list (JSON-array form)"
+    )
+    joined = " ".join(str(part) for part in cmd)
+    assert "python -m app.cli.run_job sourcing-cache-sweep" in joined
+    assert "uvicorn" not in joined
 
 
 def test_dockerfile_prod_no_sentry_token_arg():

--- a/backend/tests/test_run_job.py
+++ b/backend/tests/test_run_job.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.cli.run_job import JobSpec, UnknownJobError, main, run_job
+
+
+class _FakeSession:
+    def __init__(self) -> None:
+        self.committed = False
+        self.rolled_back = False
+        self.closed = False
+
+    def commit(self) -> None:
+        self.committed = True
+
+    def rollback(self) -> None:
+        self.rolled_back = True
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_run_job_dispatches_allow_listed_job() -> None:
+    session = _FakeSession()
+    calls: list[Session] = []
+
+    def _job(db: Session) -> int:
+        calls.append(db)
+        return 4
+
+    affected = run_job(
+        "example",
+        jobs={
+            "example": JobSpec(
+                name="example",
+                owner="tests",
+                cadence="manual",
+                idempotency="test-only",
+                run=_job,
+            )
+        },
+        session_factory=lambda: session,  # type: ignore[return-value]
+    )
+
+    assert affected == 4
+    assert calls == [session]
+    assert session.committed is True
+    assert session.rolled_back is False
+    assert session.closed is True
+
+
+def test_run_job_rejects_unknown_job() -> None:
+    try:
+        run_job("missing", jobs={}, session_factory=lambda: _FakeSession())  # type: ignore[return-value]
+    except UnknownJobError as exc:
+        assert "unknown job 'missing'" in str(exc)
+    else:
+        raise AssertionError("unknown job should raise UnknownJobError")
+
+
+def test_run_job_main_returns_nonzero_for_unknown_job(capsys) -> None:
+    exit_code = main(["missing"], jobs={}, session_factory=lambda: _FakeSession())  # type: ignore[return-value]
+
+    assert exit_code == 2
+    assert "unknown job 'missing'" in capsys.readouterr().err

--- a/backend/tests/test_sourcing_cache.py
+++ b/backend/tests/test_sourcing_cache.py
@@ -9,7 +9,12 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.core.time import utcnow
-from app.domain.sourcing.cache import canonical_query_hash, get_or_fetch, sweep_expired
+from app.domain.sourcing.cache import (
+    canonical_query_hash,
+    get_or_fetch,
+    sweep_expired,
+    sweep_expired_all_workspaces,
+)
 from app.domain.sourcing.models import SourcingCache
 from app.domain.users.models import User
 from app.domain.workspaces.models import Workspace
@@ -224,6 +229,53 @@ def test_sweep_expired_is_scoped_to_workspace(db: Session) -> None:
     assert len(rows) == 1
     assert rows[0].workspace_id == workspace_b
     assert rows[0].response_json == {"workspace": "b"}
+
+
+def test_sweep_expired_all_workspaces_preserves_unexpired_rows(db: Session) -> None:
+    workspace_a = _workspace(db)
+    workspace_b = _workspace(db)
+    db.add_all(
+        [
+            _cache_row(
+                workspace_id=workspace_a,
+                query={"mpn": "expired-a"},
+                response={"workspace": "a", "expired": True},
+                fetched_delta=-timedelta(days=1),
+                ttl=timedelta(minutes=1),
+            ),
+            _cache_row(
+                workspace_id=workspace_a,
+                query={"mpn": "active-a"},
+                response={"workspace": "a", "active": True},
+                ttl=timedelta(days=1),
+            ),
+            _cache_row(
+                workspace_id=workspace_b,
+                query={"mpn": "expired-b"},
+                response={"workspace": "b", "expired": True},
+                fetched_delta=-timedelta(days=1),
+                ttl=timedelta(minutes=1),
+            ),
+            _cache_row(
+                workspace_id=workspace_b,
+                query={"mpn": "active-b"},
+                response={"workspace": "b", "active": True},
+                ttl=timedelta(days=1),
+            ),
+        ]
+    )
+    db.flush()
+
+    assert sweep_expired_all_workspaces(db) == 2
+
+    rows = (
+        db.execute(select(SourcingCache).order_by(SourcingCache.workspace_id))
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 2
+    assert {row.workspace_id for row in rows} == {workspace_a, workspace_b}
+    assert {row.response_json["active"] for row in rows} == {True}
 
 
 def test_workspace_isolation_same_query_hash(db: Session) -> None:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -162,6 +162,52 @@ services:
     security_opt: ["no-new-privileges:true"]
     cap_drop: ["ALL"]
 
+  backend-cron:
+    build: ./backend
+    restart: unless-stopped
+    mem_limit: 512m
+    cpus: "0.5"
+    pids_limit: 256
+    oom_kill_disable: false
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"
+    environment:
+      # Same runtime config shape as backend. Keep POSTGRES_* discrete so
+      # DATABASE_URL is assembled inside Settings without leaking the password
+      # through docker inspect interpolation.
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_HOST: db
+      POSTGRES_PORT: "5432"
+      SESSION_SECRET: ${SESSION_SECRET}
+      UPLOAD_DIR: /data/uploads
+      APP_ENV: prod
+      CORS_ORIGINS: ${CORS_ORIGINS}
+      WORKSPACE_SECRETS_KEY: ${WORKSPACE_SECRETS_KEY}
+      SENTRY_DSN: ${SENTRY_DSN:-}
+      SENTRY_TRACES_SAMPLE_RATE: ${SENTRY_TRACES_SAMPLE_RATE:-0.0}
+      SENTRY_RELEASE: ${SENTRY_RELEASE:-}
+      VITE_SENTRY_DSN: ${VITE_SENTRY_DSN:-}
+      SMTP_HOST: ${SMTP_HOST}
+      SMTP_PORT: ${SMTP_PORT:-587}
+      SMTP_USER: ${SMTP_USER}
+      SMTP_PASSWORD: ${SMTP_PASSWORD}
+      MAIL_FROM: ${MAIL_FROM}
+      APP_BASE_URL: ${APP_BASE_URL}
+    depends_on:
+      backend:
+        condition: service_healthy
+    # Runs the hourly TrustedParts cache retention sweep through the shared
+    # backend CLI. The sleep happens after each run finishes, so a long run
+    # delays the next start instead of overlapping it.
+    command: ["sh", "-c", "while true; do python -m app.cli.run_job sourcing-cache-sweep; sleep 3600; done"]
+    security_opt: ["no-new-privileges:true"]
+    cap_drop: ["ALL"]
+
   web:
     build:
       # Context is the repo root so the Dockerfile can COPY both `web/` (sources)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -364,7 +364,36 @@ docker-compose commands so they run as the same user CI uses (avoids
 ```bash
 cd /srv/stockmanager
 sudo -u deploy docker compose -f docker-compose.prod.yml logs -f backend
+sudo -u deploy docker compose -f docker-compose.prod.yml logs -f backend-cron
 sudo -u deploy docker compose -f docker-compose.prod.yml logs -f web
+```
+
+### Backend periodic jobs
+
+`backend-cron` runs the allow-listed backend CLI once per hour:
+`python -m app.cli.run_job sourcing-cache-sweep`. The sidecar sleeps after
+each completed run, so a slow sweep delays the next start instead of
+overlapping it. Source: `docker-compose.prod.yml:165-207`,
+`backend/app/cli/run_job.py:46-52`.
+
+The sourcing cache job opens a backend DB session and sweeps expired
+TrustedParts cache rows by workspace-scoped deletes. Source:
+`backend/app/cli/run_job.py:57-87`,
+`backend/app/domain/sourcing/cache.py:83-97`.
+
+Run it manually on the VPS:
+
+```bash
+cd /srv/stockmanager
+sudo -u deploy docker compose -f docker-compose.prod.yml --env-file .env.prod \
+    exec backend python -m app.cli.run_job sourcing-cache-sweep
+```
+
+Run it outside Docker against a local configured backend DB:
+
+```bash
+cd backend
+uv run python -m app.cli.run_job sourcing-cache-sweep
 ```
 
 ### psql shell


### PR DESCRIPTION
## Summary
- Added `python -m app.cli.run_job sourcing-cache-sweep` as an allow-listed backend job runner with DB session ownership and unknown-job rejection.
- Added an all-workspace sourcing cache sweep that delegates to the existing workspace-scoped `sweep_expired` helper.
- Added `backend-cron` to production compose and documented manual runs/log inspection.

## Scheduler cadence
- `backend-cron` runs `sourcing-cache-sweep` hourly.
- The loop sleeps for 3600 seconds after each completed run, so slow sweeps delay the next start instead of overlapping.

## Validation output
- `cd backend && uv run --extra dev python -m pytest -q -k "sourcing_cache or run_job"` -> 14 passed, 808 deselected, 1 warning.
- `cd backend && uv run --extra dev ruff check app tests` -> failed on 333 pre-existing repository lint violations; issue-scoped files pass targeted ruff.
- `LINT_CMD="uv run --extra dev ruff check ." BASELINE_FILE=".ruff-baseline.txt" WORK_DIR="backend" bash scripts/lint-delta.sh` -> no new violations.
- `cd backend && DATABASE_URL="postgresql+psycopg://stockmgr:stockmgr@127.0.0.1:5432/stockmgr_test" uv run --extra dev python -m app.cli.run_job sourcing-cache-sweep` -> status=ok affected=0.
- `cd backend && uv run --extra dev python -m app.cli.run_job does-not-exist` -> exit 2 with unknown-job message.
- `cd backend && uv run --extra dev python -m pytest -q tests/test_ci_workflow.py::test_compose_prod_backend_cron_command_shape` -> 1 passed, 1 warning.

## Deviations
- `docker compose -f docker-compose.prod.yml --env-file .env.prod.ci config -q` was not runnable in this workspace because `docker` is not installed.
- A direct CLI run without `DATABASE_URL` outside Compose falls back to the Docker hostname `db`; docs call out running against a configured backend DB.

Refs #356
