### PR TITLE
TP-202: POST /api/parts/{id}/sourcing/refresh

### DIFF
--- a/backend/app/api/routes/sourcing.py
+++ b/backend/app/api/routes/sourcing.py
@@ -211,6 +211,83 @@ def get_part_sourcing(
     )
 
 
+@parts_router.post(
+    "/{part_id}/sourcing/refresh",
+    dependencies=[Depends(require_role("member"))],
+)
+@limiter.limit("6/minute", key_func=workspace_key)
+def refresh_part_sourcing(
+    request: Request,
+    part_id: UUID,
+    ws: CurrentWorkspace,
+    user: CurrentUser,
+    db: Session = Depends(get_db),
+):
+    part = assert_in_workspace(db, Part, part_id, ws.id, label="part")
+    mpn = (part.mpn or "").strip()
+    if not mpn:
+        return _error_response(request, 422, "validation_error", "part has no MPN")
+
+    try:
+        out = sourcing_service.search(
+            db,
+            workspace=ws,
+            mpns=[mpn],
+            use_cached_data=False,
+            ttl_seconds=_PART_SOURCING_TTL_SECONDS,
+            requested_by=user.id,
+            force_refresh=True,
+        )
+    except SourcingNotConfigured:
+        return _error_response(request, 409, "conflict", "sourcing not configured")
+    except SourcingBudgetBlocked:
+        return _error_response(request, 503, "server_error", "sourcing budget exhausted")
+    except SourcingAuthError:
+        return _error_response(
+            request,
+            502,
+            "server_error",
+            "TrustedParts rejected sourcing credentials",
+        )
+    except SourcingRateLimitError:
+        return _error_response(
+            request,
+            502,
+            "server_error",
+            "TrustedParts rate limit reached",
+        )
+    except SourcingTimeoutError:
+        return _error_response(
+            request,
+            502,
+            "server_error",
+            "TrustedParts request timed out",
+        )
+    except SourcingClientError:
+        return _error_response(
+            request,
+            502,
+            "server_error",
+            "TrustedParts sourcing request failed",
+        )
+
+    return ok(_part_sourcing_payload(out))
+
+
+def _part_sourcing_payload(out):
+    result = out.results[0]
+    return {
+        "mpn": result.mpn,
+        "offers": [offer.model_dump(mode="json") for offer in result.offers],
+        "request_id": result.request_id,
+        "powered_by": out.powered_by,
+        "fetched_at": result.fetched_at.isoformat(),
+        "cache_hit": result.cache_hit,
+        "links": out.links.model_dump(mode="json"),
+        "reason": "ok",
+    }
+
+
 def _clean_query_distributors(value: list[str] | None) -> list[str] | None:
     if value is None:
         return None

--- a/backend/app/domain/sourcing/cache.py
+++ b/backend/app/domain/sourcing/cache.py
@@ -33,18 +33,20 @@ def get_or_fetch(
     ttl_seconds: int,
     fetch_fn: Callable[[], dict[str, Any]],
     created_by: UUID | None = None,
+    force_refresh: bool = False,
 ) -> tuple[dict[str, Any], bool]:
     """Return ``(response_json, cache_hit)`` for one workspace-scoped query."""
     now = utcnow()
     query_hash = canonical_query_hash(query)
-    cached = db.execute(
-        select(SourcingCache)
-        .where(SourcingCache.workspace_id == workspace_id)
-        .where(SourcingCache.query_hash == query_hash)
-        .where(SourcingCache.expires_at > now)
-    ).scalar_one_or_none()
-    if cached is not None:
-        return cached.response_json, True
+    if not force_refresh:
+        cached = db.execute(
+            select(SourcingCache)
+            .where(SourcingCache.workspace_id == workspace_id)
+            .where(SourcingCache.query_hash == query_hash)
+            .where(SourcingCache.expires_at > now)
+        ).scalar_one_or_none()
+        if cached is not None:
+            return cached.response_json, True
 
     response = fetch_fn()
     ttl = min(timedelta(seconds=ttl_seconds), SEVEN_DAYS)

