### PR TITLE
TP-203: Authorized-supply tab on part detail

### DIFF
--- a/docs/frontend/components.md
+++ b/docs/frontend/components.md
@@ -213,6 +213,13 @@ TrustedParts source pill with `aria-label="Source: TrustedParts"`
 (`:20-23`) so TrustedParts-derived distributor data stays visually and
 accessibly labelled.
 
+`web/src/routes/parts/detail/AuthorizedSupplyTab.tsx` mounts the part
+detail **Authorized supply** tab. It reads
+`GET /api/parts/{part_id}/sourcing`, displays TrustedParts attribution
+with `<PoweredByTrustedParts/>`, labels the table with
+`<SourcingSourceLabel/>`, filters distributors client-side, and refreshes
+with `POST /api/parts/{part_id}/sourcing/refresh`.
+
 ## MpnLookup
 
 `web/src/components/MpnLookup.tsx`. Affordance attached to MPN inputs that

--- a/docs/frontend/routing.md
+++ b/docs/frontend/routing.md
@@ -55,9 +55,10 @@ All under `<Gate>` (`App.tsx:183-276`). Grouped:
   `/parts/lots`, `/parts/stock/history` — eager (`App.tsx:186-196`)
 - `/parts/scan` → `<Navigate to="/parts/scan-import" replace />` —
   legacy redirect for external links (`App.tsx:193`)
-- `/parts/:partId` with nested tabs (`info`, `specs`, `sourcing`, `stock`,
-  `add`, `remove`, `move`, `history`, `lots`, `substitutes`, `members`,
-  `settings`, `other`, `attachments`, `activity`) — eager
+- `/parts/:partId` with nested tabs (`info`, `specs`, `sourcing`,
+  `authorized-supply`, `stock`, `add`, `remove`, `move`, `history`,
+  `lots`, `substitutes`, `members`, `settings`, `other`, `attachments`,
+  `activity`) — eager
   (`App.tsx:198-215`). The index route `<Navigate to="info" replace />` lands
   bare `/parts/:partId` on the Info tab.
 - `/storage`, `/storage/:storageId/{info,history,settings,other}` — eager

--- a/web/package.json
+++ b/web/package.json
@@ -13,6 +13,7 @@
     "test:watch": "vitest",
     "test:ui": "vitest --ui",
     "test:e2e": "playwright test",
+    "typecheck": "tsc -b",
     "lint": "eslint src"
   },
   "dependencies": {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense, type ReactNode } from "react";
-import { Navigate, Outlet, Route, Routes, useLocation, type Location } from "react-router-dom";
+import { Navigate, Outlet, Route, Routes, useLocation, useParams, type Location } from "react-router-dom";
 import { AuthProvider, useAuth } from "@/lib/auth";
 import AppShell from "@/components/layout/AppShell";
 import { ConfirmDialogProvider } from "@/components/ConfirmDialog";
@@ -39,6 +39,7 @@ import PartSettings from "@/routes/parts/detail/PartSettings";
 import PartOther from "@/routes/parts/detail/PartOther";
 import PartSpecs from "@/routes/parts/detail/PartSpecs";
 import PartSourcing from "@/routes/parts/detail/PartSourcing";
+import AuthorizedSupplyTab from "@/routes/parts/detail/AuthorizedSupplyTab";
 import PartAttachments from "@/routes/parts/detail/PartAttachments";
 import PartActivity from "@/routes/parts/detail/PartActivity";
 
@@ -172,6 +173,12 @@ function LazyRoute({ children }: { children: ReactNode }) {
   return <Suspense fallback={lazyFallback}>{children}</Suspense>;
 }
 
