### PR TITLE
TP-401: Add purchase_plans + purchase_plan_lines migration

### DIFF
--- a/backend/alembic/versions/0039_purchase_plans.py
+++ b/backend/alembic/versions/0039_purchase_plans.py
@@ -1,0 +1,187 @@
+"""Add short-lived purchase plans.
+
+Revision ID: 0039
+Revises: 0038
+Create Date: 2026-05-08
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+from alembic import op
+
+revision = "0039"
+down_revision = "0038"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "purchase_plans",
+        sa.Column(
+            "id",
+            sa.UUID(as_uuid=True),
+            nullable=False,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("workspace_id", sa.UUID(as_uuid=True), nullable=False),
+        sa.Column("project_id", sa.UUID(as_uuid=True), nullable=False),
+        sa.Column("build_quantity", sa.Integer(), nullable=False),
+        sa.Column("strategy", sa.String(length=40), nullable=False),
+        sa.Column("country_code", sa.String(length=2), nullable=True),
+        sa.Column("currency_code", sa.String(length=3), nullable=True),
+        sa.Column("preferred_distributors", JSONB, nullable=True),
+        sa.Column(
+            "status",
+            sa.String(length=20),
+            nullable=False,
+            server_default="draft",
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("created_by", sa.UUID(as_uuid=True), nullable=True),
+        sa.CheckConstraint(
+            "build_quantity >= 1",
+            name="purchase_plans_build_quantity_positive",
+        ),
+        sa.CheckConstraint(
+            "strategy IN ("
+            "'lowest_total_price', "
+            "'fewest_distributors', "
+            "'fastest_availability', "
+            "'preferred_first'"
+            ")",
+            name="purchase_plans_strategy_check",
+        ),
+        sa.CheckConstraint(
+            "status IN ('draft', 'refreshed', 'converted', 'expired')",
+            name="purchase_plans_status_check",
+        ),
+        sa.CheckConstraint(
+            "expires_at <= created_at + interval '7 days'",
+            name="purchase_plans_max_7_day_ttl",
+        ),
+        sa.ForeignKeyConstraint(
+            ["project_id"],
+            ["projects.id"],
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["workspace_id"],
+            ["workspaces.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_purchase_plans_expires_at",
+        "purchase_plans",
+        ["expires_at"],
+    )
+    op.create_index(
+        "ix_purchase_plans_ws_project",
+        "purchase_plans",
+        ["workspace_id", "project_id"],
+    )
+    op.create_index(
+        "ix_purchase_plans_ws_status",
+        "purchase_plans",
+        ["workspace_id", "status"],
+    )
+
+    op.create_table(
+        "purchase_plan_lines",
+        sa.Column(
+            "id",
+            sa.UUID(as_uuid=True),
+            nullable=False,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("purchase_plan_id", sa.UUID(as_uuid=True), nullable=False),
+        sa.Column("project_entry_id", sa.UUID(as_uuid=True), nullable=True),
+        sa.Column("part_id", sa.UUID(as_uuid=True), nullable=False),
+        sa.Column("mpn_searched", sa.String(length=255), nullable=False),
+        sa.Column("required_qty", sa.Integer(), nullable=False),
+        sa.Column("internal_available_qty", sa.Integer(), nullable=False),
+        sa.Column("shortage_qty", sa.Integer(), nullable=False),
+        sa.Column("selected_distributor", sa.String(length=120), nullable=True),
+        sa.Column("selected_qty", sa.Integer(), nullable=True),
+        sa.Column("selected_unit_price", sa.Numeric(18, 6), nullable=True),
+        sa.Column("selected_currency", sa.String(length=3), nullable=True),
+        sa.Column("selected_packaging", sa.String(length=120), nullable=True),
+        sa.Column("selected_moq", sa.Integer(), nullable=True),
+        sa.Column("selected_lead_time_days", sa.Integer(), nullable=True),
+        sa.Column("selected_url", sa.Text(), nullable=True),
+        sa.Column(
+            "risk_flags",
+            JSONB,
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.CheckConstraint(
+            "required_qty >= 0",
+            name="purchase_plan_lines_required_qty_nonnegative",
+        ),
+        sa.CheckConstraint(
+            "internal_available_qty >= 0",
+            name="purchase_plan_lines_internal_available_qty_nonnegative",
+        ),
+        sa.CheckConstraint(
+            "shortage_qty >= 0",
+            name="purchase_plan_lines_shortage_qty_nonnegative",
+        ),
+        sa.CheckConstraint(
+            "selected_qty IS NULL OR selected_qty >= 0",
+            name="purchase_plan_lines_selected_qty_nonnegative",
+        ),
+        sa.CheckConstraint(
+            "selected_moq IS NULL OR selected_moq >= 1",
+            name="purchase_plan_lines_selected_moq_positive",
+        ),
+        sa.ForeignKeyConstraint(
+            ["part_id"],
+            ["parts.id"],
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["purchase_plan_id"],
+            ["purchase_plans.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_purchase_plan_lines_plan",
+        "purchase_plan_lines",
+        ["purchase_plan_id"],
+    )
+    op.create_index(
+        "ix_purchase_plan_lines_part",
+        "purchase_plan_lines",
+        ["part_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_purchase_plan_lines_part", table_name="purchase_plan_lines")
+    op.drop_index("ix_purchase_plan_lines_plan", table_name="purchase_plan_lines")
+    op.drop_table("purchase_plan_lines")
+
+    op.drop_index("ix_purchase_plans_ws_status", table_name="purchase_plans")
+    op.drop_index("ix_purchase_plans_ws_project", table_name="purchase_plans")
+    op.drop_index("ix_purchase_plans_expires_at", table_name="purchase_plans")
+    op.drop_table("purchase_plans")

--- a/backend/app/domain/all_models.py
+++ b/backend/app/domain/all_models.py
@@ -41,6 +41,7 @@ from app.domain.projects.models import (  # noqa: F401
     Project,
     ProjectEntry,
 )
+from app.domain.sourcing.models import PurchasePlan, PurchasePlanLine, SourcingCache  # noqa: F401
 from app.domain.stock.models import StockEntry  # noqa: F401
 from app.domain.storage.models import StorageLocation  # noqa: F401
 from app.domain.tags.models import Tag, TagLink  # noqa: F401

--- a/backend/app/domain/sourcing/cache.py
+++ b/backend/app/domain/sourcing/cache.py
@@ -14,7 +14,7 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import Session
 
 from app.core.time import utcnow
-from app.domain.sourcing.models import SourcingCache
+from app.domain.sourcing.models import PurchasePlan, SourcingCache
 
 SEVEN_DAYS = timedelta(days=7)
 
@@ -82,9 +82,19 @@ def sweep_expired(db: Session, *, workspace_id: UUID) -> int:
     return result.rowcount or 0
 
 
+def sweep_expired_purchase_plans(db: Session, *, workspace_id: UUID) -> int:
+    """Delete expired purchase plans for one workspace."""
+    result = db.execute(
+        delete(PurchasePlan)
+        .where(PurchasePlan.workspace_id == workspace_id)
+        .where(PurchasePlan.expires_at < utcnow())
+    )
+    return result.rowcount or 0
+
+
 def sweep_expired_all_workspaces(db: Session) -> int:
-    """Delete expired rows by iterating through workspace-scoped sweeps."""
-    workspace_ids = (
+    """Delete expired sourcing rows by iterating through workspace scopes."""
+    cache_workspace_ids = (
         db.execute(
             select(SourcingCache.workspace_id)
             .where(SourcingCache.expires_at < utcnow())
@@ -93,7 +103,18 @@ def sweep_expired_all_workspaces(db: Session) -> int:
         .scalars()
         .all()
     )
+    plan_workspace_ids = (
+        db.execute(
+            select(PurchasePlan.workspace_id)
+            .where(PurchasePlan.expires_at < utcnow())
+            .distinct()
+        )
+        .scalars()
+        .all()
+    )
+    workspace_ids = set(cache_workspace_ids) | set(plan_workspace_ids)
     return sum(
         sweep_expired(db, workspace_id=workspace_id)
+        + sweep_expired_purchase_plans(db, workspace_id=workspace_id)
         for workspace_id in workspace_ids
     )

--- a/backend/app/domain/sourcing/models.py
+++ b/backend/app/domain/sourcing/models.py
@@ -7,6 +7,7 @@ import uuid
 import sqlalchemy as sa
 from sqlalchemy import CheckConstraint, Column, DateTime, ForeignKey, Index
 from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import relationship
 
 from app.core.time import utcnow
 from app.infra.db import Base
@@ -47,3 +48,151 @@ class SourcingCache(Base):
     )
     expires_at = Column(DateTime(timezone=True), nullable=False)
     created_by = Column(UUID(as_uuid=True), nullable=True)
+
+
+class PurchasePlan(Base):
+    """Workspace-scoped short-lived purchase plan offer snapshot."""
+
+    __tablename__ = "purchase_plans"
+    __table_args__ = (
+        CheckConstraint(
+            "build_quantity >= 1",
+            name="purchase_plans_build_quantity_positive",
+        ),
+        CheckConstraint(
+            "strategy IN ("
+            "'lowest_total_price', "
+            "'fewest_distributors', "
+            "'fastest_availability', "
+            "'preferred_first'"
+            ")",
+            name="purchase_plans_strategy_check",
+        ),
+        CheckConstraint(
+            "status IN ('draft', 'refreshed', 'converted', 'expired')",
+            name="purchase_plans_status_check",
+        ),
+        CheckConstraint(
+            "expires_at <= created_at + interval '7 days'",
+            name="purchase_plans_max_7_day_ttl",
+        ),
+        Index("ix_purchase_plans_expires_at", "expires_at"),
+        Index("ix_purchase_plans_ws_project", "workspace_id", "project_id"),
+        Index("ix_purchase_plans_ws_status", "workspace_id", "status"),
+    )
+
+    id = Column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+        server_default=sa.text("gen_random_uuid()"),
+    )
+    workspace_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("workspaces.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    project_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("projects.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    build_quantity = Column(sa.Integer, nullable=False)
+    strategy = Column(sa.String(40), nullable=False)
+    country_code = Column(sa.String(2), nullable=True)
+    currency_code = Column(sa.String(3), nullable=True)
+    preferred_distributors = Column(JSONB, nullable=True)
+    status = Column(
+        sa.String(20),
+        nullable=False,
+        default="draft",
+        server_default="draft",
+    )
+    created_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=utcnow,
+        server_default=sa.func.now(),
+    )
+    expires_at = Column(DateTime(timezone=True), nullable=False)
+    created_by = Column(UUID(as_uuid=True), nullable=True)
+
+    lines = relationship(
+        "PurchasePlanLine",
+        back_populates="purchase_plan",
+        cascade="all, delete-orphan",
+    )
+
+
+class PurchasePlanLine(Base):
+    """One BOM shortage line and selected offer inside a purchase plan."""
+
+    __tablename__ = "purchase_plan_lines"
+    __table_args__ = (
+        CheckConstraint(
+            "required_qty >= 0",
+            name="purchase_plan_lines_required_qty_nonnegative",
+        ),
+        CheckConstraint(
+            "internal_available_qty >= 0",
+            name="purchase_plan_lines_internal_available_qty_nonnegative",
+        ),
+        CheckConstraint(
+            "shortage_qty >= 0",
+            name="purchase_plan_lines_shortage_qty_nonnegative",
+        ),
+        CheckConstraint(
+            "selected_qty IS NULL OR selected_qty >= 0",
+            name="purchase_plan_lines_selected_qty_nonnegative",
+        ),
+        CheckConstraint(
+            "selected_moq IS NULL OR selected_moq >= 1",
+            name="purchase_plan_lines_selected_moq_positive",
+        ),
+        Index("ix_purchase_plan_lines_plan", "purchase_plan_id"),
+        Index("ix_purchase_plan_lines_part", "part_id"),
+    )
+
+    id = Column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+        server_default=sa.text("gen_random_uuid()"),
+    )
+    purchase_plan_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("purchase_plans.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    project_entry_id = Column(UUID(as_uuid=True), nullable=True)
+    part_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("parts.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    mpn_searched = Column(sa.String(255), nullable=False)
+    required_qty = Column(sa.Integer, nullable=False)
+    internal_available_qty = Column(sa.Integer, nullable=False)
+    shortage_qty = Column(sa.Integer, nullable=False)
+    selected_distributor = Column(sa.String(120), nullable=True)
+    selected_qty = Column(sa.Integer, nullable=True)
+    selected_unit_price = Column(sa.Numeric(18, 6), nullable=True)
+    selected_currency = Column(sa.String(3), nullable=True)
+    selected_packaging = Column(sa.String(120), nullable=True)
+    selected_moq = Column(sa.Integer, nullable=True)
+    selected_lead_time_days = Column(sa.Integer, nullable=True)
+    selected_url = Column(sa.Text, nullable=True)
+    risk_flags = Column(
+        JSONB,
+        nullable=False,
+        default=list,
+        server_default=sa.text("'[]'::jsonb"),
+    )
+    created_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=utcnow,
+        server_default=sa.func.now(),
+    )
+
+    purchase_plan = relationship("PurchasePlan", back_populates="lines")

--- a/backend/tests/test_purchase_plan_models.py
+++ b/backend/tests/test_purchase_plan_models.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import uuid
+from datetime import timedelta
+
+import pytest
+from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.core.time import utcnow
+from app.domain.parts.models import Part
+from app.domain.projects.models import Project, ProjectEntry
+from app.domain.sourcing.models import PurchasePlan, PurchasePlanLine
+from app.domain.users.models import User
+from app.domain.workspaces.models import Workspace
+
+
+def _workspace_user(db: Session) -> tuple[Workspace, User]:
+    user = User(
+        email=f"purchase-plan-{uuid.uuid4().hex[:8]}@example.com",
+        name="Purchase Plan Tester",
+        password_hash="test",
+    )
+    db.add(user)
+    db.flush()
+    workspace = Workspace(
+        name=f"purchase-plan-ws-{uuid.uuid4().hex[:8]}",
+        kind="organization",
+        owner_user_id=user.id,
+    )
+    db.add(workspace)
+    db.flush()
+    return workspace, user
+
+
+def _project_and_part(db: Session) -> tuple[Workspace, User, Project, ProjectEntry, Part]:
+    workspace, user = _workspace_user(db)
+    project = Project(
+        workspace_id=workspace.id,
+        name=f"Optimizer BOM {uuid.uuid4().hex[:8]}",
+        created_by=user.id,
+        updated_by=user.id,
+    )
+    part = Part(
+        workspace_id=workspace.id,
+        name=f"STM32 {uuid.uuid4().hex[:8]}",
+        part_type="local",
+        mpn="STM32F103C8T6",
+        created_by=user.id,
+        updated_by=user.id,
+    )
+    db.add_all([project, part])
+    db.flush()
+    entry = ProjectEntry(
+        workspace_id=workspace.id,
+        project_id=project.id,
+        entry_type="part",
+        part_id=part.id,
+        name=part.name,
+        quantity=5,
+        created_by=user.id,
+        updated_by=user.id,
+    )
+    db.add(entry)
+    db.flush()
+    return workspace, user, project, entry, part
+
+
+def _purchase_plan(
+    db: Session,
+    *,
+    strategy: str = "lowest_total_price",
+    status: str = "draft",
+    line_kwargs: dict | None = None,
+    created_delta: timedelta = timedelta(),
+    expires_delta: timedelta = timedelta(days=1),
+) -> PurchasePlan:
+    workspace, user, project, entry, part = _project_and_part(db)
+    created_at = utcnow() + created_delta
+    plan = PurchasePlan(
+        workspace_id=workspace.id,
+        project_id=project.id,
+        build_quantity=2,
+        strategy=strategy,
+        country_code="CZ",
+        currency_code="EUR",
+        preferred_distributors=["DigiKey"],
+        status=status,
+        created_at=created_at,
+        expires_at=created_at + expires_delta,
+        created_by=user.id,
+    )
+    line_values = {
+        "project_entry_id": entry.id,
+        "part_id": part.id,
+        "mpn_searched": "STM32F103C8T6",
+        "required_qty": 10,
+        "internal_available_qty": 2,
+        "shortage_qty": 8,
+        "selected_distributor": "DigiKey",
+        "selected_qty": 10,
+        "selected_unit_price": 1.25,
+        "selected_currency": "EUR",
+        "selected_packaging": "Tape",
+        "selected_moq": 1,
+        "selected_lead_time_days": 3,
+        "selected_url": "https://example.test/offer",
+        "risk_flags": [],
+    }
+    if line_kwargs:
+        line_values.update(line_kwargs)
+    plan.lines.append(PurchasePlanLine(**line_values))
+    db.add(plan)
+    return plan
+
+
+def test_check_constraint_rejects_8_day_ttl(db: Session) -> None:
+    _purchase_plan(db, expires_delta=timedelta(days=8))
+
+    with pytest.raises(IntegrityError):
+        db.flush()
+    db.rollback()
+
+
+def test_strategy_check_rejects_invalid_value(db: Session) -> None:
+    _purchase_plan(db, strategy="magic")
+
+    with pytest.raises(IntegrityError):
+        db.flush()
+    db.rollback()
+
+
+def test_status_check_rejects_invalid_value(db: Session) -> None:
+    _purchase_plan(db, status="stale")
+
+    with pytest.raises(IntegrityError):
+        db.flush()
+    db.rollback()
+
+
+def test_cascade_delete_project_removes_plans_and_lines(db: Session) -> None:
+    plan = _purchase_plan(db)
+    db.flush()
+    project_id = plan.project_id
+
+    project = db.get(Project, project_id)
+    assert project is not None
+    db.delete(project)
+    db.flush()
+
+    assert db.execute(select(func.count()).select_from(PurchasePlan)).scalar_one() == 0
+    assert db.execute(select(func.count()).select_from(PurchasePlanLine)).scalar_one() == 0
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("required_qty", -1),
+        ("internal_available_qty", -1),
+        ("shortage_qty", -1),
+        ("selected_qty", -1),
+        ("selected_moq", 0),
+    ],
+)
+def test_negative_quantities_rejected(db: Session, field: str, value: int) -> None:
+    _purchase_plan(db, line_kwargs={field: value})
+
+    with pytest.raises(IntegrityError):
+        db.flush()
+    db.rollback()

--- a/backend/tests/test_sourcing_cache.py
+++ b/backend/tests/test_sourcing_cache.py
@@ -9,13 +9,14 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.core.time import utcnow
+from app.domain.projects.models import Project
 from app.domain.sourcing.cache import (
     canonical_query_hash,
     get_or_fetch,
     sweep_expired,
     sweep_expired_all_workspaces,
 )
-from app.domain.sourcing.models import SourcingCache
+from app.domain.sourcing.models import PurchasePlan, SourcingCache
 from app.domain.users.models import User
 from app.domain.workspaces.models import Workspace
 
@@ -38,6 +39,16 @@ def _workspace(db: Session) -> uuid.UUID:
     return workspace.id
 
 
+def _project(db: Session, *, workspace_id: uuid.UUID) -> Project:
+    project = Project(
+        workspace_id=workspace_id,
+        name=f"optimizer-project-{uuid.uuid4().hex[:8]}",
+    )
+    db.add(project)
+    db.flush()
+    return project
+
+
 def _cache_row(
     *,
     workspace_id: uuid.UUID,
@@ -54,6 +65,25 @@ def _cache_row(
         response_json=response,
         fetched_at=fetched_at,
         expires_at=fetched_at + ttl,
+    )
+
+
+def _purchase_plan(
+    *,
+    workspace_id: uuid.UUID,
+    project_id: uuid.UUID,
+    created_delta: timedelta = timedelta(),
+    ttl: timedelta = timedelta(days=1),
+) -> PurchasePlan:
+    created_at = utcnow() + created_delta
+    return PurchasePlan(
+        workspace_id=workspace_id,
+        project_id=project_id,
+        build_quantity=1,
+        strategy="lowest_total_price",
+        status="draft",
+        created_at=created_at,
+        expires_at=created_at + ttl,
     )
 
 
@@ -190,9 +220,7 @@ def test_sweep_expired_only_deletes_expired_rows(db: Session) -> None:
     assert sweep_expired(db, workspace_id=workspace_id) == 1
 
     rows = (
-        db.execute(
-            select(SourcingCache).where(SourcingCache.workspace_id == workspace_id)
-        )
+        db.execute(select(SourcingCache).where(SourcingCache.workspace_id == workspace_id))
         .scalars()
         .all()
     )
@@ -268,14 +296,34 @@ def test_sweep_expired_all_workspaces_preserves_unexpired_rows(db: Session) -> N
 
     assert sweep_expired_all_workspaces(db) == 2
 
-    rows = (
-        db.execute(select(SourcingCache).order_by(SourcingCache.workspace_id))
-        .scalars()
-        .all()
-    )
+    rows = db.execute(select(SourcingCache).order_by(SourcingCache.workspace_id)).scalars().all()
     assert len(rows) == 2
     assert {row.workspace_id for row in rows} == {workspace_a, workspace_b}
     assert {row.response_json["active"] for row in rows} == {True}
+
+
+def test_sweeper_also_deletes_expired_purchase_plans(db: Session) -> None:
+    workspace_id = _workspace(db)
+    project = _project(db, workspace_id=workspace_id)
+    expired = _purchase_plan(
+        workspace_id=workspace_id,
+        project_id=project.id,
+        created_delta=-timedelta(days=1),
+        ttl=timedelta(minutes=1),
+    )
+    active = _purchase_plan(
+        workspace_id=workspace_id,
+        project_id=project.id,
+        ttl=timedelta(days=1),
+    )
+    db.add_all([expired, active])
+    db.flush()
+
+    assert sweep_expired_all_workspaces(db) == 1
+
+    rows = db.execute(select(PurchasePlan)).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].id == active.id
 
 
 def test_workspace_isolation_same_query_hash(db: Session) -> None:

--- a/docs/adr/0020-trustedparts-sourcing-provider-split.md
+++ b/docs/adr/0020-trustedparts-sourcing-provider-split.md
@@ -19,6 +19,12 @@ Sourcing is a separate domain under `backend/app/domain/sourcing/`, not a third 
 
 The cache is workspace-scoped and short-lived. The database enforces a maximum seven-day retention window (`backend/app/domain/sourcing/models.py:13`), while the service currently uses a 30-minute TTL (`backend/app/domain/sourcing/service.py:24`). Expired-row cleanup is periodic-job infrastructure owned by ADR-0021. The budget is a parts-count budget, not a request-count budget, and is in-process by design while production runs one uvicorn worker (`backend/app/domain/sourcing/budget.py:104`). The client payload does not send `SourceIp`; user attribution is via the app user/session and visible API response attribution, not via TrustedParts `SourceIp`.
 
+Purchase plans follow the same retention rule because they hold TrustedParts offer
+snapshots while users review optimizer output. `purchase_plans` enforces
+`expires_at <= created_at + interval '7 days'`, and the existing sourcing sweep job removes
+expired plan rows alongside cache rows (`backend/alembic/versions/0039_purchase_plans.py:68`,
+`backend/app/domain/sourcing/cache.py:95`).
+
 TrustedParts results must stay visibly distinct from catalog-provider data. Public or UI surfaces that combine distributor data from multiple origins need an explicit future decision before launch.
 
 ## Consequences

--- a/docs/domain/sourcing.md
+++ b/docs/domain/sourcing.md
@@ -34,6 +34,28 @@ The helper also caps caller-supplied TTLs before writing the row.
 Sources: `backend/alembic/versions/0038_sourcing_cache.py:42`,
 `backend/app/domain/sourcing/cache.py:50`
 
+## Purchase Plans
+
+`purchase_plans` stores short-lived optimizer output for one workspace and project:
+build quantity, strategy, country/currency hints, optional preferred distributors, and
+status. `purchase_plan_lines` stores the per-BOM-line shortage and the selected offer
+snapshot the user is reviewing, including distributor, quantity, unit price, MOQ, lead
+time, and offer URL.
+
+Plans inherit the TrustedParts seven-day retention cap:
+
+```sql
+CHECK (expires_at <= created_at + interval '7 days')
+```
+
+The database also pins static strategy and status values with CHECK constraints. Expired
+plans are removed by the same sourcing sweep job as cache rows. When a plan is converted,
+draft orders become the permanent record; offer URLs and raw offer snapshots stay on the
+ephemeral plan rows and are not copied into order comments.
+
+Sources: `backend/alembic/versions/0039_purchase_plans.py:68`,
+`backend/app/domain/sourcing/cache.py:95`
+
 ## Workspace Isolation
 
 Reads filter by both `workspace_id` and `query_hash`, so identical canonical queries in


### PR DESCRIPTION
## Summary

- Add append-only Alembic revision `0039_purchase_plans.py` for `purchase_plans` and `purchase_plan_lines`.
- Add SQLAlchemy `PurchasePlan` / `PurchasePlanLine` models and register sourcing models in `app.domain.all_models`.
- Extend the existing `sweep_expired_all_workspaces` path so the existing `sourcing-cache-sweep` job also removes expired purchase plans.
- Add DB-model tests for TTL, enum, quantity, and cascade constraints, plus a sourcing sweeper regression test.
- Document ephemeral purchase plans in sourcing domain docs and ADR-0020.

## Validation

Docker is not installed in this worktree environment (`docker: command not found`), so I ran the closest local `uv`/Postgres commands against `postgresql+psycopg://stockmgr:stockmgr@127.0.0.1:5432/stockmgr_test`.

- `uv sync --frozen --extra dev` -> installed dev test/lint dependencies.
- `DATABASE_URL=... uv run alembic upgrade head` -> passed; ran `0038 -> 0039`.
- `DATABASE_URL=... uv run alembic downgrade -1 && DATABASE_URL=... uv run alembic upgrade head` -> passed; downgraded `0039 -> 0038`, then upgraded `0038 -> 0039`.
- `DATABASE_URL=... uv run python -m pytest -q -k "purchase_plan_models or sourcing_cache"` -> `21 passed, 874 deselected, 1 warning in 2.51s`.
- `uv run ruff check app/domain/all_models.py app/domain/sourcing/models.py app/domain/sourcing/cache.py tests/test_purchase_plan_models.py tests/test_sourcing_cache.py alembic/versions/0039_purchase_plans.py` -> `All checks passed!`.
- `LINT_CMD="ruff check app --output-format=concise" BASELINE_FILE="../.ruff-baseline.txt" WORK_DIR="." bash ../scripts/lint-delta.sh` -> `lint-delta: no new violations (baseline: 159, current: 154, fixed since baseline: 5)`.
- `git diff --check` -> passed.
- `rg -n "verify=False|trust_env=False|ssl=False" backend/app || true` -> no matches.

Full `uv run ruff check` still reports the repository's pre-existing non-baseline failures, so the PR validation uses the touched-file Ruff check plus the CI-style baseline gate above.

## 7-day CHECK confirmation

`purchase_plans` has the required non-negotiable Postgres constraint:

```sql
CONSTRAINT purchase_plans_max_7_day_ttl CHECK (expires_at <= created_at + interval '7 days')
```

A targeted DB inspection after upgrade confirmed this constraint, the static `strategy`/`status` CHECK constraints, the line quantity CHECK constraints, cascade FKs, and requested indexes are present.

## Sweeper choice

Extended `sweep_expired_all_workspaces` rather than adding a second job. The existing `sourcing-cache-sweep` job remains the single cleanup entry point for short-lived TrustedParts-derived rows.

## Migration reviewer self-check

- Append-only revision: `0039`, `down_revision = "0038"`; no merged migrations edited.
- `downgrade()` drops line indexes/table before plan indexes/table.
- Workspace/project/plan/part cascade paths are covered by FKs and tests.
- `project_entry_id` is intentionally a nullable soft pointer with no FK, matching the issue contract.
- `alembic check` is not clean on current `main` metadata because it reports unrelated pre-existing index drift on older tables; no `purchase_plans`, `purchase_plan_lines`, or `sourcing_cache` drift was listed.

Refs #373
