### PR TITLE
TP-303: Distributor coverage matrix

### DIFF
--- a/backend/app/domain/sourcing/coverage.py
+++ b/backend/app/domain/sourcing/coverage.py
@@ -1,0 +1,237 @@
+"""Distributor coverage matrix computation for sourced BOM rows."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from itertools import combinations
+from uuid import UUID
+
+from app.domain.sourcing.pricing import best_unit_price_at_qty
+from app.domain.sourcing.schemas import SourcingBomLineOut, SourcingBomOfferOut
+
+EXHAUSTIVE_COMBO_DISTRIBUTOR_LIMIT = 30
+
+
+@dataclass(frozen=True)
+class DistributorCoverageRow:
+    distributor: str
+    lines_covered: int
+    lines_uncovered: list[UUID]
+    coverage_pct: float
+    est_total_cost: Decimal | None
+    worst_lead_time_days: int | None
+
+
+@dataclass(frozen=True)
+class DistributorCoverageMatrix:
+    rows: list[DistributorCoverageRow]
+    total_lines: int
+    best_single_distributor: str | None
+    best_two_distributor_combo: tuple[str, str] | None
+
+
+def compute_coverage(
+    bom_rows: list[SourcingBomLineOut],
+    *,
+    preferred_distributors: list[str] | None = None,
+) -> DistributorCoverageMatrix:
+    """Compute per-distributor BOM line coverage.
+
+    Distributor-pair selection is exhaustive up to 30 distinct distributors.
+    Above that threshold it uses the documented greedy fallback: pick the
+    distributor covering the most lines, then the distributor covering the most
+    remaining uncovered lines.
+    """
+    total_lines = len(bom_rows)
+    if total_lines == 0:
+        return DistributorCoverageMatrix(
+            rows=[],
+            total_lines=0,
+            best_single_distributor=None,
+            best_two_distributor_combo=None,
+        )
+
+    offers_by_distributor: dict[str, list[SourcingBomOfferOut]] = {}
+    display_names: dict[str, str] = {}
+    for line in bom_rows:
+        for offer in line.offers:
+            key = offer.distributor.casefold()
+            offers_by_distributor.setdefault(key, []).append(offer)
+            display_names.setdefault(key, offer.distributor)
+
+    preferred_rank = _preferred_rank(preferred_distributors)
+    line_ids = [line.project_entry_id for line in bom_rows]
+    covered_by_distributor: dict[str, set[UUID]] = {}
+    row_costs: dict[str, Decimal | None] = {}
+    row_lead_times: dict[str, int | None] = {}
+
+    for key in offers_by_distributor:
+        covered: set[UUID] = set()
+        total_cost: Decimal | None = Decimal("0")
+        worst_lead_time: int | None = None
+        for line in bom_rows:
+            best_offer = _best_covering_offer(key, line)
+            if best_offer is None:
+                continue
+            covered.add(line.project_entry_id)
+            line_cost = _offer_extended_cost(best_offer, line.short_by)
+            if line_cost is None:
+                total_cost = None
+            elif total_cost is not None:
+                total_cost += line_cost
+            if best_offer.lead_time_days is not None:
+                worst_lead_time = (
+                    best_offer.lead_time_days
+                    if worst_lead_time is None
+                    else max(worst_lead_time, best_offer.lead_time_days)
+                )
+        covered_by_distributor[key] = covered
+        row_costs[key] = total_cost
+        row_lead_times[key] = worst_lead_time
+
+    rows = [
+        DistributorCoverageRow(
+            distributor=display_names[key],
+            lines_covered=len(covered),
+            lines_uncovered=[line_id for line_id in line_ids if line_id not in covered],
+            coverage_pct=len(covered) / total_lines,
+            est_total_cost=row_costs[key],
+            worst_lead_time_days=row_lead_times[key],
+        )
+        for key, covered in covered_by_distributor.items()
+    ]
+    rows.sort(key=lambda row: _single_sort_key(row, preferred_rank))
+
+    best_single = rows[0].distributor if rows else None
+    best_two = _best_two_distributors(
+        rows,
+        covered_by_distributor=covered_by_distributor,
+        preferred_rank=preferred_rank,
+        total_lines=total_lines,
+    )
+
+    return DistributorCoverageMatrix(
+        rows=rows,
+        total_lines=total_lines,
+        best_single_distributor=best_single,
+        best_two_distributor_combo=best_two,
+    )
+
+
+def _best_covering_offer(
+    distributor_key: str,
+    line: SourcingBomLineOut,
+) -> SourcingBomOfferOut | None:
+    candidates = [
+        offer
+        for offer in line.offers
+        if offer.distributor.casefold() == distributor_key and offer.stock >= line.short_by
+    ]
+    if not candidates:
+        return None
+    return min(
+        candidates,
+        key=lambda offer: (
+            _price_sort_value(_offer_unit_price(offer, line.short_by)),
+            offer.lead_time_days if offer.lead_time_days is not None else 10**9,
+            offer.mpn.casefold(),
+        ),
+    )
+
+
+def _offer_extended_cost(offer: SourcingBomOfferOut, qty: int) -> Decimal | None:
+    unit_price = _offer_unit_price(offer, qty)
+    if unit_price is None:
+        return None
+    return unit_price * Decimal(qty)
+
+
+def _offer_unit_price(offer: SourcingBomOfferOut, qty: int) -> Decimal | None:
+    best = best_unit_price_at_qty(offer.price_breaks, qty)
+    if best is not None:
+        return best[0]
+    return offer.unit_price
+
+
+def _best_two_distributors(
+    rows: list[DistributorCoverageRow],
+    *,
+    covered_by_distributor: dict[str, set[UUID]],
+    preferred_rank: dict[str, int],
+    total_lines: int,
+) -> tuple[str, str] | None:
+    if len(rows) < 2 or rows[0].lines_covered == total_lines:
+        return None
+
+    rows_by_key = {row.distributor.casefold(): row for row in rows}
+    keys = [row.distributor.casefold() for row in rows]
+    if len(keys) <= EXHAUSTIVE_COMBO_DISTRIBUTOR_LIMIT:
+        first_key, second_key = min(
+            combinations(keys, 2),
+            key=lambda pair: _pair_sort_key(
+                pair,
+                rows_by_key=rows_by_key,
+                covered_by_distributor=covered_by_distributor,
+                preferred_rank=preferred_rank,
+            ),
+        )
+    else:
+        first_key = rows[0].distributor.casefold()
+        remaining = (
+            set().union(*covered_by_distributor.values())
+            - covered_by_distributor[first_key]
+        )
+        second_key = min(
+            (key for key in keys if key != first_key),
+            key=lambda key: (
+                -len(covered_by_distributor[key] & remaining),
+                _single_sort_key(rows_by_key[key], preferred_rank),
+            ),
+        )
+
+    return rows_by_key[first_key].distributor, rows_by_key[second_key].distributor
+
+
+def _pair_sort_key(
+    pair: tuple[str, str],
+    *,
+    rows_by_key: dict[str, DistributorCoverageRow],
+    covered_by_distributor: dict[str, set[UUID]],
+    preferred_rank: dict[str, int],
+) -> tuple[int, tuple[object, ...], tuple[object, ...]]:
+    first, second = sorted(
+        pair,
+        key=lambda key: _single_sort_key(rows_by_key[key], preferred_rank),
+    )
+    covered = covered_by_distributor[first] | covered_by_distributor[second]
+    return (
+        -len(covered),
+        _single_sort_key(rows_by_key[first], preferred_rank),
+        _single_sort_key(rows_by_key[second], preferred_rank),
+    )
+
+
+def _single_sort_key(
+    row: DistributorCoverageRow,
+    preferred_rank: dict[str, int],
+) -> tuple[object, ...]:
+    return (
+        -row.lines_covered,
+        preferred_rank.get(row.distributor.casefold(), 10**9),
+        _price_sort_value(row.est_total_cost),
+        row.distributor.casefold(),
+    )
+
+
+def _preferred_rank(preferred_distributors: list[str] | None) -> dict[str, int]:
+    if not preferred_distributors:
+        return {}
+    return {
+        distributor.strip().casefold(): index
+        for index, distributor in enumerate(preferred_distributors)
+        if distributor.strip()
+    }
+
+
+def _price_sort_value(value: Decimal | None) -> Decimal:
+    return value if value is not None else Decimal("Infinity")

--- a/backend/app/domain/sourcing/schemas.py
+++ b/backend/app/domain/sourcing/schemas.py
@@ -23,6 +23,13 @@ class SourcingPriceBreak(BaseModel):
     unit_price: float
 
 
+class SourcingBomPriceBreakOut(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    quantity: int
+    unit_price: Decimal
+
+
 class SourcingDistributor(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -163,7 +170,28 @@ class SourcingBomOfferOut(BaseModel):
     packaging: str | None = None
     moq: int | None = None
     lead_time_days: int | None = None
+    price_breaks: list[SourcingBomPriceBreakOut] = Field(default_factory=list)
     url: str | None = None
+
+
+class DistributorCoverageRowOut(BaseModel):
+    model_config = ConfigDict(extra="forbid", from_attributes=True)
+
+    distributor: str
+    lines_covered: int
+    lines_uncovered: list[UUID]
+    coverage_pct: float
+    est_total_cost: Decimal | None
+    worst_lead_time_days: int | None
+
+
+class DistributorCoverageMatrixOut(BaseModel):
+    model_config = ConfigDict(extra="forbid", from_attributes=True)
+
+    rows: list[DistributorCoverageRowOut]
+    total_lines: int
+    best_single_distributor: str | None
+    best_two_distributor_combo: tuple[str, str] | None
 
 
 class SourcingBomLineOut(BaseModel):
@@ -198,6 +226,7 @@ class SourcingBomOut(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     rows: list[SourcingBomLineOut]
+    coverage: DistributorCoverageMatrixOut
     powered_by: Literal["TrustedParts"] = "TrustedParts"
     fetched_at: datetime
     partial: bool

--- a/backend/app/domain/sourcing/service.py
+++ b/backend/app/domain/sourcing/service.py
@@ -16,13 +16,16 @@ from app.domain.builds.service import shortage_analysis
 from app.domain.parts.models import Part
 from app.domain.sourcing import cache
 from app.domain.sourcing.budget import BUDGET
+from app.domain.sourcing.coverage import compute_coverage
 from app.domain.sourcing.factory import make_sourcing_provider
 from app.domain.sourcing.pricing import best_unit_price_at_qty
 from app.domain.sourcing.schemas import (
+    DistributorCoverageMatrixOut,
     SourcingAttributionLinks,
     SourcingBomLineOut,
     SourcingBomOfferOut,
     SourcingBomOut,
+    SourcingBomPriceBreakOut,
     SourcingQuery,
     SourcingSearchOut,
     SourcingSearchRaw,
@@ -129,6 +132,9 @@ def source_bom(
     ]
     return SourcingBomOut(
         rows=rows,
+        coverage=DistributorCoverageMatrixOut.model_validate(
+            compute_coverage(rows, preferred_distributors=preferred)
+        ),
         fetched_at=max(fetched_at_values, default=utcnow()),
         partial=partial,
         links=TRUSTEDPARTS_LINKS,
@@ -375,6 +381,7 @@ def _joined_offers(
                         packaging=distributor.packaging,
                         moq=distributor.moq,
                         lead_time_days=distributor.lead_time_days,
+                        price_breaks=_price_breaks_for_distributor(distributor),
                         url=distributor.product_url or offer.links.primary,
                     )
                 )
@@ -409,6 +416,23 @@ def _unit_price_for_distributor(distributor: Any, qty: int) -> Decimal | None:
         ]
     best = best_unit_price_at_qty(price_breaks, qty)
     return best[0] if best is not None else None
+
+
+def _price_breaks_for_distributor(distributor: Any) -> list[SourcingBomPriceBreakOut]:
+    price_breaks = list(distributor.price_breaks)
+    if not price_breaks and distributor.unit_price is not None:
+        price_breaks = [
+            {
+                "quantity": max(1, int(distributor.moq or 1)),
+                "unit_price": distributor.unit_price,
+            }
+        ]
+    return [
+        SourcingBomPriceBreakOut(quantity=quantity, unit_price=unit_price)
+        for item in price_breaks
+        if (best := best_unit_price_at_qty([item], 1)) is not None
+        for unit_price, quantity in [best]
+    ]
 
 
 def _risk_flags(

--- a/backend/tests/test_sourcing_bom_route.py
+++ b/backend/tests/test_sourcing_bom_route.py
@@ -179,6 +179,8 @@ def test_basic_bom_returns_enriched_lines(authed_client):
     datetime.fromisoformat(data["fetched_at"])
     assert data["powered_by"] == "TrustedParts"
     assert data["partial"] is False
+    assert data["coverage"]["total_lines"] == 1
+    assert data["coverage"]["best_single_distributor"] == "DigiKey"
     row = data["rows"][0]
     assert row["required"] == 20
     assert row["available"] == 0

--- a/backend/tests/test_sourcing_coverage.py
+++ b/backend/tests/test_sourcing_coverage.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from uuid import UUID
+
+from app.domain.sourcing.coverage import compute_coverage
+from app.domain.sourcing.schemas import (
+    DistributorCoverageMatrixOut,
+    SourcingBomLineOut,
+    SourcingBomOfferOut,
+    SourcingBomPriceBreakOut,
+)
+
+
+def _uuid(index: int) -> UUID:
+    return UUID(f"00000000-0000-0000-0000-{index:012d}")
+
+
+def _offer(
+    distributor: str,
+    *,
+    mpn: str = "MPN",
+    stock: int = 10,
+    unit_price: str = "1.00",
+    lead_time_days: int | None = 3,
+    price_breaks: list[tuple[int, str]] | None = None,
+) -> SourcingBomOfferOut:
+    return SourcingBomOfferOut(
+        mpn=mpn,
+        distributor=distributor,
+        stock=stock,
+        unit_price=Decimal(unit_price),
+        lead_time_days=lead_time_days,
+        price_breaks=[
+            SourcingBomPriceBreakOut(quantity=quantity, unit_price=Decimal(price))
+            for quantity, price in (price_breaks or [(1, unit_price)])
+        ],
+    )
+
+
+def _line(index: int, *, short_by: int = 5, offers: list[SourcingBomOfferOut] | None = None):
+    return SourcingBomLineOut(
+        project_entry_id=_uuid(index),
+        part_id=_uuid(index + 1000),
+        part_name=f"Line {index}",
+        required=short_by,
+        available=0,
+        substitute_available=0,
+        short_by=short_by,
+        authorized_stock=sum(offer.stock for offer in offers or []),
+        offers=offers or [],
+    )
+
+
+def test_empty_bom_returns_empty_matrix():
+    matrix = compute_coverage([])
+
+    assert matrix.total_lines == 0
+    assert matrix.rows == []
+    assert matrix.best_single_distributor is None
+    assert matrix.best_two_distributor_combo is None
+
+
+def test_single_distributor_covers_all():
+    matrix = compute_coverage(
+        [
+            _line(
+                1,
+                offers=[
+                    _offer(
+                        "DigiKey",
+                        unit_price="9.99",
+                        price_breaks=[(1, "2.00"), (5, "1.50")],
+                    )
+                ],
+            ),
+            _line(2, offers=[_offer("DigiKey", unit_price="3.00", lead_time_days=8)]),
+        ]
+    )
+
+    assert matrix.best_single_distributor == "DigiKey"
+    assert matrix.best_two_distributor_combo is None
+    assert matrix.rows[0].lines_covered == 2
+    assert matrix.rows[0].coverage_pct == 1
+    assert matrix.rows[0].est_total_cost == Decimal("22.50")
+    assert matrix.rows[0].worst_lead_time_days == 8
+
+
+def test_two_distributors_needed_finds_optimal_pair():
+    matrix = compute_coverage(
+        [
+            _line(1, offers=[_offer("D1")]),
+            _line(2, offers=[_offer("D2")]),
+            _line(3, offers=[_offer("D3", stock=1)]),
+        ]
+    )
+
+    assert matrix.best_single_distributor == "D1"
+    assert matrix.best_two_distributor_combo == ("D1", "D2")
+
+
+def test_tie_breaks_by_preferred_then_cost_then_alpha():
+    preferred_matrix = compute_coverage(
+        [
+            _line(
+                1,
+                offers=[
+                    _offer("DigiKey", unit_price="5.00"),
+                    _offer("Mouser", unit_price="1.00"),
+                ],
+            )
+        ],
+        preferred_distributors=["DigiKey", "Mouser"],
+    )
+    cost_matrix = compute_coverage(
+        [
+            _line(
+                1,
+                offers=[
+                    _offer("Zed", unit_price="5.00"),
+                    _offer("Alpha", unit_price="1.00"),
+                ],
+            )
+        ]
+    )
+    alpha_matrix = compute_coverage(
+        [
+            _line(
+                1,
+                offers=[
+                    _offer("Beta", unit_price="1.00"),
+                    _offer("Alpha", unit_price="1.00"),
+                ],
+            )
+        ]
+    )
+
+    assert preferred_matrix.best_single_distributor == "DigiKey"
+    assert cost_matrix.best_single_distributor == "Alpha"
+    assert alpha_matrix.best_single_distributor == "Alpha"
+
+
+def test_greedy_fallback_for_many_distributors():
+    rows = [
+        _line(1, offers=[_offer("D00"), _offer("D01")]),
+        _line(2, offers=[_offer("D00")]),
+        _line(3, offers=[_offer("D02")]),
+    ]
+    for index in range(3, 60):
+        rows[0].offers.append(_offer(f"D{index:02d}", stock=1))
+
+    matrix = compute_coverage(rows)
+
+    assert len(matrix.rows) == 60
+    assert matrix.best_single_distributor == "D00"
+    # Known limitation: for more than 30 distributors this is the greedy pair,
+    # not an exhaustive proof of the optimal pair.
+    assert matrix.best_two_distributor_combo == ("D00", "D02")
+
+
+def test_lines_uncovered_lists_project_entry_ids():
+    matrix = compute_coverage(
+        [
+            _line(1, offers=[_offer("D1")]),
+            _line(2, offers=[_offer("D1", stock=4)]),
+            _line(3, offers=[]),
+        ]
+    )
+
+    assert matrix.rows[0].distributor == "D1"
+    assert matrix.rows[0].lines_uncovered == [_uuid(2), _uuid(3)]
+
+
+def test_decimal_serialisation():
+    matrix = compute_coverage([_line(1, offers=[_offer("D1", unit_price="1.25")])])
+    payload = DistributorCoverageMatrixOut.model_validate(matrix).model_dump(mode="json")
+
+    assert payload["rows"][0]["est_total_cost"] == "6.25"
+    assert isinstance(payload["rows"][0]["est_total_cost"], str)


### PR DESCRIPTION
## Summary
- Add pure distributor coverage matrix computation for sourced BOM rows.
- Carry BOM offer price breaks through the sourcing DTO so coverage cost uses quantity price breaks.
- Attach coverage to `SourcingBomOut` and pin route serialization with an existing BOM route test.

## Validation
- `docker compose -f docker-compose.dev.yml exec backend pytest -k sourcing_coverage` could not run: `docker` is not installed in this environment.
- `docker compose -f docker-compose.dev.yml exec backend ruff check` could not run: `docker` is not installed in this environment.
- `uv run --extra dev pytest -k sourcing_coverage` -> 7 passed, 859 deselected, 1 warning.
- `uv run --extra dev pytest tests/test_sourcing_bom_route.py` -> 14 passed, 2 warnings.
- `uv run --extra dev ruff check app/domain/sourcing/coverage.py app/domain/sourcing/schemas.py app/domain/sourcing/service.py tests/test_sourcing_coverage.py tests/test_sourcing_bom_route.py` -> All checks passed.

## Example Matrix
Synthetic two-line BOM where D1 covers line A and D2 covers line B:

```python
{
    "total_lines": 2,
    "rows": [("D1", 1, "5.00"), ("D2", 1, "5.00")],
    "best_single_distributor": "D1",
    "best_two_distributor_combo": ("D1", "D2"),
}
```

## Scope Notes
No migrations, no frontend changes, and no build-capacity computation changes.

Refs #352
