### PR TITLE
TP-505: Low-stock report with sourcing column set

### DIFF
--- a/backend/app/api/routes/reports.py
+++ b/backend/app/api/routes/reports.py
@@ -16,9 +16,8 @@ from app.domain.builds.service import shortage_analysis
 from app.domain.lots.models import Lot
 from app.domain.parts.models import Part
 from app.domain.projects.models import Project
-from app.domain.reports.service import sourcing_risk_report
+from app.domain.reports.service import low_stock_report, sourcing_risk_report
 from app.domain.stock.service import (
-    bulk_current_quantities,
     bulk_current_quantities_by_lot,
 )
 
@@ -26,49 +25,14 @@ router = APIRouter()
 
 
 @router.get("/low-stock")
-def low_stock(db: DbSession, ws: CurrentWorkspace):
+def low_stock(
+    db: DbSession,
+    ws: CurrentWorkspace,
+    include_sourcing: bool = Query(default=False),
+):
     """Parts whose *available* (on-hand minus reserved) is below their
     `low_stock_report_quantity`. Parts without a threshold are skipped."""
-    parts = list(
-        db.execute(
-            select(Part)
-            .where(Part.workspace_id == ws.id)
-            .where(Part.archived_at.is_(None))
-            .where(Part.low_stock_report_quantity.is_not(None))
-        ).scalars()
-    )
-    # Funnel both per-part aggregations through bulk_current_quantities so
-    # the "current = SUM(delta)" invariant lives in one place (BE2-005).
-    part_ids = [p.id for p in parts]
-    on_hand = bulk_current_quantities(
-        db, workspace_id=ws.id, part_ids=part_ids, status="on_hand"
-    )
-    reserved = bulk_current_quantities(
-        db, workspace_id=ws.id, part_ids=part_ids, status="reserved"
-    )
-
-    out = []
-    for p in parts:
-        cur = on_hand.get(p.id, 0)
-        res = reserved.get(p.id, 0)
-        avail = cur - res
-        threshold = p.low_stock_report_quantity or 0
-        if avail < threshold:
-            out.append(
-                {
-                    "part_id": str(p.id),
-                    "name": p.name,
-                    "manufacturer": p.manufacturer,
-                    "mpn": p.mpn,
-                    "on_hand": cur,
-                    "reserved": res,
-                    "available": avail,
-                    "threshold": threshold,
-                    "short_by": threshold - avail,
-                }
-            )
-    out.sort(key=lambda r: r["short_by"], reverse=True)
-    return ok(out)
+    return ok(low_stock_report(db, workspace=ws, include_sourcing=include_sourcing))
 
 
 @router.get("/sourcing-risk", dependencies=[Depends(require_role("member"))])

--- a/backend/app/domain/reports/__init__.py
+++ b/backend/app/domain/reports/__init__.py
@@ -1,2 +1,1 @@
 """Read-only report services."""
-

--- a/backend/app/domain/reports/service.py
+++ b/backend/app/domain/reports/service.py
@@ -1,10 +1,11 @@
 """Read-only report services."""
 from __future__ import annotations
 
+import logging
 from collections.abc import Sequence
 from datetime import datetime
 from decimal import Decimal
-from typing import Any
+from typing import Any, Literal
 from uuid import UUID
 
 from sqlalchemy import select
@@ -25,14 +26,23 @@ from app.domain.sourcing import (
     SourcingTimeoutError,
 )
 from app.domain.sourcing import service as sourcing_service
-from app.domain.sourcing.schemas import SourcingBomOfferOut, SourcingSearchResult
+from app.domain.sourcing.schemas import (
+    SourcingBomOfferOut,
+    SourcingReportData,
+    SourcingSearchResult,
+)
 from app.domain.sourcing.service import SourcingBudgetBlocked, SourcingNotConfigured
 from app.domain.stock.service import bulk_current_quantities
 
+LOW_STOCK_SOURCING_TTL_SECONDS = 4 * 3600
 SOURCING_RISK_TTL_SECONDS = 4 * 60 * 60
 PRICE_DELTA_THRESHOLD = Decimal("0.25")
 LEAD_TIME_LONG_DAYS = 30
 MOQ_OVERBUY_MULTIPLIER = 5
