### PR TITLE
TP-304: Build-capacity computation

### DIFF
--- a/backend/app/domain/sourcing/coverage.py
+++ b/backend/app/domain/sourcing/coverage.py
@@ -30,6 +30,96 @@ class DistributorCoverageMatrix:
     best_two_distributor_combo: tuple[str, str] | None
 
 
+@dataclass(frozen=True)
+class BuildCapacity:
+    can_build_now: int
+    can_build_after_purchase: int
+    est_purchase_cost: Decimal | None
+    blocking_lines_now: list[UUID]
+    blocking_lines_after_purchase: list[UUID]
+
+
+def compute_build_capacity(
+    bom_rows: list[SourcingBomLineOut],
+    *,
+    requested_build_quantity: int,
+) -> BuildCapacity:
+    """Compute build capacity from enriched BOM sourcing rows."""
+    effective_rows = [row for row in bom_rows if row.required > 0]
+    if not effective_rows:
+        return BuildCapacity(
+            can_build_now=0,
+            can_build_after_purchase=0,
+            est_purchase_cost=None,
+            blocking_lines_now=[],
+            blocking_lines_after_purchase=[],
+        )
+
+    ratios_now = {
+        row.project_entry_id: _supported_builds(
+            row.available + row.substitute_available,
+            required=row.required,
+            requested_build_quantity=requested_build_quantity,
+        )
+        for row in effective_rows
+    }
+    ratios_after_purchase = {
+        row.project_entry_id: _supported_builds(
+            row.available + row.substitute_available + row.authorized_stock,
+            required=row.required,
+            requested_build_quantity=requested_build_quantity,
+        )
+        for row in effective_rows
+    }
+
+    can_build_now = min(ratios_now.values())
+    can_build_after_purchase = min(ratios_after_purchase.values())
+    blocking_lines_now = [
+        row.project_entry_id
+        for row in effective_rows
+        if ratios_now[row.project_entry_id] == can_build_now
+    ]
+    blocking_lines_after_purchase = [
+        row.project_entry_id
+        for row in effective_rows
+        if ratios_after_purchase[row.project_entry_id] == can_build_after_purchase
+    ]
+
+    est_purchase_cost = Decimal("0")
+    blocking_after = set(blocking_lines_after_purchase)
+    for row in effective_rows:
+        purchase_qty = max(
+            0,
+            _required_for_builds(
+                row.required,
+                builds=can_build_after_purchase,
+                requested_build_quantity=requested_build_quantity,
+            )
+            - (row.available + row.substitute_available),
+        )
+        if purchase_qty == 0:
+            if (
+                row.project_entry_id in blocking_after
+                and ratios_after_purchase[row.project_entry_id] < requested_build_quantity
+                and row.best_offer is None
+            ):
+                est_purchase_cost = None
+            continue
+        if row.best_offer is None or row.best_offer.unit_price is None:
+            est_purchase_cost = None
+            continue
+        if est_purchase_cost is not None:
+            est_purchase_cost += row.best_offer.unit_price * Decimal(purchase_qty)
+
+    return BuildCapacity(
+        can_build_now=can_build_now,
+        can_build_after_purchase=can_build_after_purchase,
+        est_purchase_cost=est_purchase_cost,
+        blocking_lines_now=blocking_lines_now,
+        blocking_lines_after_purchase=blocking_lines_after_purchase,
+    )
+
+
 def compute_coverage(
     bom_rows: list[SourcingBomLineOut],
     *,
@@ -116,6 +206,28 @@ def compute_coverage(
         best_single_distributor=best_single,
         best_two_distributor_combo=best_two,
     )
+
+
+def _supported_builds(
+    available: int,
+    *,
+    required: int,
+    requested_build_quantity: int,
+) -> int:
+    if available <= 0 or requested_build_quantity <= 0:
+        return 0
+    return available * requested_build_quantity // required
+
+
+def _required_for_builds(
+    required: int,
+    *,
+    builds: int,
+    requested_build_quantity: int,
+) -> int:
+    if builds <= 0 or requested_build_quantity <= 0:
+        return 0
+    return (required * builds + requested_build_quantity - 1) // requested_build_quantity
 
 
 def _best_covering_offer(

--- a/backend/app/domain/sourcing/schemas.py
+++ b/backend/app/domain/sourcing/schemas.py
@@ -194,6 +194,16 @@ class DistributorCoverageMatrixOut(BaseModel):
     best_two_distributor_combo: tuple[str, str] | None
 
 
+class BuildCapacityOut(BaseModel):
+    model_config = ConfigDict(extra="forbid", from_attributes=True)
+
+    can_build_now: int
+    can_build_after_purchase: int
+    est_purchase_cost: Decimal | None
+    blocking_lines_now: list[UUID]
+    blocking_lines_after_purchase: list[UUID]
+
+
 class SourcingBomLineOut(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -227,6 +237,7 @@ class SourcingBomOut(BaseModel):
 
     rows: list[SourcingBomLineOut]
     coverage: DistributorCoverageMatrixOut
+    capacity: BuildCapacityOut
     powered_by: Literal["TrustedParts"] = "TrustedParts"
     fetched_at: datetime
     partial: bool

--- a/backend/app/domain/sourcing/service.py
+++ b/backend/app/domain/sourcing/service.py
@@ -16,10 +16,11 @@ from app.domain.builds.service import shortage_analysis
 from app.domain.parts.models import Part
 from app.domain.sourcing import cache
 from app.domain.sourcing.budget import BUDGET
-from app.domain.sourcing.coverage import compute_coverage
+from app.domain.sourcing.coverage import compute_build_capacity, compute_coverage
 from app.domain.sourcing.factory import make_sourcing_provider
 from app.domain.sourcing.pricing import best_unit_price_at_qty
 from app.domain.sourcing.schemas import (
+    BuildCapacityOut,
     DistributorCoverageMatrixOut,
     SourcingAttributionLinks,
     SourcingBomLineOut,
@@ -134,6 +135,12 @@ def source_bom(
         rows=rows,
         coverage=DistributorCoverageMatrixOut.model_validate(
             compute_coverage(rows, preferred_distributors=preferred)
+        ),
+        capacity=BuildCapacityOut.model_validate(
+            compute_build_capacity(
+                rows,
+                requested_build_quantity=build_quantity,
+            )
         ),
         fetched_at=max(fetched_at_values, default=utcnow()),
         partial=partial,

--- a/backend/tests/test_sourcing_bom_route.py
+++ b/backend/tests/test_sourcing_bom_route.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime
+from decimal import Decimal
 from typing import Any
 
 import pytest
@@ -181,6 +182,9 @@ def test_basic_bom_returns_enriched_lines(authed_client):
     assert data["partial"] is False
     assert data["coverage"]["total_lines"] == 1
     assert data["coverage"]["best_single_distributor"] == "DigiKey"
+    assert data["capacity"]["can_build_now"] == 0
+    assert data["capacity"]["can_build_after_purchase"] == 6
+    assert Decimal(data["capacity"]["est_purchase_cost"]) == Decimal("6.00")
     row = data["rows"][0]
     assert row["required"] == 20
     assert row["available"] == 0

--- a/backend/tests/test_sourcing_capacity.py
+++ b/backend/tests/test_sourcing_capacity.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from uuid import UUID
+
+from app.domain.sourcing.coverage import compute_build_capacity
+from app.domain.sourcing.schemas import (
+    BuildCapacityOut,
+    SourcingBomLineOut,
+    SourcingBomOfferOut,
+    SourcingBomPriceBreakOut,
+)
+
+
+def _uuid(index: int) -> UUID:
+    return UUID(f"00000000-0000-0000-0000-{index:012d}")
+
+
+def _offer(
+    *,
+    stock: int = 100,
+    unit_price: str = "1.00",
+    distributor: str = "DigiKey",
+) -> SourcingBomOfferOut:
+    return SourcingBomOfferOut(
+        mpn="MPN",
+        distributor=distributor,
+        stock=stock,
+        unit_price=Decimal(unit_price),
+        price_breaks=[
+            SourcingBomPriceBreakOut(quantity=1, unit_price=Decimal(unit_price))
+        ],
+    )
+
+
+def _line(
+    index: int,
+    *,
+    required: int = 100,
+    available: int = 0,
+    substitute_available: int = 0,
+    authorized_stock: int = 0,
+    best_offer: SourcingBomOfferOut | None = None,
+) -> SourcingBomLineOut:
+    return SourcingBomLineOut(
+        project_entry_id=_uuid(index),
+        part_id=_uuid(index + 1000),
+        part_name=f"Line {index}",
+        required=required,
+        available=available,
+        substitute_available=substitute_available,
+        short_by=max(0, required - available - substitute_available),
+        authorized_stock=authorized_stock,
+        offers=[best_offer] if best_offer is not None else [],
+        best_offer=best_offer,
+    )
+
+
+def test_empty_bom():
+    capacity = compute_build_capacity([], requested_build_quantity=100)
+
+    assert capacity.can_build_now == 0
+    assert capacity.can_build_after_purchase == 0
+    assert capacity.est_purchase_cost is None
+    assert capacity.blocking_lines_now == []
+    assert capacity.blocking_lines_after_purchase == []
+
+
+def test_fully_stocked_internal():
+    capacity = compute_build_capacity(
+        [
+            _line(1, required=100, available=100),
+            _line(2, required=200, available=200),
+        ],
+        requested_build_quantity=100,
+    )
+
+    assert capacity.can_build_now == 100
+    assert capacity.can_build_after_purchase == 100
+    assert capacity.est_purchase_cost == Decimal("0")
+
+
+def test_partially_stocked_with_authorized_supply():
+    capacity = compute_build_capacity(
+        [
+            _line(
+                1,
+                required=100,
+                available=50,
+                authorized_stock=200,
+                best_offer=_offer(stock=200, unit_price="0.25"),
+            ),
+            _line(2, required=100, available=100),
+        ],
+        requested_build_quantity=100,
+    )
+
+    assert capacity.can_build_now == 50
+    assert capacity.can_build_after_purchase == 100
+    assert capacity.est_purchase_cost == Decimal("12.50")
+    assert capacity.blocking_lines_now == [_uuid(1)]
+
+
+def test_authorized_supply_zero_blocks_after_purchase():
+    capacity = compute_build_capacity(
+        [
+            _line(1, required=100, available=50),
+            _line(2, required=100, available=100),
+        ],
+        requested_build_quantity=100,
+    )
+
+    assert capacity.can_build_after_purchase == 50
+    assert capacity.blocking_lines_after_purchase == [_uuid(1)]
+
+
+def test_est_purchase_cost_none_when_blocker_has_no_offer():
+    capacity = compute_build_capacity(
+        [
+            _line(1, required=100, available=50),
+            _line(
+                2,
+                required=100,
+                available=75,
+                authorized_stock=100,
+                best_offer=_offer(stock=100, unit_price="1.00"),
+            ),
+        ],
+        requested_build_quantity=100,
+    )
+
+    assert capacity.can_build_after_purchase == 50
+    assert capacity.blocking_lines_after_purchase == [_uuid(1)]
+    assert capacity.est_purchase_cost is None
+
+
+def test_blocking_lines_lists_binding_constraints():
+    capacity = compute_build_capacity(
+        [
+            _line(1, required=100, available=50, authorized_stock=25),
+            _line(2, required=200, available=100, authorized_stock=50),
+            _line(3, required=100, available=80, authorized_stock=100),
+        ],
+        requested_build_quantity=100,
+    )
+
+    assert capacity.can_build_now == 50
+    assert capacity.can_build_after_purchase == 75
+    assert capacity.blocking_lines_now == [_uuid(1), _uuid(2)]
+    assert capacity.blocking_lines_after_purchase == [_uuid(1), _uuid(2)]
+
+
+def test_floor_not_round():
+    capacity = compute_build_capacity(
+        [_line(1, required=100, available=49)],
+        requested_build_quantity=10,
+    )
+
+    assert capacity.can_build_now == 4
+    assert capacity.can_build_after_purchase == 4
+
+
+def test_required_zero_line_ignored():
+    capacity = compute_build_capacity(
+        [
+            _line(1, required=0, available=0),
+            _line(2, required=100, available=100),
+        ],
+        requested_build_quantity=100,
+    )
+
+    assert capacity.can_build_now == 100
+    assert capacity.blocking_lines_now == [_uuid(2)]
+
+
+def test_decimal_serialisation():
+    capacity = compute_build_capacity(
+        [
+            _line(
+                1,
+                required=100,
+                available=50,
+                authorized_stock=50,
+                best_offer=_offer(stock=50, unit_price="1.25"),
+            )
+        ],
+        requested_build_quantity=100,
+    )
+
+    payload = BuildCapacityOut.model_validate(capacity).model_dump(mode="json")
+
+    assert payload["est_purchase_cost"] == "62.50"
+    assert isinstance(payload["est_purchase_cost"], str)


### PR DESCRIPTION
## Summary

- Adds pure `compute_build_capacity(...)` projection for BOM sourcing rows.
- Extends the BOM sourcing response with `capacity.can_build_now`, `capacity.can_build_after_purchase`, `capacity.est_purchase_cost`, and binding line IDs.
- Wires capacity computation into `source_bom` after TP-303 distributor coverage.
- Adds focused capacity tests plus a route assertion for the response envelope payload.

## Example response

```json
{
  "capacity": {
    "can_build_now": 0,
    "can_build_after_purchase": 6,
    "est_purchase_cost": "6.0",
    "blocking_lines_now": ["..."],
    "blocking_lines_after_purchase": ["..."]
  }
}
```

## Validation

- `docker compose -f docker-compose.dev.yml exec backend pytest -k sourcing_capacity` could not run in this environment: `docker: command not found`.
- `docker compose -f docker-compose.dev.yml exec backend ruff check` could not run in this environment: `docker: command not found`.
- `cd backend && uv run --extra dev python -m pytest -k sourcing_capacity -q` -> `9 passed, 866 deselected, 1 warning`.
- `cd backend && uv run --extra dev python -m pytest tests/test_sourcing_bom_route.py::test_basic_bom_returns_enriched_lines -q` -> `1 passed, 1 warning`.
- `cd backend && uv run --extra dev python -m ruff check app/domain/sourcing/coverage.py app/domain/sourcing/schemas.py app/domain/sourcing/service.py tests/test_sourcing_capacity.py tests/test_sourcing_bom_route.py` -> `All checks passed!`.
- `LINT_CMD='uv run --extra dev python -m ruff check app --output-format=concise' BASELINE_FILE='.ruff-baseline.txt' WORK_DIR='backend' bash scripts/lint-delta.sh` -> `lint-delta: no new violations (baseline: 159, current: 154, fixed since baseline: 5)`.

Refs #353
