### PR TITLE
TP-506: BOM buyability report

### DIFF
--- a/backend/app/api/routes/reports.py
+++ b/backend/app/api/routes/reports.py
@@ -16,7 +16,11 @@ from app.domain.builds.service import shortage_analysis
 from app.domain.lots.models import Lot
 from app.domain.parts.models import Part
 from app.domain.projects.models import Project
-from app.domain.reports.service import low_stock_report, sourcing_risk_report
+from app.domain.reports.service import (
+    bom_buyability_report,
+    low_stock_report,
+    sourcing_risk_report,
+)
 from app.domain.stock.service import (
     bulk_current_quantities_by_lot,
 )
@@ -70,6 +74,27 @@ def bom_shortage(
     rows = shortage_analysis(db, workspace_id=ws.id, project=project, build_quantity=quantity)
     total_short = sum(r["short_by"] for r in rows)
     return ok({"project_id": str(project_id), "quantity": quantity, "rows": rows, "total_short": total_short})
+
+
+@router.get(
+    "/bom-buyability",
+    dependencies=[Depends(require_role("member"))],
+)
+@limiter.limit("30/minute", key_func=workspace_key)
+def bom_buyability(
+    request: Request,
+    db: DbSession,
+    ws: CurrentWorkspace,
+    build_quantity: int = Query(default=1, ge=1),
+):
+    """Workspace-wide per-project BOM buyability report."""
+    out = bom_buyability_report(
+        db,
+        workspace=ws,
+        build_quantity=build_quantity,
+        use_cached_data=True,
+    )
+    return ok(out.model_dump(mode="json"))
 
 
 @router.get("/stock-value")

--- a/backend/app/domain/reports/README.md
+++ b/backend/app/domain/reports/README.md
@@ -1,6 +1,9 @@
 # Reports Domain
 
-Read-only report services over workspace-owned inventory, stock, BOM, and sourcing data.
+Read-only aggregate services for workspace reports.
 
-Report routes live in `backend/app/api/routes/reports.py`. Shared invariants are the workspace-isolation and stock-ledger rules in `docs/ARCHITECTURE.md`; sourcing-risk stock quantities go through `domain/stock/service.py::bulk_current_quantities`.
-
+- Routes live in `backend/app/api/routes/reports.py`.
+- API docs live in `docs/api/reports.md`.
+- Frontend docs live in `docs/frontend/reports.md`.
+- Shared invariants are the workspace-isolation and stock-ledger rules in `docs/ARCHITECTURE.md`.
+- Stock quantities must continue to flow through `backend/app/domain/stock/service.py`.

--- a/backend/app/domain/reports/schemas.py
+++ b/backend/app/domain/reports/schemas.py
@@ -1,4 +1,5 @@
 """Pydantic DTOs for reports."""
+
 from __future__ import annotations
 
 from datetime import datetime
@@ -10,6 +11,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from app.domain.sourcing.schemas import SourcingAttributionLinks, SourcingBomOfferOut
 
+SourcingReportStatus = Literal["ok", "not_configured", "partial", "budget_blocked"]
 SourcingRiskFlag = Literal[
     "single_source",
     "no_authorized_stock",
@@ -18,6 +20,31 @@ SourcingRiskFlag = Literal[
     "preferred_distributor_unmet",
     "price_delta",
 ]
+
+
+class ProjectBuyabilityRow(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    project_id: UUID
+    project_name: str
+    build_quantity: int
+    can_build_now: int
+    can_build_after_purchase: int
+    blocking_lines_count: int
+    est_purchase_cost: Decimal | None = None
+    partial: bool = False
+
+
+class BomBuyabilityReportOut(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    build_quantity: int = Field(ge=1)
+    rows: list[ProjectBuyabilityRow]
+    sourcing_status: SourcingReportStatus
+    truncated: bool
+    project_cap: int
+    powered_by: Literal["TrustedParts"] = "TrustedParts"
+    links: SourcingAttributionLinks
 
 
 class SourcingRiskStatusOut(BaseModel):
@@ -56,4 +83,3 @@ class SourcingRiskReportOut(BaseModel):
     partial: bool
     cache_hit: bool | None = None
     links: SourcingAttributionLinks
-

--- a/backend/app/domain/reports/service.py
+++ b/backend/app/domain/reports/service.py
@@ -1,4 +1,5 @@
 """Read-only report services."""
+
 from __future__ import annotations
 
 import logging
@@ -12,9 +13,13 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.core.time import utcnow
+from app.domain.builds.service import shortage_analysis
 from app.domain.lots.models import Lot
 from app.domain.parts.models import Part
+from app.domain.projects.models import Project
 from app.domain.reports.schemas import (
+    BomBuyabilityReportOut,
+    ProjectBuyabilityRow,
     SourcingRiskReportOut,
     SourcingRiskRow,
     SourcingRiskStatusOut,
@@ -35,6 +40,8 @@ from app.domain.sourcing.service import SourcingBudgetBlocked, SourcingNotConfig
 from app.domain.stock.service import bulk_current_quantities
 
 LOW_STOCK_SOURCING_TTL_SECONDS = 4 * 3600
+BOM_BUYABILITY_PROJECT_CAP = 50
+BOM_BUYABILITY_TTL_SECONDS = 4 * 60 * 60
 SOURCING_RISK_TTL_SECONDS = 4 * 60 * 60
 PRICE_DELTA_THRESHOLD = Decimal("0.25")
 LEAD_TIME_LONG_DAYS = 30
@@ -43,6 +50,108 @@ MOQ_OVERBUY_MULTIPLIER = 5
 SourcingStatus = Literal["ok", "not_configured", "partial", "budget_blocked"]
 
 _log = logging.getLogger(__name__)
+
+
+def bom_buyability_report(
+    db: Session,
+    *,
+    workspace: Any,
+    build_quantity: int = 1,
+    use_cached_data: bool | None = None,
+) -> BomBuyabilityReportOut:
+    """Workspace-wide per-project buildability scoreboard."""
+    effective_cache = True if use_cached_data is None else use_cached_data
+    projects = list(
+        db.execute(
+            select(Project)
+            .where(Project.workspace_id == workspace.id)
+            .where(Project.archived_at.is_(None))
+            .order_by(Project.created_at.desc(), Project.id.desc())
+            .limit(BOM_BUYABILITY_PROJECT_CAP + 1)
+        ).scalars()
+    )
+    truncated = len(projects) > BOM_BUYABILITY_PROJECT_CAP
+    projects = projects[:BOM_BUYABILITY_PROJECT_CAP]
+
+    rows: list[ProjectBuyabilityRow] = []
+    statuses: set[str] = set()
+    for project in projects:
+        try:
+            sourced = sourcing_service.source_bom(
+                db,
+                workspace=workspace,
+                project=project,
+                build_quantity=build_quantity,
+                use_cached_data=effective_cache,
+                ttl_seconds=BOM_BUYABILITY_TTL_SECONDS,
+            )
+        except SourcingNotConfigured:
+            statuses.add("not_configured")
+            rows.append(
+                _unsourced_row(
+                    db,
+                    workspace=workspace,
+                    project=project,
+                    build_quantity=build_quantity,
+                    partial=True,
+                )
+            )
+        except SourcingBudgetBlocked:
+            statuses.add("budget_blocked")
+            rows.append(
+                _unsourced_row(
+                    db,
+                    workspace=workspace,
+                    project=project,
+                    build_quantity=build_quantity,
+                    partial=True,
+                )
+            )
+        except (
+            SourcingAuthError,
+            SourcingRateLimitError,
+            SourcingTimeoutError,
+            SourcingClientError,
+        ):
+            statuses.add("partial")
+            rows.append(
+                _unsourced_row(
+                    db,
+                    workspace=workspace,
+                    project=project,
+                    build_quantity=build_quantity,
+                    partial=True,
+                )
+            )
+        else:
+            if sourced.partial:
+                statuses.add("partial")
+            capacity = sourced.capacity
+            rows.append(
+                ProjectBuyabilityRow(
+                    project_id=project.id,
+                    project_name=project.name,
+                    build_quantity=build_quantity,
+                    can_build_now=capacity.can_build_now,
+                    can_build_after_purchase=capacity.can_build_after_purchase,
+                    blocking_lines_count=(
+                        len(capacity.blocking_lines_after_purchase)
+                        if capacity.can_build_after_purchase < build_quantity
+                        else 0
+                    ),
+                    est_purchase_cost=capacity.est_purchase_cost,
+                    partial=sourced.partial,
+                )
+            )
+
+    return BomBuyabilityReportOut(
+        build_quantity=build_quantity,
+        rows=rows,
+        sourcing_status=_coalesce_status(statuses),
+        truncated=truncated,
+        project_cap=BOM_BUYABILITY_PROJECT_CAP,
+        links=sourcing_service.TRUSTEDPARTS_LINKS,
+    )
 
 
 def sourcing_risk_report(
@@ -141,6 +250,52 @@ def sourcing_risk_report(
         partial=partial,
         cache_hit=all(cache_hit_values) if cache_hit_values else None,
         links=sourcing_service.TRUSTEDPARTS_LINKS,
+    )
+
+
+def _coalesce_status(statuses: set[str]) -> str:
+    for status in ("budget_blocked", "not_configured", "partial"):
+        if status in statuses:
+            return status
+    return "ok"
+
+
+def _unsourced_row(
+    db: Session,
+    *,
+    workspace: Any,
+    project: Project,
+    build_quantity: int,
+    partial: bool,
+) -> ProjectBuyabilityRow:
+    rows = shortage_analysis(
+        db,
+        workspace_id=workspace.id,
+        project=project,
+        build_quantity=build_quantity,
+    )
+    can_build_now = _can_build_now(rows, build_quantity=build_quantity)
+    return ProjectBuyabilityRow(
+        project_id=project.id,
+        project_name=project.name,
+        build_quantity=build_quantity,
+        can_build_now=can_build_now,
+        can_build_after_purchase=can_build_now,
+        blocking_lines_count=sum(1 for row in rows if int(row["short_by"]) > 0),
+        est_purchase_cost=None,
+        partial=partial,
+    )
+
+
+def _can_build_now(rows: list[dict[str, Any]], *, build_quantity: int) -> int:
+    effective = [row for row in rows if int(row["required"]) > 0]
+    if not effective:
+        return 0
+    return min(
+        (int(row["available"]) + int(row.get("substitute_available", 0)))
+        * build_quantity
+        // int(row["required"])
+        for row in effective
     )
 
 

--- a/backend/app/domain/sourcing/service.py
+++ b/backend/app/domain/sourcing/service.py
@@ -83,6 +83,7 @@ def source_bom(
     distributors: list[str] | None = None,
     in_stock_only: bool = False,
     use_cached_data: bool | None = None,
+    ttl_seconds: int = BOM_TTL_SECONDS,
     requested_by: UUID | None = None,
 ) -> SourcingBomOut:
     shortage = shortage_analysis(
@@ -114,7 +115,7 @@ def source_bom(
             in_stock_only=in_stock_only,
             distributors=distributors,
             use_cached_data=use_cached_data,
-            ttl_seconds=BOM_TTL_SECONDS,
+            ttl_seconds=ttl_seconds,
             requested_by=requested_by,
         )
         fetched_at_values.append(out.fetched_at)

--- a/backend/tests/test_bom_buyability_report.py
+++ b/backend/tests/test_bom_buyability_report.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+import app.core.ratelimit as _ratelimit_mod
+from app.domain.sourcing.budget import BUDGET
+from app.domain.sourcing.schemas import (
+    SourcingDistributor,
+    SourcingLinks,
+    SourcingOffer,
+    SourcingQuery,
+    SourcingSearchRaw,
+)
+from app.main import app
+from tests._factories import add_stock, create_part, create_project_with_bom, signup_user
+
+
+class _FakeTrustedPartsClient:
+    calls: list[dict[str, Any]] = []
+    offers_by_mpn: dict[str, list[SourcingOffer]] = {}
+
+    def __init__(self, workspace_id: uuid.UUID) -> None:
+        self.workspace_id = workspace_id
+        self.country_code = "US"
+        self.currency_code = "USD"
+
+    def search(
+        self,
+        queries: list[SourcingQuery],
+        *,
+        in_stock_only: bool,
+        distributors: list[str] | None,
+        use_cached_data: bool,
+        **_kwargs: Any,
+    ) -> SourcingSearchRaw:
+        mpn = queries[0].search_token
+        self.calls.append(
+            {
+                "workspace_id": str(self.workspace_id),
+                "mpn": mpn,
+                "use_cached_data": use_cached_data,
+                "in_stock_only": in_stock_only,
+                "distributors": distributors,
+            }
+        )
+        return SourcingSearchRaw(
+            offers=self.offers_by_mpn.get(mpn, [_offer(mpn)]),
+            request_id=f"req-{len(self.calls)}",
+        )
+
+
+def _offer(mpn: str, *, stock: int = 100, unit_price: float = 1.0) -> SourcingOffer:
+    return SourcingOffer(
+        mpn=mpn,
+        manufacturer="TestCo",
+        description=f"Offer for {mpn}",
+        distributors=[
+            SourcingDistributor(
+                name="DigiKey",
+                stock=stock,
+                unit_price=unit_price,
+                currency="USD",
+                moq=1,
+                price_breaks=[],
+                product_url=f"https://www.trustedparts.com/{mpn}",
+            )
+        ],
+        links=SourcingLinks(primary=f"https://www.trustedparts.com/search/{mpn}"),
+    )
+
+
+@pytest.fixture(autouse=True)
+def reset_sourcing_state(monkeypatch):
+    original_limiter_enabled = _ratelimit_mod.limiter.enabled
+    _ratelimit_mod.limiter.enabled = False
+    _FakeTrustedPartsClient.calls = []
+    _FakeTrustedPartsClient.offers_by_mpn = {}
+    BUDGET._events.clear()
+    try:
+        _ratelimit_mod.limiter.reset()
+    except Exception:
+        pass
+    monkeypatch.setattr(
+        "app.domain.sourcing.service.make_sourcing_provider",
+        lambda workspace: _FakeTrustedPartsClient(workspace.id),
+    )
+    yield
+    _ratelimit_mod.limiter.enabled = original_limiter_enabled
+    BUDGET._events.clear()
+    try:
+        _ratelimit_mod.limiter.reset()
+    except Exception:
+        pass
+
+
+def _configure_sourcing(client: TestClient, *, use_cached_for_dashboards: bool = False) -> None:
+    r = client.patch(
+        "/api/workspaces/current",
+        json={
+            "sourcing_provider": "trustedparts",
+            "sourcing_company_id": "company-123",
+            "sourcing_api_key": "api-key-456",
+            "sourcing_country_code": "US",
+            "sourcing_currency_code": "USD",
+            "sourcing_preferred_distributors": ["DigiKey"],
+            "sourcing_use_cached_for_dashboards": use_cached_for_dashboards,
+        },
+    )
+    assert r.status_code == 200, r.text
+
+
+def _workspace_id(client: TestClient) -> uuid.UUID:
+    r = client.get("/api/workspaces/current")
+    assert r.status_code == 200, r.text
+    return uuid.UUID(r.json()["data"]["id"])
+
+
+def _project(client: TestClient, name: str, *, mpn: str, quantity: int = 10) -> str:
+    part_id = create_part(client, name=f"Part {mpn}", mpn=mpn)
+    return create_project_with_bom(
+        client,
+        name,
+        [{"part_id": part_id, "quantity": quantity}],
+    )
+
+
+def test_returns_one_row_per_project(authed_client):
+    _configure_sourcing(authed_client)
+    first = _project(authed_client, "Alpha", mpn="ALPHA", quantity=10)
+    second = _project(authed_client, "Beta", mpn="BETA", quantity=5)
+    _FakeTrustedPartsClient.offers_by_mpn = {
+        "ALPHA": [_offer("ALPHA", stock=20, unit_price=0.5)],
+        "BETA": [_offer("BETA", stock=3, unit_price=2.0)],
+    }
+
+    r = authed_client.get("/api/reports/bom-buyability?build_quantity=2")
+
+    assert r.status_code == 200, r.text
+    data = r.json()["data"]
+    assert data["sourcing_status"] == "ok"
+    assert data["truncated"] is False
+    rows = {row["project_id"]: row for row in data["rows"]}
+    assert set(rows) == {first, second}
+    assert rows[first]["build_quantity"] == 2
+    assert rows[first]["can_build_now"] == 0
+    assert rows[first]["can_build_after_purchase"] == 2
+    assert rows[first]["est_purchase_cost"] == "10.0"
+    assert rows[second]["can_build_after_purchase"] == 0
+    assert rows[second]["blocking_lines_count"] == 1
+
+
+def test_50_project_cap_with_truncated_flag(authed_client):
+    _configure_sourcing(authed_client)
+    for index in range(51):
+        _project(authed_client, f"Project {index:02d}", mpn=f"CAP-{index:02d}", quantity=1)
+
+    r = authed_client.get("/api/reports/bom-buyability")
+
+    assert r.status_code == 200, r.text
+    data = r.json()["data"]
+    assert data["truncated"] is True
+    assert data["project_cap"] == 50
+    assert len(data["rows"]) == 50
+
+
+def test_invalid_build_quantity_returns_422(authed_client):
+    r = authed_client.get("/api/reports/bom-buyability?build_quantity=0")
+
+    assert r.status_code == 422, r.text
+    assert r.json()["status"]["category"] == "validation_error"
+
+
+def test_not_configured_status_flag(authed_client, monkeypatch):
+    monkeypatch.setattr(
+        "app.domain.sourcing.service.make_sourcing_provider",
+        lambda _workspace: None,
+    )
+    _project(authed_client, "Unconfigured", mpn="NO-CONFIG", quantity=10)
+
+    r = authed_client.get("/api/reports/bom-buyability")
+
+    assert r.status_code == 200, r.text
+    data = r.json()["data"]
+    assert data["sourcing_status"] == "not_configured"
+    assert data["rows"][0]["partial"] is True
+    assert data["rows"][0]["can_build_after_purchase"] == data["rows"][0]["can_build_now"]
+    assert data["rows"][0]["est_purchase_cost"] is None
+
+
+def test_budget_blocked_status_flag(authed_client):
+    _configure_sourcing(authed_client)
+    _project(authed_client, "Blocked", mpn="BUDGET", quantity=10)
+    BUDGET.record(_workspace_id(authed_client), 250)
+
+    r = authed_client.get("/api/reports/bom-buyability")
+
+    assert r.status_code == 200, r.text
+    data = r.json()["data"]
+    assert data["sourcing_status"] == "budget_blocked"
+    assert data["rows"][0]["partial"] is True
+    assert _FakeTrustedPartsClient.calls == []
+
+
+def test_workspace_isolation():
+    a = TestClient(app)
+    b = TestClient(app)
+    signup_user(a, email=f"a-{uuid.uuid4().hex[:8]}@x.com")
+    signup_user(b, email=f"b-{uuid.uuid4().hex[:8]}@x.com")
+    _configure_sourcing(a)
+    _configure_sourcing(b)
+    project_a = _project(a, "A Project", mpn="TENANT-A", quantity=1)
+    project_b = _project(b, "B Project", mpn="TENANT-B", quantity=1)
+
+    r = a.get("/api/reports/bom-buyability")
+
+    assert r.status_code == 200, r.text
+    ids = {row["project_id"] for row in r.json()["data"]["rows"]}
+    assert project_a in ids
+    assert project_b not in ids
+
+
+def test_cache_hit_within_4h(authed_client):
+    _configure_sourcing(authed_client, use_cached_for_dashboards=False)
+    part_id = create_part(authed_client, name="Cache Part", mpn="CACHE-MPN")
+    add_stock(authed_client, part_id, 1)
+    create_project_with_bom(
+        authed_client,
+        "Cache Project",
+        [{"part_id": part_id, "quantity": 5}],
+    )
+
+    first = authed_client.get("/api/reports/bom-buyability")
+    second = authed_client.get("/api/reports/bom-buyability")
+
+    assert first.status_code == 200, first.text
+    assert second.status_code == 200, second.text
+    assert len(_FakeTrustedPartsClient.calls) == 1
+    assert _FakeTrustedPartsClient.calls[0]["use_cached_data"] is True

--- a/docs/api/reports.md
+++ b/docs/api/reports.md
@@ -2,7 +2,7 @@
 
 Audience: engineer
 
-Read-only aggregate queries: low-stock parts, sourcing risk, BOM shortage at a planned build quantity, stock value, and expiring lots.
+Read-only aggregate queries: low-stock parts, sourcing risk, BOM shortage at a planned build quantity, BOM buyability by project, stock value, and expiring lots.
 
 ## Conventions
 
@@ -57,7 +57,7 @@ With `include_sourcing=true`, `data` is an object:
 
 ### `GET /api/reports/bom-shortage`
 
-Project-wide shortage analysis at a given build quantity. No build is created — same engine as the Build detail page.
+Project-wide shortage analysis at a given build quantity. No build is created -- same engine as the Build detail page.
 
 **Query**
 
@@ -78,12 +78,46 @@ Project-wide shortage analysis at a given build quantity. No build is created �
 
 `rows` is whatever `shortage_analysis` returns. TODO(verify): exact per-row shape (likely `{ project_entry_id, part_id, required, available, short_by, candidates? }`).
 
-**Errors** — `404 report.project_not_found` (`reports.py:81-83`).
+**Errors** — `404 report.project_not_found`.
 
 **Notes**
 
-- Source: `backend/app/api/routes/reports.py:72-86`.
 - Service: `backend/app/domain/builds/service.py::shortage_analysis`.
+
+### `GET /api/reports/bom-buyability`
+
+Workspace-wide scoreboard of active projects at one build quantity. The report calls Source-BOM with TrustedParts cached mode enabled and degrades to stock-only rows when sourcing is not configured, budget-blocked, or temporarily unavailable.
+
+**Query**
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `build_quantity` | int (`>= 1`) | no | Default `1`. `0` or negative values return `422`. |
+
+**Response** — `200 OK`
+
+```json
+{ "data": {
+    "build_quantity": 2,
+    "sourcing_status": "ok",
+    "truncated": false,
+    "project_cap": 50,
+    "rows": [ {
+      "project_id": "...", "project_name": "Amplifier",
+      "can_build_now": 1, "can_build_after_purchase": 2,
+      "blocking_lines_count": 0, "est_purchase_cost": "12.50",
+      "partial": false
+    } ]
+}, "status": { ... } }
+```
+
+`sourcing_status` is `ok`, `not_configured`, `partial`, or `budget_blocked`. Workspaces with more than 50 active projects return the newest 50 and `truncated: true`.
+
+**Notes**
+
+- Route validates `build_quantity` and rate-limits per workspace.
+- Service filters projects by workspace and `archived_at IS NULL`, caps at 50, and forces cached sourcing.
+- Sourcing failures return `200 OK` with stock-only rows and a status flag.
 
 ### `GET /api/reports/sourcing-risk`
 
@@ -92,7 +126,7 @@ Workspace-wide sourcing risk for active parts with an MPN. The route uses Truste
 **Query**
 
 | Field | Type | Notes |
-|---|---|---|
+|---|---|
 | `only_with_flags` | bool | Default `true`; when true, clean rows are omitted. |
 | `use_cached_data` | bool \| null | Default `null`; null uses cached TrustedParts data. |
 
@@ -120,10 +154,7 @@ Workspace-wide sourcing risk for active parts with an MPN. The route uses Truste
 
 **Notes**
 
-- Route: `backend/app/api/routes/reports.py:74-91`.
-- Service: `backend/app/domain/reports/service.py:38-133`.
-- DTOs: `backend/app/domain/reports/schemas.py:13-58`.
-- Stock quantities use `bulk_current_quantities`; no report query aggregates ledger rows directly (`backend/app/domain/reports/service.py:56-62`).
+- Stock quantities use `bulk_current_quantities`; no report query aggregates ledger rows directly.
 - Risk history is not persisted; there is no report table or migration for this feature.
 
 ### `GET /api/reports/stock-value`
@@ -139,12 +170,11 @@ Sum of `lot.purchase_unit_cost * current_qty_in_lot` across all on-hand stock, b
 }, "status": { ... } }
 ```
 
-A part with lots in multiple currencies has `currency: "MIXED"` (`reports.py:126-127`).
+A part with lots in multiple currencies has `currency: "MIXED"`.
 
 **Notes**
 
 - Sorted: `by_currency` by currency code, `by_part` by `value DESC`.
-- Source: `backend/app/api/routes/reports.py:89-136`.
 
 ### `GET /api/reports/expiring-lots`
 
@@ -153,7 +183,7 @@ Lots that have on-hand quantity > 0 and an `expiration_date` within the next `da
 **Query**
 
 | Field | Type | Notes |
-|---|---|---|
+|---|---|
 | `days` | int | Default `90`, `0 <= days <= 3650`. |
 
 **Response** — `200 OK` — array sorted by `expiration_date ASC`:
@@ -172,7 +202,6 @@ Lots that have on-hand quantity > 0 and an `expiration_date` within the next `da
 **Notes**
 
 - `expired: true` when `days_until_expiry < 0`.
-- Source: `backend/app/api/routes/reports.py:139-178`.
 
 ## TODOs
 

--- a/docs/frontend/README.md
+++ b/docs/frontend/README.md
@@ -23,6 +23,7 @@ What you need to navigate `web/src/`. Conventions are sketched in [`CLAUDE.md`](
 | [components](components.md) | DataTable + reusable component catalog |
 | [parts](parts.md) | Part-detail flows that span tabs and modals |
 | [projects](projects.md) | Project-detail flows, including Source BOM |
+| [reports](reports.md) | Report routes, including BOM buyability |
 | [tailwind-utilities](tailwind-utilities.md) | The `index.css` utility set (`btn`, `card`, `pill`, …) |
 | [auth-flow](auth-flow.md) | `AuthProvider`, workspace switch, 401 redirect bus |
 | [scanner](scanner.md) | ZXing / Scandit dual-mode + `bagCode.ts` parser |

--- a/docs/frontend/reports.md
+++ b/docs/frontend/reports.md
@@ -9,21 +9,41 @@ Frontend report routes and their data-fetching conventions.
 | Route | Component | API |
 |---|---|---|
 | `/reports` | `web/src/routes/reports/Reports.tsx` | `GET /api/reports/low-stock` |
+| `/reports/buyability` | `web/src/routes/reports/BomBuyabilityReport.tsx` | `GET /api/reports/bom-buyability` |
 | `/reports/sourcing-risk` | `web/src/routes/reports/SourcingRiskReport.tsx` | `GET /api/reports/sourcing-risk` |
 
 ## Low-Stock Sourcing
 
-`LowStockReport` keeps the sourcing toggle in the URL as `include_sourcing=true`; the query key includes that boolean so cached plain low-stock rows and sourced low-stock rows stay separate. When enabled, the table renders TrustedParts attribution, sourcing status banners, sourcing columns, and a per-row draft-PO action that reuses `CreateOrderLineModal` with the row's best offer as its source. Source: `web/src/routes/reports/Reports.tsx`.
+`LowStockReport` keeps the sourcing toggle in the URL as
+`include_sourcing=true`; the query key includes that boolean so cached plain
+low-stock rows and sourced low-stock rows stay separate. When enabled, the table
+renders TrustedParts attribution, sourcing status banners, sourcing columns, and
+a per-row draft-PO action that reuses `CreateOrderLineModal` with the row's best
+offer as its source. Source: `web/src/routes/reports/Reports.tsx`.
 
-The sourcing-risk page uses TanStack Query with `useWsKey("report", "sourcing-risk", onlyWithFlags)`, renders the shared `DataTable`, and keeps the default list sorted by flag count before handing rows to the table. The page uses `PoweredByTrustedParts` and `SourcingSourceLabel` for TrustedParts attribution.
+## BOM Buyability
+
+`web/src/routes/reports/BomBuyabilityReport.tsx` reads `build_quantity` from the
+URL, defaults invalid or missing values to `1`, and fetches
+`GET /api/reports/bom-buyability?build_quantity=<n>` through
+`web/src/lib/api.ts`.
+
+The page uses the shared `DataTable`, surfaces the top-level sourcing status,
+displays `PoweredByTrustedParts` and `SourcingSourceLabel`, and shows a
+truncation badge when the backend returns `truncated: true`.
+
+Rows link to each project's Source-BOM deep dive at
+`/projects/:projectId/sourcing`. The reports tab and app route are registered in
+`web/src/routes/reports/Reports.tsx` and `web/src/App.tsx`.
 
 ## Sourcing Risk
 
-The page renders a status banner from `data.sourcing_status` instead of relying on thrown API errors for normal provider states. The "Show only flagged" checkbox maps directly to the API `only_with_flags` query parameter.
+The sourcing-risk page uses TanStack Query with
+`useWsKey("report", "sourcing-risk", onlyWithFlags)`, renders the shared
+`DataTable`, and keeps the default list sorted by flag count before handing rows
+to the table. The page uses `PoweredByTrustedParts` and
+`SourcingSourceLabel` for TrustedParts attribution.
 
-References:
-
-- Route registration: `web/src/App.tsx:91-97`, `web/src/App.tsx:269-274`
-- Navigation entry: `web/src/routes/reports/Reports.tsx:101-106`
-- Component: `web/src/routes/reports/SourcingRiskReport.tsx:93-230`
-- Tests: `web/src/routes/reports/__tests__/SourcingRiskReport.test.tsx:79-131`
+The page renders a status banner from `data.sourcing_status` instead of relying
+on thrown API errors for normal provider states. The "Show only flagged"
+checkbox maps directly to the API `only_with_flags` query parameter.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -91,6 +91,7 @@ const StockValueReport = lazy(() =>
 const BomShortageReport = lazy(() =>
   import("@/routes/reports/Reports").then(m => ({ default: m.BomShortageReport }))
 );
+const BomBuyabilityReport = lazy(() => import("@/routes/reports/BomBuyabilityReport"));
 const ExpiringLotsReport = lazy(() =>
   import("@/routes/reports/Reports").then(m => ({ default: m.ExpiringLotsReport }))
 );
@@ -270,6 +271,7 @@ export default function App() {
               <Route index element={<LazyRoute><LowStockReport /></LazyRoute>} />
               <Route path="value" element={<LazyRoute><StockValueReport /></LazyRoute>} />
               <Route path="bom" element={<LazyRoute><BomShortageReport /></LazyRoute>} />
+              <Route path="buyability" element={<LazyRoute><BomBuyabilityReport /></LazyRoute>} />
               <Route path="expiring" element={<LazyRoute><ExpiringLotsReport /></LazyRoute>} />
               <Route path="sourcing-risk" element={<LazyRoute><SourcingRiskReport /></LazyRoute>} />
             </Route>

--- a/web/src/routes/reports/BomBuyabilityReport.tsx
+++ b/web/src/routes/reports/BomBuyabilityReport.tsx
@@ -1,0 +1,184 @@
+import { useEffect, useState } from "react";
+import { Link, useSearchParams } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { BarChart3 } from "lucide-react";
+import { api, ApiError } from "@/lib/api";
+import { useWsKey } from "@/lib/queryKeys";
+import { formatMoney } from "@/lib/format";
+import { DataTable } from "@/components/DataTable";
+import EmptyState from "@/components/EmptyState";
+import { PoweredByTrustedParts } from "@/components/PoweredByTrustedParts";
+import { SourcingSourceLabel } from "@/components/SourcingSourceLabel";
+
+type SourcingStatus = "ok" | "not_configured" | "partial" | "budget_blocked";
+
+type ProjectBuyabilityRow = {
+  project_id: string;
+  project_name: string;
+  build_quantity: number;
+  can_build_now: number;
+  can_build_after_purchase: number;
+  blocking_lines_count: number;
+  est_purchase_cost: string | number | null;
+  partial: boolean;
+};
+
+type BomBuyabilityReportOut = {
+  build_quantity: number;
+  rows: ProjectBuyabilityRow[];
+  sourcing_status: SourcingStatus;
+  truncated: boolean;
+  project_cap: number;
+  powered_by: "TrustedParts";
+  links: {
+    primary: string;
+    attribution: string;
+  };
+};
+
+function parseQuantity(raw: string | null): number {
+  const value = Number(raw ?? "1");
+  if (!Number.isFinite(value) || value < 1) return 1;
+  return Math.floor(value);
+}
+
+function statusCopy(status: SourcingStatus): { label: string; className: string } {
+  switch (status) {
+    case "ok":
+      return { label: "Sourcing ok", className: "border-success/30 bg-success/10 text-success" };
+    case "not_configured":
+      return { label: "Sourcing not configured", className: "border-warning/30 bg-warning/10 text-warning" };
+    case "partial":
+      return { label: "Partial sourcing data", className: "border-warning/30 bg-warning/10 text-warning" };
+    case "budget_blocked":
+      return { label: "Sourcing budget blocked", className: "border-danger/30 bg-danger/10 text-danger" };
+    default:
+      return status satisfies never;
+  }
+}
+
+export default function BomBuyabilityReport() {
+  const [params, setParams] = useSearchParams();
+  const qtyFromUrl = parseQuantity(params.get("build_quantity"));
+  const [qty, setQty] = useState(qtyFromUrl);
+
+  useEffect(() => {
+    setQty(qtyFromUrl);
+  }, [qtyFromUrl]);
+
+  const { data, isLoading, isError, error } = useQuery({
+    queryKey: useWsKey("report", "bom-buyability", qtyFromUrl),
+    queryFn: () => api.get<BomBuyabilityReportOut>(`/reports/bom-buyability?build_quantity=${qtyFromUrl}`),
+  });
+
+  const status = statusCopy(data?.sourcing_status ?? "ok");
+  const rows = data?.rows ?? [];
+
+  function applyQuantity(next: number) {
+    const clean = Number.isFinite(next) && next >= 1 ? Math.floor(next) : 1;
+    setQty(clean);
+    setParams({ build_quantity: String(clean) });
+  }
+
+  if (isError) {
+    return (
+      <div className="text-red-600 text-sm p-4">
+        Failed to load BOM buyability report. {error instanceof ApiError ? error.userMessage : ""}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="card p-4 flex flex-wrap gap-3 items-end">
+        <div className="w-44">
+          <label className="label" htmlFor="report-buyability-qty">Build quantity</label>
+          <input
+            id="report-buyability-qty"
+            className="input"
+            type="number"
+            min={1}
+            value={qty}
+            onChange={e => setQty(Number(e.target.value))}
+            onBlur={() => applyQuantity(qty)}
+            onKeyDown={e => {
+              if (e.key === "Enter") applyQuantity(qty);
+            }}
+          />
+        </div>
+        <div className="flex items-center gap-2 pb-1">
+          <span className={`pill border ${status.className}`}>{status.label}</span>
+          {data?.truncated && (
+            <span className="pill border border-warning/30 bg-warning/10 text-warning">
+              Truncated to {data.project_cap} projects
+            </span>
+          )}
+          <PoweredByTrustedParts primaryUrl={data?.links.primary} />
+          <SourcingSourceLabel source="trustedparts" />
+        </div>
+      </div>
+
+      {isLoading ? (
+        <div className="text-muted">Loading…</div>
+      ) : (
+        <DataTable
+          rows={rows}
+          rowKey={r => r.project_id}
+          tableId="report-bom-buyability"
+          empty={
+            <EmptyState
+              icon={BarChart3}
+              title="No projects"
+              description="Active projects with consumable BOM lines will appear here."
+            />
+          }
+          exportFilename="bom-buyability"
+          columns={[
+            {
+              key: "project",
+              header: "Project",
+              accessor: r => r.project_name,
+              render: r => <Link className="text-accent" to={`/projects/${r.project_id}/sourcing`}>{r.project_name}</Link>,
+            },
+            { key: "build_quantity", header: "Build qty", accessor: r => r.build_quantity, width: "90px" },
+            {
+              key: "can_build_now",
+              header: "Can build now",
+              accessor: r => r.can_build_now,
+              width: "120px",
+              render: r => <span className={r.can_build_now >= r.build_quantity ? "text-success tabular-nums" : "tabular-nums"}>{r.can_build_now}</span>,
+            },
+            {
+              key: "can_build_after_purchase",
+              header: "After purchase",
+              accessor: r => r.can_build_after_purchase,
+              width: "130px",
+              render: r => <span className={r.can_build_after_purchase >= r.build_quantity ? "text-success tabular-nums" : "tabular-nums"}>{r.can_build_after_purchase}</span>,
+            },
+            {
+              key: "blocking_lines_count",
+              header: "Blocking lines",
+              accessor: r => r.blocking_lines_count,
+              width: "120px",
+              render: r => r.blocking_lines_count > 0 ? <span className="text-danger tabular-nums">{r.blocking_lines_count}</span> : <span className="text-muted">—</span>,
+            },
+            {
+              key: "est_purchase_cost",
+              header: "Est. purchase",
+              accessor: r => r.est_purchase_cost ?? "",
+              width: "130px",
+              render: r => r.est_purchase_cost == null ? <span className="text-muted">—</span> : <span className="tabular-nums">{formatMoney(Number(r.est_purchase_cost), null)}</span>,
+            },
+            {
+              key: "source_bom",
+              header: "Source-BOM",
+              accessor: r => r.project_name,
+              width: "110px",
+              render: r => <Link className="text-accent" to={`/projects/${r.project_id}/sourcing?build_quantity=${r.build_quantity}`}>Open</Link>,
+            },
+          ]}
+        />
+      )}
+    </div>
+  );
+}

--- a/web/src/routes/reports/Reports.tsx
+++ b/web/src/routes/reports/Reports.tsx
@@ -178,6 +178,7 @@ export default function ReportsLayout() {
         <NavLink end to="/reports" className={({ isActive }) => "btn " + (isActive ? "border-accent/50 text-accent" : "")}>Low stock</NavLink>
         <NavLink to="/reports/value" className={({ isActive }) => "btn " + (isActive ? "border-accent/50 text-accent" : "")}>Stock value</NavLink>
         <NavLink to="/reports/bom" className={({ isActive }) => "btn " + (isActive ? "border-accent/50 text-accent" : "")}>BOM shortage</NavLink>
+        <NavLink to="/reports/buyability" className={({ isActive }) => "btn " + (isActive ? "border-accent/50 text-accent" : "")}>BOM buyability</NavLink>
         <NavLink to="/reports/expiring" className={({ isActive }) => "btn " + (isActive ? "border-accent/50 text-accent" : "")}>Expiring lots</NavLink>
         <NavLink to="/reports/sourcing-risk" className={({ isActive }) => "btn " + (isActive ? "border-accent/50 text-accent" : "")}>Sourcing risk</NavLink>
       </div>

--- a/web/src/routes/reports/__tests__/BomBuyabilityReport.test.tsx
+++ b/web/src/routes/reports/__tests__/BomBuyabilityReport.test.tsx
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { api } from "@/lib/api";
+import BomBuyabilityReport from "../BomBuyabilityReport";
+
+vi.mock("@/lib/auth", () => ({
+  useAuth: () => ({ workspaceId: "ws-1" }),
+}));
+
+function report(overrides: Record<string, unknown> = {}) {
+  return {
+    build_quantity: 2,
+    sourcing_status: "ok",
+    truncated: false,
+    project_cap: 50,
+    powered_by: "TrustedParts",
+    links: {
+      primary: "https://www.trustedparts.com/",
+      attribution: "https://www.trustedparts.com/en/about",
+    },
+    rows: [
+      {
+        project_id: "project-1",
+        project_name: "Amplifier",
+        build_quantity: 2,
+        can_build_now: 1,
+        can_build_after_purchase: 2,
+        blocking_lines_count: 0,
+        est_purchase_cost: "12.50",
+        partial: false,
+      },
+      {
+        project_id: "project-2",
+        project_name: "Controller",
+        build_quantity: 2,
+        can_build_now: 0,
+        can_build_after_purchase: 1,
+        blocking_lines_count: 3,
+        est_purchase_cost: null,
+        partial: true,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function renderReport(initialPath = "/reports/buyability") {
+  const client = new QueryClient({
+    defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+  });
+  render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={[initialPath]}>
+        <Routes>
+          <Route path="/reports/buyability" element={<BomBuyabilityReport />} />
+          <Route path="*" element={<LocationProbe />} />
+        </Routes>
+        <LocationProbe />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+function LocationProbe() {
+  const location = useLocation();
+  return <div data-testid="location">{location.pathname}{location.search}</div>;
+}
+
+beforeEach(() => {
+  cleanup();
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe("BomBuyabilityReport", () => {
+  it("renders rows from server response", async () => {
+    vi.spyOn(api, "get").mockResolvedValue(report());
+
+    renderReport();
+
+    expect(await screen.findByText("Amplifier")).toBeDefined();
+    expect(screen.getByText("Controller")).toBeDefined();
+    expect(screen.getByText("Sourcing ok")).toBeDefined();
+    expect(screen.getByText("Powered by TrustedParts")).toBeDefined();
+    const amplifier = screen.getByRole("link", { name: "Amplifier" });
+    expect(amplifier.getAttribute("href")).toBe("/projects/project-1/sourcing");
+    const links = screen.getAllByRole("link", { name: "Open" });
+    expect(links[0].getAttribute("href")).toBe("/projects/project-1/sourcing?build_quantity=2");
+  });
+
+  it("truncated badge visible when truncated=true", async () => {
+    vi.spyOn(api, "get").mockResolvedValue(report({ truncated: true }));
+
+    renderReport();
+
+    expect(await screen.findByText("Truncated to 50 projects")).toBeDefined();
+  });
+
+  it("build quantity input updates URL and refetches", async () => {
+    const get = vi.spyOn(api, "get").mockResolvedValue(report());
+    const user = userEvent.setup();
+
+    renderReport();
+
+    await screen.findByText("Amplifier");
+    const input = screen.getByLabelText("Build quantity");
+    await user.clear(input);
+    await user.type(input, "5{Enter}");
+
+    await waitFor(() => {
+      expect(get).toHaveBeenCalledWith("/reports/bom-buyability?build_quantity=5");
+    });
+    expect(screen.getByTestId("location").textContent).toContain("build_quantity=5");
+    const table = screen.getByRole("table");
+    expect(within(table).getByText("Amplifier")).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Added backend BOM buyability report schema/service and `GET /api/reports/bom-buyability` with workspace-scoped active-project selection, 50-project cap/truncated flag, `build_quantity >= 1`, rate limit, cache-default true, 4h Source-BOM cache TTL, and graceful sourcing status fallback.
- Added React BOM buyability report page with URL-persisted build quantity, DataTable rows, status/truncation badges, TrustedParts attribution/source label, and Source-BOM deep links.
- Added backend/frontend tests and API/frontend docs.

## Validation
- `TEST_DATABASE_URL=postgresql+psycopg://stockmgr:stockmgr@127.0.0.1:5432/stockmgr_test_tp506 uv run --extra dev python -m pytest -q tests/test_bom_buyability_report.py` -> 7 passed, 2 warnings.
- `npm test -- BomBuyabilityReport` -> 1 file passed, 3 tests passed.
- `npm run typecheck` -> passed.
- `npx eslint src/routes/reports/BomBuyabilityReport.tsx src/routes/reports/__tests__/BomBuyabilityReport.test.tsx src/App.tsx src/routes/reports/Reports.tsx` -> passed.
- `LINT_CMD="ruff check app --output-format=concise" BASELINE_FILE=".ruff-baseline.txt" WORK_DIR="backend" bash scripts/lint-delta.sh` -> no new violations.
- `LINT_CMD="npm run lint -- --format=unix" BASELINE_FILE="../.eslint-baseline.txt" WORK_DIR="." bash ../scripts/lint-delta.sh` from `web/` -> no new violations.
- `git -C /mnt/data/WORK/stockManager-1/.codex/worktrees/tp-506-381 diff --check` -> passed.

## Screenshot
- Not captured: this environment has no Docker/dev backend available for an authenticated populated browser session.

## Deviations / Limitations
- Docker validation commands could not run because `docker` is not installed in the environment.
- Raw `npm run lint` still reports existing baseline issues in unrelated files (`bagCode.ts`, `ZxingScanner.tsx`, etc.); scoped ESLint for touched frontend files and the baseline-aware lint check both pass.
- Raw app-wide `ruff check app` reports existing baseline issues outside this change; scoped ruff for new backend files and the baseline-aware ruff check pass.

Refs #381
