### PR TITLE
TP-508: Sourcing risk report

### DIFF
--- a/backend/app/api/routes/reports.py
+++ b/backend/app/api/routes/reports.py
@@ -5,16 +5,18 @@ from collections import defaultdict
 from datetime import date, timedelta
 from uuid import UUID
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Depends, Query, Request
 from sqlalchemy import select
 
-from app.core.deps import CurrentWorkspace, DbSession
+from app.core.deps import CurrentUser, CurrentWorkspace, DbSession, require_role
 from app.core.errors import ErrorCodes, raise_http
+from app.core.ratelimit import limiter, workspace_key
 from app.core.responses import ok
 from app.domain.builds.service import shortage_analysis
 from app.domain.lots.models import Lot
 from app.domain.parts.models import Part
 from app.domain.projects.models import Project
+from app.domain.reports.service import sourcing_risk_report
 from app.domain.stock.service import (
     bulk_current_quantities,
     bulk_current_quantities_by_lot,
@@ -67,6 +69,26 @@ def low_stock(db: DbSession, ws: CurrentWorkspace):
             )
     out.sort(key=lambda r: r["short_by"], reverse=True)
     return ok(out)
+
+
+@router.get("/sourcing-risk", dependencies=[Depends(require_role("member"))])
+@limiter.limit("30/minute", key_func=workspace_key)
+def sourcing_risk(
+    request: Request,
+    db: DbSession,
+    ws: CurrentWorkspace,
+    user: CurrentUser,
+    only_with_flags: bool = Query(default=True),
+    use_cached_data: bool | None = Query(default=None),
+):
+    out = sourcing_risk_report(
+        db,
+        workspace=ws,
+        only_with_flags=only_with_flags,
+        use_cached_data=use_cached_data,
+        requested_by=user.id,
+    )
+    return ok(out.model_dump(mode="json"))
 
 
 @router.get("/bom-shortage")

--- a/backend/app/domain/reports/README.md
+++ b/backend/app/domain/reports/README.md
@@ -1,0 +1,6 @@
+# Reports Domain
+
+Read-only report services over workspace-owned inventory, stock, BOM, and sourcing data.
+
+Report routes live in `backend/app/api/routes/reports.py`. Shared invariants are the workspace-isolation and stock-ledger rules in `docs/ARCHITECTURE.md`; sourcing-risk stock quantities go through `domain/stock/service.py::bulk_current_quantities`.
+

--- a/backend/app/domain/reports/__init__.py
+++ b/backend/app/domain/reports/__init__.py
@@ -1,0 +1,2 @@
+"""Read-only report services."""
+

