### PR TITLE
TP-205: Quantity selector + price-break recompute

### DIFF
--- a/web/src/lib/__tests__/sourcing.test.ts
+++ b/web/src/lib/__tests__/sourcing.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { bestUnitPriceAtQty, extendedPrice } from "../sourcing";
+
+describe("bestUnitPriceAtQty", () => {
+  it("returns null when qty < smallest break", () => {
+    expect(
+      bestUnitPriceAtQty(
+        [
+          { quantity: 10, unit_price: 1.1 },
+          { quantity: 100, unit_price: 0.9 },
+        ],
+        1,
+      ),
+    ).toBeNull();
+  });
+
+  it("picks the highest break.quantity that is <= qty", () => {
+    expect(
+      bestUnitPriceAtQty(
+        [
+          { quantity: 1, unit_price: 1.5 },
+          { quantity: 10, unit_price: 1.2 },
+          { quantity: 100, unit_price: 0.95 },
+        ],
+        50,
+      ),
+    ).toEqual({ unitPrice: 1.2, breakQty: 10 });
+  });
+
+  it("handles unsorted price-breaks input", () => {
+    expect(
+      bestUnitPriceAtQty(
+        [
+          { quantity: 100, unit_price: 0.8 },
+          { quantity: 1, unit_price: 1.4 },
+          { quantity: 10, unit_price: 1.05 },
+        ],
+        100,
+      ),
+    ).toEqual({ unitPrice: 0.8, breakQty: 100 });
+  });
+});
+
+describe("extendedPrice", () => {
+  it("multiplies correctly", () => {
+    expect(
+      extendedPrice(
+        [
+          { quantity: 1, unit_price: 2.5 },
+          { quantity: 10, unit_price: 2.25 },
+        ],
+        12,
+      ),
+    ).toBe(27);
+  });
+});

--- a/web/src/lib/sourcing.ts
+++ b/web/src/lib/sourcing.ts
@@ -1,0 +1,41 @@
+export type SourcingPriceBreak = {
+  quantity: number;
+  unit_price: number;
+};
+
+export type BestUnitPrice = {
+  unitPrice: number;
+  breakQty: number;
+};
+
+export function bestUnitPriceAtQty(
+  priceBreaks: readonly SourcingPriceBreak[],
+  qty: number,
+): BestUnitPrice | null {
+  if (!Number.isFinite(qty) || qty < 1) return null;
+  const targetQty = Math.floor(qty);
+
+  let best: BestUnitPrice | null = null;
+  for (const priceBreak of priceBreaks) {
+    const breakQty = Math.floor(priceBreak.quantity);
+    if (
+      Number.isFinite(breakQty) &&
+      Number.isFinite(priceBreak.unit_price) &&
+      breakQty >= 1 &&
+      breakQty <= targetQty &&
+      (best === null || breakQty > best.breakQty)
+    ) {
+      best = { unitPrice: priceBreak.unit_price, breakQty };
+    }
+  }
+  return best;
+}
+
+export function extendedPrice(
+  priceBreaks: readonly SourcingPriceBreak[],
+  qty: number,
+): number | null {
+  const best = bestUnitPriceAtQty(priceBreaks, qty);
+  if (best === null) return null;
+  return best.unitPrice * Math.floor(qty);
+}

--- a/web/src/routes/parts/detail/AuthorizedSupplyTab.tsx
+++ b/web/src/routes/parts/detail/AuthorizedSupplyTab.tsx
@@ -8,6 +8,7 @@ import { useAuth } from "@/lib/auth";
 import { formatDateTime } from "@/lib/format";
 import { useApiMutation } from "@/lib/mutations";
 import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
+import { bestUnitPriceAtQty, extendedPrice, type SourcingPriceBreak } from "@/lib/sourcing";
 import type { Column } from "@/components/DataTable";
 import { DataTable } from "@/components/DataTable";
 import { PoweredByTrustedParts } from "@/components/PoweredByTrustedParts";
@@ -24,6 +25,7 @@ type SourcingDistributor = {
   stock?: number | null;
   unit_price?: number | null;
   currency?: string | null;
+  price_breaks?: SourcingPriceBreak[] | null;
   product_url?: string | null;
 };
 
@@ -61,9 +63,12 @@ type SupplyRow = {
   packaging: string | null;
   unitPrice: number | null;
   currency: string | null;
+  priceBreaks: SourcingPriceBreak[];
   leadTimeDays: number | null;
   link: string | null;
 };