--- a/backend/app/domain/sourcing/service.py
+++ b/backend/app/domain/sourcing/service.py
@@ -71,6 +71,7 @@ def search(
     use_cached_data: bool | None = None,
     ttl_seconds: int = TTL_SECONDS,
     requested_by: UUID | None = None,
+    force_refresh: bool = False,
 ) -> SourcingSearchOut:
     clean_mpns = [mpn.strip() for mpn in mpns]
     if not 1 <= len(clean_mpns) <= 50 or any(not mpn for mpn in clean_mpns):
@@ -96,7 +97,7 @@ def search(
     verdict = BUDGET.check(workspace.id, parts_count=len(clean_mpns))
     if not verdict.allow:
         raise SourcingBudgetBlocked(verdict.reason)
-    if verdict.mode == "degraded":
+    if verdict.mode == "degraded" and not force_refresh:
         effective_use_cached = True
 
     provider.country_code = effective_country
@@ -135,6 +136,7 @@ def search(
             ttl_seconds=ttl_seconds,
             fetch_fn=fetch,
             created_by=requested_by,
+            force_refresh=force_refresh,
         )
         if not cache_hit:
             BUDGET.record(workspace.id, 1)

--- a/backend/tests/test_parts_routing.py
+++ b/backend/tests/test_parts_routing.py
@@ -31,6 +31,7 @@ EXPECTED_PARTS_ROUTES: set[tuple[str, str]] = {
     ("GET", "/api/parts/{part_id}/lots"),
     ("GET", "/api/parts/{part_id}/activity"),
     ("GET", "/api/parts/{part_id}/sourcing"),
+    ("POST", "/api/parts/{part_id}/sourcing/refresh"),
     # Substitutes
     ("POST", "/api/parts/{part_id}/substitutes"),
     ("GET", "/api/parts/{part_id}/substitutes"),

--- a/backend/tests/test_sourcing_part_refresh_route.py
+++ b/backend/tests/test_sourcing_part_refresh_route.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import func, select
+
+import app.core.ratelimit as _ratelimit_mod
+from app.domain.sourcing.budget import BUDGET
+from app.domain.sourcing.models import SourcingCache
+from app.domain.sourcing.schemas import (
+    SourcingDistributor,
+    SourcingLinks,
+    SourcingOffer,
+    SourcingQuery,
+    SourcingSearchRaw,
+)
+from app.main import app
+from tests._factories import create_part, signup_user
+
+
+def _configure_sourcing(client: TestClient) -> None:
+    r = client.patch(
+        "/api/workspaces/current",
+        json={
+            "sourcing_provider": "trustedparts",
+            "sourcing_company_id": "company-123",
+            "sourcing_api_key": "api-key-456",
+            "sourcing_country_code": "CZ",
+            "sourcing_currency_code": "EUR",
+            "sourcing_preferred_distributors": ["DigiKey"],
+            "sourcing_use_cached_for_dashboards": False,
+        },
+    )
+    assert r.status_code == 200, r.text
+
+
+def _current_workspace_id(client: TestClient) -> uuid.UUID:
+    r = client.get("/api/workspaces/current")
+    assert r.status_code == 200, r.text
+    return uuid.UUID(r.json()["data"]["id"])
+
+
+def _cache_row_count(db, workspace_id: uuid.UUID) -> int:
+    return db.execute(
+        select(func.count())
+        .select_from(SourcingCache)
+        .where(SourcingCache.workspace_id == workspace_id)
+    ).scalar_one()
+
+
+class _FakeTrustedPartsClient:
+    calls: list[dict] = []
+
+    def __init__(self) -> None:
+        self.country_code = "CZ"
+        self.currency_code = "EUR"
+
+    def search(
+        self,
+        queries: list[SourcingQuery],
+        *,
+        in_stock_only: bool,
+        distributors: list[str] | None,
+        use_cached_data: bool,
+        **_kwargs,
+    ) -> SourcingSearchRaw:
+        query = queries[0]
+        self.calls.append(
+            {
+                "queries": [item.model_dump(exclude_none=True) for item in queries],
+                "country_code": self.country_code,
+                "currency_code": self.currency_code,
+                "in_stock_only": in_stock_only,
+                "distributors": distributors,
+                "use_cached_data": use_cached_data,
+            }
+        )
+        return SourcingSearchRaw(
+            offers=[
+                SourcingOffer(
+                    mpn=query.search_token,
+                    manufacturer="ST",
+                    description="Test offer",
+                    distributors=[
+                        SourcingDistributor(
+                            name="DigiKey",
+                            sku=f"{query.search_token}-DK",
+                            stock=42,
+                            unit_price=1.23,
+                            currency=self.currency_code,
+                            product_url="https://www.trustedparts.com/product",
+                        )
+                    ],
+                    links=SourcingLinks(
+                        primary=f"https://www.trustedparts.com/search/{query.search_token}"
+                    ),
+                )
+            ],
+            request_id=f"req-{len(self.calls)}",
+        )
+
+
+@pytest.fixture(autouse=True)
+def reset_sourcing_state(monkeypatch):
+    original_limiter_enabled = _ratelimit_mod.limiter.enabled
+    _ratelimit_mod.limiter.enabled = False
+    _FakeTrustedPartsClient.calls = []
+    BUDGET._events.clear()
+    try:
+        _ratelimit_mod.limiter.reset()
+    except Exception:
+        pass
+    monkeypatch.setattr(
+        "app.domain.sourcing.service.make_sourcing_provider",
+        lambda _workspace: _FakeTrustedPartsClient(),
+    )
+    yield
+    _ratelimit_mod.limiter.enabled = original_limiter_enabled
+    BUDGET._events.clear()
+    try:
+        _ratelimit_mod.limiter.reset()
+    except Exception:
+        pass
+
+
+def test_refresh_bypasses_existing_cache_row(authed_client):
+    _configure_sourcing(authed_client)
+    part_id = create_part(authed_client, name="STM32", mpn="STM32F103C8T6")
+
+    cached = authed_client.get(f"/api/parts/{part_id}/sourcing")
+    assert cached.status_code == 200, cached.text
+    assert cached.json()["data"]["cache_hit"] is False
+    assert len(_FakeTrustedPartsClient.calls) == 1
+
+    _FakeTrustedPartsClient.calls = []
+    refreshed = authed_client.post(f"/api/parts/{part_id}/sourcing/refresh")
+
+    assert refreshed.status_code == 200, refreshed.text
+    assert refreshed.json()["data"]["cache_hit"] is False
+    assert _FakeTrustedPartsClient.calls == [
+        {
+            "queries": [{"search_token": "STM32F103C8T6"}],
+            "country_code": "CZ",
+            "currency_code": "EUR",
+            "in_stock_only": False,
+            "distributors": ["DigiKey"],
+            "use_cached_data": False,
+        }
+    ]
+
+
+def test_refresh_replaces_cache_row_not_duplicates(authed_client, db):
+    _configure_sourcing(authed_client)
+    workspace_id = _current_workspace_id(authed_client)
+    part_id = create_part(authed_client, name="BAV99", mpn="BAV99")
+
+    cached = authed_client.get(f"/api/parts/{part_id}/sourcing")
+    assert cached.status_code == 200, cached.text
+    assert _cache_row_count(db, workspace_id) == 1
+
+    refreshed = authed_client.post(f"/api/parts/{part_id}/sourcing/refresh")
+
+    assert refreshed.status_code == 200, refreshed.text
+    assert _cache_row_count(db, workspace_id) == 1
+    row = db.execute(
+        select(SourcingCache).where(SourcingCache.workspace_id == workspace_id)
+    ).scalar_one()
+    assert row.response_json["request_id"] == "req-2"
+
+
+def test_part_without_mpn_returns_422(authed_client):
+    part_id = create_part(authed_client, name="Manual part")
+
+    r = authed_client.post(f"/api/parts/{part_id}/sourcing/refresh")
+
+    assert r.status_code == 422, r.text
+    body = r.json()
+    assert body["data"] is None
+    assert body["status"] == {
+        "category": "validation_error",
+        "message": "part has no MPN",
+    }
+    assert _FakeTrustedPartsClient.calls == []
+
+
+def test_foreign_part_returns_404(authed_client):
+    foreign_client = TestClient(app)
+    signup_user(foreign_client)
+    foreign_part_id = create_part(foreign_client, name="Foreign", mpn="BAT54C")
+
+    r = authed_client.post(f"/api/parts/{foreign_part_id}/sourcing/refresh")
+
+    assert r.status_code == 404, r.text
+    body = r.json()
+    assert body["data"] is None
+    assert body["status"]["category"] == "not_found"
+
+
+def test_rate_limit_at_6_per_minute(authed_client):
+    _ratelimit_mod.limiter.enabled = True
+    _configure_sourcing(authed_client)
+    part_id = create_part(authed_client, name="MAX232", mpn="MAX232")
+
+    for _index in range(6):
+        r = authed_client.post(f"/api/parts/{part_id}/sourcing/refresh")
+        assert r.status_code == 200, r.text
+
+    r = authed_client.post(f"/api/parts/{part_id}/sourcing/refresh")
+
+    assert r.status_code == 429, r.text
+    assert r.json()["status"]["category"] == "rate_limited"
+
+
+def test_budget_block_returns_503(authed_client):
+    _configure_sourcing(authed_client)
+    workspace_id = _current_workspace_id(authed_client)
+    part_id = create_part(authed_client, name="BAT54", mpn="BAT54C")
+    BUDGET.record(workspace_id, 250)
+
+    r = authed_client.post(f"/api/parts/{part_id}/sourcing/refresh")
+
+    assert r.status_code == 503, r.text
+    assert r.json()["status"] == {
+        "category": "server_error",
+        "message": "sourcing budget exhausted",
+    }
+    assert _FakeTrustedPartsClient.calls == []
+
+
+def test_refresh_consumes_budget(authed_client):
+    _configure_sourcing(authed_client)
+    workspace_id = _current_workspace_id(authed_client)
+    part_id = create_part(authed_client, name="LM358", mpn="LM358")
+
+    before = BUDGET._window_total(workspace_id, 10)
+    r = authed_client.post(f"/api/parts/{part_id}/sourcing/refresh")
+
+    assert r.status_code == 200, r.text
+    assert BUDGET._window_total(workspace_id, 10) == before + 1

--- a/docs/api/sourcing.md
+++ b/docs/api/sourcing.md
@@ -79,6 +79,50 @@ Parts without an MPN return a successful no-network response.
 - Source: `backend/app/api/routes/sourcing.py:132-220`.
 - Service: `backend/app/domain/sourcing/service.py:62-138`.
 
+### `POST /api/parts/{part_id}/sourcing/refresh`
+
+Force a live TrustedParts fetch for one part's MPN and replace the local cache row.
+
+**Request**
+
+Path: `part_id` is a part UUID in the current workspace. No body.
+
+**Response** — `200 OK` (envelope: `{ data, status }`)
+
+Shape matches `GET /api/parts/{part_id}/sourcing`. `cache_hit` is `false` when the upstream fetch succeeds.
+
+```json
+{
+  "data": {
+    "mpn": "STM32F103C8T6",
+    "offers": [],
+    "request_id": "trustedparts-request-id",
+    "powered_by": "TrustedParts",
+    "cache_hit": false,
+    "reason": "ok"
+  },
+  "status": { "category": "ok", "message": "OK" }
+}
+```
+
+**Errors**
+
+- `404 Not Found` — `part_id` is missing or belongs to another workspace.
+- `409 Conflict` — `{ "data": null, "status": { "category": "conflict", "message": "sourcing not configured" } }`.
+- `422 Unprocessable Entity` — `{ "data": null, "status": { "category": "validation_error", "message": "part has no MPN" } }`.
+- `429 Too Many Requests` — workspace rate limit: 6 requests/minute.
+- `502 Bad Gateway` — TrustedParts auth, rate-limit, timeout, upstream, or response-shape failure.
+- `503 Service Unavailable` — `{ "data": null, "status": { "category": "server_error", "message": "sourcing budget exhausted" } }`.
+
+**Notes**
+
+- The route validates `part_id` with `assert_in_workspace()` before reading the part MPN.
+- Refresh calls sourcing search with `use_cached_data=false`, `ttl_seconds=1800`, and `force_refresh=true`; the cache helper still upserts on `(workspace_id, query_hash)`.
+- Forced refreshes consume the in-process parts-count budget because they always call TrustedParts unless the hard budget check blocks first.
+- Source: `backend/app/api/routes/sourcing.py:214-274`.
+- Service: `backend/app/domain/sourcing/service.py:62-142`.
+- Cache: `backend/app/domain/sourcing/cache.py:28-72`.
+
 ### `POST /api/sourcing/search`
 
 Search TrustedParts for 1-50 exact MPNs using the current workspace's encrypted sourcing credentials.


### PR DESCRIPTION
## Summary
- Added member-gated `POST /api/parts/{part_id}/sourcing/refresh` with a 6/min per-workspace SlowAPI limit, workspace-scoped part lookup, no-MPN 422 envelope, and the same sourcing exception mapping as the existing part read route.
- Added explicit `force_refresh` support in the sourcing service/cache path so refresh bypasses valid cache rows while still upserting the existing `(workspace_id, query_hash)` row and recording live budget use.
- Added focused route tests and updated the sourcing API docs plus the `/api/parts` route snapshot.

## Validation
- `docker compose -f docker-compose.dev.yml exec backend pytest -k sourcing_part_refresh_route` could not run: `docker: command not found`.
- `docker compose -f docker-compose.dev.yml exec backend ruff check` could not run: `docker: command not found`.
- `cd backend && uv run --extra dev python -m pytest -k sourcing_part_refresh_route` -> 7 passed, 830 deselected, 1 warning.
- `cd backend && uv run --extra dev python -m pytest tests/test_parts_routing.py -q` -> 1 passed, 1 warning.
- `cd backend && uv run --extra dev ruff check app/api/routes/sourcing.py app/domain/sourcing/cache.py app/domain/sourcing/service.py tests/test_sourcing_part_refresh_route.py tests/test_parts_routing.py` -> All checks passed.
- `cd backend && LINT_CMD="uv run --extra dev ruff check app --output-format=concise" BASELINE_FILE="../.ruff-baseline.txt" WORK_DIR="." bash ../scripts/lint-delta.sh` -> no new violations (baseline: 159, current: 154, fixed since baseline: 5).
- `cd backend && uv run --extra dev ruff check` was also attempted as the closest full Ruff command; it fails on existing repository baseline violations, so lint-delta is the meaningful gate outside Docker.

## ttl_seconds=0 vs force_refresh
- Used a new `force_refresh: bool = False` kwarg instead of `ttl_seconds=0`.
- Reason: the existing cache helper checks for a valid cache row before TTL affects writes, and `ttl_seconds=0` would write an immediately expiring replacement instead of the required fresh row with the normal 30-minute expiry.

## Deviations
- Docker validation was unavailable in this environment because the `docker` executable is not installed.
- Updated `backend/tests/test_parts_routing.py` in addition to the named test file because this repo has a route snapshot that must include deliberate new `/api/parts` routes.

Refs #345