+
+SourcingStatus = Literal["ok", "not_configured", "partial", "budget_blocked"]
+
+_log = logging.getLogger(__name__)
 
 
 def sourcing_risk_report(
@@ -260,7 +270,171 @@ def _price_delta_pct(
     return (best_offer.unit_price - historical_unit_cost) / historical_unit_cost
 
 
+def low_stock_report(
+    db: Session,
+    *,
+    workspace: Any,
+    include_sourcing: bool = False,
+    requested_by: UUID | None = None,
+) -> list[dict[str, Any]] | dict[str, Any]:
+    parts = _low_stock_candidate_parts(db, workspace_id=workspace.id)
+    rows = _low_stock_rows(db, workspace_id=workspace.id, parts=parts)
+    if not include_sourcing:
+        return rows
+
+    for row in rows:
+        row["sourcing"] = None
+
+    status = _attach_low_stock_sourcing(
+        db,
+        workspace=workspace,
+        rows=rows,
+        requested_by=requested_by,
+    )
+    return {
+        "rows": rows,
+        "sourcing_status": status,
+        "powered_by": "TrustedParts" if status in {"ok", "partial", "budget_blocked"} else None,
+        "links": (
+            sourcing_service.TRUSTEDPARTS_LINKS
+            if status in {"ok", "partial", "budget_blocked"}
+            else None
+        ),
+    }
+
+
+def _low_stock_candidate_parts(db: Session, *, workspace_id: UUID) -> list[Part]:
+    return list(
+        db.execute(
+            select(Part)
+            .where(Part.workspace_id == workspace_id)
+            .where(Part.archived_at.is_(None))
+            .where(Part.low_stock_report_quantity.is_not(None))
+        ).scalars()
+    )
+
+
+def _low_stock_rows(
+    db: Session,
+    *,
+    workspace_id: UUID,
+    parts: list[Part],
+) -> list[dict[str, Any]]:
+    part_ids = [part.id for part in parts]
+    on_hand = bulk_current_quantities(
+        db, workspace_id=workspace_id, part_ids=part_ids, status="on_hand"
+    )
+    reserved = bulk_current_quantities(
+        db, workspace_id=workspace_id, part_ids=part_ids, status="reserved"
+    )
+
+    rows: list[dict[str, Any]] = []
+    for part in parts:
+        cur = on_hand.get(part.id, 0)
+        res = reserved.get(part.id, 0)
+        avail = cur - res
+        threshold = part.low_stock_report_quantity or 0
+        if avail < threshold:
+            rows.append(
+                {
+                    "part_id": str(part.id),
+                    "name": part.name,
+                    "manufacturer": part.manufacturer,
+                    "mpn": part.mpn,
+                    "on_hand": cur,
+                    "reserved": res,
+                    "available": avail,
+                    "threshold": threshold,
+                    "short_by": threshold - avail,
+                }
+            )
+    rows.sort(key=lambda row: row["short_by"], reverse=True)
+    return rows
+
+
+def _attach_low_stock_sourcing(
+    db: Session,
+    *,
+    workspace: Any,
+    rows: list[dict[str, Any]],
+    requested_by: UUID | None,
+) -> SourcingStatus:
+    mpns = sourcing_service.dedupe_mpns(row.get("mpn") for row in rows)
+    if not mpns:
+        return "ok"
+
+    search_results: dict[str, Any] = {}
+    partial = False
+    try:
+        for chunk in sourcing_service.chunk_mpns(mpns):
+            verdict = sourcing_service.BUDGET.check(workspace.id, parts_count=len(chunk))
+            if not verdict.allow:
+                return "budget_blocked" if not search_results else "partial"
+            partial = partial or verdict.mode == "degraded"
+            out = sourcing_service.search(
+                db,
+                workspace=workspace,
+                mpns=chunk,
+                use_cached_data=bool(workspace.sourcing_use_cached_for_dashboards),
+                ttl_seconds=LOW_STOCK_SOURCING_TTL_SECONDS,
+                requested_by=requested_by,
+            )
+            for result in out.results:
+                search_results[result.mpn.casefold()] = result
+    except sourcing_service.SourcingNotConfigured:
+        return "not_configured"
+    except sourcing_service.SourcingBudgetBlocked:
+        return "budget_blocked" if not search_results else "partial"
+    except Exception:
+        _log.exception(
+            "low-stock sourcing enrichment failed",
+            extra={"workspace_id": str(workspace.id)},
+        )
+        return "partial"
+
+    preferred = _preferred_distributors(workspace.sourcing_preferred_distributors)
+    preferred_keys = {item.casefold() for item in preferred}
+    for row in rows:
+        mpn = row.get("mpn")
+        if not mpn:
+            continue
+        result = search_results.get(str(mpn).casefold())
+        if result is None:
+            continue
+        short_by = max(1, int(row["short_by"]))
+        offers = sourcing_service._joined_offers([str(mpn)], search_results, qty=short_by)
+        best_offer = sourcing_service._best_offer_at_qty(offers, short_by)
+        row["sourcing"] = SourcingReportData(
+            authorized_stock=sum(offer.stock for offer in offers),
+            offers=offers,
+            best_offer=best_offer,
+            est_replenishment_cost=_extended_cost(best_offer, short_by),
+            lead_time_days=best_offer.lead_time_days if best_offer is not None else None,
+            preferred_distributor_available=(
+                bool(preferred_keys)
+                and any(
+                    offer.distributor.casefold() in preferred_keys and offer.stock > 0
+                    for offer in offers
+                )
+            ),
+            cache_hit=result.cache_hit,
+            fetched_at=result.fetched_at,
+        )
+    return "partial" if partial else "ok"
+
+
+def _extended_cost(best_offer: Any, quantity: int) -> Decimal | None:
+    if best_offer is None or best_offer.unit_price is None:
+        return None
+    purchase_quantity = max(quantity, int(best_offer.moq or 1))
+    return best_offer.unit_price * Decimal(purchase_quantity)
+
+
 def _clean_distributors(value: Any) -> list[str]:
     if not isinstance(value, list):
         return []
     return [str(item).strip() for item in value if str(item).strip()]
+
+
+def _preferred_distributors(value: Any) -> list[str]:
+    return _clean_distributors(value)

--- a/backend/app/domain/sourcing/schemas.py
+++ b/backend/app/domain/sourcing/schemas.py
@@ -232,6 +232,19 @@ class SourcingBomLineOut(BaseModel):
     ] = Field(default_factory=list)
 
 
+class SourcingReportData(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    authorized_stock: int
+    offers: list[SourcingBomOfferOut] = Field(default_factory=list)
+    best_offer: SourcingBomOfferOut | None = None
+    est_replenishment_cost: Decimal | None = None
+    lead_time_days: int | None = None
+    preferred_distributor_available: bool
+    cache_hit: bool
+    fetched_at: datetime
+
+
 class SourcingBomOut(BaseModel):
     model_config = ConfigDict(extra="forbid")
 

--- a/backend/tests/test_low_stock_report_with_sourcing.py
+++ b/backend/tests/test_low_stock_report_with_sourcing.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+import app.core.ratelimit as _ratelimit_mod
+from app.domain.reports.service import LOW_STOCK_SOURCING_TTL_SECONDS
+from app.domain.sourcing.budget import BUDGET
+from app.domain.sourcing.schemas import (
+    SourcingDistributor,
+    SourcingLinks,
+    SourcingOffer,
+    SourcingPriceBreak,
+    SourcingQuery,
+    SourcingSearchRaw,
+)
+from app.main import app
+from tests._factories import add_stock, create_part, signup_user
+
+
+def _configure_sourcing(
+    client: TestClient,
+    *,
+    preferred: list[str] | None = None,
+    use_cached_for_dashboards: bool = True,
+) -> None:
+    r = client.patch(
+        "/api/workspaces/current",
+        json={
+            "sourcing_provider": "trustedparts",
+            "sourcing_company_id": "company-123",
+            "sourcing_api_key": "api-key-456",
+            "sourcing_country_code": "CZ",
+            "sourcing_currency_code": "EUR",
+            "sourcing_preferred_distributors": preferred or ["DigiKey"],
+            "sourcing_use_cached_for_dashboards": use_cached_for_dashboards,
+        },
+    )
+    assert r.status_code == 200, r.text
+
+
+def _current_workspace_id(client: TestClient) -> uuid.UUID:
+    r = client.get("/api/workspaces/current")
+    assert r.status_code == 200, r.text
+    return uuid.UUID(r.json()["data"]["id"])
+
+
+def _offer(
+    mpn: str,
+    *,
+    distributor: str = "DigiKey",
+    stock: int = 100,
+    unit_price: float = 1.0,
+    moq: int | None = 1,
+    lead_time_days: int | None = 3,
+    currency: str = "EUR",
+) -> SourcingOffer:
+    return SourcingOffer(
+        mpn=mpn,
+        manufacturer="TestCo",
+        description=f"Offer for {mpn}",
+        distributors=[
+            SourcingDistributor(
+                name=distributor,
+                sku=f"{mpn}-{distributor}",
+                stock=stock,
+                unit_price=unit_price,
+                currency=currency,
+                moq=moq,
+                lead_time_days=lead_time_days,
+                price_breaks=[SourcingPriceBreak(quantity=1, unit_price=unit_price)],
+                product_url=f"https://www.trustedparts.com/{mpn}/{distributor}",
+            )
+        ],
+        links=SourcingLinks(primary=f"https://www.trustedparts.com/search/{mpn}"),
+    )
+
+
+class _FakeTrustedPartsClient:
+    calls: list[dict[str, Any]] = []
+    offers_by_mpn: dict[str, list[SourcingOffer]] = {}
+
+    def __init__(self, workspace_id: uuid.UUID | None = None) -> None:
+        self.workspace_id = workspace_id
+        self.country_code = "CZ"
+        self.currency_code = "EUR"
+
+    def search(
+        self,
+        queries: list[SourcingQuery],
+        *,
+        in_stock_only: bool,
+        distributors: list[str] | None,
+        use_cached_data: bool,
+        **_kwargs: Any,
+    ) -> SourcingSearchRaw:
+        query = queries[0]
+        self.calls.append(
+            {
+                "workspace_id": str(self.workspace_id) if self.workspace_id else None,
+                "mpn": query.search_token,
+                "use_cached_data": use_cached_data,
+                "distributors": distributors,
+                "in_stock_only": in_stock_only,
+            }
+        )
+        offers = self.offers_by_mpn.get(query.search_token)
+        if offers is None and self.workspace_id is not None:
+            offers = [
+                _offer(
+                    query.search_token,
+                    distributor=f"WS-{str(self.workspace_id)[:8]}",
+                )
+            ]
+        if offers is None:
+            offers = [_offer(query.search_token)]
+        return SourcingSearchRaw(offers=offers, request_id=f"req-{len(self.calls)}")
+
+
+@pytest.fixture(autouse=True)
+def reset_sourcing_state(monkeypatch):
+    original_limiter_enabled = _ratelimit_mod.limiter.enabled
+    _ratelimit_mod.limiter.enabled = False
+    _FakeTrustedPartsClient.calls = []
+    _FakeTrustedPartsClient.offers_by_mpn = {}
+    BUDGET._events.clear()
+    try:
+        _ratelimit_mod.limiter.reset()
+    except Exception:
+        pass
+    monkeypatch.setattr(
+        "app.domain.sourcing.service.make_sourcing_provider",
+        lambda workspace: _FakeTrustedPartsClient(workspace.id),
+    )
+    yield
+    _ratelimit_mod.limiter.enabled = original_limiter_enabled
+    BUDGET._events.clear()
+    try:
+        _ratelimit_mod.limiter.reset()
+    except Exception:
+        pass
+
+
+def _low_stock_part(
+    client: TestClient,
+    *,
+    name: str = "Low",
+    mpn: str | None = "LOW-MPN",
+    threshold: int = 100,
+    on_hand: int = 25,
+) -> str:
+    payload: dict[str, Any] = {
+        "name": name,
+        "low_stock_report_quantity": threshold,
+    }
+    if mpn is not None:
+        payload["mpn"] = mpn
+    part_id = create_part(client, **payload)
+    if on_hand:
+        add_stock(client, part_id, on_hand)
+    return part_id
+
+
+def test_include_sourcing_false_unchanged_from_baseline(authed_client):
+    part_id = _low_stock_part(authed_client)
+
+    r = authed_client.get("/api/reports/low-stock")
+
+    assert r.status_code == 200, r.text
+    data = r.json()["data"]
+    assert isinstance(data, list)
+    assert data[0]["part_id"] == part_id
+    assert "sourcing" not in data[0]
+    assert "sourcing_status" not in data[0]
+    assert _FakeTrustedPartsClient.calls == []
+
+
+def test_include_sourcing_true_attaches_offers_for_parts_with_mpn(authed_client):
+    _configure_sourcing(authed_client, preferred=["DigiKey"])
+    part_id = _low_stock_part(authed_client, mpn="STM32")
+    _FakeTrustedPartsClient.offers_by_mpn = {
+        "STM32": [_offer("STM32", stock=80, unit_price=0.25, moq=10, lead_time_days=5)]
+    }
+
+    r = authed_client.get("/api/reports/low-stock?include_sourcing=true")
+
+    assert r.status_code == 200, r.text
+    data = r.json()["data"]
+    assert data["sourcing_status"] == "ok"
+    row = data["rows"][0]
+    assert row["part_id"] == part_id
+    assert row["sourcing"]["authorized_stock"] == 80
+    assert row["sourcing"]["best_offer"]["distributor"] == "DigiKey"
+    assert row["sourcing"]["best_offer"]["moq"] == 10
+    assert row["sourcing"]["lead_time_days"] == 5
+    assert row["sourcing"]["preferred_distributor_available"] is True
+    assert row["sourcing"]["est_replenishment_cost"] == "18.75"
+    assert _FakeTrustedPartsClient.calls[-1]["use_cached_data"] is True
+
+
+def test_part_without_mpn_returns_null_sourcing(authed_client):
+    _configure_sourcing(authed_client)
+    _low_stock_part(authed_client, mpn=None)
+
+    r = authed_client.get("/api/reports/low-stock?include_sourcing=true")
+
+    assert r.status_code == 200, r.text
+    data = r.json()["data"]
+    assert data["sourcing_status"] == "ok"
+    assert data["rows"][0]["mpn"] is None
+    assert data["rows"][0]["sourcing"] is None
+    assert _FakeTrustedPartsClient.calls == []
+
+
+def test_not_configured_returns_status_flag_not_409(authed_client, monkeypatch):
+    monkeypatch.setattr(
+        "app.domain.sourcing.service.make_sourcing_provider",
+        lambda _workspace: None,
+    )
+    _low_stock_part(authed_client)
+
+    r = authed_client.get("/api/reports/low-stock?include_sourcing=true")
+
+    assert r.status_code == 200, r.text
+    data = r.json()["data"]
+    assert data["sourcing_status"] == "not_configured"
+    assert data["rows"][0]["sourcing"] is None
+
+
+def test_budget_blocked_returns_status_flag_not_503(authed_client):
+    _configure_sourcing(authed_client)
+    _low_stock_part(authed_client)
+    BUDGET.record(_current_workspace_id(authed_client), 250)
+
+    r = authed_client.get("/api/reports/low-stock?include_sourcing=true")
+
+    assert r.status_code == 200, r.text
+    data = r.json()["data"]
+    assert data["sourcing_status"] == "budget_blocked"
+    assert data["rows"][0]["sourcing"] is None
+
+
+def test_4h_cache_ttl(authed_client, monkeypatch):
+    _configure_sourcing(authed_client)
+    _low_stock_part(authed_client, mpn="CACHE-MPN")
+    ttl_values: list[int] = []
+    original_search = __import__("app.domain.sourcing.service", fromlist=["search"]).search
+
+    def spy_search(*args: Any, **kwargs: Any):
+        ttl_values.append(kwargs["ttl_seconds"])
+        return original_search(*args, **kwargs)
+
+    monkeypatch.setattr("app.domain.sourcing.service.search", spy_search)
+
+    first = authed_client.get("/api/reports/low-stock?include_sourcing=true")
+    second = authed_client.get("/api/reports/low-stock?include_sourcing=true")
+
+    assert first.status_code == 200, first.text
+    assert second.status_code == 200, second.text
+    assert ttl_values == [LOW_STOCK_SOURCING_TTL_SECONDS, LOW_STOCK_SOURCING_TTL_SECONDS]
+    assert first.json()["data"]["rows"][0]["sourcing"]["cache_hit"] is False
+    assert second.json()["data"]["rows"][0]["sourcing"]["cache_hit"] is True
+    assert len(_FakeTrustedPartsClient.calls) == 1
+
+
+def test_workspace_isolation_two_workspaces_same_part_mpn(authed_client):
+    _configure_sourcing(authed_client)
+    _low_stock_part(authed_client, mpn="SHARED-MPN")
+
+    client_b = TestClient(app)
+    signup_user(client_b)
+    _configure_sourcing(client_b)
+    _low_stock_part(client_b, mpn="SHARED-MPN")
+
+    first = authed_client.get("/api/reports/low-stock?include_sourcing=true")
+    second = client_b.get("/api/reports/low-stock?include_sourcing=true")
+
+    assert first.status_code == 200, first.text
+    assert second.status_code == 200, second.text
+    first_offer = first.json()["data"]["rows"][0]["sourcing"]["best_offer"]
+    second_offer = second.json()["data"]["rows"][0]["sourcing"]["best_offer"]
+    assert first_offer["distributor"] != second_offer["distributor"]
+    assert [call["mpn"] for call in _FakeTrustedPartsClient.calls] == [
+        "SHARED-MPN",
+        "SHARED-MPN",
+    ]

--- a/docs/api/reports.md
+++ b/docs/api/reports.md
@@ -14,6 +14,12 @@ See [API conventions](./README.md) for envelope, errors, pagination. Mounted at 
 
 Live parts whose `available = on_hand - reserved` is below their `low_stock_report_quantity`. Parts without a threshold are skipped.
 
+**Query**
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `include_sourcing` | boolean | no | Default `false`. When `true`, enriches rows from the workspace TrustedParts cache/search path with a 4-hour TTL and dashboard cache preference. |
+
 **Response** — `200 OK` — array sorted by `short_by DESC`:
 
 ```json
@@ -24,10 +30,30 @@ Live parts whose `available = on_hand - reserved` is below their `low_stock_repo
 } ], "status": { ... } }
 ```
 
+With `include_sourcing=true`, `data` is an object:
+
+```json
+{ "data": {
+    "sourcing_status": "ok",
+    "rows": [ {
+      "part_id": "...", "short_by": 13,
+      "sourcing": {
+        "authorized_stock": 400,
+        "best_offer": { "distributor": "DigiKey", "moq": 1, "lead_time_days": 3 },
+        "est_replenishment_cost": "3.25",
+        "preferred_distributor_available": true
+      }
+    } ]
+}, "status": { ... } }
+```
+
+`sourcing_status` is one of `ok`, `not_configured`, `partial`, or `budget_blocked`. Sourcing failures do not change the HTTP status; the report still returns `200 OK` with low-stock rows and `sourcing: null` where enrichment was unavailable.
+
 **Notes**
 
-- Filters `archived_at IS NULL` (`reports.py:34`).
-- Source: `backend/app/api/routes/reports.py:26-69`.
+- Filters `archived_at IS NULL` (`backend/app/domain/reports/service.py:61-63`).
+- Source: `backend/app/api/routes/reports.py:26-34`.
+- Service: `backend/app/domain/reports/service.py:24-174`.
 
 ### `GET /api/reports/bom-shortage`
 

--- a/docs/frontend/reports.md
+++ b/docs/frontend/reports.md
@@ -8,7 +8,12 @@ Frontend report routes and their data-fetching conventions.
 
 | Route | Component | API |
 |---|---|---|
+| `/reports` | `web/src/routes/reports/Reports.tsx` | `GET /api/reports/low-stock` |
 | `/reports/sourcing-risk` | `web/src/routes/reports/SourcingRiskReport.tsx` | `GET /api/reports/sourcing-risk` |
+
+## Low-Stock Sourcing
+
+`LowStockReport` keeps the sourcing toggle in the URL as `include_sourcing=true`; the query key includes that boolean so cached plain low-stock rows and sourced low-stock rows stay separate. When enabled, the table renders TrustedParts attribution, sourcing status banners, sourcing columns, and a per-row draft-PO action that reuses `CreateOrderLineModal` with the row's best offer as its source. Source: `web/src/routes/reports/Reports.tsx`.
 
 The sourcing-risk page uses TanStack Query with `useWsKey("report", "sourcing-risk", onlyWithFlags)`, renders the shared `DataTable`, and keeps the default list sorted by flag count before handing rows to the table. The page uses `PoweredByTrustedParts` and `SourcingSourceLabel` for TrustedParts attribution.
 

--- a/docs/runbooks/provider-outage.md
+++ b/docs/runbooks/provider-outage.md
@@ -157,7 +157,7 @@ needs a code change:
 
 ## TrustedParts outage
 
-TrustedParts sourcing is separate from the Mouser/DigiKey catalog providers. It backs `POST /api/sourcing/search`, the workspace sourcing connection test, and future sourcing UI surfaces; catalog lookup, manual part creation, stock movements, and existing parts remain available.
+TrustedParts sourcing is separate from the Mouser/DigiKey catalog providers. It backs `POST /api/sourcing/search`, the workspace sourcing connection test, and sourcing UI surfaces; catalog lookup, manual part creation, stock movements, and existing parts remain available. The low-stock report degrades gracefully: `GET /api/reports/low-stock?include_sourcing=true` still returns `200 OK` rows with a `sourcing_status` flag when TrustedParts is unavailable or budget-blocked.
 
 Integration entry points:
 

--- a/web/src/routes/reports/Reports.tsx
+++ b/web/src/routes/reports/Reports.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Link, NavLink, Outlet, useNavigate } from "react-router-dom";
+import { Link, NavLink, Outlet, useNavigate, useSearchParams } from "react-router-dom";
 import { useQuery, useQueryClient, type QueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { BarChart3, ShoppingCart } from "lucide-react";
@@ -8,8 +8,14 @@ import { useAuth } from "@/lib/auth";
 import { useApiMutation } from "@/lib/mutations";
 import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
 import { formatDate, formatMoney } from "@/lib/format";
-import { DataTable } from "@/components/DataTable";
+import { DataTable, type Column } from "@/components/DataTable";
 import EmptyState from "@/components/EmptyState";
+import { PoweredByTrustedParts } from "@/components/PoweredByTrustedParts";
+import { SourcingSourceLabel } from "@/components/SourcingSourceLabel";
+import {
+  CreateOrderLineModal,
+  type CreateOrderLineSource,
+} from "@/routes/parts/detail/CreateOrderLineModal";
 import type { Order, Project } from "@/types";
 
 type LowStockRow = {
@@ -22,6 +28,43 @@ type LowStockRow = {
   available: number;
   threshold: number;
   short_by: number;
+  sourcing?: LowStockSourcing | null;
+};
+
+type LowStockSourcingOffer = {
+  mpn: string;
+  distributor: string;
+  sku?: string | null;
+  stock: number;
+  unit_price?: string | number | null;
+  currency?: string | null;
+  packaging?: string | null;
+  moq?: number | null;
+  lead_time_days?: number | null;
+  url?: string | null;
+};
+
+type LowStockSourcing = {
+  authorized_stock: number;
+  offers: LowStockSourcingOffer[];
+  best_offer?: LowStockSourcingOffer | null;
+  est_replenishment_cost?: string | number | null;
+  lead_time_days?: number | null;
+  preferred_distributor_available: boolean;
+  cache_hit: boolean;
+  fetched_at: string;
+};
+
+type LowStockSourcingStatus = "ok" | "not_configured" | "partial" | "budget_blocked";
+
+type LowStockWithSourcing = {
+  rows: LowStockRow[];
+  sourcing_status: LowStockSourcingStatus;
+  powered_by?: "TrustedParts" | null;
+  links?: {
+    primary: string;
+    attribution: string;
+  } | null;
 };
 
 type StockValue = {
@@ -92,6 +135,39 @@ async function createRestockOrder(
 
 function todayISO(): string {
   return new Date().toISOString().slice(0, 10);
+}
+
+function numberOrNull(value: string | number | null | undefined): number | null {
+  if (value == null || value === "") return null;
+  const numeric = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(numeric) ? numeric : null;
+}
+
+function formatSourcingMoney(value: string | number | null | undefined, currency?: string | null): string {
+  const numeric = numberOrNull(value);
+  if (numeric == null) return "—";
+  return formatMoney(numeric, currency);
+}
+
+function formatLeadTime(days: number | null | undefined): string {
+  if (days == null) return "—";
+  return days === 1 ? "1 day" : `${days.toLocaleString()} days`;
+}
+
+function createOrderLineSource(row: LowStockRow): CreateOrderLineSource | null {
+  const offer = row.sourcing?.best_offer;
+  if (!row.sourcing || !offer) return null;
+  return {
+    partId: row.part_id,
+    distributor: offer.distributor,
+    packaging: offer.packaging ?? null,
+    leadTimeDays: offer.lead_time_days ?? null,
+    fetchedAt: row.sourcing.fetched_at ?? null,
+    quantity: Math.max(1, row.short_by, offer.moq ?? 1),
+    unitPrice: numberOrNull(offer.unit_price),
+    currency: offer.currency ?? null,
+    productUrl: offer.url ?? null,
+  };
 }
 
 export default function ReportsLayout() {
@@ -203,9 +279,15 @@ export function LowStockReport() {
   const nav = useNavigate();
   const qc = useQueryClient();
   const { workspaceId } = useAuth();
-  const { data, isLoading, isError, error } = useQuery({
-    queryKey: useWsKey("report", "low-stock"),
-    queryFn: () => api.get<LowStockRow[]>("/reports/low-stock"),
+  const [searchParams, setSearchParams] = useSearchParams();
+  const includeSourcing = searchParams.get("include_sourcing") === "true";
+  const [orderLineSource, setOrderLineSource] = useState<CreateOrderLineSource | null>(null);
+  const { data, isLoading, isError, error } = useQuery<LowStockRow[] | LowStockWithSourcing>({
+    queryKey: useWsKey("report", "low-stock", includeSourcing),
+    queryFn: () =>
+      includeSourcing
+        ? api.get<LowStockWithSourcing>("/reports/low-stock?include_sourcing=true")
+        : api.get<LowStockRow[]>("/reports/low-stock"),
   });
 
   const restockMutation = useApiMutation<void, { name: string; lines: { part_id: string; quantity: number }[] }>({
@@ -218,8 +300,17 @@ export function LowStockReport() {
 
   if (isError) return <div className="text-red-600 text-sm p-4">Failed to load low-stock report. {error instanceof ApiError ? error.userMessage : ""}</div>;
   if (isLoading) return <div className="text-muted">Loading…</div>;
-  const rows = data ?? [];
+  const sourcedData = includeSourcing && data && !Array.isArray(data) ? data : null;
+  const rows = Array.isArray(data) ? data : data?.rows ?? [];
   const busy = restockMutation.isPending;
+  const sourcingStatus = sourcedData?.sourcing_status;
+
+  function setIncludeSourcing(next: boolean) {
+    const params = new URLSearchParams(searchParams);
+    if (next) params.set("include_sourcing", "true");
+    else params.delete("include_sourcing");
+    setSearchParams(params, { replace: false });
+  }
 
   function orderShortages() {
     if (busy || rows.length === 0) return;
@@ -229,10 +320,101 @@ export function LowStockReport() {
     });
   }
 
+  const columns: Column<LowStockRow>[] = [
+    { key: "name", header: "Part", accessor: r => r.name, render: r => <Link className="text-accent" to={`/parts/${r.part_id}/info`}>{r.name}</Link> },
+    { key: "mpn", header: "MPN", accessor: r => r.mpn ?? "" },
+    { key: "manufacturer", header: "Manufacturer", accessor: r => r.manufacturer ?? "" },
+    { key: "on_hand", header: "On hand", accessor: r => r.on_hand, width: "80px" },
+    { key: "reserved", header: "Reserved", accessor: r => r.reserved ?? 0, width: "90px",
+      render: r => <span className="tabular-nums text-muted">{r.reserved ?? 0}</span> },
+    { key: "available", header: "Available", accessor: r => r.available ?? r.on_hand, width: "90px" },
+    { key: "threshold", header: "Threshold", accessor: r => r.threshold, width: "100px" },
+    { key: "short_by", header: "Short by", accessor: r => r.short_by, width: "100px",
+      render: r => <span className="tabular-nums text-danger">{r.short_by}</span> },
+    ...(includeSourcing ? [
+      {
+        key: "authorized_stock",
+        header: "Authorized stock",
+        accessor: (r: LowStockRow) => r.sourcing?.authorized_stock ?? null,
+        render: (r: LowStockRow) => r.sourcing ? <span className="tabular-nums">{r.sourcing.authorized_stock}</span> : <span className="text-muted">—</span>,
+        align: "right" as const,
+      },
+      {
+        key: "best_offer",
+        header: "Best offer",
+        accessor: (r: LowStockRow) => numberOrNull(r.sourcing?.best_offer?.unit_price),
+        render: (r: LowStockRow) => r.sourcing?.best_offer
+          ? formatSourcingMoney(r.sourcing.best_offer.unit_price, r.sourcing.best_offer.currency)
+          : <span className="text-muted">—</span>,
+        align: "right" as const,
+      },
+      {
+        key: "moq",
+        header: "MOQ",
+        accessor: (r: LowStockRow) => r.sourcing?.best_offer?.moq ?? null,
+        render: (r: LowStockRow) => r.sourcing?.best_offer?.moq ?? <span className="text-muted">—</span>,
+        align: "right" as const,
+      },
+      {
+        key: "lead_time",
+        header: "Lead time",
+        accessor: (r: LowStockRow) => r.sourcing?.lead_time_days ?? null,
+        render: (r: LowStockRow) => formatLeadTime(r.sourcing?.lead_time_days),
+        align: "right" as const,
+      },
+      {
+        key: "preferred",
+        header: "Preferred?",
+        accessor: (r: LowStockRow) => r.sourcing?.preferred_distributor_available ?? false,
+        render: (r: LowStockRow) => r.sourcing?.preferred_distributor_available ? "✓" : <span className="text-muted">—</span>,
+        align: "center" as const,
+      },
+      {
+        key: "source",
+        header: "Source",
+        accessor: () => "TrustedParts",
+        render: () => <SourcingSourceLabel source="trustedparts" />,
+      },
+      {
+        key: "draft_po",
+        header: "Draft PO",
+        accessor: (r: LowStockRow) => r.sourcing?.best_offer?.distributor ?? "",
+        render: (r: LowStockRow) => {
+          const source = createOrderLineSource(r);
+          return (
+            <button
+              type="button"
+              className="btn-sm"
+              disabled={!source}
+              onClick={() => setOrderLineSource(source)}
+            >
+              Create draft PO
+            </button>
+          );
+        },
+      },
+    ] satisfies Column<LowStockRow>[] : []),
+  ];
+
   return (
     <div className="space-y-3">
-      {rows.length > 0 && (
-        <div className="flex justify-end">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <label className="inline-flex items-center gap-2 text-sm text-text" htmlFor="low-stock-include-sourcing">
+          <input
+            id="low-stock-include-sourcing"
+            type="checkbox"
+            checked={includeSourcing}
+            onChange={event => setIncludeSourcing(event.currentTarget.checked)}
+          />
+          Include sourcing data
+        </label>
+        {includeSourcing && (
+          <div className="flex flex-wrap items-center gap-2">
+            <PoweredByTrustedParts primaryUrl={sourcedData?.links?.primary} />
+            <SourcingSourceLabel source="trustedparts" />
+          </div>
+        )}
+        {rows.length > 0 && (
           <button
             type="button"
             className="btn-primary inline-flex items-center gap-1.5"
@@ -242,7 +424,16 @@ export function LowStockReport() {
             <ShoppingCart size={14} />
             Create restock order ({rows.length})
           </button>
-        </div>
+        )}
+      </div>
+      {includeSourcing && sourcingStatus === "not_configured" && (
+        <div className="card p-3 text-sm text-muted" role="status">Sourcing not configured.</div>
+      )}
+      {includeSourcing && sourcingStatus === "partial" && (
+        <div className="card p-3 text-sm text-warning" role="status">Partial — some rows from cache.</div>
+      )}
+      {includeSourcing && sourcingStatus === "budget_blocked" && (
+        <div className="card p-3 text-sm text-warning" role="status">Budget exhausted — sourcing data omitted for some rows.</div>
       )}
     <DataTable
       rows={rows}
@@ -256,18 +447,12 @@ export function LowStockReport() {
         />
       }
       exportFilename="low-stock"
-      columns={[
-        { key: "name", header: "Part", accessor: r => r.name, render: r => <Link className="text-accent" to={`/parts/${r.part_id}/info`}>{r.name}</Link> },
-        { key: "mpn", header: "MPN", accessor: r => r.mpn ?? "" },
-        { key: "manufacturer", header: "Manufacturer", accessor: r => r.manufacturer ?? "" },
-        { key: "on_hand", header: "On hand", accessor: r => r.on_hand, width: "80px" },
-        { key: "reserved", header: "Reserved", accessor: r => r.reserved ?? 0, width: "90px",
-          render: r => <span className="tabular-nums text-muted">{r.reserved ?? 0}</span> },
-        { key: "available", header: "Available", accessor: r => r.available ?? r.on_hand, width: "90px" },
-        { key: "threshold", header: "Threshold", accessor: r => r.threshold, width: "100px" },
-        { key: "short_by", header: "Short by", accessor: r => r.short_by, width: "100px",
-          render: r => <span className="tabular-nums text-danger">{r.short_by}</span> },
-      ]}
+      columns={columns}
+    />
+    <CreateOrderLineModal
+      open={orderLineSource !== null}
+      source={orderLineSource}
+      onClose={() => setOrderLineSource(null)}
     />
     </div>
   );

--- a/web/src/routes/reports/__tests__/LowStockReport.test.tsx
+++ b/web/src/routes/reports/__tests__/LowStockReport.test.tsx
@@ -1,0 +1,181 @@
+// @vitest-environment jsdom
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { api } from "@/lib/api";
+import type { Order } from "@/types";
+import { LowStockReport } from "../Reports";
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+    warning: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({
+  useAuth: () => ({ workspaceId: "ws-1" }),
+}));
+
+const lowStockRow = {
+  part_id: "part-1",
+  name: "STM32",
+  manufacturer: "ST",
+  mpn: "STM32F103C8T6",
+  on_hand: 4,
+  reserved: 0,
+  available: 4,
+  threshold: 20,
+  short_by: 16,
+};
+
+const sourcedLowStock = {
+  rows: [
+    {
+      ...lowStockRow,
+      sourcing: {
+        authorized_stock: 120,
+        offers: [
+          {
+            mpn: "STM32F103C8T6",
+            distributor: "DigiKey",
+            stock: 120,
+            unit_price: "1.25",
+            currency: "USD",
+            packaging: "Tape",
+            moq: 25,
+            lead_time_days: 3,
+            url: "https://www.trustedparts.com/digikey/stm32",
+          },
+        ],
+        best_offer: {
+          mpn: "STM32F103C8T6",
+          distributor: "DigiKey",
+          stock: 120,
+          unit_price: "1.25",
+          currency: "USD",
+          packaging: "Tape",
+          moq: 25,
+          lead_time_days: 3,
+          url: "https://www.trustedparts.com/digikey/stm32",
+        },
+        est_replenishment_cost: "31.25",
+        lead_time_days: 3,
+        preferred_distributor_available: true,
+        cache_hit: false,
+        fetched_at: "2026-05-08T12:00:00+00:00",
+      },
+    },
+  ],
+  sourcing_status: "ok" as const,
+  powered_by: "TrustedParts" as const,
+  links: {
+    primary: "https://www.trustedparts.com/",
+    attribution: "https://www.trustedparts.com/en/about",
+  },
+};
+
+const draftOrder: Order = {
+  id: "order-1",
+  name: "May sourcing",
+  order_type: "purchase",
+  supplier: "DigiKey",
+  status: "draft",
+  ordered_on: null,
+  expected_on: null,
+  received_on: null,
+  currency: "USD",
+  comments: null,
+  archived_at: null,
+  totals: { ordered: 0, received: 0 },
+  created_at: "2026-05-08T12:00:00+00:00",
+  updated_at: "2026-05-08T12:00:00+00:00",
+};
+
+function LocationProbe() {
+  const location = useLocation();
+  return <div data-testid="location">{location.pathname + location.search}</div>;
+}
+
+function renderReport(initialPath = "/reports") {
+  const client = new QueryClient({
+    defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+  });
+  render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={[initialPath]}>
+        <Routes>
+          <Route path="/reports" element={<><LocationProbe /><LowStockReport /></>} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  cleanup();
+  localStorage.clear();
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+});
+
+describe("LowStockReport", () => {
+  it("toggling include sourcing reflects in URL", async () => {
+    const user = userEvent.setup();
+    vi.spyOn(api, "get").mockImplementation(async path => {
+      if (path === "/reports/low-stock") return [lowStockRow] as never;
+      if (path === "/reports/low-stock?include_sourcing=true") return sourcedLowStock as never;
+      throw new Error(`unexpected GET ${path}`);
+    });
+
+    renderReport();
+
+    expect(await screen.findByText("STM32")).toBeDefined();
+    await user.click(screen.getByLabelText("Include sourcing data"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("location").textContent).toBe("/reports?include_sourcing=true");
+    });
+    expect(await screen.findAllByText("Authorized stock")).toHaveLength(2);
+    expect(screen.getByText("Powered by TrustedParts")).toBeDefined();
+  });
+
+  it("not-configured banner renders when status flag set", async () => {
+    vi.spyOn(api, "get").mockResolvedValue({
+      rows: [{ ...lowStockRow, sourcing: null }],
+      sourcing_status: "not_configured",
+      powered_by: null,
+      links: null,
+    });
+
+    renderReport("/reports?include_sourcing=true");
+
+    expect(await screen.findByText("Sourcing not configured.")).toBeDefined();
+    expect(screen.getByLabelText("Include sourcing data")).toHaveProperty("checked", true);
+  });
+
+  it("Create draft PO opens modal with prefilled source", async () => {
+    const user = userEvent.setup();
+    vi.spyOn(api, "get").mockImplementation(async path => {
+      if (path === "/reports/low-stock?include_sourcing=true") return sourcedLowStock as never;
+      if (path === "/orders?order_status=draft") return [draftOrder] as never;
+      throw new Error(`unexpected GET ${path}`);
+    });
+
+    renderReport("/reports?include_sourcing=true");
+
+    await user.click(await screen.findByRole("button", { name: "Create draft PO" }));
+
+    expect(await screen.findByRole("dialog", { name: "Create order line" })).toBeDefined();
+    await waitFor(() => {
+      expect((screen.getByLabelText("Order") as HTMLSelectElement).value).toBe("order-1");
+    });
+    expect(screen.getByDisplayValue("25")).toBeDefined();
+    expect(screen.getByDisplayValue("1.25")).toBeDefined();
+    expect(screen.getByDisplayValue("USD")).toBeDefined();
+    expect(screen.getByText("DigiKey")).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `include_sourcing=true` to the low-stock report with 4-hour TrustedParts cache TTL, workspace dashboard cache preference, per-row sourcing data, and graceful `sourcing_status` flags.
- Adds low-stock sourcing columns, URL-persisted toggle, TrustedParts attribution, status banners, and per-row `CreateOrderLineModal` draft-PO action.
- Adds backend and frontend tests plus report API/frontend docs and provider-outage runbook note.

## Validation
- `docker compose -f docker-compose.dev.yml ps` could not run: Docker is not installed in this environment.
- `cd backend && uv run python -m pytest -q tests/test_reports.py tests/test_low_stock_report_with_sourcing.py` -> 13 passed, 1 warning.
- `cd backend && uv run ruff check app/domain/reports/service.py tests/test_low_stock_report_with_sourcing.py app/domain/sourcing/schemas.py` -> passed.
- `cd web && npm run typecheck && npm test -- LowStockReport && npx eslint src/routes/reports/Reports.tsx src/routes/reports/__tests__/LowStockReport.test.tsx` -> passed; Vitest reported React Router future-flag warnings only.
- `cd web && npm run lint` still reports pre-existing baseline issues outside this PR (`ZxingScanner`, `bagCode`, responsive grid/order/parts/storage files); changed report files pass targeted ESLint.
- `git -C /mnt/data/WORK/stockManager-1/.codex/worktrees/tp-505-380 diff --check` -> passed.

## Screenshot Note
- Not captured: Docker/dev server is unavailable in this environment, so I could not run the full app stack for toggle-off/toggle-on/budget-blocked screenshots.

## Deviations
- The existing low-stock implementation lived in `backend/app/api/routes/reports.py`, not a report service. This PR extracts only low-stock report logic into `backend/app/domain/reports/service.py` and leaves the route as a thin wrapper.
- Full raw backend `ruff check app` and web `npm run lint` are affected by existing repository lint baselines; scoped checks were run for changed files.

Refs #380