--- a/backend/app/domain/reports/schemas.py
+++ b/backend/app/domain/reports/schemas.py
@@ -1,0 +1,59 @@
+"""Pydantic DTOs for reports."""
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.domain.sourcing.schemas import SourcingAttributionLinks, SourcingBomOfferOut
+
+SourcingRiskFlag = Literal[
+    "single_source",
+    "no_authorized_stock",
+    "moq_overbuy",
+    "lead_time_long",
+    "preferred_distributor_unmet",
+    "price_delta",
+]
+
+
+class SourcingRiskStatusOut(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    state: Literal["ok", "not_configured", "budget_blocked", "upstream_error"]
+    message: str
+
+
+class SourcingRiskRow(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    part_id: UUID
+    name: str
+    manufacturer: str | None = None
+    mpn: str
+    on_hand: int
+    distributors_with_stock: list[str] = Field(default_factory=list)
+    authorized_stock: int
+    best_offer: SourcingBomOfferOut | None = None
+    lead_time_days: int | None = None
+    typical_reorder_quantity: int
+    historical_unit_cost: Decimal | None = None
+    historical_currency: str | None = None
+    price_delta_pct: Decimal | None = None
+    risk_flags: list[SourcingRiskFlag] = Field(default_factory=list)
+
+
+class SourcingRiskReportOut(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    rows: list[SourcingRiskRow]
+    sourcing_status: SourcingRiskStatusOut
+    powered_by: Literal["TrustedParts"] = "TrustedParts"
+    fetched_at: datetime
+    partial: bool
+    cache_hit: bool | None = None
+    links: SourcingAttributionLinks
+

--- a/backend/app/domain/reports/service.py
+++ b/backend/app/domain/reports/service.py
@@ -1,0 +1,266 @@
+"""Read-only report services."""
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import datetime
+from decimal import Decimal
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.core.time import utcnow
+from app.domain.lots.models import Lot
+from app.domain.parts.models import Part
+from app.domain.reports.schemas import (
+    SourcingRiskReportOut,
+    SourcingRiskRow,
+    SourcingRiskStatusOut,
+)
+from app.domain.sourcing import (
+    SourcingAuthError,
+    SourcingClientError,
+    SourcingRateLimitError,
+    SourcingTimeoutError,
+)
+from app.domain.sourcing import service as sourcing_service
+from app.domain.sourcing.schemas import SourcingBomOfferOut, SourcingSearchResult
+from app.domain.sourcing.service import SourcingBudgetBlocked, SourcingNotConfigured
+from app.domain.stock.service import bulk_current_quantities
+
+SOURCING_RISK_TTL_SECONDS = 4 * 60 * 60
+PRICE_DELTA_THRESHOLD = Decimal("0.25")
+LEAD_TIME_LONG_DAYS = 30
+MOQ_OVERBUY_MULTIPLIER = 5
+
+
+def sourcing_risk_report(
+    db: Session,
+    *,
+    workspace: Any,
+    only_with_flags: bool = True,
+    use_cached_data: bool | None = None,
+    requested_by: UUID | None = None,
+) -> SourcingRiskReportOut:
+    parts = list(
+        db.execute(
+            select(Part)
+            .where(Part.workspace_id == workspace.id)
+            .where(Part.archived_at.is_(None))
+            .where(Part.mpn.is_not(None))
+            .order_by(Part.name)
+        ).scalars()
+    )
+    parts = [part for part in parts if (part.mpn or "").strip()]
+    part_ids = [part.id for part in parts]
+    on_hand = bulk_current_quantities(
+        db,
+        workspace_id=workspace.id,
+        part_ids=part_ids,
+        status="on_hand",
+    )
+    historical = _historical_unit_costs(db, workspace_id=workspace.id, part_ids=part_ids)
+
+    mpns = sourcing_service.dedupe_mpns(part.mpn for part in parts)
+    search_results: dict[str, SourcingSearchResult] = {}
+    fetched_at_values: list[datetime] = []
+    partial = False
+    cache_hit_values: list[bool] = []
+    effective_use_cached = True if use_cached_data is None else use_cached_data
+    sourcing_status = SourcingRiskStatusOut(state="ok", message="OK")
+
+    if mpns:
+        try:
+            for chunk in sourcing_service.chunk_mpns(mpns):
+                out = sourcing_service.search(
+                    db,
+                    workspace=workspace,
+                    mpns=chunk,
+                    distributors=[],
+                    use_cached_data=effective_use_cached,
+                    ttl_seconds=SOURCING_RISK_TTL_SECONDS,
+                    requested_by=requested_by,
+                )
+                fetched_at_values.append(out.fetched_at)
+                cache_hit_values.append(out.cache_hit)
+                for result in out.results:
+                    search_results[result.mpn.casefold()] = result
+        except SourcingNotConfigured:
+            sourcing_status = SourcingRiskStatusOut(
+                state="not_configured",
+                message="TrustedParts sourcing is not configured",
+            )
+        except SourcingBudgetBlocked:
+            partial = True
+            sourcing_status = SourcingRiskStatusOut(
+                state="budget_blocked",
+                message="TrustedParts sourcing budget exhausted",
+            )
+        except (
+            SourcingAuthError,
+            SourcingRateLimitError,
+            SourcingTimeoutError,
+            SourcingClientError,
+        ):
+            partial = True
+            sourcing_status = SourcingRiskStatusOut(
+                state="upstream_error",
+                message="TrustedParts sourcing request failed",
+            )
+
+    preferred = _clean_distributors(workspace.sourcing_preferred_distributors)
+    rows = [
+        _sourcing_risk_row(
+            part,
+            result=search_results.get((part.mpn or "").casefold()),
+            on_hand=on_hand.get(part.id, 0),
+            historical=historical.get(part.id),
+            preferred_distributors=preferred,
+        )
+        for part in parts
+    ]
+    if only_with_flags:
+        rows = [row for row in rows if row.risk_flags]
+    rows.sort(key=lambda row: (-len(row.risk_flags), row.name.casefold(), row.mpn.casefold()))
+
+    return SourcingRiskReportOut(
+        rows=rows,
+        sourcing_status=sourcing_status,
+        fetched_at=max(fetched_at_values, default=utcnow()),
+        partial=partial,
+        cache_hit=all(cache_hit_values) if cache_hit_values else None,
+        links=sourcing_service.TRUSTEDPARTS_LINKS,
+    )
+
+
+def _sourcing_risk_row(
+    part: Part,
+    *,
+    result: SourcingSearchResult | None,
+    on_hand: int,
+    historical: tuple[Decimal, str | None] | None,
+    preferred_distributors: list[str],
+) -> SourcingRiskRow:
+    mpn = (part.mpn or "").strip()
+    typical_qty = max(int(part.low_stock_report_quantity or 10), 10)
+    offers = sourcing_service._joined_offers(  # noqa: SLF001
+        [mpn],
+        {mpn.casefold(): result} if result is not None else {},
+        qty=typical_qty,
+    )
+    best_offer = _best_stocked_offer(offers, typical_qty)
+    distributors_with_stock = _distributors_with_stock(offers)
+    authorized_stock = sum(max(0, offer.stock) for offer in offers)
+    historical_unit_cost, historical_currency = historical or (None, None)
+    price_delta_pct = _price_delta_pct(best_offer, historical_unit_cost, historical_currency)
+
+    flags: list[str] = []
+    if len(distributors_with_stock) == 1:
+        flags.append("single_source")
+    if not distributors_with_stock and on_hand > 0:
+        flags.append("no_authorized_stock")
+    if (
+        best_offer is not None
+        and best_offer.moq is not None
+        and best_offer.moq > typical_qty * MOQ_OVERBUY_MULTIPLIER
+    ):
+        flags.append("moq_overbuy")
+    if (
+        best_offer is not None
+        and best_offer.lead_time_days is not None
+        and best_offer.lead_time_days > LEAD_TIME_LONG_DAYS
+    ):
+        flags.append("lead_time_long")
+    if preferred_distributors and not (
+        {item.casefold() for item in preferred_distributors}
+        & {item.casefold() for item in distributors_with_stock}
+    ):
+        flags.append("preferred_distributor_unmet")
+    if price_delta_pct is not None and price_delta_pct >= PRICE_DELTA_THRESHOLD:
+        flags.append("price_delta")
+
+    return SourcingRiskRow(
+        part_id=part.id,
+        name=part.name,
+        manufacturer=part.manufacturer,
+        mpn=mpn,
+        on_hand=on_hand,
+        distributors_with_stock=distributors_with_stock,
+        authorized_stock=authorized_stock,
+        best_offer=best_offer,
+        lead_time_days=best_offer.lead_time_days if best_offer is not None else None,
+        typical_reorder_quantity=typical_qty,
+        historical_unit_cost=historical_unit_cost,
+        historical_currency=historical_currency,
+        price_delta_pct=price_delta_pct,
+        risk_flags=flags,
+    )
+
+
+def _best_stocked_offer(
+    offers: Sequence[SourcingBomOfferOut],
+    qty: int,
+) -> SourcingBomOfferOut | None:
+    stocked = [offer for offer in offers if offer.stock > 0]
+    if stocked:
+        return sourcing_service._best_offer_at_qty(list(stocked), qty)  # noqa: SLF001
+    return sourcing_service._best_offer_at_qty(list(offers), qty)  # noqa: SLF001
+
+
+def _distributors_with_stock(offers: Sequence[SourcingBomOfferOut]) -> list[str]:
+    by_key: dict[str, str] = {}
+    stock_by_key: dict[str, int] = {}
+    for offer in offers:
+        key = offer.distributor.casefold()
+        by_key.setdefault(key, offer.distributor)
+        stock_by_key[key] = stock_by_key.get(key, 0) + max(0, offer.stock)
+    return sorted(
+        [by_key[key] for key, stock in stock_by_key.items() if stock > 0],
+        key=str.casefold,
+    )
+
+
+def _historical_unit_costs(
+    db: Session,
+    *,
+    workspace_id: UUID,
+    part_ids: list[UUID],
+) -> dict[UUID, tuple[Decimal, str | None]]:
+    if not part_ids:
+        return {}
+    rows = db.execute(
+        select(Lot)
+        .where(Lot.workspace_id == workspace_id)
+        .where(Lot.part_id.in_(part_ids))
+        .where(Lot.purchase_unit_cost.is_not(None))
+        .order_by(Lot.part_id, Lot.created_at.desc())
+    ).scalars()
+    out: dict[UUID, tuple[Decimal, str | None]] = {}
+    for lot in rows:
+        if lot.part_id not in out and lot.purchase_unit_cost is not None:
+            out[lot.part_id] = (Decimal(lot.purchase_unit_cost), lot.purchase_currency)
+    return out
+
+
+def _price_delta_pct(
+    best_offer: SourcingBomOfferOut | None,
+    historical_unit_cost: Decimal | None,
+    historical_currency: str | None,
+) -> Decimal | None:
+    if (
+        best_offer is None
+        or best_offer.unit_price is None
+        or historical_unit_cost is None
+        or historical_unit_cost <= 0
+    ):
+        return None
+    if historical_currency and best_offer.currency and historical_currency != best_offer.currency:
+        return None
+    return (best_offer.unit_price - historical_unit_cost) / historical_unit_cost
+
+
+def _clean_distributors(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item).strip() for item in value if str(item).strip()]

--- a/backend/tests/test_sourcing_risk_report.py
+++ b/backend/tests/test_sourcing_risk_report.py
@@ -1,0 +1,313 @@
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import inspect
+
+import app.core.ratelimit as _ratelimit_mod
+from app.domain.sourcing.budget import BUDGET
+from app.domain.sourcing.schemas import (
+    SourcingDistributor,
+    SourcingLinks,
+    SourcingOffer,
+    SourcingPriceBreak,
+    SourcingQuery,
+    SourcingSearchRaw,
+)
+from app.infra.db import Base
+from app.main import app
+from tests._factories import add_stock, create_part, create_storage, signup_user
+
+
+def _configure_sourcing(
+    client: TestClient,
+    *,
+    preferred: list[str] | None = None,
+    use_cached: bool = True,
+) -> None:
+    r = client.patch(
+        "/api/workspaces/current",
+        json={
+            "sourcing_provider": "trustedparts",
+            "sourcing_company_id": "company-123",
+            "sourcing_api_key": "api-key-456",
+            "sourcing_country_code": "CZ",
+            "sourcing_currency_code": "EUR",
+            "sourcing_preferred_distributors": preferred or [],
+            "sourcing_use_cached_for_dashboards": use_cached,
+        },
+    )
+    assert r.status_code == 200, r.text
+
+
+def _current_workspace_id(client: TestClient) -> uuid.UUID:
+    r = client.get("/api/workspaces/current")
+    assert r.status_code == 200, r.text
+    return uuid.UUID(r.json()["data"]["id"])
+
+
+def _offer(
+    mpn: str,
+    *,
+    distributor: str = "DigiKey",
+    stock: int = 100,
+    unit_price: float = 1.0,
+    moq: int | None = 1,
+    lead_time_days: int | None = 3,
+    currency: str = "EUR",
+) -> SourcingOffer:
+    return SourcingOffer(
+        mpn=mpn,
+        manufacturer="TestCo",
+        description=f"Offer for {mpn}",
+        distributors=[
+            SourcingDistributor(
+                name=distributor,
+                sku=f"{mpn}-{distributor}",
+                stock=stock,
+                unit_price=unit_price,
+                currency=currency,
+                moq=moq,
+                lead_time_days=lead_time_days,
+                price_breaks=[SourcingPriceBreak(quantity=1, unit_price=unit_price)],
+                product_url=f"https://www.trustedparts.com/{mpn}/{distributor}",
+            )
+        ],
+        links=SourcingLinks(primary=f"https://www.trustedparts.com/search/{mpn}"),
+    )
+
+
+class _FakeTrustedPartsClient:
+    calls: list[dict[str, Any]] = []
+    offers_by_mpn: dict[str, list[SourcingOffer]] = {}
+
+    def __init__(self, workspace: Any) -> None:
+        self.workspace = workspace
+        self.country_code = "CZ"
+        self.currency_code = "EUR"
+
+    def search(
+        self,
+        queries: list[SourcingQuery],
+        *,
+        in_stock_only: bool,
+        distributors: list[str] | None,
+        use_cached_data: bool,
+        **_kwargs,
+    ) -> SourcingSearchRaw:
+        query = queries[0]
+        self.calls.append(
+            {
+                "workspace_id": str(self.workspace.id),
+                "mpn": query.search_token,
+                "distributors": distributors,
+                "use_cached_data": use_cached_data,
+            }
+        )
+        return SourcingSearchRaw(
+            offers=self.offers_by_mpn.get(query.search_token, []),
+            request_id=f"req-{len(self.calls)}",
+        )
+
+
+@pytest.fixture(autouse=True)
+def reset_sourcing_state(monkeypatch):
+    original_limiter_enabled = _ratelimit_mod.limiter.enabled
+    _ratelimit_mod.limiter.enabled = False
+    _FakeTrustedPartsClient.calls = []
+    _FakeTrustedPartsClient.offers_by_mpn = {}
+    BUDGET._events.clear()
+    try:
+        _ratelimit_mod.limiter.reset()
+    except Exception:
+        pass
+
+    def fake_provider(workspace):
+        if workspace.sourcing_provider != "trustedparts":
+            return None
+        return _FakeTrustedPartsClient(workspace)
+
+    monkeypatch.setattr("app.domain.sourcing.service.make_sourcing_provider", fake_provider)
+    yield
+    _ratelimit_mod.limiter.enabled = original_limiter_enabled
+    BUDGET._events.clear()
+    try:
+        _ratelimit_mod.limiter.reset()
+    except Exception:
+        pass
+
+
+def _report(client: TestClient, *, only_with_flags: bool = True):
+    r = client.get(f"/api/reports/sourcing-risk?only_with_flags={str(only_with_flags).lower()}")
+    assert r.status_code == 200, r.text
+    return r.json()["data"]
+
+
+def test_single_source_flag(authed_client):
+    _configure_sourcing(authed_client)
+    create_part(authed_client, name="Single", mpn="SINGLE")
+    _FakeTrustedPartsClient.offers_by_mpn = {
+        "SINGLE": [_offer("SINGLE", distributor="DigiKey", stock=25)]
+    }
+
+    row = _report(authed_client)["rows"][0]
+
+    assert row["risk_flags"] == ["single_source"]
+    assert row["distributors_with_stock"] == ["DigiKey"]
+
+
+def test_no_authorized_stock_flag(authed_client):
+    _configure_sourcing(authed_client)
+    part_id = create_part(authed_client, name="On hand unavailable", mpn="NOAUTH")
+    storage_id = create_storage(authed_client)
+    add_stock(authed_client, part_id, 3, storage_id)
+    _FakeTrustedPartsClient.offers_by_mpn = {"NOAUTH": [_offer("NOAUTH", stock=0)]}
+
+    row = _report(authed_client)["rows"][0]
+
+    assert row["on_hand"] == 3
+    assert row["risk_flags"] == ["no_authorized_stock"]
+
+
+def test_moq_overbuy_uses_workspace_threshold(authed_client):
+    _configure_sourcing(authed_client)
+    create_part(authed_client, name="MOQ", mpn="MOQ", low_stock_report_quantity=20)
+    _FakeTrustedPartsClient.offers_by_mpn = {"MOQ": [_offer("MOQ", stock=1000, moq=101)]}
+
+    row = _report(authed_client)["rows"][0]
+
+    assert row["typical_reorder_quantity"] == 20
+    assert "moq_overbuy" in row["risk_flags"]
+
+
+def test_lead_time_long_threshold(authed_client):
+    _configure_sourcing(authed_client)
+    create_part(authed_client, name="Lead", mpn="LEAD")
+    _FakeTrustedPartsClient.offers_by_mpn = {"LEAD": [_offer("LEAD", stock=50, lead_time_days=31)]}
+
+    row = _report(authed_client)["rows"][0]
+
+    assert "lead_time_long" in row["risk_flags"]
+
+
+def test_preferred_distributor_unmet(authed_client):
+    _configure_sourcing(authed_client, preferred=["DigiKey"])
+    create_part(authed_client, name="Preferred", mpn="PREF")
+    _FakeTrustedPartsClient.offers_by_mpn = {
+        "PREF": [_offer("PREF", distributor="Mouser", stock=20)]
+    }
+
+    row = _report(authed_client)["rows"][0]
+
+    assert row["distributors_with_stock"] == ["Mouser"]
+    assert "preferred_distributor_unmet" in row["risk_flags"]
+
+
+def test_price_delta_25pct(authed_client):
+    _configure_sourcing(authed_client)
+    part_id = create_part(authed_client, name="Price", mpn="PRICE")
+    storage_id = create_storage(authed_client)
+    add_stock(
+        authed_client,
+        part_id,
+        10,
+        storage_id,
+        price={"mode": "per_component", "unit_price": "1.00", "currency": "EUR"},
+        lot={"name": "purchase"},
+    )
+    _FakeTrustedPartsClient.offers_by_mpn = {"PRICE": [_offer("PRICE", stock=10, unit_price=1.25)]}
+
+    row = _report(authed_client)["rows"][0]
+
+    assert row["historical_unit_cost"] == "1.000000"
+    assert row["price_delta_pct"] == "0.25"
+    assert "price_delta" in row["risk_flags"]
+
+
+def test_only_with_flags_filters_clean_parts(authed_client):
+    _configure_sourcing(authed_client)
+    create_part(authed_client, name="Risky", mpn="RISKY")
+    create_part(authed_client, name="Clean", mpn="CLEAN")
+    _FakeTrustedPartsClient.offers_by_mpn = {
+        "RISKY": [_offer("RISKY", distributor="DigiKey", stock=10)],
+        "CLEAN": [
+            _offer("CLEAN", distributor="DigiKey", stock=10),
+            _offer("CLEAN", distributor="Mouser", stock=10),
+        ],
+    }
+
+    flagged = _report(authed_client, only_with_flags=True)["rows"]
+    all_rows = _report(authed_client, only_with_flags=False)["rows"]
+
+    assert [row["mpn"] for row in flagged] == ["RISKY"]
+    assert {row["mpn"] for row in all_rows} == {"RISKY", "CLEAN"}
+
+
+def test_sort_by_flag_count_then_alpha(authed_client):
+    _configure_sourcing(authed_client, preferred=["DigiKey"])
+    create_part(authed_client, name="Bravo", mpn="BRAVO")
+    create_part(authed_client, name="Alpha", mpn="ALPHA")
+    _FakeTrustedPartsClient.offers_by_mpn = {
+        "BRAVO": [_offer("BRAVO", distributor="Mouser", stock=10, lead_time_days=31)],
+        "ALPHA": [_offer("ALPHA", distributor="Mouser", stock=10)],
+    }
+
+    rows = _report(authed_client)["rows"]
+
+    assert [row["name"] for row in rows] == ["Bravo", "Alpha"]
+    assert len(rows[0]["risk_flags"]) == 3
+    assert len(rows[1]["risk_flags"]) == 2
+
+
+def test_workspace_isolation(authed_client):
+    _configure_sourcing(authed_client)
+    create_part(authed_client, name="Own", mpn="OWN")
+    other = TestClient(app)
+    signup_user(other)
+    _configure_sourcing(other)
+    create_part(other, name="Foreign", mpn="FOREIGN")
+    _FakeTrustedPartsClient.offers_by_mpn = {
+        "OWN": [_offer("OWN", stock=10)],
+        "FOREIGN": [_offer("FOREIGN", stock=10)],
+    }
+
+    rows = _report(authed_client)["rows"]
+
+    assert [row["mpn"] for row in rows] == ["OWN"]
+    assert {call["workspace_id"] for call in _FakeTrustedPartsClient.calls} == {
+        str(_current_workspace_id(authed_client))
+    }
+
+
+def test_cache_hit_within_4h(authed_client):
+    _configure_sourcing(authed_client, use_cached=False)
+    create_part(authed_client, name="Cached", mpn="CACHE")
+    _FakeTrustedPartsClient.offers_by_mpn = {"CACHE": [_offer("CACHE", stock=10)]}
+
+    first = _report(authed_client)
+    second = _report(authed_client)
+
+    assert first["cache_hit"] is False
+    assert second["cache_hit"] is True
+    assert len(_FakeTrustedPartsClient.calls) == 1
+    assert _FakeTrustedPartsClient.calls[0]["use_cached_data"] is True
+
+
+def test_sourcing_not_configured_returns_status(authed_client):
+    create_part(authed_client, name="Unconfigured", mpn="UNCONFIGURED")
+
+    data = _report(authed_client)
+
+    assert data["sourcing_status"]["state"] == "not_configured"
+    assert data["rows"] == []
+
+
+def test_no_persistent_risk_table(db):
+    table_names = set(inspect(db.bind).get_table_names())
+    metadata_tables = set(Base.metadata.tables)
+
+    assert not any("sourcing_risk" in name or "risk_history" in name for name in table_names)
+    assert not any("sourcing_risk" in name or "risk_history" in name for name in metadata_tables)

--- a/docs/api/reports.md
+++ b/docs/api/reports.md
@@ -2,7 +2,7 @@
 
 Audience: engineer
 
-Read-only aggregate queries: low-stock parts, BOM shortage at a planned build quantity, stock value, and expiring lots.
+Read-only aggregate queries: low-stock parts, sourcing risk, BOM shortage at a planned build quantity, stock value, and expiring lots.
 
 ## Conventions
 
@@ -58,6 +58,47 @@ Project-wide shortage analysis at a given build quantity. No build is created â€
 
 - Source: `backend/app/api/routes/reports.py:72-86`.
 - Service: `backend/app/domain/builds/service.py::shortage_analysis`.
+
+### `GET /api/reports/sourcing-risk`
+
+Workspace-wide sourcing risk for active parts with an MPN. The route uses TrustedParts through the sourcing service with a 4-hour cache TTL, returns a top-level `sourcing_status`, and recomputes flags on each request.
+
+**Query**
+
+| Field | Type | Notes |
+|---|---|---|
+| `only_with_flags` | bool | Default `true`; when true, clean rows are omitted. |
+| `use_cached_data` | bool \| null | Default `null`; null uses cached TrustedParts data. |
+
+**Response** â€” `200 OK` (envelope: `{ data, status }`)
+
+```json
+{ "data": {
+  "sourcing_status": { "state": "ok", "message": "OK" },
+  "rows": [ { "mpn": "STM32F103", "risk_flags": ["single_source"] } ]
+}, "status": { ... } }
+```
+
+`sourcing_status.state` is `ok`, `not_configured`, `budget_blocked`, or `upstream_error`. Non-`ok` states are reported in the payload so the report page can render a banner without violating the API envelope.
+
+**Risk flags**
+
+| Flag | Heuristic |
+|---|---|
+| `single_source` | Exactly one distributor has authorized stock for the part MPN. |
+| `no_authorized_stock` | No distributor has authorized stock and the part has internal on-hand quantity. |
+| `moq_overbuy` | Best offer MOQ is greater than `5 * typical_reorder_quantity`, where typical is `max(part.low_stock_report_quantity, 10)`. |
+| `lead_time_long` | Best offer lead time is greater than 30 days. |
+| `preferred_distributor_unmet` | Workspace preferred distributors are configured, but none has stock. |
+| `price_delta` | Best replacement price is at least 25% above the latest historical lot purchase price in the same currency. |
+
+**Notes**
+
+- Route: `backend/app/api/routes/reports.py:74-91`.
+- Service: `backend/app/domain/reports/service.py:38-133`.
+- DTOs: `backend/app/domain/reports/schemas.py:13-58`.
+- Stock quantities use `bulk_current_quantities`; no report query aggregates ledger rows directly (`backend/app/domain/reports/service.py:56-62`).
+- Risk history is not persisted; there is no report table or migration for this feature.
 
 ### `GET /api/reports/stock-value`
 

--- a/docs/frontend/reports.md
+++ b/docs/frontend/reports.md
@@ -1,0 +1,24 @@
+# Reports Frontend
+
+Audience: engineer
+
+Frontend report routes and their data-fetching conventions.
+
+## Routes
+
+| Route | Component | API |
+|---|---|---|
+| `/reports/sourcing-risk` | `web/src/routes/reports/SourcingRiskReport.tsx` | `GET /api/reports/sourcing-risk` |
+
+The sourcing-risk page uses TanStack Query with `useWsKey("report", "sourcing-risk", onlyWithFlags)`, renders the shared `DataTable`, and keeps the default list sorted by flag count before handing rows to the table. The page uses `PoweredByTrustedParts` and `SourcingSourceLabel` for TrustedParts attribution.
+
+## Sourcing Risk
+
+The page renders a status banner from `data.sourcing_status` instead of relying on thrown API errors for normal provider states. The "Show only flagged" checkbox maps directly to the API `only_with_flags` query parameter.
+
+References:
+
+- Route registration: `web/src/App.tsx:91-97`, `web/src/App.tsx:269-274`
+- Navigation entry: `web/src/routes/reports/Reports.tsx:101-106`
+- Component: `web/src/routes/reports/SourcingRiskReport.tsx:93-230`
+- Tests: `web/src/routes/reports/__tests__/SourcingRiskReport.test.tsx:79-131`

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -94,6 +94,7 @@ const BomShortageReport = lazy(() =>
 const ExpiringLotsReport = lazy(() =>
   import("@/routes/reports/Reports").then(m => ({ default: m.ExpiringLotsReport }))
 );
+const SourcingRiskReport = lazy(() => import("@/routes/reports/SourcingRiskReport"));
 
 const ProjectsList = lazy(() => import("@/routes/projects/ProjectsList"));
 const ProjectCreate = lazy(() => import("@/routes/projects/ProjectCreate"));
@@ -270,6 +271,7 @@ export default function App() {
               <Route path="value" element={<LazyRoute><StockValueReport /></LazyRoute>} />
               <Route path="bom" element={<LazyRoute><BomShortageReport /></LazyRoute>} />
               <Route path="expiring" element={<LazyRoute><ExpiringLotsReport /></LazyRoute>} />
+              <Route path="sourcing-risk" element={<LazyRoute><SourcingRiskReport /></LazyRoute>} />
             </Route>
 
             <Route path="/projects" element={<LazyRoute><ProjectsList /></LazyRoute>} />

--- a/web/src/routes/reports/Reports.tsx
+++ b/web/src/routes/reports/Reports.tsx
@@ -103,6 +103,7 @@ export default function ReportsLayout() {
         <NavLink to="/reports/value" className={({ isActive }) => "btn " + (isActive ? "border-accent/50 text-accent" : "")}>Stock value</NavLink>
         <NavLink to="/reports/bom" className={({ isActive }) => "btn " + (isActive ? "border-accent/50 text-accent" : "")}>BOM shortage</NavLink>
         <NavLink to="/reports/expiring" className={({ isActive }) => "btn " + (isActive ? "border-accent/50 text-accent" : "")}>Expiring lots</NavLink>
+        <NavLink to="/reports/sourcing-risk" className={({ isActive }) => "btn " + (isActive ? "border-accent/50 text-accent" : "")}>Sourcing risk</NavLink>
       </div>
       <Outlet />
     </div>

--- a/web/src/routes/reports/SourcingRiskReport.tsx
+++ b/web/src/routes/reports/SourcingRiskReport.tsx
@@ -1,0 +1,230 @@
+import { useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { AlertTriangle, BarChart3 } from "lucide-react";
+import { DataTable } from "@/components/DataTable";
+import EmptyState from "@/components/EmptyState";
+import { PoweredByTrustedParts } from "@/components/PoweredByTrustedParts";
+import { SourcingSourceLabel } from "@/components/SourcingSourceLabel";
+import { api, ApiError } from "@/lib/api";
+import { formatMoney } from "@/lib/format";
+import { useWsKey } from "@/lib/queryKeys";
+
+type SourcingRiskFlag =
+  | "single_source"
+  | "no_authorized_stock"
+  | "moq_overbuy"
+  | "lead_time_long"
+  | "preferred_distributor_unmet"
+  | "price_delta";
+
+type SourcingRiskOffer = {
+  mpn: string;
+  distributor: string;
+  sku: string | null;
+  stock: number;
+  unit_price: string | null;
+  currency: string | null;
+  packaging: string | null;
+  moq: number | null;
+  lead_time_days: number | null;
+  url: string | null;
+};
+
+type SourcingRiskRow = {
+  part_id: string;
+  name: string;
+  manufacturer: string | null;
+  mpn: string;
+  on_hand: number;
+  distributors_with_stock: string[];
+  authorized_stock: number;
+  best_offer: SourcingRiskOffer | null;
+  lead_time_days: number | null;
+  typical_reorder_quantity: number;
+  historical_unit_cost: string | null;
+  historical_currency: string | null;
+  price_delta_pct: string | null;
+  risk_flags: SourcingRiskFlag[];
+};
+
+type SourcingRiskReportOut = {
+  rows: SourcingRiskRow[];
+  sourcing_status: {
+    state: "ok" | "not_configured" | "budget_blocked" | "upstream_error";
+    message: string;
+  };
+  powered_by: "TrustedParts";
+  fetched_at: string;
+  partial: boolean;
+  cache_hit: boolean | null;
+  links: {
+    primary: string;
+    attribution: string;
+  };
+};
+
+const flagLabels: Record<SourcingRiskFlag, string> = {
+  single_source: "Single source",
+  no_authorized_stock: "No authorized stock",
+  moq_overbuy: "MOQ overbuy",
+  lead_time_long: "Long lead time",
+  preferred_distributor_unmet: "Preferred unmet",
+  price_delta: "Price delta",
+};
+
+function bestOfferLabel(offer: SourcingRiskOffer | null): string {
+  if (!offer) return "—";
+  const price = offer.unit_price ? formatMoney(Number(offer.unit_price), offer.currency) : "—";
+  return `${offer.distributor} · ${price}`;
+}
+
+function statusTone(state: SourcingRiskReportOut["sourcing_status"]["state"]): string {
+  switch (state) {
+    case "ok":
+      return "border-success/30 bg-success/10 text-success";
+    case "not_configured":
+      return "border-warning/30 bg-warning/10 text-warning";
+    default:
+      return "border-danger/30 bg-danger/10 text-danger";
+  }
+}
+
+export default function SourcingRiskReport() {
+  const [onlyWithFlags, setOnlyWithFlags] = useState(true);
+  const { data, isLoading, isError, error } = useQuery({
+    queryKey: useWsKey("report", "sourcing-risk", onlyWithFlags),
+    queryFn: () =>
+      api.get<SourcingRiskReportOut>(
+        `/reports/sourcing-risk?only_with_flags=${String(onlyWithFlags)}`
+      ),
+  });
+
+  const rows = useMemo(
+    () =>
+      [...(data?.rows ?? [])].sort((a, b) => {
+        const byFlags = b.risk_flags.length - a.risk_flags.length;
+        if (byFlags !== 0) return byFlags;
+        return a.name.localeCompare(b.name);
+      }),
+    [data?.rows],
+  );
+
+  if (isError) {
+    return (
+      <div className="text-danger text-sm p-4">
+        Failed to load sourcing risk report. {error instanceof ApiError ? error.userMessage : ""}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center gap-3">
+        <label className="inline-flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={onlyWithFlags}
+            onChange={e => setOnlyWithFlags(e.target.checked)}
+          />
+          Show only flagged
+        </label>
+        {data && <PoweredByTrustedParts primaryUrl={data.links.primary} />}
+      </div>
+
+      {data && (
+        <div className={`rounded-md border px-3 py-2 text-sm ${statusTone(data.sourcing_status.state)}`}>
+          <div className="flex items-center gap-2">
+            <AlertTriangle size={14} />
+            <span>{data.sourcing_status.message}</span>
+            {data.partial && <span className="text-muted">Partial</span>}
+          </div>
+        </div>
+      )}
+
+      {isLoading ? (
+        <div className="text-muted">Loading…</div>
+      ) : (
+        <DataTable
+          rows={rows}
+          rowKey={r => r.part_id}
+          tableId="report-sourcing-risk"
+          empty={
+            <EmptyState
+              icon={BarChart3}
+              title="All clear"
+              description="No parts match this sourcing-risk view."
+            />
+          }
+          exportFilename="sourcing-risk"
+          columns={[
+            {
+              key: "name",
+              header: "Part",
+              accessor: r => r.name,
+              render: r => <Link className="text-accent" to={`/parts/${r.part_id}/info`}>{r.name}</Link>,
+            },
+            { key: "mpn", header: "MPN", accessor: r => r.mpn },
+            { key: "on_hand", header: "On hand", accessor: r => r.on_hand, width: "90px" },
+            {
+              key: "distributors",
+              header: "Stocked distributors",
+              accessor: r => r.distributors_with_stock.join(", "),
+              render: r => (
+                <div className="flex flex-wrap gap-1">
+                  {r.distributors_with_stock.length
+                    ? r.distributors_with_stock.map(distributor => (
+                      <span key={distributor} className="pill">{distributor}</span>
+                    ))
+                    : <span className="text-muted">—</span>}
+                </div>
+              ),
+            },
+            {
+              key: "best_offer",
+              header: "Best offer",
+              accessor: r => bestOfferLabel(r.best_offer),
+              render: r => (
+                <div className="flex flex-col gap-1">
+                  <span>{bestOfferLabel(r.best_offer)}</span>
+                  {r.best_offer && <SourcingSourceLabel source="trustedparts" className="w-fit" />}
+                </div>
+              ),
+            },
+            {
+              key: "lead_time",
+              header: "Lead time",
+              accessor: r => r.lead_time_days ?? "",
+              width: "100px",
+              render: r => r.lead_time_days == null ? <span className="text-muted">—</span> : <span>{r.lead_time_days}d</span>,
+            },
+            {
+              key: "flags",
+              header: "Flags",
+              accessor: r => r.risk_flags.length,
+              render: r => (
+                <div className="flex flex-wrap gap-1">
+                  {r.risk_flags.length
+                    ? r.risk_flags.map(flag => (
+                      <span key={flag} className="pill bg-warning/15 text-warning">{flagLabels[flag]}</span>
+                    ))
+                    : <span className="text-muted">—</span>}
+                </div>
+              ),
+            },
+            {
+              key: "action",
+              header: "",
+              render: r => (
+                <Link className="btn btn-sm whitespace-nowrap" to={`/parts/${r.part_id}/sourcing`}>
+                  Source BOM
+                </Link>
+              ),
+              width: "90px",
+            },
+          ]}
+        />
+      )}
+    </div>
+  );
+}

--- a/web/src/routes/reports/__tests__/SourcingRiskReport.test.tsx
+++ b/web/src/routes/reports/__tests__/SourcingRiskReport.test.tsx
@@ -1,0 +1,131 @@
+// @vitest-environment jsdom
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { api } from "@/lib/api";
+import SourcingRiskReport from "../SourcingRiskReport";
+
+vi.mock("@/lib/auth", () => ({
+  useAuth: () => ({ workspaceId: "ws-1" }),
+}));
+
+function report(rows: unknown[]) {
+  return {
+    rows,
+    sourcing_status: { state: "ok", message: "OK" },
+    powered_by: "TrustedParts",
+    fetched_at: "2026-05-08T12:00:00+00:00",
+    partial: false,
+    cache_hit: false,
+    links: {
+      primary: "https://www.trustedparts.com/",
+      attribution: "https://www.trustedparts.com/en/about",
+    },
+  };
+}
+
+function row(overrides: Record<string, unknown>) {
+  return {
+    part_id: "part-1",
+    name: "STM32",
+    manufacturer: null,
+    mpn: "STM32F103",
+    on_hand: 4,
+    distributors_with_stock: ["DigiKey"],
+    authorized_stock: 20,
+    best_offer: {
+      mpn: "STM32F103",
+      distributor: "DigiKey",
+      sku: "DK-1",
+      stock: 20,
+      unit_price: "1.25",
+      currency: "USD",
+      packaging: null,
+      moq: 1,
+      lead_time_days: 3,
+      url: "https://www.trustedparts.com/digikey/stm32",
+    },
+    lead_time_days: 3,
+    typical_reorder_quantity: 10,
+    historical_unit_cost: null,
+    historical_currency: null,
+    price_delta_pct: null,
+    risk_flags: ["single_source"],
+    ...overrides,
+  };
+}
+
+function renderPage() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <SourcingRiskReport />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  cleanup();
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe("SourcingRiskReport", () => {
+  it("renders flag pills", async () => {
+    vi.spyOn(api, "get").mockResolvedValue(report([
+      row({ risk_flags: ["single_source", "lead_time_long", "price_delta"] }),
+    ]));
+
+    renderPage();
+
+    expect(await screen.findByText("Single source")).toBeDefined();
+    expect(screen.getByText("Long lead time")).toBeDefined();
+    expect(screen.getByText("Price delta")).toBeDefined();
+    expect(screen.getByLabelText("Source: TrustedParts")).toBeDefined();
+    expect(screen.getByRole("link", { name: "Powered by TrustedParts" })).toBeDefined();
+  });
+
+  it("show only flagged toggle filters list through the report query", async () => {
+    const get = vi.spyOn(api, "get").mockImplementation(async path => {
+      if (String(path).includes("only_with_flags=true")) {
+        return report([row({ part_id: "part-risk", name: "Risky", mpn: "RISKY" })]) as never;
+      }
+      return report([
+        row({ part_id: "part-risk", name: "Risky", mpn: "RISKY" }),
+        row({ part_id: "part-clean", name: "Clean", mpn: "CLEAN", distributors_with_stock: ["DigiKey", "Mouser"], risk_flags: [] }),
+      ]) as never;
+    });
+
+    renderPage();
+
+    expect(await screen.findByText("Risky")).toBeDefined();
+    expect(screen.queryByText("Clean")).toBeNull();
+
+    await userEvent.click(screen.getByLabelText("Show only flagged"));
+
+    expect(await screen.findByText("Clean")).toBeDefined();
+    expect(get).toHaveBeenCalledWith("/reports/sourcing-risk?only_with_flags=false");
+  });
+
+  it("sorts by flag count desc by default", async () => {
+    vi.spyOn(api, "get").mockResolvedValue(report([
+      row({ part_id: "part-clean", name: "Clean", mpn: "CLEAN", distributors_with_stock: ["DigiKey", "Mouser"], risk_flags: [] }),
+      row({ part_id: "part-risk", name: "Risky", mpn: "RISKY", risk_flags: ["single_source", "lead_time_long"] }),
+    ]));
+
+    renderPage();
+
+    await screen.findByText("Risky");
+    await waitFor(() => {
+      const bodyRows = screen.getAllByRole("row").slice(1);
+      expect(within(bodyRows[0]).getByText("Risky")).toBeDefined();
+      expect(within(bodyRows[1]).getByText("Clean")).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `GET /api/reports/sourcing-risk` with a report-domain service and schemas for workspace-wide sourcing risk.
- Computes `single_source`, `no_authorized_stock`, `moq_overbuy`, `lead_time_long`, `preferred_distributor_unmet`, and `price_delta` inline with no persistent risk-history table.
- Adds the Sourcing risk report page, reports routing/nav, TrustedParts attribution, flag pills, show-only-flagged toggle, and tests.
- Documents the API/frontend report behavior and the risk-flag heuristics table.

## Validation

Docker was unavailable in this environment (`docker: command not found`), so I ran the closest local commands.

- `TEST_DATABASE_URL=postgresql+psycopg://stockmgr:stockmgr@127.0.0.1:5432/stockmgr_test_tp508 uv run python -m pytest -q -k sourcing_risk_report`
  - `12 passed, 884 deselected, 1 warning in 4.31s`
- `uv run ruff check app/domain/reports tests/test_sourcing_risk_report.py`
  - `All checks passed!`
- `npm run typecheck && npm test -- SourcingRiskReport && npm run lint`
  - `tsc -b` passed
  - `SourcingRiskReport` Vitest passed: `1 passed`, `3 passed`
  - full `npm run lint` failed on existing unrelated files: `bagCode.ts` `no-control-regex` errors plus existing warnings in scanner/order/parts/storage files
- `npx eslint src/routes/reports/SourcingRiskReport.tsx src/routes/reports/__tests__/SourcingRiskReport.test.tsx src/App.tsx src/routes/reports/Reports.tsx`
  - passed
- `git -C /mnt/data/WORK/stockManager-1/.codex/worktrees/tp-508-383 diff --check`
  - passed
- `rg "verify=False|ssl=False|trust_env=False" backend/app || true`
  - no matches

Local backend note: the default shared `stockmgr_test` database failed Alembic setup with a duplicate `pg_type` entry for `alembic_version`, likely from concurrent workers. The targeted pytest run was rerun successfully against the isolated `stockmgr_test_tp508` database.

## Example response

```json
{
  "data": {
    "sourcing_status": { "state": "ok", "message": "OK" },
    "powered_by": "TrustedParts",
    "partial": false,
    "cache_hit": false,
    "rows": [
      {
        "name": "STM32",
        "mpn": "STM32F103",
        "on_hand": 4,
        "distributors_with_stock": ["DigiKey"],
        "risk_flags": ["single_source", "lead_time_long", "price_delta"]
      }
    ]
  },
  "status": { "category": "ok", "message": "OK" }
}
```

## Deviations

- No Docker validation because Docker is not installed in this runner.
- Full frontend lint still fails on existing unrelated baseline issues; scoped lint for changed frontend files passes.
- Full backend `ruff check app` still reports existing unrelated baseline violations in shared files; the new report package and test file pass Ruff.

Refs #383