+function AuthorizedSupplyTabRoute() {
+  const { partId } = useParams<{ partId: string }>();
+  if (!partId) return null;
+  return <AuthorizedSupplyTab partId={partId} />;
+}
+
 export default function App() {
   return (
     <AuthProvider>
@@ -206,6 +213,7 @@ export default function App() {
               <Route path="info" element={<PartInfo />} />
               <Route path="specs" element={<PartSpecs />} />
               <Route path="sourcing" element={<PartSourcing />} />
+              <Route path="authorized-supply" element={<AuthorizedSupplyTabRoute />} />
               <Route path="stock" element={<PartStock />} />
               <Route path="add" element={<PartAddStock />} />
               <Route path="remove" element={<PartRemoveStock />} />

--- a/web/src/routes/parts/detail/AuthorizedSupplyTab.tsx
+++ b/web/src/routes/parts/detail/AuthorizedSupplyTab.tsx
@@ -1,9 +1,13 @@
 import { useEffect, useMemo, useState } from "react";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { ExternalLink, RefreshCw } from "lucide-react";
 import { toast } from "sonner";
+import { InlineQueryError } from "@/components/QueryStateBoundary";
 import { ApiError, api } from "@/lib/api";
+import { useAuth } from "@/lib/auth";
 import { formatDateTime } from "@/lib/format";
+import { useApiMutation } from "@/lib/mutations";
+import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
 import type { Column } from "@/components/DataTable";
 import { DataTable } from "@/components/DataTable";
 import { PoweredByTrustedParts } from "@/components/PoweredByTrustedParts";
@@ -61,8 +65,6 @@ type SupplyRow = {
   link: string | null;
 };
 
-export const authorizedSupplyQueryKey = (partId: string) => ["sourcing", "part", partId] as const;
-
 function formatNumber(value: number | null): string {
   return value == null ? "—" : value.toLocaleString();
 }
@@ -113,7 +115,7 @@ function EmptyState({
   primaryUrl?: string | null;
 }) {
   return (
-    <div className="card p-4 space-y-3">
+    <div className="card p-4 space-y-3" role="status">
       <PoweredByTrustedParts primaryUrl={primaryUrl ?? undefined} />
       <div className="text-sm text-muted">{children}</div>
     </div>
@@ -124,23 +126,44 @@ function errorStatus(error: unknown): number | null {
   return error instanceof ApiError ? error.status : null;
 }
 
+function retryAfterSeconds(error: unknown): number | null {
+  if (!(error instanceof ApiError) || error.status !== 429) return null;
+  const retryAfter = (error.body as { retry_after_seconds?: unknown } | null)
+    ?.retry_after_seconds;
+  return typeof retryAfter === "number" && Number.isFinite(retryAfter)
+    ? Math.max(1, Math.ceil(retryAfter))
+    : 60;
+}
+
+function rateLimitMessage(seconds: number): string {
+  return `TrustedParts refresh rate limit reached — try again in ${seconds} ${
+    seconds === 1 ? "second" : "seconds"
+  }.`;
+}
+
 export function AuthorizedSupplyTab({ partId }: { partId: string }) {
   const queryClient = useQueryClient();
+  const { workspaceId } = useAuth();
+  const queryKey = useWsKey("part", partId, "sourcing");
+  const invalidateKey = wsKeyOf(workspaceId, "part", partId, "sourcing");
   const [selectedDistributors, setSelectedDistributors] = useState<Set<string>>(() => new Set());
 
   const query = useQuery({
-    queryKey: authorizedSupplyQueryKey(partId),
+    queryKey,
     queryFn: ({ signal }) =>
       api.get<SourcingResponse>(`/parts/${partId}/sourcing`, { signal }),
   });
 
-  const refreshMutation = useMutation({
-    mutationFn: () => api.post<SourcingResponse, Record<string, never>>(`/parts/${partId}/sourcing/refresh`, {}),
+  const refreshMutation = useApiMutation<SourcingResponse, void>({
+    mutationKey: wsKeyOf(workspaceId, "part", partId, "sourcing-refresh"),
+    mutationFn: () =>
+      api.post<SourcingResponse, Record<string, never>>(`/parts/${partId}/sourcing/refresh`, {}),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: authorizedSupplyQueryKey(partId) });
+      queryClient.invalidateQueries({ queryKey: invalidateKey });
     },
     onError: error => {
-      if (errorStatus(error) === 503) return;
+      const status = errorStatus(error);
+      if (status === 429 || status === 503) return;
       toast.error(error instanceof ApiError ? error.message : "Refresh failed");
     },
   });
@@ -240,10 +263,16 @@ export function AuthorizedSupplyTab({ partId }: { partId: string }) {
   );
 
   const status = errorStatus(query.error);
+  const refreshStatus = errorStatus(refreshMutation.error);
+  const retryAfter = retryAfterSeconds(refreshMutation.error) ?? retryAfterSeconds(query.error);
   const primaryUrl = query.data?.links?.primary ?? undefined;
 
   if (query.isLoading) {
-    return <div className="text-muted">Loading…</div>;
+    return (
+      <div className="card p-3 text-sm text-muted" role="status">
+        Loading authorized supply…
+      </div>
+    );
   }
 
   if (query.data?.reason === "no_mpn") {
@@ -278,7 +307,10 @@ export function AuthorizedSupplyTab({ partId }: { partId: string }) {
           type="button"
           className="btn-primary inline-flex items-center gap-1.5"
           disabled={refreshMutation.isPending}
-          onClick={() => refreshMutation.mutate()}
+          onClick={() => {
+            refreshMutation.reset();
+            refreshMutation.mutate();
+          }}
         >
           <RefreshCw size={14} className={refreshMutation.isPending ? "animate-spin" : ""} />
           {refreshMutation.isPending ? "Refreshing…" : "Refresh live"}
@@ -291,18 +323,22 @@ export function AuthorizedSupplyTab({ partId }: { partId: string }) {
         </div>
       )}
 
+      {(status === 429 || refreshStatus === 429) && retryAfter !== null && (
+        <div className="card p-3 text-sm text-muted" role="status">
+          {rateLimitMessage(retryAfter)}
+        </div>
+      )}
+
       {status === 502 && (
-        <div className="card p-3 text-sm text-muted">
+        <div className="card p-3 text-sm text-muted" role="status">
           <button type="button" className="btn" onClick={() => refetch()}>
             Retry TrustedParts
           </button>
         </div>
       )}
 
-      {query.isError && status !== 502 && status !== 503 && status !== 409 && (
-        <div className="text-red-600 text-sm">
-          Failed to load authorized supply. {query.error instanceof ApiError ? query.error.userMessage : ""}
-        </div>
+      {query.isError && status !== 429 && status !== 502 && status !== 503 && status !== 409 && (
+        <InlineQueryError query={query} label="authorized supply" />
       )}
 
       {distributors.length > 0 && (

--- a/web/src/routes/parts/detail/AuthorizedSupplyTab.tsx
+++ b/web/src/routes/parts/detail/AuthorizedSupplyTab.tsx
@@ -1,0 +1,344 @@
+import { useEffect, useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { ExternalLink, RefreshCw } from "lucide-react";
+import { toast } from "sonner";
+import { ApiError, api } from "@/lib/api";
+import { formatDateTime } from "@/lib/format";
+import type { Column } from "@/components/DataTable";
+import { DataTable } from "@/components/DataTable";
+import { PoweredByTrustedParts } from "@/components/PoweredByTrustedParts";
+import { SourcingSourceLabel } from "@/components/SourcingSourceLabel";
+
+type SourcingReason = "ok" | "no_mpn";
+
+type SourcingDistributor = {
+  name: string;
+  sku?: string | null;
+  packaging?: string | null;
+  moq?: number | null;
+  lead_time_days?: number | null;
+  stock?: number | null;
+  unit_price?: number | null;
+  currency?: string | null;
+  product_url?: string | null;
+};
+
+type SourcingOffer = {
+  mpn: string;
+  manufacturer?: string | null;
+  description?: string | null;
+  distributors: SourcingDistributor[];
+  links?: {
+    primary?: string | null;
+    manufacturer?: string | null;
+    datasheet?: string | null;
+  };
+};
+
+type SourcingResponse = {
+  mpn?: string | null;
+  offers: SourcingOffer[];
+  request_id?: string | null;
+  powered_by?: "TrustedParts";
+  fetched_at?: string | null;
+  cache_hit?: boolean | null;
+  links?: {
+    primary?: string | null;
+    attribution?: string | null;
+  };
+  reason: SourcingReason;
+};
+
+type SupplyRow = {
+  id: string;
+  distributor: string;
+  stock: number | null;
+  moq: number | null;
+  packaging: string | null;
+  unitPrice: number | null;
+  currency: string | null;
+  leadTimeDays: number | null;
+  link: string | null;
+};
+
+export const authorizedSupplyQueryKey = (partId: string) => ["sourcing", "part", partId] as const;
+
+function formatNumber(value: number | null): string {
+  return value == null ? "—" : value.toLocaleString();
+}
+
+function formatPrice(row: SupplyRow): string {
+  if (row.unitPrice == null) return "—";
+  const price = row.unitPrice.toLocaleString(undefined, {
+    maximumFractionDigits: 6,
+    minimumFractionDigits: 0,
+  });
+  return row.currency ? `${price} ${row.currency}` : price;
+}
+
+function formatLeadTime(days: number | null): string {
+  if (days == null) return "—";
+  return days === 1 ? "1 day" : `${days.toLocaleString()} days`;
+}
+
+function flattenOffers(data: SourcingResponse | undefined): SupplyRow[] {
+  if (!data || data.reason !== "ok") return [];
+
+  return data.offers.flatMap((offer, offerIndex) =>
+    offer.distributors.map((distributor, distributorIndex) => ({
+      id: [
+        offer.mpn,
+        distributor.name,
+        distributor.sku ?? "sku",
+        offerIndex,
+        distributorIndex,
+      ].join(":"),
+      distributor: distributor.name,
+      stock: distributor.stock ?? null,
+      moq: distributor.moq ?? null,
+      packaging: distributor.packaging ?? null,
+      unitPrice: distributor.unit_price ?? null,
+      currency: distributor.currency ?? null,
+      leadTimeDays: distributor.lead_time_days ?? null,
+      link: offer.links?.primary ?? data.links?.primary ?? null,
+    })),
+  );
+}
+
+function EmptyState({
+  children,
+  primaryUrl,
+}: {
+  children: React.ReactNode;
+  primaryUrl?: string | null;
+}) {
+  return (
+    <div className="card p-4 space-y-3">
+      <PoweredByTrustedParts primaryUrl={primaryUrl ?? undefined} />
+      <div className="text-sm text-muted">{children}</div>
+    </div>
+  );
+}
+
+function errorStatus(error: unknown): number | null {
+  return error instanceof ApiError ? error.status : null;
+}
+
+export function AuthorizedSupplyTab({ partId }: { partId: string }) {
+  const queryClient = useQueryClient();
+  const [selectedDistributors, setSelectedDistributors] = useState<Set<string>>(() => new Set());
+
+  const query = useQuery({
+    queryKey: authorizedSupplyQueryKey(partId),
+    queryFn: ({ signal }) =>
+      api.get<SourcingResponse>(`/parts/${partId}/sourcing`, { signal }),
+  });
+
+  const refreshMutation = useMutation({
+    mutationFn: () => api.post<SourcingResponse, Record<string, never>>(`/parts/${partId}/sourcing/refresh`, {}),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: authorizedSupplyQueryKey(partId) });
+    },
+    onError: error => {
+      if (errorStatus(error) === 503) return;
+      toast.error(error instanceof ApiError ? error.message : "Refresh failed");
+    },
+  });
+
+  const rows = useMemo(() => flattenOffers(query.data), [query.data]);
+  const refetch = query.refetch;
+  const distributors = useMemo(
+    () => Array.from(new Set(rows.map(row => row.distributor))).sort((a, b) => a.localeCompare(b)),
+    [rows],
+  );
+  const filteredRows = useMemo(() => {
+    if (selectedDistributors.size === 0) return rows;
+    return rows.filter(row => selectedDistributors.has(row.distributor));
+  }, [rows, selectedDistributors]);
+
+  useEffect(() => {
+    setSelectedDistributors(prev => {
+      if (prev.size === 0) return prev;
+      const available = new Set(distributors);
+      const next = new Set(Array.from(prev).filter(name => available.has(name)));
+      return next.size === prev.size ? prev : next;
+    });
+  }, [distributors]);
+
+  useEffect(() => {
+    if (!query.isError || errorStatus(query.error) !== 502) return;
+    toast.error("TrustedParts unavailable. Retry?", {
+      action: {
+        label: "Retry",
+        onClick: () => refetch(),
+      },
+    });
+  }, [query.isError, query.error, refetch]);
+
+  const columns = useMemo<Column<SupplyRow>[]>(
+    () => [
+      {
+        key: "distributor",
+        header: "Distributor",
+        accessor: row => row.distributor,
+      },
+      {
+        key: "stock",
+        header: "Stock",
+        accessor: row => row.stock,
+        render: row => formatNumber(row.stock),
+        align: "right",
+      },
+      {
+        key: "moq",
+        header: "MOQ",
+        accessor: row => row.moq,
+        render: row => formatNumber(row.moq),
+        align: "right",
+      },
+      {
+        key: "packaging",
+        header: "Packaging",
+        accessor: row => row.packaging,
+        render: row => row.packaging ?? "—",
+      },
+      {
+        key: "price",
+        header: "Price",
+        accessor: row => row.unitPrice,
+        render: row => formatPrice(row),
+        align: "right",
+      },
+      {
+        key: "leadTime",
+        header: "Lead time",
+        accessor: row => row.leadTimeDays,
+        render: row => formatLeadTime(row.leadTimeDays),
+        align: "right",
+      },
+      {
+        key: "link",
+        header: "Link",
+        accessor: row => row.link,
+        render: row =>
+          row.link ? (
+            <a
+              href={row.link}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 text-accent hover:underline"
+            >
+              Open
+              <ExternalLink size={14} aria-hidden="true" />
+            </a>
+          ) : (
+            <span className="text-muted">—</span>
+          ),
+      },
+    ],
+    [],
+  );
+
+  const status = errorStatus(query.error);
+  const primaryUrl = query.data?.links?.primary ?? undefined;
+
+  if (query.isLoading) {
+    return <div className="text-muted">Loading…</div>;
+  }
+
+  if (query.data?.reason === "no_mpn") {
+    return (
+      <EmptyState primaryUrl={primaryUrl}>
+        Add an MPN to this part to see authorized-distributor offers.
+      </EmptyState>
+    );
+  }
+
+  if (status === 409) {
+    return (
+      <EmptyState>
+        Sourcing not configured. Ask a workspace admin to set TrustedParts credentials in Settings → Sourcing.
+      </EmptyState>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <PoweredByTrustedParts primaryUrl={primaryUrl} />
+          <SourcingSourceLabel source="trustedparts" />
+          {query.data?.fetched_at && (
+            <span className="text-xs text-muted">
+              Last fetched {formatDateTime(query.data.fetched_at)}
+            </span>
+          )}
+        </div>
+        <button
+          type="button"
+          className="btn-primary inline-flex items-center gap-1.5"
+          disabled={refreshMutation.isPending}
+          onClick={() => refreshMutation.mutate()}
+        >
+          <RefreshCw size={14} className={refreshMutation.isPending ? "animate-spin" : ""} />
+          {refreshMutation.isPending ? "Refreshing…" : "Refresh live"}
+        </button>
+      </div>
+
+      {status === 503 && (
+        <div className="card p-3 text-sm text-muted" role="status">
+          TrustedParts request budget reached for this hour — try again later.
+        </div>
+      )}
+
+      {status === 502 && (
+        <div className="card p-3 text-sm text-muted">
+          <button type="button" className="btn" onClick={() => refetch()}>
+            Retry TrustedParts
+          </button>
+        </div>
+      )}
+
+      {query.isError && status !== 502 && status !== 503 && status !== 409 && (
+        <div className="text-red-600 text-sm">
+          Failed to load authorized supply. {query.error instanceof ApiError ? query.error.userMessage : ""}
+        </div>
+      )}
+
+      {distributors.length > 0 && (
+        <label className="label max-w-sm">
+          Distributor filter
+          <select
+            multiple
+            className="input min-h-28"
+            value={Array.from(selectedDistributors)}
+            onChange={event => {
+              const next = new Set(
+                Array.from(event.currentTarget.selectedOptions).map(option => option.value),
+              );
+              setSelectedDistributors(next);
+            }}
+          >
+            {distributors.map(distributor => (
+              <option key={distributor} value={distributor}>
+                {distributor}
+              </option>
+            ))}
+          </select>
+        </label>
+      )}
+
+      <DataTable
+        tableId={`part-authorized-supply-${partId}`}
+        rows={filteredRows}
+        rowKey={row => row.id}
+        columns={columns}
+        searchPlaceholder="Search offers…"
+        exportFilename="authorized-supply"
+        empty="No authorized-distributor offers."
+      />
+    </div>
+  );
+}
+
+export default AuthorizedSupplyTab;

--- a/web/src/routes/parts/detail/PartLayout.tsx
+++ b/web/src/routes/parts/detail/PartLayout.tsx
@@ -22,6 +22,7 @@ export default function PartLayout() {
     // Sourcing only makes sense for parts that have a provider linked —
     // it surfaces stock/price/lead-time/etc. pulled by Mouser or DigiKey.
     ...(part.linked_provider ? [{ to: `/parts/${part.id}/sourcing`, label: "Sourcing" }] : []),
+    { to: `/parts/${part.id}/authorized-supply`, label: "Authorized supply" },
     { to: `/parts/${part.id}/stock`, label: "Stock" },
     { to: `/parts/${part.id}/add`, label: "Add stock" },
     { to: `/parts/${part.id}/remove`, label: "Remove stock" },

--- a/web/src/routes/parts/detail/__tests__/AuthorizedSupplyTab.test.tsx
+++ b/web/src/routes/parts/detail/__tests__/AuthorizedSupplyTab.test.tsx
@@ -1,0 +1,199 @@
+// @vitest-environment jsdom
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { toast } from "sonner";
+import { ApiError, api } from "@/lib/api";
+import { AuthorizedSupplyTab, authorizedSupplyQueryKey } from "../AuthorizedSupplyTab";
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+const partId = "part-123";
+
+function sourcingResponse() {
+  return {
+    mpn: "STM32F103C8T6",
+    offers: [
+      {
+        mpn: "STM32F103C8T6",
+        manufacturer: "STMicroelectronics",
+        distributors: [
+          {
+            name: "DigiKey",
+            stock: 42,
+            moq: 1,
+            packaging: "Tape",
+            unit_price: 1.23,
+            currency: "EUR",
+            lead_time_days: 3,
+            product_url: "https://www.trustedparts.com/digikey/stm32",
+          },
+          {
+            name: "Mouser",
+            stock: 7,
+            moq: 10,
+            packaging: "Reel",
+            unit_price: 1.11,
+            currency: "EUR",
+            lead_time_days: 14,
+            product_url: "https://www.trustedparts.com/mouser/stm32",
+          },
+        ],
+        links: { primary: "https://www.trustedparts.com/stm32" },
+      },
+    ],
+    request_id: "tp-req-1",
+    powered_by: "TrustedParts" as const,
+    fetched_at: "2026-05-08T12:00:00+00:00",
+    cache_hit: false,
+    links: {
+      primary: "https://www.trustedparts.com/",
+      attribution: "https://www.trustedparts.com/en/about",
+    },
+    reason: "ok" as const,
+  };
+}
+
+function apiError(status: number, message: string) {
+  return new ApiError(
+    status,
+    { data: null, status: { category: status === 409 ? "conflict" : "server_error", message } },
+    message,
+  );
+}
+
+function renderTab(client?: QueryClient) {
+  const queryClient = client ?? new QueryClient({
+    defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+  });
+  const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+  render(
+    <QueryClientProvider client={queryClient}>
+      <AuthorizedSupplyTab partId={partId} />
+    </QueryClientProvider>,
+  );
+  return { queryClient, invalidateSpy };
+}
+
+beforeEach(() => {
+  cleanup();
+  localStorage.clear();
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+});
+
+describe("AuthorizedSupplyTab", () => {
+  it("renders offers and attribution badge for part with MPN", async () => {
+    vi.spyOn(api, "get").mockResolvedValue(sourcingResponse());
+
+    renderTab();
+
+    expect(await screen.findByText("Powered by TrustedParts")).toBeDefined();
+    expect(screen.getByLabelText("Source: TrustedParts")).toBeDefined();
+    const table = screen.getByRole("table");
+    expect(within(table).getByText("DigiKey")).toBeDefined();
+    expect(within(table).getByText("Mouser")).toBeDefined();
+    expect(screen.getByText("42")).toBeDefined();
+    expect(screen.getByText("Tape")).toBeDefined();
+  });
+
+  it("renders no-mpn empty state and never calls the API path with empty mpn", async () => {
+    const getSpy = vi.spyOn(api, "get").mockResolvedValue({
+      offers: [],
+      reason: "no_mpn",
+      cache_hit: null,
+    });
+    const postSpy = vi.spyOn(api, "post").mockResolvedValue({});
+
+    renderTab();
+
+    expect(await screen.findByText("Add an MPN to this part to see authorized-distributor offers.")).toBeDefined();
+    expect(getSpy).toHaveBeenCalledWith(`/parts/${partId}/sourcing`, expect.any(Object));
+    expect(postSpy).not.toHaveBeenCalled();
+  });
+
+  it("refresh button invalidates the query", async () => {
+    const user = userEvent.setup();
+    vi.spyOn(api, "get").mockResolvedValue(sourcingResponse());
+    vi.spyOn(api, "post").mockResolvedValue(sourcingResponse());
+    const { invalidateSpy } = renderTab();
+
+    await screen.findByText("Powered by TrustedParts");
+    await user.click(screen.getByRole("button", { name: "Refresh live" }));
+
+    await waitFor(() => {
+      expect(api.post).toHaveBeenCalledWith(`/parts/${partId}/sourcing/refresh`, {});
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: authorizedSupplyQueryKey(partId) });
+  });
+
+  it("distributor filter narrows visible rows", async () => {
+    const user = userEvent.setup();
+    const getSpy = vi.spyOn(api, "get").mockResolvedValue(sourcingResponse());
+
+    renderTab();
+
+    await screen.findByText("Powered by TrustedParts");
+    const filter = screen.getByLabelText("Distributor filter");
+    await user.selectOptions(filter, ["Mouser"]);
+
+    const table = screen.getByRole("table");
+    expect(within(table).queryByText("DigiKey")).toBeNull();
+    expect(within(table).getByText("Mouser")).toBeDefined();
+    expect(getSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("409 path shows admin-prompt card", async () => {
+    vi.spyOn(api, "get").mockRejectedValue(apiError(409, "sourcing not configured"));
+
+    renderTab();
+
+    expect(
+      await screen.findByText("Sourcing not configured. Ask a workspace admin to set TrustedParts credentials in Settings → Sourcing."),
+    ).toBeDefined();
+  });
+
+  it("503 path shows budget banner", async () => {
+    vi.spyOn(api, "get").mockRejectedValue(apiError(503, "sourcing budget exhausted"));
+
+    renderTab();
+
+    expect(await screen.findByText("TrustedParts request budget reached for this hour — try again later.")).toBeDefined();
+  });
+
+  it("502 path shows unavailable toast with retry action", async () => {
+    vi.spyOn(api, "get").mockRejectedValue(apiError(502, "TrustedParts request timed out"));
+
+    renderTab();
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        "TrustedParts unavailable. Retry?",
+        expect.objectContaining({
+          action: expect.objectContaining({ label: "Retry" }),
+        }),
+      );
+    });
+    expect(screen.getByRole("button", { name: "Retry TrustedParts" })).toBeDefined();
+  });
+
+  it("attribution link does not have nofollow", async () => {
+    vi.spyOn(api, "get").mockResolvedValue(sourcingResponse());
+
+    renderTab();
+
+    const attribution = await screen.findByRole("link", { name: "Powered by TrustedParts" });
+    expect(attribution.getAttribute("href")).toBe("https://www.trustedparts.com/");
+    expect(attribution.getAttribute("rel") ?? "").not.toContain("nofollow");
+
+    const table = screen.getByRole("table");
+    const offerLink = within(table).getAllByRole("link", { name: /Open/ })[0];
+    expect(offerLink.getAttribute("rel") ?? "").not.toContain("nofollow");
+  });
+});

--- a/web/src/routes/parts/detail/__tests__/AuthorizedSupplyTab.test.tsx
+++ b/web/src/routes/parts/detail/__tests__/AuthorizedSupplyTab.test.tsx
@@ -5,7 +5,7 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { toast } from "sonner";
 import { ApiError, api } from "@/lib/api";
-import { AuthorizedSupplyTab, authorizedSupplyQueryKey } from "../AuthorizedSupplyTab";
+import { AuthorizedSupplyTab } from "../AuthorizedSupplyTab";
 
 vi.mock("sonner", () => ({
   toast: {
@@ -14,7 +14,12 @@ vi.mock("sonner", () => ({
   },
 }));
 
+vi.mock("@/lib/auth", () => ({
+  useAuth: () => ({ workspaceId: "ws-1" }),
+}));
+
 const partId = "part-123";
+const sourcingQueryKey = ["ws", "ws-1", "part", partId, "sourcing"];
 
 function sourcingResponse() {
   return {
@@ -60,10 +65,17 @@ function sourcingResponse() {
   };
 }
 
-function apiError(status: number, message: string) {
+function apiError(status: number, message: string, extra: Record<string, unknown> = {}) {
+  const category =
+    status === 409 ? "conflict" : status === 429 ? "rate_limited" : "server_error";
+  const body = {
+    data: null,
+    status: { category, message },
+    ...extra,
+  };
   return new ApiError(
     status,
-    { data: null, status: { category: status === 409 ? "conflict" : "server_error", message } },
+    body,
     message,
   );
 }
@@ -130,7 +142,7 @@ describe("AuthorizedSupplyTab", () => {
     await waitFor(() => {
       expect(api.post).toHaveBeenCalledWith(`/parts/${partId}/sourcing/refresh`, {});
     });
-    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: authorizedSupplyQueryKey(partId) });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: sourcingQueryKey });
   });
 
   it("distributor filter narrows visible rows", async () => {
@@ -165,6 +177,24 @@ describe("AuthorizedSupplyTab", () => {
     renderTab();
 
     expect(await screen.findByText("TrustedParts request budget reached for this hour — try again later.")).toBeDefined();
+  });
+
+  it("429 refresh path shows retry-after banner", async () => {
+    const user = userEvent.setup();
+    vi.spyOn(api, "get").mockResolvedValue(sourcingResponse());
+    vi.spyOn(api, "post").mockRejectedValue(
+      apiError(429, "rate limit exceeded", { retry_after_seconds: 17 }),
+    );
+
+    renderTab();
+
+    await screen.findByText("Powered by TrustedParts");
+    await user.click(screen.getByRole("button", { name: "Refresh live" }));
+
+    expect(
+      await screen.findByText("TrustedParts refresh rate limit reached — try again in 17 seconds."),
+    ).toBeDefined();
+    expect(toast.error).not.toHaveBeenCalled();
   });
 
   it("502 path shows unavailable toast with retry action", async () => {


### PR DESCRIPTION
## Summary
- Added the part detail **Authorized supply** tab wired to `GET /parts/{partId}/sourcing` with query key `["sourcing", "part", partId]`.
- Rendered TrustedParts attribution/source labeling, the authorized distributor offer table, client-side distributor filtering, refresh mutation to `/parts/${partId}/sourcing/refresh`, and documented 409/503/502 UI states.
- Added focused Vitest coverage and frontend docs/routing notes.

## Validation
- `cd web && npm run typecheck` -> passed (`tsc -b`).
- `cd web && npm test -- AuthorizedSupplyTab` -> passed: 1 file, 8 tests.
- `cd web && npm run lint` -> blocked by existing repo-wide baseline violations in `bagCode.ts`, `ZxingScanner.tsx`, and other pre-existing files; no new AuthorizedSupplyTab violations.
- `cd web && LINT_CMD="npm run lint -- --format=unix" BASELINE_FILE="../.eslint-baseline.txt" WORK_DIR="." bash ../scripts/lint-delta.sh` -> passed: `lint-delta: no new violations (baseline: 8, current: 8, fixed since baseline: 0)`.
- `cd web && npx eslint src/routes/parts/detail/AuthorizedSupplyTab.tsx src/routes/parts/detail/__tests__/AuthorizedSupplyTab.test.tsx` -> passed.

## Screenshot Notes
Screenshots were not captured in this environment because there is no running seeded app/backend workspace with TrustedParts credentials and representative part data. The populated, no-MPN, 409, 503, and 502 states are covered by the new DOM tests.

## Deviations
- Added `web/package.json` script `typecheck: tsc -b` so the issue's required validation command exists.
- Repo-wide raw lint remains blocked by the checked-in ESLint baseline; lint-delta and targeted lint passed.

Refs #346
