### PR TITLE
TP-206: Create order line from sourcing tab

### DIFF
--- a/docs/api/orders.md
+++ b/docs/api/orders.md
@@ -124,6 +124,7 @@ Append an entry. Auto-flips `status="draft"` to `"open"` (`orders.py:258-259`).
 **Notes**
 
 - `order_index` is `max(order_index)+1` (`orders.py:235-243`).
+- The part Authorized-supply tab can create entries through this route; see [parts frontend](../frontend/parts.md) for the UI flow.
 - Source: `backend/app/api/routes/orders.py:231-261`.
 
 ### `PATCH /api/orders/{order_id}/entries/{entry_id}`

--- a/docs/frontend/README.md
+++ b/docs/frontend/README.md
@@ -21,6 +21,7 @@ What you need to navigate `web/src/`. Conventions are sketched in [`CLAUDE.md`](
 | [api-layer](api-layer.md) | `lib/api.ts` (envelope unwrap, ApiError), Zod schemas, `categoryToUserMessage` |
 | [tanstack-patterns](tanstack-patterns.md) | `["ws", wsId, …]` keys, invalidation helpers, `useApiMutation` |
 | [components](components.md) | DataTable + reusable component catalog |
+| [parts](parts.md) | Part-detail flows that span tabs and modals |
 | [tailwind-utilities](tailwind-utilities.md) | The `index.css` utility set (`btn`, `card`, `pill`, …) |
 | [auth-flow](auth-flow.md) | `AuthProvider`, workspace switch, 401 redirect bus |
 | [scanner](scanner.md) | ZXing / Scandit dual-mode + `bagCode.ts` parser |

--- a/docs/frontend/parts.md
+++ b/docs/frontend/parts.md
@@ -1,0 +1,9 @@
+# Parts Frontend
+
+Audience: engineer
+
+Part-detail UI flows that are larger than one tab component.
+
+## Authorized Supply To Order
+
+The Authorized-supply tab renders one `Add to order` action per distributor row and opens `CreateOrderLineModal`, which lists draft orders with `GET /api/orders?order_status=draft` and submits through the documented order endpoints. Existing draft orders receive a line via `POST /api/orders/{order_id}/entries`; the create-new branch posts `POST /api/orders` with one initial entry. The saved entry `comments` value is the compliance-safe TrustedParts summary only; the distributor page is available as a modal link but is not persisted in comments. Source: `web/src/routes/parts/detail/AuthorizedSupplyTab.tsx:318-343`, `web/src/routes/parts/detail/CreateOrderLineModal.tsx:82-154`.

--- a/web/src/routes/parts/detail/AuthorizedSupplyTab.tsx
+++ b/web/src/routes/parts/detail/AuthorizedSupplyTab.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { ExternalLink, RefreshCw } from "lucide-react";
+import { ExternalLink, Plus, RefreshCw } from "lucide-react";
 import { toast } from "sonner";
 import { InlineQueryError } from "@/components/QueryStateBoundary";
 import { ApiError, api } from "@/lib/api";
@@ -13,6 +13,10 @@ import type { Column } from "@/components/DataTable";
 import { DataTable } from "@/components/DataTable";
 import { PoweredByTrustedParts } from "@/components/PoweredByTrustedParts";
 import { SourcingSourceLabel } from "@/components/SourcingSourceLabel";
+import {
+  CreateOrderLineModal,
+  type CreateOrderLineSource,
+} from "./CreateOrderLineModal";
 
 type SourcingReason = "ok" | "no_mpn";
 
@@ -118,7 +122,7 @@ function flattenOffers(data: SourcingResponse | undefined): SupplyRow[] {
       currency: distributor.currency ?? null,
       priceBreaks: distributor.price_breaks ?? [],
       leadTimeDays: distributor.lead_time_days ?? null,
-      link: offer.links?.primary ?? data.links?.primary ?? null,
+      link: distributor.product_url ?? offer.links?.primary ?? data.links?.primary ?? null,
     })),
   );
 }
