### PR TITLE
TP-302: BOM sourcing endpoint

### DIFF
--- a/backend/app/api/routes/sourcing.py
+++ b/backend/app/api/routes/sourcing.py
@@ -13,6 +13,7 @@ from app.core.deps import CurrentUser, CurrentWorkspace, require_role
 from app.core.ratelimit import limiter, workspace_key
 from app.core.responses import err, ok
 from app.domain.parts.models import Part
+from app.domain.projects.models import Project
 from app.domain.sourcing import (
     SourcingAuthError,
     SourcingClientError,
@@ -21,13 +22,14 @@ from app.domain.sourcing import (
 )
 from app.domain.sourcing import service as sourcing_service
 from app.domain.sourcing.factory import make_sourcing_provider
-from app.domain.sourcing.schemas import SourcingQuery, SourcingSearchIn
+from app.domain.sourcing.schemas import SourcingBomIn, SourcingQuery, SourcingSearchIn
 from app.domain.sourcing.service import SourcingBudgetBlocked, SourcingNotConfigured
 from app.infra.db import get_db
 
 router = APIRouter()
 search_router = APIRouter()
 parts_router = APIRouter()
+projects_router = APIRouter()
 
 _TEST_PROBE_TOKEN = "TEST_PROBE_DO_NOT_BUY"
 _PART_SOURCING_TTL_SECONDS = 1800
@@ -90,6 +92,69 @@ def search_sourcing(
             currency=payload.currency,
             in_stock_only=payload.in_stock_only,
             distributors=payload.distributors,
+            use_cached_data=payload.use_cached_data,
+            requested_by=user.id,
+        )
+    except SourcingNotConfigured:
+        return _error_response(request, 409, "conflict", "sourcing not configured")
+    except SourcingBudgetBlocked:
+        return _error_response(request, 503, "server_error", "sourcing budget exhausted")
+    except SourcingAuthError:
+        return _error_response(
+            request,
+            502,
+            "server_error",
+            "TrustedParts rejected sourcing credentials",
+        )
+    except SourcingRateLimitError:
+        return _error_response(
+            request,
+            502,
+            "server_error",
+            "TrustedParts rate limit reached",
+        )
+    except SourcingTimeoutError:
+        return _error_response(
+            request,
+            502,
+            "server_error",
+            "TrustedParts request timed out",
+        )
+    except SourcingClientError:
+        return _error_response(
+            request,
+            502,
+            "server_error",
+            "TrustedParts sourcing request failed",
+        )
+
+    return ok(out.model_dump(mode="json"))
+
+
+@projects_router.post(
+    "/{project_id}/sourcing",
+    dependencies=[Depends(require_role("member"))],
+)
+@limiter.limit("30/minute", key_func=workspace_key)
+def source_project_bom(
+    request: Request,
+    project_id: UUID,
+    payload: SourcingBomIn,
+    ws: CurrentWorkspace,
+    user: CurrentUser,
+    db: Session = Depends(get_db),
+):
+    project = assert_in_workspace(db, Project, project_id, ws.id, label="project")
+    try:
+        out = sourcing_service.source_bom(
+            db,
+            workspace=ws,
+            project=project,
+            build_quantity=payload.build_quantity,
+            country=payload.country,
+            currency=payload.currency,
+            distributors=payload.distributors,
+            in_stock_only=payload.in_stock_only,
             use_cached_data=payload.use_cached_data,
             requested_by=user.id,
         )

--- a/backend/app/domain/sourcing/pricing.py
+++ b/backend/app/domain/sourcing/pricing.py
@@ -1,0 +1,58 @@
+"""Pricing helpers for sourcing offers."""
+from __future__ import annotations
+
+from collections.abc import Iterable
+from decimal import Decimal
+from typing import Any
+
+
+def best_unit_price_at_qty(
+    price_breaks: Iterable[Any],
+    qty: int,
+) -> tuple[Decimal, int] | None:
+    """Return the applicable unit price and break quantity for `qty`.
+
+    If `qty` is below the smallest break, the smallest break applies. If it
+    is above the largest break, the largest break applies.
+    """
+    breaks = [
+        item
+        for item in (_normalise_break(item) for item in price_breaks)
+        if item is not None
+    ]
+    breaks.sort(key=lambda item: item[0])
+    if not breaks or qty < 1:
+        return None
+
+    selected = breaks[0]
+    for candidate in breaks:
+        if candidate[0] > qty:
+            break
+        selected = candidate
+    quantity, unit_price = selected
+    return unit_price, quantity
+
+
+def extended_price(price_breaks: Iterable[Any], qty: int) -> Decimal | None:
+    best = best_unit_price_at_qty(price_breaks, qty)
+    if best is None:
+        return None
+    unit_price, _break_quantity = best
+    return unit_price * Decimal(qty)
+
+
+def _normalise_break(item: Any) -> tuple[int, Decimal] | None:
+    if isinstance(item, dict):
+        quantity = item.get("quantity")
+        unit_price = item.get("unit_price")
+    else:
+        quantity = getattr(item, "quantity", None)
+        unit_price = getattr(item, "unit_price", None)
+
+    if quantity is None or unit_price is None:
+        return None
+
+    quantity_int = int(quantity)
+    if quantity_int < 1:
+        return None
+    return quantity_int, Decimal(str(unit_price))

--- a/backend/app/domain/sourcing/schemas.py
+++ b/backend/app/domain/sourcing/schemas.py
@@ -2,7 +2,9 @@
 from __future__ import annotations
 
 from datetime import datetime
+from decimal import Decimal
 from typing import Literal
+from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
@@ -120,4 +122,83 @@ class SourcingSearchOut(BaseModel):
     powered_by: Literal["TrustedParts"] = "TrustedParts"
     fetched_at: datetime
     cache_hit: bool
+    links: SourcingAttributionLinks
+
+
+class SourcingBomIn(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    build_quantity: int = Field(ge=1)
+    country: str | None = Field(default=None, min_length=2, max_length=2)
+    currency: str | None = Field(default=None, min_length=3, max_length=3)
+    distributors: list[str] | None = None
+    in_stock_only: bool = False
+    use_cached_data: bool | None = None
+
+    @field_validator("country", "currency")
+    @classmethod
+    def _uppercase_codes(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return value.strip().upper()
+
+    @field_validator("distributors")
+    @classmethod
+    def _strip_distributors(cls, value: list[str] | None) -> list[str] | None:
+        if value is None:
+            return None
+        stripped = [item.strip() for item in value if item.strip()]
+        return stripped or None
+
+
+class SourcingBomOfferOut(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    mpn: str
+    distributor: str
+    sku: str | None = None
+    stock: int
+    unit_price: Decimal | None = None
+    currency: str | None = None
+    packaging: str | None = None
+    moq: int | None = None
+    lead_time_days: int | None = None
+    url: str | None = None
+
+
+class SourcingBomLineOut(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    project_entry_id: UUID
+    part_id: UUID
+    part_name: str
+    mpn: str | None = None
+    required: int
+    available: int
+    substitute_ids: list[UUID] = Field(default_factory=list)
+    substitute_available: int
+    short_by: int
+    authorized_stock: int
+    offers: list[SourcingBomOfferOut] = Field(default_factory=list)
+    best_offer: SourcingBomOfferOut | None = None
+    est_extended_cost: Decimal | None = None
+    lead_time_days: int | None = None
+    risk_flags: list[
+        Literal[
+            "single_source",
+            "no_authorized_stock",
+            "moq_overbuy",
+            "lead_time_long",
+            "preferred_distributor_unmet",
+        ]
+    ] = Field(default_factory=list)
+
+
+class SourcingBomOut(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    rows: list[SourcingBomLineOut]
+    powered_by: Literal["TrustedParts"] = "TrustedParts"
+    fetched_at: datetime
+    partial: bool
     links: SourcingAttributionLinks

--- a/backend/app/domain/sourcing/service.py
+++ b/backend/app/domain/sourcing/service.py
@@ -4,17 +4,25 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Sequence
 from datetime import datetime
+from decimal import Decimal
 from typing import Any
 from uuid import UUID
 
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.core.time import utcnow
+from app.domain.builds.service import shortage_analysis
+from app.domain.parts.models import Part
 from app.domain.sourcing import cache
 from app.domain.sourcing.budget import BUDGET
 from app.domain.sourcing.factory import make_sourcing_provider
+from app.domain.sourcing.pricing import best_unit_price_at_qty
 from app.domain.sourcing.schemas import (
     SourcingAttributionLinks,
+    SourcingBomLineOut,
+    SourcingBomOfferOut,
+    SourcingBomOut,
     SourcingQuery,
     SourcingSearchOut,
     SourcingSearchRaw,
@@ -22,6 +30,7 @@ from app.domain.sourcing.schemas import (
 )
 
 TTL_SECONDS = 30 * 60
+BOM_TTL_SECONDS = 10 * 60
 TRUSTEDPARTS_LINKS = SourcingAttributionLinks(
     primary="https://www.trustedparts.com/",
     attribution="https://www.trustedparts.com/en/about",
@@ -57,6 +66,73 @@ def chunk_mpns(mpns: Sequence[str], size: int = 50) -> list[list[str]]:
     if size < 1 or size > 50:
         raise ValueError("MPN chunk size must be between 1 and 50")
     return [list(mpns[index : index + size]) for index in range(0, len(mpns), size)]
+
+
+def source_bom(
+    db: Session,
+    *,
+    workspace: Any,
+    project: Any,
+    build_quantity: int,
+    country: str | None = None,
+    currency: str | None = None,
+    distributors: list[str] | None = None,
+    in_stock_only: bool = False,
+    use_cached_data: bool | None = None,
+    requested_by: UUID | None = None,
+) -> SourcingBomOut:
+    shortage = shortage_analysis(
+        db,
+        workspace_id=workspace.id,
+        project=project,
+        build_quantity=build_quantity,
+    )
+    part_ids = _part_ids_from_shortage(shortage)
+    parts_by_id = _parts_by_id(db, workspace_id=workspace.id, part_ids=part_ids)
+    mpns = dedupe_mpns(
+        parts_by_id[part_id].mpn
+        for part_id in part_ids
+        if part_id in parts_by_id
+    )
+
+    search_results: dict[str, SourcingSearchResult] = {}
+    fetched_at_values: list[datetime] = []
+    partial = False
+    for chunk in chunk_mpns(mpns):
+        verdict = BUDGET.check(workspace.id, parts_count=len(chunk))
+        partial = partial or verdict.mode == "degraded"
+        out = search(
+            db,
+            workspace=workspace,
+            mpns=chunk,
+            country=country,
+            currency=currency,
+            in_stock_only=in_stock_only,
+            distributors=distributors,
+            use_cached_data=use_cached_data,
+            ttl_seconds=BOM_TTL_SECONDS,
+            requested_by=requested_by,
+        )
+        fetched_at_values.append(out.fetched_at)
+        for result in out.results:
+            search_results[result.mpn.casefold()] = result
+
+    preferred = _clean_distributors(workspace.sourcing_preferred_distributors)
+    rows = [
+        _source_bom_line(
+            row,
+            parts_by_id=parts_by_id,
+            search_results=search_results,
+            preferred_distributors=preferred,
+        )
+        for row in shortage
+    ]
+    return SourcingBomOut(
+        rows=rows,
+        fetched_at=max(fetched_at_values, default=utcnow()),
+        partial=partial,
+        links=TRUSTEDPARTS_LINKS,
+    )
 
 
 def search(
@@ -199,6 +275,180 @@ def _fetched_at_from_response(response: dict[str, Any]) -> datetime:
     if isinstance(fetched_at, str):
         return datetime.fromisoformat(fetched_at)
     return utcnow()
+
+
+def _part_ids_from_shortage(shortage: list[dict[str, Any]]) -> list[UUID]:
+    out: list[UUID] = []
+    for row in shortage:
+        raw_ids = [row.get("part_id"), *row.get("substitute_ids", [])]
+        for raw_id in raw_ids:
+            if raw_id is None:
+                continue
+            part_id = UUID(str(raw_id))
+            if part_id not in out:
+                out.append(part_id)
+    return out
+
+
+def _parts_by_id(
+    db: Session,
+    *,
+    workspace_id: UUID,
+    part_ids: list[UUID],
+) -> dict[UUID, Part]:
+    if not part_ids:
+        return {}
+    parts = db.execute(
+        select(Part).where(Part.workspace_id == workspace_id, Part.id.in_(part_ids))
+    ).scalars()
+    return {part.id: part for part in parts}
+
+
+def _source_bom_line(
+    row: dict[str, Any],
+    *,
+    parts_by_id: dict[UUID, Part],
+    search_results: dict[str, SourcingSearchResult],
+    preferred_distributors: list[str] | None,
+) -> SourcingBomLineOut:
+    part_id = UUID(str(row["part_id"]))
+    substitute_ids = [UUID(str(item)) for item in row.get("substitute_ids", [])]
+    candidate_ids = [part_id, *substitute_ids]
+    candidate_mpns = dedupe_mpns(
+        parts_by_id[item].mpn for item in candidate_ids if item in parts_by_id
+    )
+    short_by = int(row["short_by"])
+    offers = _joined_offers(candidate_mpns, search_results, qty=max(short_by, 1))
+    best_offer = _best_offer_at_qty(offers, short_by)
+    authorized_stock = sum(offer.stock for offer in offers)
+
+    return SourcingBomLineOut(
+        project_entry_id=UUID(str(row["project_entry_id"])),
+        part_id=part_id,
+        part_name=str(row["part_name"]),
+        mpn=parts_by_id[part_id].mpn if part_id in parts_by_id else None,
+        required=int(row["required"]),
+        available=int(row["available"]),
+        substitute_ids=substitute_ids,
+        substitute_available=int(row.get("substitute_available", 0)),
+        short_by=short_by,
+        authorized_stock=authorized_stock,
+        offers=offers,
+        best_offer=best_offer,
+        est_extended_cost=(
+            best_offer.unit_price * Decimal(short_by)
+            if best_offer is not None and best_offer.unit_price is not None
+            else None
+        ),
+        lead_time_days=best_offer.lead_time_days if best_offer is not None else None,
+        risk_flags=_risk_flags(
+            offers,
+            best_offer=best_offer,
+            short_by=short_by,
+            preferred_distributors=preferred_distributors,
+        ),
+    )
+
+
+def _joined_offers(
+    mpns: list[str],
+    search_results: dict[str, SourcingSearchResult],
+    *,
+    qty: int,
+) -> list[SourcingBomOfferOut]:
+    out: list[SourcingBomOfferOut] = []
+    for mpn in mpns:
+        result = search_results.get(mpn.casefold())
+        if result is None:
+            continue
+        for offer in result.offers:
+            offer_mpn = offer.mpn or mpn
+            for distributor in offer.distributors:
+                out.append(
+                    SourcingBomOfferOut(
+                        mpn=offer_mpn,
+                        distributor=distributor.name,
+                        sku=distributor.sku,
+                        stock=max(0, int(distributor.stock or 0)),
+                        unit_price=_unit_price_for_distributor(distributor, qty),
+                        currency=distributor.currency,
+                        packaging=distributor.packaging,
+                        moq=distributor.moq,
+                        lead_time_days=distributor.lead_time_days,
+                        url=distributor.product_url or offer.links.primary,
+                    )
+                )
+    return out
+
+
+def _best_offer_at_qty(
+    offers: list[SourcingBomOfferOut],
+    qty: int,
+) -> SourcingBomOfferOut | None:
+    if qty < 1:
+        return None
+
+    best: tuple[Decimal, SourcingBomOfferOut] | None = None
+    for offer in offers:
+        price = offer.unit_price
+        if price is None:
+            continue
+        if best is None or price < best[0]:
+            best = (price, offer)
+    return best[1] if best is not None else None
+
+
+def _unit_price_for_distributor(distributor: Any, qty: int) -> Decimal | None:
+    price_breaks = list(distributor.price_breaks)
+    if not price_breaks and distributor.unit_price is not None:
+        price_breaks = [
+            {
+                "quantity": max(1, int(distributor.moq or 1)),
+                "unit_price": distributor.unit_price,
+            }
+        ]
+    best = best_unit_price_at_qty(price_breaks, qty)
+    return best[0] if best is not None else None
+
+
+def _risk_flags(
+    offers: list[SourcingBomOfferOut],
+    *,
+    best_offer: SourcingBomOfferOut | None,
+    short_by: int,
+    preferred_distributors: list[str] | None,
+) -> list[str]:
+    stock_by_distributor: dict[str, int] = {}
+    for offer in offers:
+        key = offer.distributor.casefold()
+        stock_by_distributor[key] = stock_by_distributor.get(key, 0) + offer.stock
+
+    stocked_distributors = {
+        distributor for distributor, stock in stock_by_distributor.items() if stock > 0
+    }
+    flags: list[str] = []
+    if len(stocked_distributors) == 1:
+        flags.append("single_source")
+    if not stocked_distributors:
+        flags.append("no_authorized_stock")
+    if (
+        best_offer is not None
+        and best_offer.moq is not None
+        and short_by > 0
+        and best_offer.moq > short_by * 3
+    ):
+        flags.append("moq_overbuy")
+    if (
+        best_offer is not None
+        and best_offer.lead_time_days is not None
+        and best_offer.lead_time_days > 30
+    ):
+        flags.append("lead_time_long")
+    if preferred_distributors:
+        preferred = {item.casefold() for item in preferred_distributors}
+        if not (preferred & stocked_distributors):
+            flags.append("preferred_distributor_unmet")
+    return flags
 
 
 def _clean_code(value: str | None) -> str | None:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -388,6 +388,12 @@ app.include_router(search.router, prefix="/api/search", tags=["search"], depende
 app.include_router(sourcing.router, prefix="/api/workspaces", tags=["sourcing"])
 app.include_router(sourcing.search_router, prefix="/api/sourcing", tags=["sourcing"])
 app.include_router(
+    sourcing.projects_router,
+    prefix="/api/projects",
+    tags=["sourcing"],
+    dependencies=_member_gate,
+)
+app.include_router(
     sourcing.parts_router,
     prefix="/api/parts",
     tags=["sourcing"],

--- a/backend/tests/test_sourcing_bom_route.py
+++ b/backend/tests/test_sourcing_bom_route.py
@@ -1,0 +1,404 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+import app.core.ratelimit as _ratelimit_mod
+from app.domain.sourcing.budget import BUDGET
+from app.domain.sourcing.schemas import (
+    SourcingDistributor,
+    SourcingLinks,
+    SourcingOffer,
+    SourcingPriceBreak,
+    SourcingQuery,
+    SourcingSearchRaw,
+)
+from app.main import app
+from tests._factories import add_stock, create_part, create_project_with_bom, signup_user
+
+
+def _configure_sourcing(
+    client: TestClient,
+    *,
+    preferred: list[str] | None = None,
+) -> None:
+    r = client.patch(
+        "/api/workspaces/current",
+        json={
+            "sourcing_provider": "trustedparts",
+            "sourcing_company_id": "company-123",
+            "sourcing_api_key": "api-key-456",
+            "sourcing_country_code": "CZ",
+            "sourcing_currency_code": "EUR",
+            "sourcing_preferred_distributors": preferred or ["DigiKey"],
+            "sourcing_use_cached_for_dashboards": False,
+        },
+    )
+    assert r.status_code == 200, r.text
+
+
+def _current_workspace_id(client: TestClient) -> str:
+    r = client.get("/api/workspaces/current")
+    assert r.status_code == 200, r.text
+    return r.json()["data"]["id"]
+
+
+def _offer(
+    mpn: str,
+    *,
+    distributor: str = "DigiKey",
+    stock: int = 100,
+    unit_price: float = 1.0,
+    moq: int | None = 1,
+    lead_time_days: int | None = 3,
+    currency: str = "EUR",
+) -> SourcingOffer:
+    return SourcingOffer(
+        mpn=mpn,
+        manufacturer="TestCo",
+        description=f"Offer for {mpn}",
+        distributors=[
+            SourcingDistributor(
+                name=distributor,
+                sku=f"{mpn}-{distributor}",
+                stock=stock,
+                unit_price=unit_price,
+                currency=currency,
+                moq=moq,
+                lead_time_days=lead_time_days,
+                price_breaks=[SourcingPriceBreak(quantity=1, unit_price=unit_price)],
+                product_url=f"https://www.trustedparts.com/{mpn}/{distributor}",
+            )
+        ],
+        links=SourcingLinks(primary=f"https://www.trustedparts.com/search/{mpn}"),
+    )
+
+
+class _FakeTrustedPartsClient:
+    calls: list[dict[str, Any]] = []
+    offers_by_mpn: dict[str, list[SourcingOffer]] = {}
+
+    def __init__(self, workspace_id: uuid.UUID | None = None) -> None:
+        self.workspace_id = workspace_id
+        self.country_code = "CZ"
+        self.currency_code = "EUR"
+
+    def search(
+        self,
+        queries: list[SourcingQuery],
+        *,
+        in_stock_only: bool,
+        distributors: list[str] | None,
+        use_cached_data: bool,
+        **_kwargs,
+    ) -> SourcingSearchRaw:
+        query = queries[0]
+        self.calls.append(
+            {
+                "workspace_id": str(self.workspace_id) if self.workspace_id else None,
+                "mpn": query.search_token,
+                "country_code": self.country_code,
+                "currency_code": self.currency_code,
+                "in_stock_only": in_stock_only,
+                "distributors": distributors,
+                "use_cached_data": use_cached_data,
+            }
+        )
+        offers = self.offers_by_mpn.get(query.search_token)
+        if offers is None and self.workspace_id is not None:
+            distributor = f"WS-{str(self.workspace_id)[:8]}"
+            offers = [_offer(query.search_token, distributor=distributor)]
+        if offers is None:
+            offers = [_offer(query.search_token)]
+        return SourcingSearchRaw(
+            offers=offers,
+            request_id=f"req-{len(self.calls)}",
+        )
+
+
+@pytest.fixture(autouse=True)
+def reset_sourcing_state(monkeypatch):
+    original_limiter_enabled = _ratelimit_mod.limiter.enabled
+    _ratelimit_mod.limiter.enabled = False
+    _FakeTrustedPartsClient.calls = []
+    _FakeTrustedPartsClient.offers_by_mpn = {}
+    BUDGET._events.clear()
+    try:
+        _ratelimit_mod.limiter.reset()
+    except Exception:
+        pass
+    monkeypatch.setattr(
+        "app.domain.sourcing.service.make_sourcing_provider",
+        lambda workspace: _FakeTrustedPartsClient(workspace.id),
+    )
+    yield
+    _ratelimit_mod.limiter.enabled = original_limiter_enabled
+    BUDGET._events.clear()
+    try:
+        _ratelimit_mod.limiter.reset()
+    except Exception:
+        pass
+
+
+def _single_line_project(client: TestClient, *, mpn: str = "BOM-MPN", quantity: int = 10) -> str:
+    part_id = create_part(client, name=mpn, mpn=mpn)
+    return create_project_with_bom(
+        client,
+        f"Project {mpn}",
+        [{"part_id": part_id, "quantity": quantity}],
+    )
+
+
+def _post_sourcing(client: TestClient, project_id: str, build_quantity: int = 1):
+    return client.post(
+        f"/api/projects/{project_id}/sourcing",
+        json={"build_quantity": build_quantity},
+    )
+
+
+def test_basic_bom_returns_enriched_lines(authed_client):
+    _configure_sourcing(authed_client)
+    project_id = _single_line_project(authed_client, mpn="STM32F103C8T6", quantity=10)
+    _FakeTrustedPartsClient.offers_by_mpn = {
+        "STM32F103C8T6": [
+            _offer("STM32F103C8T6", distributor="DigiKey", stock=20, unit_price=0.2),
+            _offer("STM32F103C8T6", distributor="Mouser", stock=40, unit_price=0.1),
+        ]
+    }
+
+    r = _post_sourcing(authed_client, project_id, build_quantity=2)
+
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["status"]["category"] == "ok"
+    data = body["data"]
+    datetime.fromisoformat(data["fetched_at"])
+    assert data["powered_by"] == "TrustedParts"
+    assert data["partial"] is False
+    row = data["rows"][0]
+    assert row["required"] == 20
+    assert row["available"] == 0
+    assert row["short_by"] == 20
+    assert row["authorized_stock"] == 60
+    assert row["best_offer"]["distributor"] == "Mouser"
+    assert isinstance(row["best_offer"]["unit_price"], str)
+    assert isinstance(row["est_extended_cost"], str)
+
+
+def test_bom_with_substitutes_dedupes_mpns(authed_client, monkeypatch):
+    _configure_sourcing(authed_client)
+    main = create_part(authed_client, name="Main", mpn="MAIN-MPN")
+    alt = create_part(authed_client, name="Alt", mpn="ALT-MPN")
+    r = authed_client.post(f"/api/parts/{main}/substitutes", json={"substitute_part_id": alt})
+    assert r.status_code == 200, r.text
+    project_id = create_project_with_bom(
+        authed_client,
+        "Sub BOM",
+        [{"part_id": main, "quantity": 1}, {"part_id": main, "quantity": 2}],
+    )
+    chunks: list[list[str]] = []
+    original_search = __import__(
+        "app.domain.sourcing.service",
+        fromlist=["search"],
+    ).search
+
+    def spy_search(*args, **kwargs):
+        chunks.append(list(kwargs["mpns"]))
+        return original_search(*args, **kwargs)
+
+    monkeypatch.setattr("app.domain.sourcing.service.search", spy_search)
+
+    r = _post_sourcing(authed_client, project_id)
+
+    assert r.status_code == 200, r.text
+    assert chunks == [["MAIN-MPN", "ALT-MPN"]]
+    row = r.json()["data"]["rows"][0]
+    assert {offer["mpn"] for offer in row["offers"]} == {"MAIN-MPN", "ALT-MPN"}
+
+
+def test_bom_over_50_mpns_chunks_correctly(authed_client, monkeypatch):
+    _configure_sourcing(authed_client)
+    bom = []
+    for index in range(73):
+        part_id = create_part(authed_client, name=f"P{index}", mpn=f"MPN-{index:02d}")
+        bom.append({"part_id": part_id, "quantity": 1})
+    project_id = create_project_with_bom(authed_client, "Large BOM", bom)
+    chunks: list[list[str]] = []
+    original_search = __import__(
+        "app.domain.sourcing.service",
+        fromlist=["search"],
+    ).search
+
+    def spy_search(*args, **kwargs):
+        chunks.append(list(kwargs["mpns"]))
+        return original_search(*args, **kwargs)
+
+    monkeypatch.setattr("app.domain.sourcing.service.search", spy_search)
+
+    r = _post_sourcing(authed_client, project_id)
+
+    assert r.status_code == 200, r.text
+    assert [len(chunk) for chunk in chunks] == [50, 23]
+    assert len(_FakeTrustedPartsClient.calls) == 73
+    ws_id = uuid.UUID(_current_workspace_id(authed_client))
+    assert sum(count for _timestamp, count in BUDGET._events[(ws_id, 10)]) == 73
+
+
+def test_foreign_project_returns_404(authed_client):
+    other = TestClient(app)
+    signup_user(other)
+    _configure_sourcing(authed_client)
+    foreign_project_id = _single_line_project(other, mpn="FOREIGN-MPN")
+
+    r = _post_sourcing(authed_client, foreign_project_id)
+
+    assert r.status_code == 404, r.text
+    assert r.json()["status"]["category"] == "not_found"
+
+
+def test_invalid_build_quantity_returns_422(authed_client):
+    _configure_sourcing(authed_client)
+    project_id = _single_line_project(authed_client)
+
+    r = _post_sourcing(authed_client, project_id, build_quantity=0)
+
+    assert r.status_code == 422, r.text
+    assert r.json()["status"]["category"] == "validation_error"
+
+
+def test_unconfigured_returns_409(authed_client, monkeypatch):
+    monkeypatch.setattr(
+        "app.domain.sourcing.service.make_sourcing_provider",
+        lambda _workspace: None,
+    )
+    project_id = _single_line_project(authed_client)
+
+    r = _post_sourcing(authed_client, project_id)
+
+    assert r.status_code == 409, r.text
+    assert r.json()["status"] == {
+        "category": "conflict",
+        "message": "sourcing not configured",
+    }
+
+
+def test_budget_blocked_returns_503(authed_client):
+    _configure_sourcing(authed_client)
+    project_id = _single_line_project(authed_client)
+    BUDGET.record(uuid.UUID(_current_workspace_id(authed_client)), 250)
+
+    r = _post_sourcing(authed_client, project_id)
+
+    assert r.status_code == 503, r.text
+    assert r.json()["status"] == {
+        "category": "server_error",
+        "message": "sourcing budget exhausted",
+    }
+
+
+def test_partial_flag_when_budget_degrades(authed_client):
+    _configure_sourcing(authed_client)
+    project_id = _single_line_project(authed_client)
+    BUDGET.record(uuid.UUID(_current_workspace_id(authed_client)), 50)
+
+    r = _post_sourcing(authed_client, project_id)
+
+    assert r.status_code == 200, r.text
+    assert r.json()["data"]["partial"] is True
+    assert _FakeTrustedPartsClient.calls[-1]["use_cached_data"] is True
+
+
+def test_risk_flag_single_source(authed_client):
+    _configure_sourcing(authed_client)
+    project_id = _single_line_project(authed_client, mpn="SINGLE")
+    _FakeTrustedPartsClient.offers_by_mpn = {"SINGLE": [_offer("SINGLE", stock=5)]}
+
+    r = _post_sourcing(authed_client, project_id)
+
+    assert r.status_code == 200, r.text
+    assert "single_source" in r.json()["data"]["rows"][0]["risk_flags"]
+
+
+def test_risk_flag_no_authorized_stock(authed_client):
+    _configure_sourcing(authed_client)
+    part_id = create_part(authed_client, name="No Stock", mpn="NO-STOCK")
+    add_stock(authed_client, part_id, 1)
+    project_id = create_project_with_bom(
+        authed_client,
+        "No authorized stock",
+        [{"part_id": part_id, "quantity": 10}],
+    )
+    _FakeTrustedPartsClient.offers_by_mpn = {
+        "NO-STOCK": [_offer("NO-STOCK", stock=0)]
+    }
+
+    r = _post_sourcing(authed_client, project_id)
+
+    assert r.status_code == 200, r.text
+    assert "no_authorized_stock" in r.json()["data"]["rows"][0]["risk_flags"]
+
+
+def test_risk_flag_moq_overbuy(authed_client):
+    _configure_sourcing(authed_client)
+    project_id = _single_line_project(authed_client, mpn="MOQ", quantity=5)
+    _FakeTrustedPartsClient.offers_by_mpn = {
+        "MOQ": [_offer("MOQ", stock=100, moq=100)]
+    }
+
+    r = _post_sourcing(authed_client, project_id)
+
+    assert r.status_code == 200, r.text
+    assert "moq_overbuy" in r.json()["data"]["rows"][0]["risk_flags"]
+
+
+def test_risk_flag_lead_time_long(authed_client):
+    _configure_sourcing(authed_client)
+    project_id = _single_line_project(authed_client, mpn="SLOW")
+    _FakeTrustedPartsClient.offers_by_mpn = {
+        "SLOW": [_offer("SLOW", stock=100, lead_time_days=45)]
+    }
+
+    r = _post_sourcing(authed_client, project_id)
+
+    assert r.status_code == 200, r.text
+    assert "lead_time_long" in r.json()["data"]["rows"][0]["risk_flags"]
+
+
+def test_risk_flag_preferred_distributor_unmet(authed_client):
+    _configure_sourcing(authed_client, preferred=["DigiKey"])
+    project_id = _single_line_project(authed_client, mpn="PREF")
+    _FakeTrustedPartsClient.offers_by_mpn = {
+        "PREF": [_offer("PREF", distributor="Mouser", stock=100)]
+    }
+
+    r = _post_sourcing(authed_client, project_id)
+
+    assert r.status_code == 200, r.text
+    assert "preferred_distributor_unmet" in r.json()["data"]["rows"][0]["risk_flags"]
+
+
+def test_workspace_isolation_two_projects_same_mpns(authed_client):
+    _configure_sourcing(authed_client)
+    project_a = _single_line_project(authed_client, mpn="SHARED-MPN")
+
+    client_b = TestClient(app)
+    signup_user(client_b)
+    _configure_sourcing(client_b)
+    project_b = _single_line_project(client_b, mpn="SHARED-MPN")
+
+    first = _post_sourcing(authed_client, project_a)
+    second = _post_sourcing(client_b, project_b)
+
+    assert first.status_code == 200, first.text
+    assert second.status_code == 200, second.text
+    first_offer = first.json()["data"]["rows"][0]["offers"][0]
+    second_offer = second.json()["data"]["rows"][0]["offers"][0]
+    assert first_offer["distributor"] != second_offer["distributor"]
+    assert [call["mpn"] for call in _FakeTrustedPartsClient.calls] == [
+        "SHARED-MPN",
+        "SHARED-MPN",
+    ]

--- a/backend/tests/test_sourcing_pricing.py
+++ b/backend/tests/test_sourcing_pricing.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from app.domain.sourcing.pricing import best_unit_price_at_qty, extended_price
+
+
+@pytest.mark.parametrize(
+    ("breaks", "qty", "expected"),
+    [
+        ([], 10, None),
+        ([{"quantity": 10, "unit_price": "1.25"}], 5, (Decimal("1.25"), 10)),
+        (
+            [
+                {"quantity": 1, "unit_price": "2.00"},
+                {"quantity": 10, "unit_price": "1.50"},
+            ],
+            10,
+            (Decimal("1.50"), 10),
+        ),
+        (
+            [
+                {"quantity": 1, "unit_price": "2.00"},
+                {"quantity": 10, "unit_price": "1.50"},
+            ],
+            99,
+            (Decimal("1.50"), 10),
+        ),
+    ],
+)
+def test_best_unit_price_at_qty(breaks, qty, expected):
+    assert best_unit_price_at_qty(breaks, qty) == expected
+
+
+@pytest.mark.parametrize(
+    ("breaks", "qty", "expected"),
+    [
+        ([], 10, None),
+        ([{"quantity": 10, "unit_price": "1.25"}], 5, Decimal("6.25")),
+        (
+            [
+                {"quantity": 1, "unit_price": "2.00"},
+                {"quantity": 10, "unit_price": "1.50"},
+            ],
+            10,
+            Decimal("15.00"),
+        ),
+        (
+            [
+                {"quantity": 1, "unit_price": "2.00"},
+                {"quantity": 10, "unit_price": "1.50"},
+            ],
+            99,
+            Decimal("148.50"),
+        ),
+    ],
+)
+def test_extended_price(breaks, qty, expected):
+    assert extended_price(breaks, qty) == expected

--- a/docs/api/sourcing.md
+++ b/docs/api/sourcing.md
@@ -10,6 +10,73 @@ See [API conventions](./README.md) for envelope, errors, pagination. Connection 
 
 ## Routes
 
+### `POST /api/projects/{project_id}/sourcing`
+
+Join a project's BOM shortage analysis to TrustedParts authorized-distributor offers.
+
+**Request**
+
+Path: `project_id` is a project UUID in the current workspace.
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `build_quantity` | `integer` | Yes | Must be at least `1`. |
+| `country` | `string` | No | Two-letter override; falls back to workspace sourcing default. |
+| `currency` | `string` | No | Three-letter override; falls back to workspace sourcing default. |
+| `distributors` | `string[]` | No | Falls back to `sourcing_preferred_distributors` when omitted. |
+| `in_stock_only` | `boolean` | No | Defaults to `false`. |
+| `use_cached_data` | `boolean` | No | Falls back to `sourcing_use_cached_for_dashboards`; forced true when the request is in degraded budget mode. |
+
+**Response** — `200 OK` (envelope: `{ data, status }`)
+
+```json
+{
+  "data": {
+    "rows": [
+      {
+        "part_name": "STM32",
+        "mpn": "STM32F103C8T6",
+        "required": 20,
+        "available": 0,
+        "short_by": 20,
+        "authorized_stock": 60,
+        "best_offer": {
+          "distributor": "Mouser",
+          "unit_price": "0.10",
+          "currency": "EUR",
+          "moq": 1,
+          "lead_time_days": 3
+        },
+        "est_extended_cost": "2.00",
+        "risk_flags": []
+      }
+    ],
+    "powered_by": "TrustedParts",
+    "fetched_at": "2026-05-08T12:00:00+00:00",
+    "partial": false
+  },
+  "status": { "category": "ok", "message": "OK" }
+}
+```
+
+**Errors**
+
+- `404 Not Found` — `project_id` is missing or belongs to another workspace.
+- `409 Conflict` — `{ "data": null, "status": { "category": "conflict", "message": "sourcing not configured" } }`.
+- `422 Unprocessable Entity` — validation envelope when `build_quantity < 1` or request fields are malformed.
+- `429 Too Many Requests` — workspace rate limit: 30 requests/minute.
+- `502 Bad Gateway` — TrustedParts auth, rate-limit, timeout, upstream, or response-shape failure.
+- `503 Service Unavailable` — `{ "data": null, "status": { "category": "server_error", "message": "sourcing budget exhausted" } }`.
+
+**Notes**
+
+- The route validates `project_id` with `assert_in_workspace()` before calling the sourcing service.
+- The service reuses `shortage_analysis()`, `dedupe_mpns()`, `chunk_mpns()`, and per-MPN `search()` cache rows; BOM chunks use `ttl_seconds=600`.
+- Decimal prices and extended costs serialize as strings.
+- Source: `backend/app/api/routes/sourcing.py:134-194`.
+- Service: `backend/app/domain/sourcing/service.py:71-135`.
+- Pricing: `backend/app/domain/sourcing/pricing.py:9-40`.
+
 ### `GET /api/parts/{part_id}/sourcing`
 
 Return cached TrustedParts offers for one part's MPN.


### PR DESCRIPTION
## Summary
- Added `POST /api/projects/{project_id}/sourcing` with member role gating, 30/min workspace rate limit, project workspace validation, and sourcing error mapping.
- Added BOM sourcing service logic that reuses `shortage_analysis`, `dedupe_mpns`, `chunk_mpns`, and existing per-MPN `search` cache rows with a 600s BOM TTL.
- Added Decimal pricing helpers, string-serialized BOM price fields, risk flags, route tests, pricing tests, and API docs.

## Validation
Docker validation could not run because this environment has no Docker binary:

```text
$ docker compose -f docker-compose.dev.yml exec backend pytest -k "sourcing_bom or sourcing_pricing or workspace_isolation"
/bin/bash: line 1: docker: command not found

$ docker compose -f docker-compose.dev.yml exec backend ruff check
/bin/bash: line 1: docker: command not found
```

Local fallback results:

```text
$ cd backend && uv run --extra dev python -m pytest -k "sourcing_bom or sourcing_pricing or workspace_isolation"
67 passed, 792 deselected, 3 warnings in 23.05s

$ cd backend && uv run --extra dev ruff check app/domain/sourcing/service.py app/domain/sourcing/pricing.py app/domain/sourcing/schemas.py app/api/routes/sourcing.py tests/test_sourcing_bom_route.py tests/test_sourcing_pricing.py
All checks passed!

$ LINT_CMD="uv run --extra dev ruff check app --output-format=concise" BASELINE_FILE=".ruff-baseline.txt" WORK_DIR="backend" bash scripts/lint-delta.sh
lint-delta: no new violations (baseline: 159, current: 154, fixed since baseline: 5)
```

## Example response payload

```json
{
  "data": {
    "rows": [{
      "part_name": "STM32",
      "mpn": "STM32F103C8T6",
      "required": 20,
      "available": 0,
      "short_by": 20,
      "authorized_stock": 60,
      "best_offer": {
        "mpn": "STM32F103C8T6",
        "distributor": "Mouser",
        "stock": 40,
        "unit_price": "0.1",
        "currency": "EUR",
        "moq": 1,
        "lead_time_days": 3
      },
      "est_extended_cost": "2.0",
      "risk_flags": []
    }],
    "powered_by": "TrustedParts",
    "partial": false
  },
  "status": { "category": "ok", "message": "OK" }
}
```

## Workspace Isolation
- Route validates `project_id` through `assert_in_workspace(db, Project, project_id, ws.id)` before sourcing.
- BOM part/substitute lookups filter `Part.workspace_id == workspace.id`.
- Existing cache/search calls remain scoped by `workspace.id`; `test_workspace_isolation_two_projects_same_mpns` verifies same-MPN projects in separate workspaces do not share cache rows/offers.

## Deviations
- Docker validation was unavailable, so the documented local `uv` fallback was used.
- Added `backend/app/main.py` only to mount the new project-scoped sourcing router.

Refs #351