+
+const QUANTITY_PRESETS = [1, 10, 100, 1000] as const;
 
 function formatNumber(value: number | null): string {
   return value == null ? "—" : value.toLocaleString();
@@ -71,16 +76,26 @@ function formatNumber(value: number | null): string {
 
 function formatPrice(row: SupplyRow): string {
   if (row.unitPrice == null) return "—";
-  const price = row.unitPrice.toLocaleString(undefined, {
+  return formatPriceValue(row.unitPrice, row.currency);
+}
+
+function formatPriceValue(value: number, currency: string | null): string {
+  const price = value.toLocaleString(undefined, {
     maximumFractionDigits: 6,
     minimumFractionDigits: 0,
   });
-  return row.currency ? `${price} ${row.currency}` : price;
+  return currency ? `${price} ${currency}` : price;
 }
 
 function formatLeadTime(days: number | null): string {
   if (days == null) return "—";
   return days === 1 ? "1 day" : `${days.toLocaleString()} days`;
+}
+
+function normaliseQuantity(value: string): number | null {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 1) return null;
+  return Math.floor(parsed);
 }
 
 function flattenOffers(data: SourcingResponse | undefined): SupplyRow[] {
@@ -101,6 +116,7 @@ function flattenOffers(data: SourcingResponse | undefined): SupplyRow[] {
       packaging: distributor.packaging ?? null,
       unitPrice: distributor.unit_price ?? null,
       currency: distributor.currency ?? null,
+      priceBreaks: distributor.price_breaks ?? [],
       leadTimeDays: distributor.lead_time_days ?? null,
       link: offer.links?.primary ?? data.links?.primary ?? null,
     })),
@@ -147,6 +163,8 @@ export function AuthorizedSupplyTab({ partId }: { partId: string }) {
   const queryKey = useWsKey("part", partId, "sourcing");
   const invalidateKey = wsKeyOf(workspaceId, "part", partId, "sourcing");
   const [selectedDistributors, setSelectedDistributors] = useState<Set<string>>(() => new Set());
+  const [quantity, setQuantity] = useState(1);
+  const [customQuantity, setCustomQuantity] = useState("1");
 
   const query = useQuery({
     queryKey,
@@ -198,8 +216,41 @@ export function AuthorizedSupplyTab({ partId }: { partId: string }) {
     });
   }, [query.isError, query.error, refetch]);
 
-  const columns = useMemo<Column<SupplyRow>[]>(
-    () => [
+  const columns = useMemo<Column<SupplyRow>[]>(() => {
+    const quantityColumns: Column<SupplyRow>[] = quantity > 1
+      ? [
+          {
+            key: "unitPriceAtQty",
+            header: `Unit price @ ${quantity.toLocaleString()}`,
+            accessor: row => bestUnitPriceAtQty(row.priceBreaks, quantity)?.unitPrice,
+            render: row => {
+              const best = bestUnitPriceAtQty(row.priceBreaks, quantity);
+              return best === null ? (
+                <span className="text-muted">Below MOQ</span>
+              ) : (
+                formatPriceValue(best.unitPrice, row.currency)
+              );
+            },
+            align: "right",
+          },
+          {
+            key: "extendedAtQty",
+            header: `Extended @ ${quantity.toLocaleString()}`,
+            accessor: row => extendedPrice(row.priceBreaks, quantity),
+            render: row => {
+              const extended = extendedPrice(row.priceBreaks, quantity);
+              return extended === null ? (
+                <span className="text-muted">—</span>
+              ) : (
+                formatPriceValue(extended, row.currency)
+              );
+            },
+            align: "right",
+          },
+        ]
+      : [];
+
+    const baseColumns: Column<SupplyRow>[] = [
       {
         key: "distributor",
         header: "Distributor",
@@ -232,6 +283,7 @@ export function AuthorizedSupplyTab({ partId }: { partId: string }) {
         render: row => formatPrice(row),
         align: "right",
       },
+      ...quantityColumns,
       {
         key: "leadTime",
         header: "Lead time",
@@ -258,9 +310,9 @@ export function AuthorizedSupplyTab({ partId }: { partId: string }) {
             <span className="text-muted">—</span>
           ),
       },
-    ],
-    [],
-  );
+    ];
+    return baseColumns;
+  }, [quantity]);
 
   const status = errorStatus(query.error);
   const refreshStatus = errorStatus(refreshMutation.error);
@@ -342,26 +394,75 @@ export function AuthorizedSupplyTab({ partId }: { partId: string }) {
       )}
 
       {distributors.length > 0 && (
-        <label className="label max-w-sm">
-          Distributor filter
-          <select
-            multiple
-            className="input min-h-28"
-            value={Array.from(selectedDistributors)}
-            onChange={event => {
-              const next = new Set(
-                Array.from(event.currentTarget.selectedOptions).map(option => option.value),
-              );
-              setSelectedDistributors(next);
-            }}
-          >
-            {distributors.map(distributor => (
-              <option key={distributor} value={distributor}>
-                {distributor}
-              </option>
-            ))}
-          </select>
-        </label>
+        <div className="flex flex-wrap items-end gap-4">
+          <label className="label max-w-sm">
+            Distributor filter
+            <select
+              multiple
+              className="input min-h-28"
+              value={Array.from(selectedDistributors)}
+              onChange={event => {
+                const next = new Set(
+                  Array.from(event.currentTarget.selectedOptions).map(option => option.value),
+                );
+                setSelectedDistributors(next);
+              }}
+            >
+              {distributors.map(distributor => (
+                <option key={distributor} value={distributor}>
+                  {distributor}
+                </option>
+              ))}
+            </select>
+          </label>
+          <div className="space-y-2">
+            <div className="text-xs font-medium uppercase tracking-wide text-muted">
+              Quantity
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+              {QUANTITY_PRESETS.map(preset => (
+                <button
+                  key={preset}
+                  type="button"
+                  className={preset === quantity ? "btn-primary btn-sm" : "btn btn-sm"}
+                  aria-pressed={preset === quantity}
+                  onClick={() => {
+                    setQuantity(preset);
+                    setCustomQuantity(String(preset));
+                  }}
+                >
+                  {preset.toLocaleString()}
+                </button>
+              ))}
+              <label className="flex items-center gap-2 text-sm text-muted">
+                Custom:
+                <input
+                  className="input h-8 w-24"
+                  type="number"
+                  min={1}
+                  step={1}
+                  inputMode="numeric"
+                  value={customQuantity}
+                  onChange={event => setCustomQuantity(event.currentTarget.value)}
+                  onBlur={() => {
+                    const nextQuantity = normaliseQuantity(customQuantity);
+                    if (nextQuantity === null) {
+                      setCustomQuantity(String(quantity));
+                      return;
+                    }
+                    setQuantity(nextQuantity);
+                    setCustomQuantity(String(nextQuantity));
+                  }}
+                  onKeyDown={event => {
+                    if (event.key === "Enter") {
+                      event.currentTarget.blur();
+                    }
+                  }}
+                />
+              </label>
+            </div>
+          </div>
+        </div>
       )}
 
       <DataTable

--- a/web/src/routes/parts/detail/__tests__/AuthorizedSupplyTab.test.tsx
+++ b/web/src/routes/parts/detail/__tests__/AuthorizedSupplyTab.test.tsx
@@ -36,6 +36,12 @@ function sourcingResponse() {
             packaging: "Tape",
             unit_price: 1.23,
             currency: "EUR",
+            price_breaks: [
+              { quantity: 1, unit_price: 1.23 },
+              { quantity: 10, unit_price: 1.0 },
+              { quantity: 100, unit_price: 0.8 },
+              { quantity: 1000, unit_price: 0.62 },
+            ],
             lead_time_days: 3,
             product_url: "https://www.trustedparts.com/digikey/stm32",
           },
@@ -46,6 +52,11 @@ function sourcingResponse() {
             packaging: "Reel",
             unit_price: 1.11,
             currency: "EUR",
+            price_breaks: [
+              { quantity: 10, unit_price: 1.11 },
+              { quantity: 100, unit_price: 0.7 },
+              { quantity: 1000, unit_price: 0.65 },
+            ],
             lead_time_days: 14,
             product_url: "https://www.trustedparts.com/mouser/stm32",
           },
@@ -225,5 +236,88 @@ describe("AuthorizedSupplyTab", () => {
     const table = screen.getByRole("table");
     const offerLink = within(table).getAllByRole("link", { name: /Open/ })[0];
     expect(offerLink.getAttribute("rel") ?? "").not.toContain("nofollow");
+  });
+
+  it("quantity preset 100 recomputes unit price across rows", async () => {
+    const user = userEvent.setup();
+    vi.spyOn(api, "get").mockResolvedValue(sourcingResponse());
+
+    renderTab();
+
+    await screen.findByText("Powered by TrustedParts");
+    expect(screen.queryByText("Unit price @ 100")).toBeNull();
+
+    await user.click(screen.getByRole("button", { name: "100" }));
+
+    expect(screen.getByRole("columnheader", { name: "Unit price @ 100" })).toBeDefined();
+    expect(screen.getByRole("columnheader", { name: "Extended @ 100" })).toBeDefined();
+    expect(screen.getByText("0.8 EUR")).toBeDefined();
+    expect(screen.getByText("0.7 EUR")).toBeDefined();
+    expect(screen.getByText("80 EUR")).toBeDefined();
+    expect(screen.getByText("70 EUR")).toBeDefined();
+  });
+
+  it("custom quantity input is applied on blur", async () => {
+    const user = userEvent.setup();
+    vi.spyOn(api, "get").mockResolvedValue(sourcingResponse());
+
+    renderTab();
+
+    await screen.findByText("Powered by TrustedParts");
+    const customInput = screen.getByLabelText("Custom:");
+    await user.clear(customInput);
+    await user.type(customInput, "25");
+
+    expect(screen.queryByText("Unit price @ 25")).toBeNull();
+
+    await user.tab();
+
+    expect(screen.getByRole("columnheader", { name: "Unit price @ 25" })).toBeDefined();
+    expect(screen.getByText("25 EUR")).toBeDefined();
+    expect(screen.getByText("27.75 EUR")).toBeDefined();
+  });
+
+  it("quantity change does not refetch", async () => {
+    const user = userEvent.setup();
+    const getSpy = vi.spyOn(api, "get").mockResolvedValue(sourcingResponse());
+
+    renderTab();
+
+    await screen.findByText("Powered by TrustedParts");
+    await user.click(screen.getByRole("button", { name: "1,000" }));
+    await user.click(screen.getByRole("button", { name: "10" }));
+
+    expect(getSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("below-MOQ rendering is visible at low quantities", async () => {
+    const user = userEvent.setup();
+    vi.spyOn(api, "get").mockResolvedValue(sourcingResponse());
+
+    renderTab();
+
+    await screen.findByText("Powered by TrustedParts");
+    const customInput = screen.getByLabelText("Custom:");
+    await user.clear(customInput);
+    await user.type(customInput, "5");
+    await user.tab();
+
+    expect(screen.getByRole("columnheader", { name: "Unit price @ 5" })).toBeDefined();
+    expect(screen.getByText("Below MOQ")).toBeDefined();
+  });
+
+  it("sorts by unit price at selected quantity", async () => {
+    const user = userEvent.setup();
+    vi.spyOn(api, "get").mockResolvedValue(sourcingResponse());
+
+    renderTab();
+
+    await screen.findByText("Powered by TrustedParts");
+    await user.click(screen.getByRole("button", { name: "100" }));
+    await user.click(screen.getByRole("columnheader", { name: "Unit price @ 100" }));
+
+    const rows = within(screen.getByRole("table")).getAllByRole("row").slice(1);
+    expect(within(rows[0]).getByText("Mouser")).toBeDefined();
+    expect(within(rows[1]).getByText("DigiKey")).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary
- Added pure frontend sourcing helpers for best unit price and extended price from cached price breaks.
- Added Authorized Supply quantity presets plus custom quantity-on-blur input.
- Added conditional Unit price @ Q and Extended @ Q columns with sortable computed accessors and Below MOQ rendering.
- Extended helper and tab tests for recompute, custom blur, no refetch, Below MOQ, and computed-column sorting.

## Validation
- `cd web && npm run typecheck` ✅ passed
- `cd web && npm test -- src/lib/__tests__/sourcing.test.ts src/routes/parts/detail/__tests__/AuthorizedSupplyTab.test.tsx` ✅ passed: 2 files, 18 tests
- `cd web && npx eslint src/lib/sourcing.ts src/lib/__tests__/sourcing.test.ts src/routes/parts/detail/AuthorizedSupplyTab.tsx src/routes/parts/detail/__tests__/AuthorizedSupplyTab.test.tsx` ✅ passed
- `cd web && npm test -- "sourcing.test|AuthorizedSupplyTab"` ⚠️ this installed Vitest treats the quoted argument as a file filter and reports no files found; explicit file filters above were used for the same target set.
- `cd web && npm run lint` ⚠️ blocked by pre-existing unrelated lint findings in `src/lib/bagCode.ts`, `src/components/scanner/ZxingScanner.tsx`, and other untouched files; TP-205 changed files lint clean.

## Notes
- Custom quantity is applied on blur, with Enter blurring the field.
- Screenshots were not captured in this isolated worktree; the DOM tests cover qty=1 hidden computed columns and qty changes through 100/1000 paths.

Refs #348