@@ -165,6 +169,7 @@ export function AuthorizedSupplyTab({ partId }: { partId: string }) {
   const [selectedDistributors, setSelectedDistributors] = useState<Set<string>>(() => new Set());
   const [quantity, setQuantity] = useState(1);
   const [customQuantity, setCustomQuantity] = useState("1");
+  const [orderLineSource, setOrderLineSource] = useState<CreateOrderLineSource | null>(null);
 
   const query = useQuery({
     queryKey,
@@ -310,9 +315,36 @@ export function AuthorizedSupplyTab({ partId }: { partId: string }) {
             <span className="text-muted">—</span>
           ),
       },
+      {
+        key: "order",
+        header: "",
+        render: row => (
+          <button
+            type="button"
+            className="btn btn-sm"
+            onClick={() => {
+              const best = bestUnitPriceAtQty(row.priceBreaks, quantity);
+              setOrderLineSource({
+                partId,
+                distributor: row.distributor,
+                packaging: row.packaging,
+                leadTimeDays: row.leadTimeDays,
+                fetchedAt: query.data?.fetched_at ?? null,
+                quantity,
+                unitPrice: best?.unitPrice ?? row.unitPrice,
+                currency: row.currency,
+                productUrl: row.link,
+              });
+            }}
+          >
+            <Plus size={14} aria-hidden="true" />
+            Add to order
+          </button>
+        ),
+      },
     ];
     return baseColumns;
-  }, [quantity]);
+  }, [partId, quantity, query.data?.fetched_at]);
 
   const status = errorStatus(query.error);
   const refreshStatus = errorStatus(refreshMutation.error);
@@ -473,6 +505,11 @@ export function AuthorizedSupplyTab({ partId }: { partId: string }) {
         searchPlaceholder="Search offers…"
         exportFilename="authorized-supply"
         empty="No authorized-distributor offers."
+      />
+      <CreateOrderLineModal
+        open={orderLineSource !== null}
+        source={orderLineSource}
+        onClose={() => setOrderLineSource(null)}
       />
     </div>
   );

