### PR TITLE
TP-305: Source BOM page (capacity + coverage + enriched rows)

### DIFF
--- a/docs/frontend/README.md
+++ b/docs/frontend/README.md
@@ -22,6 +22,7 @@ What you need to navigate `web/src/`. Conventions are sketched in [`CLAUDE.md`](
 | [tanstack-patterns](tanstack-patterns.md) | `["ws", wsId, …]` keys, invalidation helpers, `useApiMutation` |
 | [components](components.md) | DataTable + reusable component catalog |
 | [parts](parts.md) | Part-detail flows that span tabs and modals |
+| [projects](projects.md) | Project-detail flows, including Source BOM |
 | [tailwind-utilities](tailwind-utilities.md) | The `index.css` utility set (`btn`, `card`, `pill`, …) |
 | [auth-flow](auth-flow.md) | `AuthProvider`, workspace switch, 401 redirect bus |
 | [scanner](scanner.md) | ZXing / Scandit dual-mode + `bagCode.ts` parser |

--- a/docs/frontend/projects.md
+++ b/docs/frontend/projects.md
@@ -1,0 +1,15 @@
+# Projects Frontend
+
+Audience: engineer
+
+Project-detail UI flows that span the project tabs, builds, and sourcing routes.
+
+## Source BOM
+
+Project detail and build detail both render the shared `SourceBomButton`. It reads `GET /api/workspaces/current` through `api.get()` and the workspace-scoped `["ws", wsId, "ws", "current"]` query key; when `has_sourcing_company_id` is false, the button is disabled with the `Sourcing not configured` cue instead of linking to the sourcing route. Sources: `web/src/routes/projects/sourcing/SourceBomButton.tsx:18-48`, `web/src/routes/projects/detail/ProjectLayout.tsx:24-29`, `web/src/routes/builds/BuildDetail.tsx:179-186`.
+
+`/projects/:projectId/sourcing` is a lazy child of the project detail route. The page initializes build quantity plus country, currency, and distributor filters from workspace sourcing settings, then posts to `POST /api/projects/{project_id}/sourcing` through `api.post()` with a workspace-scoped TanStack key. Sources: `web/src/App.tsx:98-106`, `web/src/App.tsx:278-285`, `web/src/routes/projects/sourcing/ProjectSourcingPage.tsx:390-424`.
+
+The populated response renders three `DataTable`-backed areas: the capacity banner, distributor coverage matrix, and enriched BOM rows. Coverage highlights the best single distributor and best two-distributor combo; BOM rows render authorized stock, best offer, distributor, estimated cost, one risk pill per `risk_flag`, and a `SourcingSourceLabel` column for TrustedParts attribution. Sources: `web/src/routes/projects/sourcing/ProjectSourcingPage.tsx:208-252`, `web/src/routes/projects/sourcing/ProjectSourcingPage.tsx:254-307`, `web/src/routes/projects/sourcing/ProjectSourcingPage.tsx:309-379`.
+
+Status handling is local to the route: loading skeletons, 409 not-configured settings link, 503 budget pause, 502 retry/toast, empty-BOM call to action, and `partial=true` badge are all rendered before the populated tables. Sources: `web/src/routes/projects/sourcing/ProjectSourcingPage.tsx:160-206`, `web/src/routes/projects/sourcing/ProjectSourcingPage.tsx:429-547`.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -103,6 +103,7 @@ const ProjectBOM = lazy(() => import("@/routes/projects/detail/ProjectBOM"));
 const ProjectImport = lazy(() => import("@/routes/projects/detail/ProjectImport"));
 const ProjectBuilds = lazy(() => import("@/routes/projects/detail/ProjectBuilds"));
 const ProjectOther = lazy(() => import("@/routes/projects/detail/ProjectOther"));
+const ProjectSourcingPage = lazy(() => import("@/routes/projects/sourcing/ProjectSourcingPage"));
 
 const Account = lazy(() => import("@/routes/settings/Account"));
 const WorkspaceSettings = lazy(() => import("@/routes/settings/Workspace"));
@@ -280,6 +281,7 @@ export default function App() {
               <Route path="bom" element={<LazyRoute><ProjectBOM /></LazyRoute>} />
               <Route path="import" element={<LazyRoute><ProjectImport /></LazyRoute>} />
               <Route path="builds" element={<LazyRoute><ProjectBuilds /></LazyRoute>} />
+              <Route path="sourcing" element={<LazyRoute><ProjectSourcingPage /></LazyRoute>} />
               <Route path="other" element={<LazyRoute><ProjectOther /></LazyRoute>} />
             </Route>
 

--- a/web/src/routes/builds/BuildDetail.tsx
+++ b/web/src/routes/builds/BuildDetail.tsx
@@ -10,6 +10,7 @@ import { formatDateTime } from "@/lib/format";
 import EntityHeader from "@/components/EntityHeader";
 import AttachmentsPanel from "@/components/AttachmentsPanel";
 import ActivityTimeline from "@/components/ActivityTimeline";
+import { SourceBomButton } from "@/routes/projects/sourcing/SourceBomButton";
 import type { Build, BuildShortageRow, Part, Project, ProjectEntry, StorageLocation } from "@/types";
 
 type DetailOut = { build: Build; shortage: BuildShortageRow[] };
@@ -177,6 +178,7 @@ export default function BuildDetail() {
         ]}
         actions={
           <div className="flex gap-2">
+            <SourceBomButton projectId={projectId} />
             {isEditable && (
               <button className="btn" onClick={fillSuggested}>Auto-fill</button>
             )}

--- a/web/src/routes/projects/detail/ProjectLayout.tsx
+++ b/web/src/routes/projects/detail/ProjectLayout.tsx
@@ -5,6 +5,7 @@ import { useWsKey } from "@/lib/queryKeys";
 import EntityHeader from "@/components/EntityHeader";
 import SubNav from "@/components/SubNav";
 import type { Project } from "@/types";
+import { SourceBomButton } from "@/routes/projects/sourcing/SourceBomButton";
 
 export default function ProjectLayout() {
   const { projectId } = useParams<{ projectId: string }>();
@@ -20,7 +21,12 @@ export default function ProjectLayout() {
   ];
   return (
     <div>
-      <EntityHeader title={data.name} subtitle={data.description ?? ""} idCode={data.id} />
+      <EntityHeader
+        title={data.name}
+        subtitle={data.description ?? ""}
+        idCode={data.id}
+        actions={<SourceBomButton projectId={data.id} />}
+      />
       <SubNav items={items} />
       <Outlet key={data.id} context={{ project: data }} />
     </div>

--- a/web/src/routes/projects/sourcing/ProjectSourcingPage.tsx
+++ b/web/src/routes/projects/sourcing/ProjectSourcingPage.tsx
@@ -214,7 +214,7 @@ function CapacityBanner({ data }: { data: SourcingBomResponse }) {
 
   return (
     <div className="card p-4">
-      <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
         <div>
           <div className="section-title">Can build now</div>
           <div className="text-2xl font-semibold tabular-nums">{data.capacity.can_build_now}</div>

--- a/web/src/routes/projects/sourcing/ProjectSourcingPage.tsx
+++ b/web/src/routes/projects/sourcing/ProjectSourcingPage.tsx
@@ -1,0 +1,555 @@
+import { useEffect, useMemo, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { FolderKanban, RefreshCw } from "lucide-react";
+import { toast } from "sonner";
+import EmptyState from "@/components/EmptyState";
+import { DataTable, type Column } from "@/components/DataTable";
+import { PoweredByTrustedParts } from "@/components/PoweredByTrustedParts";
+import { SourcingSourceLabel } from "@/components/SourcingSourceLabel";
+import { ApiError, api } from "@/lib/api";
+import { useWsKey } from "@/lib/queryKeys";
+import type { Project } from "@/types";
+import type { SourcingWorkspaceSettings } from "./SourceBomButton";
+
+type SourcingBomOffer = {
+  mpn: string;
+  distributor: string;
+  sku?: string | null;
+  stock: number;
+  unit_price?: string | number | null;
+  currency?: string | null;
+  packaging?: string | null;
+  moq?: number | null;
+  lead_time_days?: number | null;
+  url?: string | null;
+};
+
+type RiskFlag =
+  | "single_source"
+  | "no_authorized_stock"
+  | "moq_overbuy"
+  | "lead_time_long"
+  | "preferred_distributor_unmet";
+
+type SourcingBomLine = {
+  project_entry_id: string;
+  part_id: string;
+  part_name: string;
+  mpn?: string | null;
+  required: number;
+  available: number;
+  substitute_ids: string[];
+  substitute_available: number;
+  short_by: number;
+  authorized_stock: number;
+  offers: SourcingBomOffer[];
+  best_offer?: SourcingBomOffer | null;
+  est_extended_cost?: string | number | null;
+  lead_time_days?: number | null;
+  risk_flags: RiskFlag[];
+};
+
+type CoverageRow = {
+  distributor: string;
+  lines_covered: number;
+  lines_uncovered: string[];
+  coverage_pct: number;
+  est_total_cost?: string | number | null;
+  worst_lead_time_days?: number | null;
+};
+
+type SourcingBomResponse = {
+  rows: SourcingBomLine[];
+  coverage: {
+    rows: CoverageRow[];
+    total_lines: number;
+    best_single_distributor?: string | null;
+    best_two_distributor_combo?: [string, string] | null;
+  };
+  capacity: {
+    can_build_now: number;
+    can_build_after_purchase: number;
+    est_purchase_cost?: string | number | null;
+    blocking_lines_now: string[];
+    blocking_lines_after_purchase: string[];
+  };
+  powered_by: "TrustedParts";
+  fetched_at: string;
+  partial: boolean;
+  links: {
+    primary: string;
+    attribution: string;
+  };
+};
+
+type SourcingRequest = {
+  build_quantity: number;
+  country?: string;
+  currency?: string;
+  distributors?: string[];
+};
+
+function numberOrNull(value: string | number | null | undefined): number | null {
+  if (value == null || value === "") return null;
+  const parsed = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function formatCount(value: number | null | undefined): string {
+  return value == null ? "—" : value.toLocaleString();
+}
+
+function formatMoney(value: string | number | null | undefined, currency?: string | null): string {
+  const numeric = numberOrNull(value);
+  if (numeric == null) return "—";
+  const formatted = numeric.toLocaleString(undefined, {
+    maximumFractionDigits: 2,
+    minimumFractionDigits: numeric % 1 === 0 ? 0 : 2,
+  });
+  return currency ? `${formatted} ${currency}` : formatted;
+}
+
+function formatLeadTime(days: number | null | undefined): string {
+  if (days == null) return "—";
+  return days === 1 ? "1 day" : `${days.toLocaleString()} days`;
+}
+
+function splitDistributors(value: string): string[] {
+  return value
+    .split(",")
+    .map(item => item.trim())
+    .filter(Boolean);
+}
+
+function riskLabel(flag: RiskFlag): string {
+  switch (flag) {
+    case "single_source":
+      return "Single source";
+    case "no_authorized_stock":
+      return "No authorized stock";
+    case "moq_overbuy":
+      return "MOQ overbuy";
+    case "lead_time_long":
+      return "Long lead time";
+    case "preferred_distributor_unmet":
+      return "Preferred unmet";
+  }
+}
+
+function errorStatus(error: unknown): number | null {
+  return error instanceof ApiError ? error.status : null;
+}
+
+function SourcingSkeleton() {
+  return (
+    <div className="space-y-3" role="status" aria-label="Loading sourced BOM">
+      {[0, 1, 2].map(section => (
+        <div key={section} className="card p-4 animate-pulse">
+          <div className="h-4 w-48 rounded bg-panel2 mb-4" />
+          <div className="space-y-2">
+            {[0, 1, 2].map(row => (
+              <div key={row} className="grid grid-cols-5 gap-3">
+                {[0, 1, 2, 3, 4].map(cell => (
+                  <div key={cell} className="h-3 rounded bg-panel2" />
+                ))}
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function EmptyBomState({ projectId }: { projectId: string }) {
+  return (
+    <EmptyState
+      icon={FolderKanban}
+      title="BOM is empty"
+      description="Add BOM lines first to run sourcing coverage."
+      action={{ label: "Add BOM lines first", to: `/projects/${projectId}/import` }}
+    />
+  );
+}
+
+function NotConfiguredState() {
+  return (
+    <div className="card p-4 space-y-3" role="status">
+      <div className="font-medium">Sourcing not configured.</div>
+      <div className="text-sm text-muted">
+        Ask a workspace admin to configure TrustedParts in Settings → Sourcing.
+      </div>
+      <Link className="btn" to="/settings/workspace">
+        Open Settings → Sourcing
+      </Link>
+    </div>
+  );
+}
+
+function BudgetState({
+  disabledUntil,
+  onRetry,
+}: {
+  disabledUntil: number | null;
+  onRetry: () => void;
+}) {
+  const disabled = disabledUntil != null && Date.now() < disabledUntil;
+  return (
+    <div className="card p-4 text-sm text-muted" role="status">
+      <div>TrustedParts request budget reached for this hour. Retry is paused for 5 minutes.</div>
+      <button type="button" className="btn mt-3" disabled={disabled} onClick={onRetry}>
+        Retry Source BOM
+      </button>
+    </div>
+  );
+}
+
+function CapacityBanner({ data }: { data: SourcingBomResponse }) {
+  const blocking = data.capacity.blocking_lines_after_purchase.length > 0
+    ? data.capacity.blocking_lines_after_purchase
+    : data.capacity.blocking_lines_now;
+  const linesById = new Map(data.rows.map(row => [row.project_entry_id, row]));
+  const purchaseCurrency = data.rows.find(row => row.best_offer?.currency)?.best_offer?.currency ?? null;
+
+  return (
+    <div className="card p-4">
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+        <div>
+          <div className="section-title">Can build now</div>
+          <div className="text-2xl font-semibold tabular-nums">{data.capacity.can_build_now}</div>
+        </div>
+        <div>
+          <div className="section-title">After purchase</div>
+          <div className="text-2xl font-semibold tabular-nums">{data.capacity.can_build_after_purchase}</div>
+        </div>
+        <div>
+          <div className="section-title">Est. cost</div>
+          <div className="text-2xl font-semibold tabular-nums">{formatMoney(data.capacity.est_purchase_cost, purchaseCurrency)}</div>
+        </div>
+        <div>
+          <div className="section-title">Blocking lines</div>
+          <div className="text-2xl font-semibold tabular-nums">{blocking.length}</div>
+        </div>
+      </div>
+      {blocking.length > 0 && (
+        <div className="mt-4 border-t border-border pt-3">
+          <div className="section-title mb-2">Blocking lines</div>
+          <div className="flex flex-wrap gap-2">
+            {blocking.map(lineId => {
+              const line = linesById.get(lineId);
+              return (
+                <span key={lineId} className="pill">
+                  {line?.part_name ?? lineId}
+                </span>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CoverageMatrix({ data }: { data: SourcingBomResponse }) {
+  const bestSingle = data.coverage.best_single_distributor;
+  const bestTwo: string[] = data.coverage.best_two_distributor_combo ?? [];
+  const columns: Column<CoverageRow>[] = [
+    {
+      key: "distributor",
+      header: "Distributor",
+      accessor: row => row.distributor,
+      render: row => (
+        <span className="flex flex-wrap items-center gap-2">
+          <span>{row.distributor}</span>
+          {row.distributor === bestSingle && <span className="pill bg-success/10 text-success">Best single distributor</span>}
+          {bestTwo.includes(row.distributor) && <span className="pill bg-accent/15 text-accent">Best two-distributor combo</span>}
+        </span>
+      ),
+    },
+    { key: "lines", header: "Lines covered", accessor: row => row.lines_covered, align: "right" },
+    {
+      key: "coverage",
+      header: "Coverage",
+      accessor: row => row.coverage_pct,
+      render: row => `${Math.round(row.coverage_pct * 100)}%`,
+      align: "right",
+    },
+    {
+      key: "cost",
+      header: "Est. total cost",
+      accessor: row => numberOrNull(row.est_total_cost),
+      render: row => formatMoney(row.est_total_cost),
+      align: "right",
+    },
+    {
+      key: "lead",
+      header: "Worst lead time",
+      accessor: row => row.worst_lead_time_days,
+      render: row => formatLeadTime(row.worst_lead_time_days),
+      align: "right",
+    },
+  ];
+
+  return (
+    <section className="space-y-2">
+      <h2 className="text-md font-semibold">Coverage matrix</h2>
+      <DataTable
+        rows={data.coverage.rows}
+        columns={columns}
+        rowKey={row => row.distributor}
+        tableId="project-sourcing-coverage"
+        exportFilename="sourcing-coverage"
+        empty={<div className="text-muted">No distributor coverage.</div>}
+      />
+    </section>
+  );
+}
+
+function BomRows({ rows }: { rows: SourcingBomLine[] }) {
+  const columns: Column<SourcingBomLine>[] = [
+    { key: "part", header: "Part", accessor: row => row.part_name },
+    { key: "mpn", header: "MPN", accessor: row => row.mpn ?? "", render: row => row.mpn ?? "—" },
+    { key: "required", header: "Required", accessor: row => row.required, align: "right" },
+    { key: "available", header: "On hand", accessor: row => row.available + row.substitute_available, align: "right" },
+    { key: "short", header: "Short", accessor: row => row.short_by, align: "right" },
+    { key: "stock", header: "Authorized stock", accessor: row => row.authorized_stock, align: "right" },
+    {
+      key: "offer",
+      header: "Best offer",
+      accessor: row => numberOrNull(row.best_offer?.unit_price),
+      render: row => row.best_offer
+        ? formatMoney(row.best_offer.unit_price, row.best_offer.currency)
+        : <span className="text-muted">—</span>,
+      align: "right",
+    },
+    {
+      key: "distributor",
+      header: "Distributor",
+      accessor: row => row.best_offer?.distributor ?? "",
+      render: row => row.best_offer?.url ? (
+        <a className="text-accent hover:underline" href={row.best_offer.url} target="_blank" rel="noopener noreferrer">
+          {row.best_offer.distributor}
+        </a>
+      ) : row.best_offer?.distributor ?? "—",
+    },
+    {
+      key: "cost",
+      header: "Est. cost",
+      accessor: row => numberOrNull(row.est_extended_cost),
+      render: row => formatMoney(row.est_extended_cost, row.best_offer?.currency),
+      align: "right",
+    },
+    {
+      key: "risk",
+      header: "Risk",
+      accessor: row => row.risk_flags.join(" "),
+      render: row => (
+        <span className="flex flex-wrap gap-1">
+          {row.risk_flags.length === 0 ? (
+            <span className="text-muted">—</span>
+          ) : row.risk_flags.map(flag => (
+            <span key={flag} className="pill bg-warning/10 text-warning">
+              {riskLabel(flag)}
+            </span>
+          ))}
+        </span>
+      ),
+    },
+    {
+      key: "source",
+      header: "Source",
+      accessor: () => "TrustedParts",
+      render: () => <SourcingSourceLabel source="trustedparts" />,
+    },
+  ];
+
+  return (
+    <section className="space-y-2">
+      <h2 className="text-md font-semibold">BOM rows</h2>
+      <DataTable
+        rows={rows}
+        columns={columns}
+        rowKey={row => row.project_entry_id}
+        tableId="project-sourcing-bom"
+        exportFilename="sourced-bom"
+      />
+    </section>
+  );
+}
+
+export default function ProjectSourcingPage() {
+  const { projectId } = useParams<{ projectId: string }>();
+  const [buildQuantity, setBuildQuantity] = useState(1);
+  const [country, setCountry] = useState("");
+  const [currency, setCurrency] = useState("");
+  const [distributors, setDistributors] = useState("");
+  const [defaultsApplied, setDefaultsApplied] = useState(false);
+  const [budgetDisabledUntil, setBudgetDisabledUntil] = useState<number | null>(null);
+
+  const { data: workspace } = useQuery({
+    queryKey: useWsKey("ws", "current"),
+    queryFn: () => api.get<SourcingWorkspaceSettings>("/workspaces/current"),
+  });
+  const { data: project } = useQuery({
+    queryKey: useWsKey("project", projectId),
+    queryFn: () => api.get<Project>(`/projects/${projectId}`),
+    enabled: !!projectId,
+  });
+
+  useEffect(() => {
+    if (!workspace || defaultsApplied) return;
+    setCountry(workspace.sourcing_country_code ?? "");
+    setCurrency(workspace.sourcing_currency_code ?? "");
+    setDistributors((workspace.sourcing_preferred_distributors ?? []).join(", "));
+    setDefaultsApplied(true);
+  }, [workspace, defaultsApplied]);
+
+  const requestBody = useMemo<SourcingRequest>(() => {
+    const body: SourcingRequest = { build_quantity: Math.max(1, Math.floor(buildQuantity || 1)) };
+    const cleanCountry = country.trim().toUpperCase();
+    const cleanCurrency = currency.trim().toUpperCase();
+    const cleanDistributors = splitDistributors(distributors);
+    if (cleanCountry) body.country = cleanCountry;
+    if (cleanCurrency) body.currency = cleanCurrency;
+    if (cleanDistributors.length > 0) body.distributors = cleanDistributors;
+    return body;
+  }, [buildQuantity, country, currency, distributors]);
+
+  const query = useQuery({
+    queryKey: useWsKey("sourcing", "project", projectId, requestBody),
+    queryFn: ({ signal }) =>
+      api.post<SourcingBomResponse, SourcingRequest>(`/projects/${projectId}/sourcing`, requestBody, { signal }),
+    enabled: !!projectId && buildQuantity >= 1 && defaultsApplied,
+  });
+  const queryIsError = query.isError;
+  const queryError = query.error;
+  const refetchSourcing = query.refetch;
+
+  useEffect(() => {
+    if (!queryIsError) return;
+    const status = errorStatus(queryError);
+    if (status === 503) setBudgetDisabledUntil(Date.now() + 5 * 60 * 1000);
+    if (status === 502 || (queryError instanceof Error && queryError.name === "AbortError")) {
+      toast.error("TrustedParts unavailable. Retry?", {
+        action: { label: "Retry", onClick: () => refetchSourcing() },
+      });
+    }
+  }, [queryIsError, queryError, refetchSourcing]);
+
+  useEffect(() => {
+    if (budgetDisabledUntil == null) return;
+    const delay = Math.max(0, budgetDisabledUntil - Date.now());
+    const timeout = window.setTimeout(() => setBudgetDisabledUntil(null), delay);
+    return () => window.clearTimeout(timeout);
+  }, [budgetDisabledUntil]);
+
+  const status = errorStatus(query.error);
+  const sourceDisabled = query.isFetching || buildQuantity < 1 || (budgetDisabledUntil != null && Date.now() < budgetDisabledUntil);
+  const hasRows = (query.data?.rows.length ?? 0) > 0;
+  const primaryUrl = query.data?.links.primary;
+
+  if (!projectId) return null;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <div className="text-sm text-muted">Projects · {project?.name ?? "Project"} · Sourcing</div>
+          <div className="mt-1 flex flex-wrap items-center gap-2">
+            <h1 className="text-xl font-semibold">Source BOM</h1>
+            {query.data?.partial && <span className="pill bg-warning/10 text-warning">Partial — some chunks served from cache</span>}
+          </div>
+        </div>
+        <PoweredByTrustedParts primaryUrl={primaryUrl} />
+      </div>
+
+      <div className="card p-4">
+        <div className="grid grid-cols-1 md:grid-cols-5 gap-3">
+          <div>
+            <label className="label" htmlFor="sourcing-build-quantity">Build quantity</label>
+            <input
+              id="sourcing-build-quantity"
+              className="input"
+              type="number"
+              min={1}
+              step={1}
+              value={buildQuantity}
+              onChange={event => setBuildQuantity(Number(event.target.value))}
+            />
+          </div>
+          <div>
+            <label className="label" htmlFor="sourcing-country">Country</label>
+            <input
+              id="sourcing-country"
+              className="input uppercase"
+              maxLength={2}
+              value={country}
+              onChange={event => setCountry(event.target.value.toUpperCase())}
+              placeholder="US"
+            />
+          </div>
+          <div>
+            <label className="label" htmlFor="sourcing-currency">Currency</label>
+            <input
+              id="sourcing-currency"
+              className="input uppercase"
+              maxLength={3}
+              value={currency}
+              onChange={event => setCurrency(event.target.value.toUpperCase())}
+              placeholder="USD"
+            />
+          </div>
+          <div className="md:col-span-2">
+            <label className="label" htmlFor="sourcing-distributors">Distributors</label>
+            <input
+              id="sourcing-distributors"
+              className="input"
+              value={distributors}
+              onChange={event => setDistributors(event.target.value)}
+              placeholder="DigiKey, Mouser"
+            />
+          </div>
+        </div>
+        <div className="mt-3 flex justify-end">
+          <button
+            type="button"
+            className="btn-primary"
+            disabled={sourceDisabled}
+            onClick={() => query.refetch()}
+          >
+            <RefreshCw size={14} className={query.isFetching ? "animate-spin" : ""} />
+            {query.isFetching ? "Sourcing…" : "Source"}
+          </button>
+        </div>
+      </div>
+
+      {query.isLoading && <SourcingSkeleton />}
+      {status === 409 && <NotConfiguredState />}
+      {status === 503 && <BudgetState disabledUntil={budgetDisabledUntil} onRetry={() => query.refetch()} />}
+      {status === 502 && (
+        <div className="card p-4" role="status">
+          <button type="button" className="btn" onClick={() => query.refetch()}>
+            Retry Source BOM
+          </button>
+        </div>
+      )}
+      {query.isError && status !== 409 && status !== 502 && status !== 503 && (
+        <div className="card p-4 text-sm text-danger">Failed to source BOM.</div>
+      )}
+
+      {query.data && !hasRows && <EmptyBomState projectId={projectId} />}
+
+      {query.data && hasRows && (
+        <>
+          <CapacityBanner data={query.data} />
+          <CoverageMatrix data={query.data} />
+          <BomRows rows={query.data.rows} />
+          <div className="text-xs text-muted">
+            {formatCount(query.data.rows.length)} line{query.data.rows.length === 1 ? "" : "s"} fetched from {query.data.powered_by}.
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/web/src/routes/projects/sourcing/SourceBomButton.tsx
+++ b/web/src/routes/projects/sourcing/SourceBomButton.tsx
@@ -1,0 +1,49 @@
+import { Link } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+import { useWsKey } from "@/lib/queryKeys";
+
+export type SourcingWorkspaceSettings = {
+  sourcing_country_code: string | null;
+  sourcing_currency_code: string | null;
+  sourcing_preferred_distributors: string[] | null;
+  has_sourcing_company_id: boolean;
+};
+
+type Props = {
+  projectId: string | null | undefined;
+  className?: string;
+};
+
+export function SourceBomButton({ projectId, className }: Props) {
+  const { data: workspace } = useQuery({
+    queryKey: useWsKey("ws", "current"),
+    queryFn: () => api.get<SourcingWorkspaceSettings>("/workspaces/current"),
+  });
+  const disabled = workspace?.has_sourcing_company_id === false;
+  const classes = className ?? "btn-primary";
+
+  if (!projectId || disabled) {
+    return (
+      <span className="inline-flex flex-col items-end gap-1">
+        <button
+          type="button"
+          className={classes}
+          disabled
+          title="Sourcing not configured"
+        >
+          Source BOM
+        </button>
+        {disabled && (
+          <span className="text-xs text-muted">Sourcing not configured</span>
+        )}
+      </span>
+    );
+  }
+
+  return (
+    <Link className={classes} to={`/projects/${projectId}/sourcing`}>
+      Source BOM
+    </Link>
+  );
+}

--- a/web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.test.tsx
+++ b/web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.test.tsx
@@ -1,0 +1,313 @@
+// @vitest-environment jsdom
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen, waitFor, within } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { toast } from "sonner";
+import { ApiError, api } from "@/lib/api";
+import ProjectSourcingPage from "../ProjectSourcingPage";
+import { SourceBomButton } from "../SourceBomButton";
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({
+  useAuth: () => ({ workspaceId: "ws-1" }),
+}));
+
+const projectId = "project-123";
+
+function workspace(overrides: Record<string, unknown> = {}) {
+  return {
+    sourcing_country_code: "US",
+    sourcing_currency_code: "USD",
+    sourcing_preferred_distributors: ["DigiKey", "Mouser"],
+    has_sourcing_company_id: true,
+    ...overrides,
+  };
+}
+
+function project() {
+  return {
+    id: projectId,
+    name: "Amplifier",
+    description: null,
+    notes_markdown: null,
+    archived_at: null,
+    created_at: "2026-05-08T12:00:00+00:00",
+    updated_at: "2026-05-08T12:00:00+00:00",
+  };
+}
+
+function sourcingResponse(overrides: Record<string, unknown> = {}) {
+  return {
+    rows: [
+      {
+        project_entry_id: "entry-1",
+        part_id: "part-1",
+        part_name: "STM32",
+        mpn: "STM32F103C8T6",
+        required: 20,
+        available: 4,
+        substitute_ids: [],
+        substitute_available: 0,
+        short_by: 16,
+        authorized_stock: 60,
+        offers: [
+          {
+            mpn: "STM32F103C8T6",
+            distributor: "DigiKey",
+            stock: 60,
+            unit_price: "1.25",
+            currency: "USD",
+            moq: 1,
+            lead_time_days: 3,
+            url: "https://www.trustedparts.com/digikey/stm32",
+          },
+        ],
+        best_offer: {
+          mpn: "STM32F103C8T6",
+          distributor: "DigiKey",
+          stock: 60,
+          unit_price: "1.25",
+          currency: "USD",
+          moq: 1,
+          lead_time_days: 3,
+          url: "https://www.trustedparts.com/digikey/stm32",
+        },
+        est_extended_cost: "20.00",
+        lead_time_days: 3,
+        risk_flags: ["single_source", "lead_time_long"],
+      },
+      {
+        project_entry_id: "entry-2",
+        part_id: "part-2",
+        part_name: "Regulator",
+        mpn: "LM1117",
+        required: 10,
+        available: 0,
+        substitute_ids: [],
+        substitute_available: 0,
+        short_by: 10,
+        authorized_stock: 20,
+        offers: [
+          {
+            mpn: "LM1117",
+            distributor: "Mouser",
+            stock: 20,
+            unit_price: "0.50",
+            currency: "USD",
+            moq: 1,
+            lead_time_days: 7,
+          },
+        ],
+        best_offer: {
+          mpn: "LM1117",
+          distributor: "Mouser",
+          stock: 20,
+          unit_price: "0.50",
+          currency: "USD",
+          moq: 1,
+          lead_time_days: 7,
+        },
+        est_extended_cost: "5.00",
+        lead_time_days: 7,
+        risk_flags: ["preferred_distributor_unmet"],
+      },
+    ],
+    coverage: {
+      rows: [
+        {
+          distributor: "DigiKey",
+          lines_covered: 1,
+          lines_uncovered: ["entry-2"],
+          coverage_pct: 0.5,
+          est_total_cost: "20.00",
+          worst_lead_time_days: 3,
+        },
+        {
+          distributor: "Mouser",
+          lines_covered: 1,
+          lines_uncovered: ["entry-1"],
+          coverage_pct: 0.5,
+          est_total_cost: "5.00",
+          worst_lead_time_days: 7,
+        },
+      ],
+      total_lines: 2,
+      best_single_distributor: "DigiKey",
+      best_two_distributor_combo: ["DigiKey", "Mouser"],
+    },
+    capacity: {
+      can_build_now: 0,
+      can_build_after_purchase: 3,
+      est_purchase_cost: "25.00",
+      blocking_lines_now: ["entry-2"],
+      blocking_lines_after_purchase: ["entry-1"],
+    },
+    powered_by: "TrustedParts" as const,
+    fetched_at: "2026-05-08T12:00:00+00:00",
+    partial: false,
+    links: {
+      primary: "https://www.trustedparts.com/",
+      attribution: "https://www.trustedparts.com/en/about",
+    },
+    ...overrides,
+  };
+}
+
+function apiError(status: number, message: string) {
+  return new ApiError(
+    status,
+    {
+      data: null,
+      status: {
+        category: status === 409 ? "conflict" : "server_error",
+        message,
+      },
+    },
+    message,
+  );
+}
+
+function mockReads(workspaceOverrides: Record<string, unknown> = {}) {
+  vi.spyOn(api, "get").mockImplementation(async path => {
+    if (path === "/workspaces/current") return workspace(workspaceOverrides) as never;
+    if (path === `/projects/${projectId}`) return project() as never;
+    throw new Error(`unexpected GET ${path}`);
+  });
+}
+
+function renderPage() {
+  const client = new QueryClient({
+    defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+  });
+  render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={[`/projects/${projectId}/sourcing`]}>
+        <Routes>
+          <Route path="/projects/:projectId/sourcing" element={<ProjectSourcingPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  cleanup();
+  localStorage.clear();
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+});
+
+describe("ProjectSourcingPage", () => {
+  it("renders capacity banner with both numbers from server response", async () => {
+    mockReads();
+    vi.spyOn(api, "post").mockResolvedValue(sourcingResponse());
+
+    renderPage();
+
+    expect(await screen.findByText("Can build now")).toBeDefined();
+    expect(screen.getByText("After purchase")).toBeDefined();
+    expect(screen.getByText("3")).toBeDefined();
+    expect(screen.getAllByText("Est. cost").length).toBeGreaterThan(0);
+    expect(screen.getByText("25 USD")).toBeDefined();
+  });
+
+  it("renders coverage matrix with best-single + best-two highlights", async () => {
+    mockReads();
+    vi.spyOn(api, "post").mockResolvedValue(sourcingResponse());
+
+    renderPage();
+
+    const coverage = await screen.findByText("Coverage matrix");
+    expect(coverage).toBeDefined();
+    const table = screen.getAllByRole("table")[0];
+    expect(within(table).getByText("DigiKey")).toBeDefined();
+    expect(within(table).getByText("Best single distributor")).toBeDefined();
+    expect(within(table).getAllByText("Best two-distributor combo")).toHaveLength(2);
+  });
+
+  it("renders risk pills for each flag returned", async () => {
+    mockReads();
+    vi.spyOn(api, "post").mockResolvedValue(sourcingResponse());
+
+    renderPage();
+
+    expect(await screen.findByText("Single source")).toBeDefined();
+    expect(screen.getByText("Long lead time")).toBeDefined();
+    expect(screen.getByText("Preferred unmet")).toBeDefined();
+    expect(screen.getAllByLabelText("Source: TrustedParts").length).toBeGreaterThan(0);
+  });
+
+  it("409 path renders not-configured card with settings link", async () => {
+    mockReads();
+    vi.spyOn(api, "post").mockRejectedValue(apiError(409, "sourcing not configured"));
+
+    renderPage();
+
+    expect(await screen.findByText("Sourcing not configured.")).toBeDefined();
+    const link = screen.getByRole("link", { name: "Open Settings → Sourcing" });
+    expect(link.getAttribute("href")).toBe("/settings/workspace");
+  });
+
+  it("503 path renders budget banner", async () => {
+    mockReads();
+    vi.spyOn(api, "post").mockRejectedValue(apiError(503, "sourcing budget exhausted"));
+
+    renderPage();
+
+    expect(await screen.findByText("TrustedParts request budget reached for this hour. Retry is paused for 5 minutes.")).toBeDefined();
+    expect((screen.getByRole("button", { name: "Retry Source BOM" }) as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("partial flag surfaces the partial badge", async () => {
+    mockReads();
+    vi.spyOn(api, "post").mockResolvedValue(sourcingResponse({ partial: true }));
+
+    renderPage();
+
+    expect(await screen.findByText("Partial — some chunks served from cache")).toBeDefined();
+  });
+
+  it("Source BOM button is disabled when workspace lacks sourcing creds", async () => {
+    mockReads({ has_sourcing_company_id: false });
+    const client = new QueryClient({
+      defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+    });
+
+    render(
+      <QueryClientProvider client={client}>
+        <MemoryRouter>
+          <SourceBomButton projectId={projectId} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const button = await screen.findByRole("button", { name: "Source BOM" });
+    await waitFor(() => expect((button as HTMLButtonElement).disabled).toBe(true));
+    expect(button.getAttribute("title")).toBe("Sourcing not configured");
+    expect(screen.getByText("Sourcing not configured")).toBeDefined();
+  });
+
+  it("502 path shows toast and retry action", async () => {
+    mockReads();
+    vi.spyOn(api, "post").mockRejectedValue(apiError(502, "TrustedParts request timed out"));
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        "TrustedParts unavailable. Retry?",
+        expect.objectContaining({
+          action: expect.objectContaining({ label: "Retry" }),
+        }),
+      );
+    });
+    expect(screen.getByRole("button", { name: "Retry Source BOM" })).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `/projects/:projectId/sourcing` with build quantity/filter controls, TrustedParts attribution, capacity banner, distributor coverage matrix, enriched BOM rows, risk pills, and partial/empty/error states.
- Adds shared Source BOM buttons to project detail and build detail, disabled with a visible cue when `has_sourcing_company_id` is false.
- Documents the project Source BOM frontend flow.

## Validation
- `cd web && npm run typecheck` — passed.
- `cd web && npm test -- ProjectSourcingPage` — passed: 1 file, 8 tests.
- `cd web && npm run lint` — fails on the existing ESLint baseline only: `bagCode.ts` no-control-regex errors plus existing unused/ref warnings. No TP-305 files are reported.
- `cd web && LINT_CMD="npm run lint -- --format=unix" BASELINE_FILE="../.eslint-baseline.txt" WORK_DIR="." bash ../scripts/lint-delta.sh` — passed: no new violations.

## Deviations
- `npm run lint` is not green because this checkout already has the committed ESLint baseline violations; I did not touch those unrelated files or update the baseline.
- No backend changes were needed.

## Screenshots
- Not produced in this environment. The page depends on authenticated workspace/project sourcing data from the local API, and no seeded TrustedParts-backed UI session was available here for the populated, 409, or partial-state screenshots.

Refs #354