--- a/web/src/routes/parts/detail/CreateOrderLineModal.tsx
+++ b/web/src/routes/parts/detail/CreateOrderLineModal.tsx
@@ -1,0 +1,342 @@
+import { useEffect, useMemo, useState } from "react";
+import type { FormEvent } from "react";
+import { ExternalLink } from "lucide-react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { ApiError, api } from "@/lib/api";
+import { useAuth } from "@/lib/auth";
+import { useApiMutation } from "@/lib/mutations";
+import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
+import type { Order, OrderEntry } from "@/types";
+
+const CREATE_NEW = "__create_new__";
+
+export type CreateOrderLineSource = {
+  partId: string;
+  distributor: string;
+  packaging: string | null;
+  leadTimeDays: number | null;
+  fetchedAt: string | null;
+  quantity: number;
+  unitPrice: number | null;
+  currency: string | null;
+  productUrl: string | null;
+};
+
+type OrderEntryPayload = {
+  part_id: string;
+  quantity_ordered: number;
+  unit_price?: string;
+  currency?: string;
+  comments?: string;
+};
+
+type OrderCreatePayload = {
+  name: string;
+  order_type: "purchase";
+  supplier?: string;
+  currency?: string;
+  entries: OrderEntryPayload[];
+};
+
+export function buildComplianceSafeOrderLineNote(source: CreateOrderLineSource): string {
+  const packaging = source.packaging?.trim() || "unknown";
+  const leadTime = source.leadTimeDays == null ? "unknown" : String(source.leadTimeDays);
+  const fetchedAt = source.fetchedAt?.trim() || "unknown";
+  return `From TrustedParts: distributor=${source.distributor}, packaging=${packaging}, lead_time=${leadTime} days, fetched_at=${fetchedAt}`;
+}
+
+function stripUrls(value: string): string {
+  return value.replace(/https?:\/\/\S+/gi, "[link omitted]").trim();
+}
+
+function todayIsoDate(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function orderLabel(order: Order | undefined, fallbackId: string): string {
+  return order?.name || fallbackId.slice(0, 8);
+}
+
+export function CreateOrderLineModal({
+  open,
+  source,
+  onClose,
+}: {
+  open: boolean;
+  source: CreateOrderLineSource | null;
+  onClose: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const { workspaceId } = useAuth();
+  const ordersKey = useWsKey("orders", "draft");
+  const [targetOrderId, setTargetOrderId] = useState("");
+  const [name, setName] = useState("");
+  const [supplier, setSupplier] = useState("");
+  const [quantity, setQuantity] = useState(1);
+  const [unitPrice, setUnitPrice] = useState("");
+  const [currency, setCurrency] = useState("");
+  const [note, setNote] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const ordersQuery = useQuery({
+    queryKey: ordersKey,
+    queryFn: () => api.get<Order[]>("/orders?order_status=draft"),
+    enabled: open,
+  });
+
+  const draftOrders = useMemo(() => ordersQuery.data ?? [], [ordersQuery.data]);
+  const selectedOrder = draftOrders.find(order => order.id === targetOrderId);
+  const isCreatingNew = targetOrderId === CREATE_NEW;
+
+  useEffect(() => {
+    if (!open || !source) return;
+    setTargetOrderId("");
+    setName(`TrustedParts ${source.distributor} ${todayIsoDate()}`);
+    setSupplier(source.distributor);
+    setQuantity(Math.max(1, Math.floor(source.quantity || 1)));
+    setUnitPrice(source.unitPrice == null ? "" : String(source.unitPrice));
+    setCurrency(source.currency ?? "");
+    setNote(buildComplianceSafeOrderLineNote(source));
+    setError(null);
+  }, [open, source]);
+
+  useEffect(() => {
+    if (!open || targetOrderId || draftOrders.length === 0) return;
+    setTargetOrderId(draftOrders[0].id);
+  }, [draftOrders, open, targetOrderId]);
+
+  const entryPayload = useMemo<OrderEntryPayload | null>(() => {
+    if (!source) return null;
+    const cleanCurrency = currency.trim().toUpperCase();
+    const cleanUnitPrice = unitPrice.trim();
+    return {
+      part_id: source.partId,
+      quantity_ordered: Math.max(1, Math.floor(quantity || 1)),
+      unit_price: cleanUnitPrice || undefined,
+      currency: cleanCurrency || undefined,
+      comments: stripUrls(note) || undefined,
+    };
+  }, [currency, note, quantity, source, unitPrice]);
+
+  const submitMutation = useApiMutation<Order | OrderEntry, void>({
+    mutationKey: ["parts", source?.partId, "create-order-line"],
+    mutationFn: async () => {
+      if (!entryPayload) throw new Error("Missing source row");
+      if (isCreatingNew) {
+        return api.post<Order, OrderCreatePayload>("/orders", {
+          name: name.trim(),
+          order_type: "purchase",
+          supplier: supplier.trim() || undefined,
+          currency: currency.trim().toUpperCase() || undefined,
+          entries: [entryPayload],
+        });
+      }
+      if (!targetOrderId) throw new Error("Pick an order");
+      return api.post<OrderEntry, OrderEntryPayload>(
+        `/orders/${targetOrderId}/entries`,
+        entryPayload,
+      );
+    },
+    onSuccess: result => {
+      const orderId = "order_id" in result ? result.order_id : result.id;
+      const label = "order_id" in result
+        ? orderLabel(selectedOrder, result.order_id)
+        : orderLabel(result, result.id);
+      queryClient.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "orders") });
+      queryClient.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "orders", orderId) });
+      queryClient.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "order", orderId) });
+      toast.success("Order line created", {
+        action: {
+          label: `Open ${label}`,
+          onClick: () => window.location.assign(`/orders/${orderId}`),
+        },
+      });
+      onClose();
+    },
+    onError: err => {
+      setError(err instanceof ApiError ? err.userMessage : "Failed to create order line");
+    },
+  });
+
+  if (!open || !source) return null;
+
+  function submit(event: FormEvent) {
+    event.preventDefault();
+    setError(null);
+    if (isCreatingNew && !name.trim()) {
+      setError("Order name is required.");
+      return;
+    }
+    submitMutation.mutate();
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="create-order-line-title"
+      onMouseDown={event => {
+        if (event.target === event.currentTarget && !submitMutation.isPending) onClose();
+      }}
+    >
+      <form className="card w-full max-w-2xl p-4 shadow-lg" onSubmit={submit}>
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <h2 id="create-order-line-title" className="text-base font-semibold text-text">
+              Create order line
+            </h2>
+            <p className="mt-1 text-sm text-muted">{source.distributor}</p>
+          </div>
+          <button
+            type="button"
+            className="btn-ghost btn-sm"
+            onClick={onClose}
+            disabled={submitMutation.isPending}
+          >
+            Close
+          </button>
+        </div>
+
+        {error && (
+          <div className="mt-3 card p-3 text-sm text-danger" role="alert">
+            {error}
+          </div>
+        )}
+
+        <div className="mt-4 space-y-3">
+          <label className="label" htmlFor="order-line-order">
+            Order
+            <select
+              id="order-line-order"
+              className="input"
+              value={targetOrderId}
+              onChange={event => setTargetOrderId(event.currentTarget.value)}
+              disabled={ordersQuery.isLoading || submitMutation.isPending}
+              required
+            >
+              <option value="" disabled>
+                {ordersQuery.isLoading ? "Loading draft orders..." : "Choose an order"}
+              </option>
+              {draftOrders.map(order => (
+                <option key={order.id} value={order.id}>
+                  {order.name}
+                </option>
+              ))}
+              <option value={CREATE_NEW}>Or create a new order</option>
+            </select>
+          </label>
+
+          {isCreatingNew && (
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <label className="label" htmlFor="order-line-name">
+                Order name
+                <input
+                  id="order-line-name"
+                  className="input"
+                  value={name}
+                  onChange={event => setName(event.currentTarget.value)}
+                  disabled={submitMutation.isPending}
+                  required
+                />
+              </label>
+              <label className="label" htmlFor="order-line-supplier">
+                Supplier
+                <input
+                  id="order-line-supplier"
+                  className="input"
+                  value={supplier}
+                  onChange={event => setSupplier(event.currentTarget.value)}
+                  disabled={submitMutation.isPending}
+                />
+              </label>
+            </div>
+          )}
+
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+            <label className="label" htmlFor="order-line-quantity">
+              Quantity
+              <input
+                id="order-line-quantity"
+                className="input"
+                type="number"
+                min={1}
+                step={1}
+                inputMode="numeric"
+                value={quantity}
+                onChange={event => setQuantity(Number(event.currentTarget.value))}
+                disabled={submitMutation.isPending}
+                required
+              />
+            </label>
+            <label className="label" htmlFor="order-line-unit-price">
+              Unit price
+              <input
+                id="order-line-unit-price"
+                className="input"
+                type="number"
+                min={0}
+                step="0.000001"
+                value={unitPrice}
+                onChange={event => setUnitPrice(event.currentTarget.value)}
+                disabled={submitMutation.isPending}
+              />
+            </label>
+            <label className="label" htmlFor="order-line-currency">
+              Currency
+              <input
+                id="order-line-currency"
+                className="input"
+                maxLength={3}
+                value={currency}
+                onChange={event => setCurrency(event.currentTarget.value.toUpperCase())}
+                disabled={submitMutation.isPending}
+              />
+            </label>
+          </div>
+
+          <label className="label" htmlFor="order-line-note">
+            Note
+            <textarea
+              id="order-line-note"
+              className="input"
+              rows={3}
+              value={note}
+              onChange={event => setNote(event.currentTarget.value)}
+              disabled={submitMutation.isPending}
+            />
+          </label>
+
+          {source.productUrl && (
+            <a
+              href={source.productUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 text-sm text-accent hover:underline"
+            >
+              Open distributor page
+              <ExternalLink size={14} aria-hidden="true" />
+            </a>
+          )}
+        </div>
+
+        <div className="mt-4 flex justify-end gap-2">
+          <button
+            type="button"
+            className="btn-ghost"
+            onClick={onClose}
+            disabled={submitMutation.isPending}
+          >
+            Cancel
+          </button>
+          <button type="submit" className="btn-primary" disabled={submitMutation.isPending}>
+            {submitMutation.isPending ? "Creating..." : "Create order line"}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+export default CreateOrderLineModal;

--- a/web/src/routes/parts/detail/__tests__/AuthorizedSupplyTab.test.tsx
+++ b/web/src/routes/parts/detail/__tests__/AuthorizedSupplyTab.test.tsx
@@ -122,6 +122,7 @@ describe("AuthorizedSupplyTab", () => {
     const table = screen.getByRole("table");
     expect(within(table).getByText("DigiKey")).toBeDefined();
     expect(within(table).getByText("Mouser")).toBeDefined();
+    expect(within(table).getAllByRole("button", { name: "Add to order" })).toHaveLength(2);
     expect(screen.getByText("42")).toBeDefined();
     expect(screen.getByText("Tape")).toBeDefined();
   });

--- a/web/src/routes/parts/detail/__tests__/CreateOrderLineModal.test.tsx
+++ b/web/src/routes/parts/detail/__tests__/CreateOrderLineModal.test.tsx
@@ -1,0 +1,217 @@
+// @vitest-environment jsdom
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { toast } from "sonner";
+import { ApiError, api } from "@/lib/api";
+import type { Order } from "@/types";
+import {
+  buildComplianceSafeOrderLineNote,
+  CreateOrderLineModal,
+  type CreateOrderLineSource,
+} from "../CreateOrderLineModal";
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({
+  useAuth: () => ({ workspaceId: "ws-1" }),
+}));
+
+const source: CreateOrderLineSource = {
+  partId: "11111111-1111-1111-1111-111111111111",
+  distributor: "DigiKey",
+  packaging: "Tape",
+  leadTimeDays: 3,
+  fetchedAt: "2026-05-08T12:00:00+00:00",
+  quantity: 25,
+  unitPrice: 1.23,
+  currency: "EUR",
+  productUrl: "https://www.trustedparts.com/digikey/stm32",
+};
+
+const draftOrder: Order = {
+  id: "22222222-2222-2222-2222-222222222222",
+  name: "May sourcing",
+  order_type: "purchase",
+  supplier: "DigiKey",
+  status: "draft",
+  ordered_on: null,
+  expected_on: null,
+  received_on: null,
+  currency: "EUR",
+  comments: null,
+  archived_at: null,
+  totals: { ordered: 0, received: 0 },
+  created_at: "2026-05-08T12:00:00+00:00",
+  updated_at: "2026-05-08T12:00:00+00:00",
+};
+
+function apiError(status: number, message: string) {
+  return new ApiError(
+    status,
+    {
+      data: null,
+      status: { category: status === 422 ? "validation_error" : "server_error", message },
+    },
+    message,
+  );
+}
+
+function renderModal(onClose = vi.fn()) {
+  const client = new QueryClient({
+    defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+  });
+  const invalidateSpy = vi.spyOn(client, "invalidateQueries");
+  render(
+    <QueryClientProvider client={client}>
+      <CreateOrderLineModal open source={source} onClose={onClose} />
+    </QueryClientProvider>,
+  );
+  return { invalidateSpy, onClose };
+}
+
+beforeEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+});
+
+describe("CreateOrderLineModal", () => {
+  it("submitting with an existing draft order appends the line", async () => {
+    const user = userEvent.setup();
+    vi.spyOn(api, "get").mockResolvedValue([draftOrder]);
+    const postSpy = vi.spyOn(api, "post").mockResolvedValue({
+      id: "entry-1",
+      order_id: draftOrder.id,
+      part_id: source.partId,
+      name: null,
+      quantity_ordered: 25,
+      quantity_received: 0,
+      unit_price: 1.23,
+      currency: "EUR",
+      comments: buildComplianceSafeOrderLineNote(source),
+      order_index: 0,
+    });
+    const onClose = vi.fn();
+    const { invalidateSpy } = renderModal(onClose);
+
+    await screen.findByRole("dialog", { name: "Create order line" });
+    await waitFor(() => {
+      expect((screen.getByLabelText("Order") as HTMLSelectElement).value).toBe(draftOrder.id);
+    });
+    await user.click(screen.getByRole("button", { name: "Create order line" }));
+
+    await waitFor(() => {
+      expect(postSpy).toHaveBeenCalledWith(`/orders/${draftOrder.id}/entries`, {
+        part_id: source.partId,
+        quantity_ordered: 25,
+        unit_price: "1.23",
+        currency: "EUR",
+        comments: buildComplianceSafeOrderLineNote(source),
+      });
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["ws", "ws-1", "orders"] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["ws", "ws-1", "order", draftOrder.id] });
+    expect(toast.success).toHaveBeenCalledWith(
+      "Order line created",
+      expect.objectContaining({
+        action: expect.objectContaining({ label: "Open May sourcing" }),
+      }),
+    );
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("submitting with create new order posts to /orders with one entry", async () => {
+    const user = userEvent.setup();
+    vi.spyOn(api, "get").mockResolvedValue([draftOrder]);
+    const postSpy = vi.spyOn(api, "post").mockResolvedValue({
+      ...draftOrder,
+      id: "33333333-3333-3333-3333-333333333333",
+      name: "TrustedParts DigiKey 2026-05-08",
+      status: "open",
+      totals: { ordered: 25, received: 0 },
+    });
+
+    renderModal();
+
+    await screen.findByRole("dialog", { name: "Create order line" });
+    const orderSelect = screen.getByLabelText("Order");
+    await waitFor(() => {
+      expect((orderSelect as HTMLSelectElement).value).toBe(draftOrder.id);
+    });
+    await user.selectOptions(orderSelect, "__create_new__");
+    const orderName = await screen.findByLabelText("Order name");
+    await user.clear(orderName);
+    await user.type(orderName, "TrustedParts DigiKey 2026-05-08");
+    await user.click(screen.getByRole("button", { name: "Create order line" }));
+
+    await waitFor(() => {
+      expect(postSpy).toHaveBeenCalledWith("/orders", {
+        name: "TrustedParts DigiKey 2026-05-08",
+        order_type: "purchase",
+        supplier: "DigiKey",
+        currency: "EUR",
+        entries: [
+          {
+            part_id: source.partId,
+            quantity_ordered: 25,
+            unit_price: "1.23",
+            currency: "EUR",
+            comments: buildComplianceSafeOrderLineNote(source),
+          },
+        ],
+      });
+    });
+  });
+
+  it("the saved note contains compliance-safe metadata only", async () => {
+    const user = userEvent.setup();
+    vi.spyOn(api, "get").mockResolvedValue([draftOrder]);
+    const postSpy = vi.spyOn(api, "post").mockResolvedValue({
+      id: "entry-1",
+      order_id: draftOrder.id,
+    });
+
+    renderModal();
+
+    await screen.findByRole("dialog", { name: "Create order line" });
+    expect(screen.getByRole("link", { name: "Open distributor page" }).getAttribute("href"))
+      .toBe(source.productUrl);
+    await user.clear(screen.getByLabelText("Note"));
+    await user.type(
+      screen.getByLabelText("Note"),
+      `${buildComplianceSafeOrderLineNote(source)} ${source.productUrl}`,
+    );
+    await user.click(screen.getByRole("button", { name: "Create order line" }));
+
+    await waitFor(() => {
+      expect(postSpy).toHaveBeenCalled();
+    });
+    const payload = postSpy.mock.calls[0][1] as { comments?: string; product_url?: string };
+    expect(payload.comments).toContain("From TrustedParts: distributor=DigiKey");
+    expect(payload.comments).toContain("packaging=Tape");
+    expect(payload.comments).toContain("lead_time=3 days");
+    expect(payload.comments).toContain("fetched_at=2026-05-08T12:00:00+00:00");
+    expect(payload.comments).not.toContain(source.productUrl);
+    expect(payload.product_url).toBeUndefined();
+  });
+
+  it("error path renders form-level error message", async () => {
+    const user = userEvent.setup();
+    vi.spyOn(api, "get").mockResolvedValue([draftOrder]);
+    vi.spyOn(api, "post").mockRejectedValue(apiError(422, "bad payload"));
+
+    renderModal();
+
+    await screen.findByRole("dialog", { name: "Create order line" });
+    await user.click(screen.getByRole("button", { name: "Create order line" }));
+
+    expect((await screen.findByRole("alert")).textContent).toBe("Some fields don't look right. Check the form and retry.");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a per-row Add to order action on the Authorized-supply tab.
- Adds CreateOrderLineModal for appending to an existing draft order or creating a new purchase order with one line through the existing orders API.
- Stores only the compliance-safe TrustedParts summary in order-entry comments; distributor URLs are shown in the modal but not persisted.
- Adds modal coverage and updates orders/frontend docs.

## Validation
- PASS: `cd web && npm run typecheck`
- PASS: `cd web && npm test -- CreateOrderLineModal AuthorizedSupplyTab` (18 tests)
- FAIL: `cd web && npm run lint` exits 1 on pre-existing unrelated lint debt only: `web/src/lib/bagCode.ts` no-control-regex errors plus existing warnings in scanner, responsive grid test, orders detail, parts list, part layout nav test, and storage detail. No TP-206 files are reported.

Note: the issue-specified `npm test -- "CreateOrderLineModal|AuthorizedSupplyTab"` filter returns `No test files found` under the current Vitest CLI, so the equivalent two-filter command above was used.

## Compliance
- Confirmed the saved `comments` payload contains `From TrustedParts: distributor=<name>, packaging=<pkg>, lead_time=<n> days, fetched_at=<ISO>` and excludes the raw distributor URL.
- Backend endpoint verification: existing `POST /api/orders` and `POST /api/orders/{order_id}/entries` support this frontend flow; no backend route changes.

Refs #349