### PR TITLE
TP-507: Replenishment cost report (no persistent history)

### DIFF
--- a/backend/app/api/routes/reports.py
+++ b/backend/app/api/routes/reports.py
@@ -16,9 +16,11 @@ from app.domain.builds.service import shortage_analysis
 from app.domain.lots.models import Lot
 from app.domain.parts.models import Part
 from app.domain.projects.models import Project
+from app.domain.reports.schemas import ReplenishmentCostSort
 from app.domain.reports.service import (
     bom_buyability_report,
     low_stock_report,
+    replenishment_cost_report,
     sourcing_risk_report,
 )
 from app.domain.stock.service import (
@@ -145,6 +147,24 @@ def stock_value(db: DbSession, ws: CurrentWorkspace):
             "by_part": sorted(by_part.values(), key=lambda r: r["value"], reverse=True),
         }
     )
+
+
+@router.get("/replenishment-cost")
+@limiter.limit("30/minute", key_func=workspace_key)
+def replenishment_cost(
+    request: Request,
+    db: DbSession,
+    ws: CurrentWorkspace,
+    sort: ReplenishmentCostSort = Query(default="delta_pct"),
+    use_cached_data: bool | None = None,
+):
+    out = replenishment_cost_report(
+        db,
+        workspace=ws,
+        use_cached_data=use_cached_data,
+        sort=sort,
+    )
+    return ok(out.model_dump(mode="json"))
 
 
 @router.get("/expiring-lots")

--- a/backend/app/domain/reports/README.md
+++ b/backend/app/domain/reports/README.md
@@ -1,9 +1,13 @@
 # Reports Domain
 
-Read-only aggregate services for workspace reports.
+Audience: engineer
+
+Read-only aggregate services for workspace reports over inventory, stock, BOM,
+and sourcing data.
 
 - Routes live in `backend/app/api/routes/reports.py`.
 - API docs live in `docs/api/reports.md`.
 - Frontend docs live in `docs/frontend/reports.md`.
 - Shared invariants are the workspace-isolation and stock-ledger rules in `docs/ARCHITECTURE.md`.
 - Stock quantities must continue to flow through `backend/app/domain/stock/service.py`.
+- Sourcing-backed reports use the short-lived TrustedParts cache and must not add persistent price-history storage.

--- a/backend/app/domain/reports/schemas.py
+++ b/backend/app/domain/reports/schemas.py
@@ -12,6 +12,14 @@ from pydantic import BaseModel, ConfigDict, Field
 from app.domain.sourcing.schemas import SourcingAttributionLinks, SourcingBomOfferOut
 
 SourcingReportStatus = Literal["ok", "not_configured", "partial", "budget_blocked"]
+ReplenishmentCostSort = Literal["delta_pct", "delta_abs", "name"]
+ReplenishmentCostReason = Literal[
+    "no_offer",
+    "currency_mismatch",
+    "sourcing_not_configured",
+    "sourcing_unavailable",
+]
+
 SourcingRiskFlag = Literal[
     "single_source",
     "no_authorized_stock",
@@ -45,6 +53,62 @@ class BomBuyabilityReportOut(BaseModel):
     project_cap: int
     powered_by: Literal["TrustedParts"] = "TrustedParts"
     links: SourcingAttributionLinks
+
+
+class CurrencyAmountOut(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    currency: str | None
+    value: Decimal
+
+
+class ReplenishmentCostStatusOut(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    state: Literal["ok", "not_configured", "degraded", "error"]
+    message: str | None = None
+    fetched_at: datetime | None = None
+    cache_hit: bool | None = None
+    partial: bool = False
+    powered_by: Literal["TrustedParts"] = "TrustedParts"
+    links: SourcingAttributionLinks | None = None
+
+
+class ReplenishmentCostRow(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    part_id: UUID
+    name: str
+    manufacturer: str | None = None
+    mpn: str
+    on_hand: int = Field(ge=1)
+    currency: str | None = None
+    historical_costs: list[CurrencyAmountOut]
+    historical_cost: Decimal | None = None
+    replacement_unit_price: Decimal | None = None
+    replacement_cost: Decimal | None = None
+    replacement_currency: str | None = None
+    delta_abs: Decimal | None = None
+    delta_pct: Decimal | None = None
+    reason: ReplenishmentCostReason | None = None
+    source: Literal["trustedparts"] | None = None
+
+
+class ReplenishmentCostTotalOut(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    currency: str | None
+    historical_cost: Decimal
+    replacement_cost: Decimal
+    delta_abs: Decimal | None
+
+
+class ReplenishmentCostReportOut(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    rows: list[ReplenishmentCostRow]
+    totals: list[ReplenishmentCostTotalOut]
+    sourcing_status: ReplenishmentCostStatusOut
 
 
 class SourcingRiskStatusOut(BaseModel):

--- a/backend/app/domain/reports/service.py
+++ b/backend/app/domain/reports/service.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import logging
+from collections import defaultdict
 from collections.abc import Sequence
 from datetime import datetime
-from decimal import Decimal
+from decimal import ROUND_HALF_UP, Decimal
 from typing import Any, Literal
 from uuid import UUID
 
@@ -19,7 +20,13 @@ from app.domain.parts.models import Part
 from app.domain.projects.models import Project
 from app.domain.reports.schemas import (
     BomBuyabilityReportOut,
+    CurrencyAmountOut,
     ProjectBuyabilityRow,
+    ReplenishmentCostReportOut,
+    ReplenishmentCostRow,
+    ReplenishmentCostSort,
+    ReplenishmentCostStatusOut,
+    ReplenishmentCostTotalOut,
     SourcingRiskReportOut,
     SourcingRiskRow,
     SourcingRiskStatusOut,
@@ -37,15 +44,83 @@ from app.domain.sourcing.schemas import (
     SourcingSearchResult,
 )
 from app.domain.sourcing.service import SourcingBudgetBlocked, SourcingNotConfigured
-from app.domain.stock.service import bulk_current_quantities
+from app.domain.stock.service import bulk_current_quantities, bulk_current_quantities_by_lot
 
 LOW_STOCK_SOURCING_TTL_SECONDS = 4 * 3600
 BOM_BUYABILITY_PROJECT_CAP = 50
 BOM_BUYABILITY_TTL_SECONDS = 4 * 60 * 60
+REPLENISHMENT_COST_TTL_SECONDS = 4 * 60 * 60
 SOURCING_RISK_TTL_SECONDS = 4 * 60 * 60
 PRICE_DELTA_THRESHOLD = Decimal("0.25")
 LEAD_TIME_LONG_DAYS = 30
 MOQ_OVERBUY_MULTIPLIER = 5
+_MONEY_ZERO = Decimal("0")
+_PCT_QUANT = Decimal("0.01")
+
+
+def replenishment_cost_report(
+    db: Session,
+    *,
+    workspace: Any,
+    use_cached_data: bool | None = None,
+    sort: ReplenishmentCostSort = "delta_pct",
+) -> ReplenishmentCostReportOut:
+    """Transient replacement-cost report.
+
+    TrustedParts-derived prices are read through the short-lived sourcing
+    cache and are never persisted outside that cache.
+    """
+    parts = list(
+        db.execute(
+            select(Part)
+            .where(Part.workspace_id == workspace.id)
+            .where(Part.archived_at.is_(None))
+            .where(Part.mpn.is_not(None))
+        ).scalars()
+    )
+    on_hand_by_part = bulk_current_quantities(
+        db,
+        workspace_id=workspace.id,
+        part_ids=[part.id for part in parts],
+        status="on_hand",
+    )
+    report_parts = [
+        part
+        for part in parts
+        if on_hand_by_part.get(part.id, 0) > 0 and part.mpn and part.mpn.strip()
+    ]
+    if not report_parts:
+        return ReplenishmentCostReportOut(
+            rows=[],
+            totals=[],
+            sourcing_status=_status_ok(),
+        )
+
+    historical_by_part = _historical_costs_by_part(db, workspace_id=workspace.id)
+    search_results, status = _search_replenishment_offers(
+        db,
+        workspace=workspace,
+        mpns=[part.mpn or "" for part in report_parts],
+        use_cached_data=use_cached_data,
+    )
+
+    rows = [
+        _row_for_part(
+            part,
+            on_hand=on_hand_by_part.get(part.id, 0),
+            historical_costs=historical_by_part.get(part.id, {}),
+            search_result=search_results.get((part.mpn or "").casefold()),
+            sourcing_status=status,
+        )
+        for part in report_parts
+    ]
+    rows.sort(key=_sort_key(sort))
+    return ReplenishmentCostReportOut(
+        rows=rows,
+        totals=_totals(rows),
+        sourcing_status=status,
+    )
+
 
 SourcingStatus = Literal["ok", "not_configured", "partial", "budget_blocked"]
 
@@ -296,6 +371,259 @@ def _can_build_now(rows: list[dict[str, Any]], *, build_quantity: int) -> int:
         * build_quantity
         // int(row["required"])
         for row in effective
+    )
+
+
+def _historical_costs_by_part(
+    db: Session,
+    *,
+    workspace_id: UUID,
+) -> dict[UUID, dict[str | None, Decimal]]:
+    lot_qty = bulk_current_quantities_by_lot(db, workspace_id=workspace_id)
+    lots = {
+        lot.id: lot
+        for lot in db.execute(select(Lot).where(Lot.workspace_id == workspace_id)).scalars()
+    }
+    by_part: dict[UUID, dict[str | None, Decimal]] = defaultdict(lambda: defaultdict(Decimal))
+    for lot_id, qty in lot_qty.items():
+        if qty <= 0:
+            continue
+        lot = lots.get(lot_id)
+        if lot is None:
+            continue
+        unit_cost = Decimal(lot.purchase_unit_cost or 0)
+        by_part[lot.part_id][lot.purchase_currency] += unit_cost * Decimal(qty)
+    return {part_id: dict(values) for part_id, values in by_part.items()}
+
+
+def _search_replenishment_offers(
+    db: Session,
+    *,
+    workspace: Any,
+    mpns: list[str],
+    use_cached_data: bool | None,
+) -> tuple[dict[str, SourcingSearchResult], ReplenishmentCostStatusOut]:
+    results: dict[str, SourcingSearchResult] = {}
+    fetched_at_values: list[datetime] = []
+    cache_hits: list[bool] = []
+    partial = False
+
+    for chunk in sourcing_service.chunk_mpns(sourcing_service.dedupe_mpns(mpns)):
+        try:
+            out = sourcing_service.search(
+                db,
+                workspace=workspace,
+                mpns=chunk,
+                use_cached_data=use_cached_data,
+                ttl_seconds=REPLENISHMENT_COST_TTL_SECONDS,
+            )
+        except SourcingNotConfigured:
+            return {}, ReplenishmentCostStatusOut(
+                state="not_configured",
+                message="sourcing not configured",
+                links=sourcing_service.TRUSTEDPARTS_LINKS,
+            )
+        except SourcingBudgetBlocked:
+            partial = True
+            break
+        except (
+            SourcingAuthError,
+            SourcingRateLimitError,
+            SourcingTimeoutError,
+            SourcingClientError,
+        ):
+            return results, ReplenishmentCostStatusOut(
+                state="error",
+                message="TrustedParts sourcing unavailable",
+                partial=bool(results),
+                links=sourcing_service.TRUSTEDPARTS_LINKS,
+            )
+
+        fetched_at_values.append(out.fetched_at)
+        cache_hits.append(out.cache_hit)
+        for result in out.results:
+            results[result.mpn.casefold()] = result
+
+    if partial:
+        return results, ReplenishmentCostStatusOut(
+            state="degraded",
+            message="TrustedParts budget exhausted; partial report returned",
+            fetched_at=max(fetched_at_values, default=None),
+            cache_hit=all(cache_hits) if cache_hits else None,
+            partial=True,
+            links=sourcing_service.TRUSTEDPARTS_LINKS,
+        )
+
+    return results, ReplenishmentCostStatusOut(
+        state="ok",
+        fetched_at=max(fetched_at_values, default=utcnow()),
+        cache_hit=all(cache_hits) if cache_hits else None,
+        links=sourcing_service.TRUSTEDPARTS_LINKS,
+    )
+
+
+def _status_ok() -> ReplenishmentCostStatusOut:
+    return ReplenishmentCostStatusOut(
+        state="ok",
+        fetched_at=utcnow(),
+        cache_hit=None,
+        links=sourcing_service.TRUSTEDPARTS_LINKS,
+    )
+
+
+def _row_for_part(
+    part: Part,
+    *,
+    on_hand: int,
+    historical_costs: dict[str | None, Decimal],
+    search_result: SourcingSearchResult | None,
+    sourcing_status: ReplenishmentCostStatusOut,
+) -> ReplenishmentCostRow:
+    best_offer = _best_replacement_offer(search_result, qty=on_hand)
+    historical_items = [
+        CurrencyAmountOut(currency=currency, value=value)
+        for currency, value in sorted(historical_costs.items(), key=lambda item: item[0] or "")
+    ]
+    if not historical_items:
+        historical_items = [CurrencyAmountOut(currency=None, value=_MONEY_ZERO)]
+
+    if best_offer is None:
+        reason = (
+            "sourcing_not_configured"
+            if sourcing_status.state == "not_configured"
+            else "sourcing_unavailable"
+            if sourcing_status.state in {"degraded", "error"}
+            else "no_offer"
+        )
+        return ReplenishmentCostRow(
+            part_id=part.id,
+            name=part.name,
+            manufacturer=part.manufacturer,
+            mpn=part.mpn or "",
+            on_hand=on_hand,
+            currency=_single_currency(historical_costs),
+            historical_costs=historical_items,
+            historical_cost=_single_historical_cost(historical_costs),
+            reason=reason,
+        )
+
+    unit_price, currency = best_offer
+    replacement_cost = unit_price * Decimal(on_hand)
+    historical_cost = historical_costs.get(currency)
+    if historical_cost is None:
+        return ReplenishmentCostRow(
+            part_id=part.id,
+            name=part.name,
+            manufacturer=part.manufacturer,
+            mpn=part.mpn or "",
+            on_hand=on_hand,
+            currency=currency,
+            historical_costs=historical_items,
+            replacement_unit_price=unit_price,
+            replacement_cost=replacement_cost,
+            replacement_currency=currency,
+            reason="currency_mismatch",
+            source="trustedparts",
+        )
+
+    delta_abs = replacement_cost - historical_cost
+    delta_pct = None
+    if historical_cost != 0:
+        delta_pct = ((delta_abs / historical_cost) * Decimal("100")).quantize(
+            _PCT_QUANT,
+            rounding=ROUND_HALF_UP,
+        )
+    return ReplenishmentCostRow(
+        part_id=part.id,
+        name=part.name,
+        manufacturer=part.manufacturer,
+        mpn=part.mpn or "",
+        on_hand=on_hand,
+        currency=currency,
+        historical_costs=historical_items,
+        historical_cost=historical_cost,
+        replacement_unit_price=unit_price,
+        replacement_cost=replacement_cost,
+        replacement_currency=currency,
+        delta_abs=delta_abs,
+        delta_pct=delta_pct,
+        source="trustedparts",
+    )
+
+
+def _best_replacement_offer(
+    search_result: SourcingSearchResult | None,
+    *,
+    qty: int,
+) -> tuple[Decimal, str | None] | None:
+    if search_result is None or qty < 1:
+        return None
+
+    best: tuple[Decimal, str | None] | None = None
+    for offer in search_result.offers:
+        for distributor in offer.distributors:
+            price = sourcing_service._unit_price_for_distributor(distributor, qty)
+            if price is None:
+                continue
+            candidate = (price, distributor.currency)
+            if best is None or candidate[0] < best[0]:
+                best = candidate
+    return best
+
+
+def _single_currency(values: dict[str | None, Decimal]) -> str | None:
+    currencies = list(values.keys())
+    if len(currencies) == 1:
+        return currencies[0]
+    if len(currencies) > 1:
+        return "MIXED"
+    return None
+
+
+def _single_historical_cost(values: dict[str | None, Decimal]) -> Decimal | None:
+    if len(values) == 1:
+        return next(iter(values.values()))
+    return None
+
+
+def _totals(rows: list[ReplenishmentCostRow]) -> list[ReplenishmentCostTotalOut]:
+    historical: dict[str | None, Decimal] = defaultdict(Decimal)
+    replacement: dict[str | None, Decimal] = defaultdict(Decimal)
+    for row in rows:
+        for item in row.historical_costs:
+            historical[item.currency] += item.value
+        if row.replacement_cost is not None:
+            replacement[row.replacement_currency] += row.replacement_cost
+
+    currencies = sorted(set(historical) | set(replacement), key=lambda item: item or "")
+    return [
+        ReplenishmentCostTotalOut(
+            currency=currency,
+            historical_cost=historical.get(currency, _MONEY_ZERO),
+            replacement_cost=replacement.get(currency, _MONEY_ZERO),
+            delta_abs=(
+                replacement.get(currency, _MONEY_ZERO) - historical.get(currency, _MONEY_ZERO)
+                if currency in replacement
+                else None
+            ),
+        )
+        for currency in currencies
+    ]
+
+
+def _sort_key(sort: ReplenishmentCostSort):
+    if sort == "name":
+        return lambda row: (row.name.casefold(), row.mpn.casefold())
+    if sort == "delta_abs":
+        return lambda row: (
+            row.delta_abs is None,
+            -(row.delta_abs or _MONEY_ZERO),
+            row.name.casefold(),
+        )
+    return lambda row: (
+        row.delta_pct is None,
+        -(row.delta_pct or _MONEY_ZERO),
+        row.name.casefold(),
     )
 
 

--- a/backend/tests/test_replenishment_cost_report.py
+++ b/backend/tests/test_replenishment_cost_report.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import inspect, select
+
+from app.domain.sourcing.models import SourcingCache
+from app.domain.sourcing.schemas import (
+    SourcingDistributor,
+    SourcingLinks,
+    SourcingOffer,
+    SourcingQuery,
+    SourcingSearchRaw,
+)
+from app.main import app
+from tests._factories import add_stock, create_part, create_storage, signup_user
+
+
+class _FakeTrustedPartsClient:
+    calls: list[dict[str, Any]] = []
+    offers_by_mpn: dict[str, dict[str, Any] | None] = {}
+
+    def __init__(self) -> None:
+        self.country_code = "CZ"
+        self.currency_code = "EUR"
+
+    @classmethod
+    def reset(cls) -> None:
+        cls.calls = []
+        cls.offers_by_mpn = {}
+
+    def search(
+        self,
+        queries: list[SourcingQuery],
+        *,
+        in_stock_only: bool,
+        distributors: list[str] | None,
+        use_cached_data: bool,
+        **_kwargs,
+    ) -> SourcingSearchRaw:
+        self.calls.append(
+            {
+                "queries": [query.search_token for query in queries],
+                "use_cached_data": use_cached_data,
+                "in_stock_only": in_stock_only,
+                "distributors": distributors,
+            }
+        )
+        offers = []
+        for query in queries:
+            spec = self.offers_by_mpn.get(query.search_token)
+            if spec is None:
+                continue
+            offers.append(
+                SourcingOffer(
+                    mpn=query.search_token,
+                    manufacturer="ReportCo",
+                    distributors=[
+                        SourcingDistributor(
+                            name="DigiKey",
+                            sku=f"{query.search_token}-DK",
+                            stock=100,
+                            unit_price=spec["unit_price"],
+                            currency=spec["currency"],
+                            product_url=f"https://www.trustedparts.com/{query.search_token}",
+                        )
+                    ],
+                    links=SourcingLinks(
+                        primary=f"https://www.trustedparts.com/search/{query.search_token}"
+                    ),
+                )
+            )
+        return SourcingSearchRaw(offers=offers, request_id=f"req-{len(self.calls)}")
+
+
+@pytest.fixture(autouse=True)
+def _fake_sourcing(monkeypatch):
+    _FakeTrustedPartsClient.reset()
+    monkeypatch.setattr(
+        "app.domain.sourcing.service.make_sourcing_provider",
+        lambda _workspace: _FakeTrustedPartsClient(),
+    )
+    yield
+    _FakeTrustedPartsClient.reset()
+
+
+def _authed_client(email_prefix: str = "replenishment") -> TestClient:
+    client = TestClient(app)
+    signup_user(client, email=f"{email_prefix}-{uuid.uuid4().hex[:8]}@example.com")
+    return client
+
+
+def _configure_sourcing(client: TestClient) -> None:
+    r = client.patch(
+        "/api/workspaces/current",
+        json={
+            "sourcing_provider": "trustedparts",
+            "sourcing_company_id": "company-123",
+            "sourcing_api_key": "api-key-456",
+            "sourcing_country_code": "CZ",
+            "sourcing_currency_code": "EUR",
+            "sourcing_preferred_distributors": ["DigiKey"],
+            "sourcing_use_cached_for_dashboards": False,
+        },
+    )
+    assert r.status_code == 200, r.text
+
+
+def _stocked_part(
+    client: TestClient,
+    *,
+    name: str,
+    mpn: str,
+    quantity: int = 10,
+    unit_cost: str = "0.50",
+    currency: str = "EUR",
+) -> str:
+    part_id = create_part(client, name=name, mpn=mpn)
+    storage_id = create_storage(client, name=f"{name} bin")
+    add_stock(
+        client,
+        part_id,
+        quantity,
+        storage_id=storage_id,
+        lot_name=f"{name} lot",
+        price={
+            "mode": "per_component",
+            "unit_price": unit_cost,
+            "currency": currency,
+        },
+    )
+    return part_id
+
+
+def _report(client: TestClient, query: str = "") -> dict[str, Any]:
+    r = client.get(f"/api/reports/replenishment-cost{query}")
+    assert r.status_code == 200, r.text
+    assert r.json()["status"]["category"] == "ok"
+    return r.json()["data"]
+
+
+def test_basic_report_with_matching_currency():
+    client = _authed_client()
+    _configure_sourcing(client)
+    part_id = _stocked_part(client, name="Cap", mpn="CAP-10UF")
+    _FakeTrustedPartsClient.offers_by_mpn = {"CAP-10UF": {"unit_price": 0.75, "currency": "EUR"}}
+
+    data = _report(client)
+
+    assert data["sourcing_status"]["state"] == "ok"
+    row = data["rows"][0]
+    assert row["part_id"] == part_id
+    assert row["on_hand"] == 10
+    assert row["historical_cost"] == "5.000000"
+    assert row["replacement_cost"] == "7.50"
+    assert row["delta_abs"] == "2.500000"
+    assert row["delta_pct"] == "50.00"
+    assert row["source"] == "trustedparts"
+
+
+def test_currency_mismatch_returns_null_delta_with_reason():
+    client = _authed_client()
+    _configure_sourcing(client)
+    _stocked_part(client, name="Reg", mpn="REG-3V3", currency="USD")
+    _FakeTrustedPartsClient.offers_by_mpn = {"REG-3V3": {"unit_price": 1.25, "currency": "EUR"}}
+
+    row = _report(client)["rows"][0]
+
+    assert row["replacement_currency"] == "EUR"
+    assert row["delta_abs"] is None
+    assert row["delta_pct"] is None
+    assert row["reason"] == "currency_mismatch"
+
+
+def test_part_without_offer_returns_null_replacement():
+    client = _authed_client()
+    _configure_sourcing(client)
+    _stocked_part(client, name="No offer", mpn="NO-OFFER")
+    _FakeTrustedPartsClient.offers_by_mpn = {"NO-OFFER": None}
+
+    row = _report(client)["rows"][0]
+
+    assert row["replacement_cost"] is None
+    assert row["delta_abs"] is None
+    assert row["reason"] == "no_offer"
+
+
+def test_no_persistent_price_history_table(engine):
+    inspector = inspect(engine)
+    schema_names = set(inspector.get_table_names())
+    for table_name in inspector.get_table_names():
+        schema_names.update(column["name"] for column in inspector.get_columns(table_name))
+    forbidden_fragments = {
+        "replenishment_cost",
+        "price_history",
+        "price_snapshot",
+        "trustedparts_price",
+    }
+
+    assert not any(fragment in name for name in schema_names for fragment in forbidden_fragments)
+
+
+def test_sort_by_delta_pct():
+    client = _authed_client()
+    _configure_sourcing(client)
+    _stocked_part(client, name="Low delta", mpn="LOW", unit_cost="1.00")
+    _stocked_part(client, name="High delta", mpn="HIGH", unit_cost="1.00")
+    _FakeTrustedPartsClient.offers_by_mpn = {
+        "LOW": {"unit_price": 1.10, "currency": "EUR"},
+        "HIGH": {"unit_price": 2.00, "currency": "EUR"},
+    }
+
+    rows = _report(client, "?sort=delta_pct")["rows"]
+
+    assert [row["mpn"] for row in rows] == ["HIGH", "LOW"]
+
+
+def test_workspace_isolation():
+    a = _authed_client("a-replenishment")
+    b = _authed_client("b-replenishment")
+    _configure_sourcing(a)
+    _configure_sourcing(b)
+    part_a = _stocked_part(a, name="A private", mpn="A-PRIVATE")
+    part_b = _stocked_part(b, name="B private", mpn="B-PRIVATE")
+    _FakeTrustedPartsClient.offers_by_mpn = {
+        "A-PRIVATE": {"unit_price": 1.00, "currency": "EUR"},
+        "B-PRIVATE": {"unit_price": 1.00, "currency": "EUR"},
+    }
+
+    rows_a = _report(a)["rows"]
+    rows_b = _report(b)["rows"]
+
+    assert [row["part_id"] for row in rows_a] == [part_a]
+    assert [row["part_id"] for row in rows_b] == [part_b]
+
+
+def test_not_configured_status_flag(monkeypatch):
+    client = _authed_client()
+    _stocked_part(client, name="No config", mpn="NO-CONFIG")
+    monkeypatch.setattr(
+        "app.domain.sourcing.service.make_sourcing_provider",
+        lambda _workspace: None,
+    )
+
+    data = _report(client)
+
+    assert data["sourcing_status"]["state"] == "not_configured"
+    assert data["rows"][0]["replacement_cost"] is None
+    assert data["rows"][0]["reason"] == "sourcing_not_configured"
+
+
+def test_cache_hit_within_4h(db):
+    client = _authed_client()
+    _configure_sourcing(client)
+    _stocked_part(client, name="Cached", mpn="CACHE-1")
+    _FakeTrustedPartsClient.offers_by_mpn = {"CACHE-1": {"unit_price": 0.75, "currency": "EUR"}}
+
+    first = _report(client)
+    second = _report(client)
+
+    assert first["sourcing_status"]["cache_hit"] is False
+    assert second["sourcing_status"]["cache_hit"] is True
+    assert len(_FakeTrustedPartsClient.calls) == 1
+    cache_row = db.execute(select(SourcingCache)).scalar_one()
+    assert int((cache_row.expires_at - cache_row.fetched_at).total_seconds()) == 4 * 60 * 60

--- a/docs/adr/0020-trustedparts-sourcing-provider-split.md
+++ b/docs/adr/0020-trustedparts-sourcing-provider-split.md
@@ -27,6 +27,10 @@ expired plan rows alongside cache rows (`backend/alembic/versions/0039_purchase_
 
 TrustedParts results must stay visibly distinct from catalog-provider data. Public or UI surfaces that combine distributor data from multiple origins need an explicit future decision before launch.
 
+## Reports policy: no persistent price history
+
+Reports may use TrustedParts prices only as a transient request-time input. The replenishment-cost report recomputes replacement cost from existing on-hand lot costs and the short-lived sourcing cache on each request (`backend/app/domain/reports/service.py:39`); it must not add a report-specific table, column, or long-lived price snapshot because that would turn cached TrustedParts offers into persistent price history.
+
 ## Consequences
 
 - **Good**:

--- a/docs/api/reports.md
+++ b/docs/api/reports.md
@@ -2,17 +2,24 @@
 
 Audience: engineer
 
-Read-only aggregate queries: low-stock parts, sourcing risk, BOM shortage at a planned build quantity, BOM buyability by project, stock value, and expiring lots.
+Read-only aggregate queries: low-stock parts, BOM shortage at a planned build
+quantity, BOM buyability by project, sourcing risk, stock value, replenishment
+cost, and expiring lots.
 
 ## Conventions
 
-See [API conventions](./README.md) for envelope, errors, pagination. Mounted at `/api/reports` (`backend/app/main.py:376`). All quantity reads funnel through `domain/stock/service.py::bulk_current_quantities` / `bulk_current_quantities_by_lot` so the SUM-of-delta invariant lives in one place (BE2-005, [ADR-0001](../adr/0001-append-only-stock-ledger.md)).
+See [API conventions](./README.md) for envelope, errors, pagination. Mounted at
+`/api/reports` (`backend/app/main.py:376`). All quantity reads funnel through
+`domain/stock/service.py::bulk_current_quantities` /
+`bulk_current_quantities_by_lot` so the SUM-of-delta invariant lives in one
+place (BE2-005, [ADR-0001](../adr/0001-append-only-stock-ledger.md)).
 
 ## Routes
 
 ### `GET /api/reports/low-stock`
 
-Live parts whose `available = on_hand - reserved` is below their `low_stock_report_quantity`. Parts without a threshold are skipped.
+Live parts whose `available = on_hand - reserved` is below their
+`low_stock_report_quantity`. Parts without a threshold are skipped.
 
 **Query**
 
@@ -20,7 +27,7 @@ Live parts whose `available = on_hand - reserved` is below their `low_stock_repo
 |---|---|---|---|
 | `include_sourcing` | boolean | no | Default `false`. When `true`, enriches rows from the workspace TrustedParts cache/search path with a 4-hour TTL and dashboard cache preference. |
 
-**Response** — `200 OK` — array sorted by `short_by DESC`:
+**Response** - `200 OK` - array sorted by `short_by DESC`:
 
 ```json
 { "data": [ {
@@ -30,34 +37,15 @@ Live parts whose `available = on_hand - reserved` is below their `low_stock_repo
 } ], "status": { ... } }
 ```
 
-With `include_sourcing=true`, `data` is an object:
-
-```json
-{ "data": {
-    "sourcing_status": "ok",
-    "rows": [ {
-      "part_id": "...", "short_by": 13,
-      "sourcing": {
-        "authorized_stock": 400,
-        "best_offer": { "distributor": "DigiKey", "moq": 1, "lead_time_days": 3 },
-        "est_replenishment_cost": "3.25",
-        "preferred_distributor_available": true
-      }
-    } ]
-}, "status": { ... } }
-```
-
-`sourcing_status` is one of `ok`, `not_configured`, `partial`, or `budget_blocked`. Sourcing failures do not change the HTTP status; the report still returns `200 OK` with low-stock rows and `sourcing: null` where enrichment was unavailable.
-
-**Notes**
-
-- Filters `archived_at IS NULL` (`backend/app/domain/reports/service.py:61-63`).
-- Source: `backend/app/api/routes/reports.py:26-34`.
-- Service: `backend/app/domain/reports/service.py:24-174`.
+With `include_sourcing=true`, `data` is an object with `rows`,
+`sourcing_status`, `powered_by`, and TrustedParts `links`. Sourcing failures do
+not change the HTTP status; the report still returns `200 OK` with low-stock
+rows and `sourcing: null` where enrichment was unavailable.
 
 ### `GET /api/reports/bom-shortage`
 
-Project-wide shortage analysis at a given build quantity. No build is created -- same engine as the Build detail page.
+Project-wide shortage analysis at a given build quantity. No build is created;
+same engine as the Build detail page.
 
 **Query**
 
@@ -66,7 +54,7 @@ Project-wide shortage analysis at a given build quantity. No build is created --
 | `project_id` | UUID | yes | |
 | `quantity` | int (>0) | no | Default `1`. |
 
-**Response** — `200 OK`
+**Response** - `200 OK`
 
 ```json
 { "data": {
@@ -76,17 +64,18 @@ Project-wide shortage analysis at a given build quantity. No build is created --
 }, "status": { ... } }
 ```
 
-`rows` is whatever `shortage_analysis` returns. TODO(verify): exact per-row shape (likely `{ project_entry_id, part_id, required, available, short_by, candidates? }`).
+`rows` is whatever `shortage_analysis` returns. TODO(verify): exact per-row
+shape (likely `{ project_entry_id, part_id, required, available, short_by,
+candidates? }`).
 
-**Errors** — `404 report.project_not_found`.
-
-**Notes**
-
-- Service: `backend/app/domain/builds/service.py::shortage_analysis`.
+**Errors** - `404 report.project_not_found`.
 
 ### `GET /api/reports/bom-buyability`
 
-Workspace-wide scoreboard of active projects at one build quantity. The report calls Source-BOM with TrustedParts cached mode enabled and degrades to stock-only rows when sourcing is not configured, budget-blocked, or temporarily unavailable.
+Workspace-wide scoreboard of active projects at one build quantity. The report
+calls Source-BOM with TrustedParts cached mode enabled and degrades to
+stock-only rows when sourcing is not configured, budget-blocked, or temporarily
+unavailable.
 
 **Query**
 
@@ -94,7 +83,7 @@ Workspace-wide scoreboard of active projects at one build quantity. The report c
 |---|---|---|---|
 | `build_quantity` | int (`>= 1`) | no | Default `1`. `0` or negative values return `422`. |
 
-**Response** — `200 OK`
+**Response** - `200 OK`
 
 ```json
 { "data": {
@@ -111,26 +100,24 @@ Workspace-wide scoreboard of active projects at one build quantity. The report c
 }, "status": { ... } }
 ```
 
-`sourcing_status` is `ok`, `not_configured`, `partial`, or `budget_blocked`. Workspaces with more than 50 active projects return the newest 50 and `truncated: true`.
-
-**Notes**
-
-- Route validates `build_quantity` and rate-limits per workspace.
-- Service filters projects by workspace and `archived_at IS NULL`, caps at 50, and forces cached sourcing.
-- Sourcing failures return `200 OK` with stock-only rows and a status flag.
+`sourcing_status` is `ok`, `not_configured`, `partial`, or `budget_blocked`.
+Workspaces with more than 50 active projects return the newest 50 and
+`truncated: true`.
 
 ### `GET /api/reports/sourcing-risk`
 
-Workspace-wide sourcing risk for active parts with an MPN. The route uses TrustedParts through the sourcing service with a 4-hour cache TTL, returns a top-level `sourcing_status`, and recomputes flags on each request.
+Workspace-wide sourcing risk for active parts with an MPN. The route uses
+TrustedParts through the sourcing service with a 4-hour cache TTL, returns a
+top-level `sourcing_status`, and recomputes flags on each request.
 
 **Query**
 
 | Field | Type | Notes |
-|---|---|
+|---|---|---|
 | `only_with_flags` | bool | Default `true`; when true, clean rows are omitted. |
 | `use_cached_data` | bool \| null | Default `null`; null uses cached TrustedParts data. |
 
-**Response** — `200 OK` (envelope: `{ data, status }`)
+**Response** - `200 OK` (envelope: `{ data, status }`)
 
 ```json
 { "data": {
@@ -139,7 +126,9 @@ Workspace-wide sourcing risk for active parts with an MPN. The route uses Truste
 }, "status": { ... } }
 ```
 
-`sourcing_status.state` is `ok`, `not_configured`, `budget_blocked`, or `upstream_error`. Non-`ok` states are reported in the payload so the report page can render a banner without violating the API envelope.
+`sourcing_status.state` is `ok`, `not_configured`, `budget_blocked`, or
+`upstream_error`. Non-`ok` states are reported in the payload so the report page
+can render a banner without violating the API envelope.
 
 **Risk flags**
 
@@ -152,56 +141,63 @@ Workspace-wide sourcing risk for active parts with an MPN. The route uses Truste
 | `preferred_distributor_unmet` | Workspace preferred distributors are configured, but none has stock. |
 | `price_delta` | Best replacement price is at least 25% above the latest historical lot purchase price in the same currency. |
 
-**Notes**
-
-- Stock quantities use `bulk_current_quantities`; no report query aggregates ledger rows directly.
-- Risk history is not persisted; there is no report table or migration for this feature.
-
 ### `GET /api/reports/stock-value`
 
-Sum of `lot.purchase_unit_cost * current_qty_in_lot` across all on-hand stock, broken down by currency and by part. Lots without a recorded purchase cost contribute `0`.
+Sum of `lot.purchase_unit_cost * current_qty_in_lot` across all on-hand stock,
+broken down by currency and by part. Lots without a recorded purchase cost
+contribute `0`.
 
-**Response** — `200 OK`
+### `GET /api/reports/replenishment-cost`
 
-```json
-{ "data": {
-    "by_currency": [ { "currency": "USD", "value": 12345.6789 } ],
-    "by_part":     [ { "part_id": "...", "name": "...", "on_hand": 100, "value": 42.0, "currency": "USD" } ]
-}, "status": { ... } }
-```
-
-A part with lots in multiple currencies has `currency: "MIXED"`.
-
-**Notes**
-
-- Sorted: `by_currency` by currency code, `by_part` by `value DESC`.
-
-### `GET /api/reports/expiring-lots`
-
-Lots that have on-hand quantity > 0 and an `expiration_date` within the next `days` days (or already past).
+Transient replacement-cost view for each on-hand part with an MPN. Historical
+cost comes from current on-hand lot quantities and `lot.purchase_unit_cost`;
+replacement cost comes from the best current TrustedParts offer. TrustedParts
+prices are recomputed through the sourcing cache on each request and are not
+stored in a report table.
 
 **Query**
 
 | Field | Type | Notes |
-|---|---|
-| `days` | int | Default `90`, `0 <= days <= 3650`. |
+|---|---|---|
+| `sort` | `delta_pct \| delta_abs \| name` | Default `delta_pct`. |
+| `use_cached_data` | bool | Optional TrustedParts dashboard-cache preference override. |
 
-**Response** — `200 OK` — array sorted by `expiration_date ASC`:
+**Response** - `200 OK`
 
 ```json
-{ "data": [ {
-    "lot_id": "...", "name": "...",
-    "part_id": "...", "part_name": "...",
-    "on_hand": 25,
-    "expiration_date": "2026-07-01",
-    "days_until_expiry": 60,
-    "expired": false
-} ], "status": { ... } }
+{ "data": {
+    "rows": [ {
+      "part_id": "...", "name": "...", "mpn": "STM32F103C8T6",
+      "on_hand": 10,
+      "historical_costs": [ { "currency": "EUR", "value": "5.000000" } ],
+      "replacement_cost": "7.50",
+      "delta_abs": "2.500000",
+      "delta_pct": "50.00",
+      "reason": null,
+      "source": "trustedparts"
+    } ],
+    "totals": [ { "currency": "EUR", "historical_cost": "5.000000", "replacement_cost": "7.50", "delta_abs": "2.500000" } ],
+    "sourcing_status": { "state": "ok", "powered_by": "TrustedParts" }
+}, "status": { ... } }
 ```
 
-**Notes**
+`reason` is `currency_mismatch` when the TrustedParts offer currency does not
+match any historical lot currency for the part. Sourcing configuration, budget,
+auth, rate-limit, timeout, and upstream failures return `200 OK` with
+`sourcing_status.state` set and row replacement fields left null.
 
-- `expired: true` when `days_until_expiry < 0`.
+### `GET /api/reports/expiring-lots`
+
+Lots that have on-hand quantity > 0 and an `expiration_date` within the next
+`days` days (or already past).
+
+**Query**
+
+| Field | Type | Notes |
+|---|---|---|
+| `days` | int | Default `90`, `0 <= days <= 3650`. |
+
+**Response** - `200 OK` - array sorted by `expiration_date ASC`.
 
 ## TODOs
 

--- a/docs/frontend/README.md
+++ b/docs/frontend/README.md
@@ -23,7 +23,7 @@ What you need to navigate `web/src/`. Conventions are sketched in [`CLAUDE.md`](
 | [components](components.md) | DataTable + reusable component catalog |
 | [parts](parts.md) | Part-detail flows that span tabs and modals |
 | [projects](projects.md) | Project-detail flows, including Source BOM |
-| [reports](reports.md) | Report routes, including BOM buyability |
+| [reports](reports.md) | Report routes, including BOM buyability and replenishment cost |
 | [tailwind-utilities](tailwind-utilities.md) | The `index.css` utility set (`btn`, `card`, `pill`, …) |
 | [auth-flow](auth-flow.md) | `AuthProvider`, workspace switch, 401 redirect bus |
 | [scanner](scanner.md) | ZXing / Scandit dual-mode + `bagCode.ts` parser |

--- a/docs/frontend/reports.md
+++ b/docs/frontend/reports.md
@@ -2,7 +2,7 @@
 
 Audience: engineer
 
-Frontend report routes and their data-fetching conventions.
+React routes under `/reports` for inventory aggregate views.
 
 ## Routes
 
@@ -10,6 +10,7 @@ Frontend report routes and their data-fetching conventions.
 |---|---|---|
 | `/reports` | `web/src/routes/reports/Reports.tsx` | `GET /api/reports/low-stock` |
 | `/reports/buyability` | `web/src/routes/reports/BomBuyabilityReport.tsx` | `GET /api/reports/bom-buyability` |
+| `/reports/replenishment-cost` | `web/src/routes/reports/ReplenishmentCostReport.tsx` | `GET /api/reports/replenishment-cost` |
 | `/reports/sourcing-risk` | `web/src/routes/reports/SourcingRiskReport.tsx` | `GET /api/reports/sourcing-risk` |
 
 ## Low-Stock Sourcing
@@ -36,14 +37,32 @@ Rows link to each project's Source-BOM deep dive at
 `/projects/:projectId/sourcing`. The reports tab and app route are registered in
 `web/src/routes/reports/Reports.tsx` and `web/src/App.tsx`.
 
+## Replenishment Cost
+
+`/reports/replenishment-cost` renders `ReplenishmentCostReport`, a TanStack
+Query page keyed by workspace and sort mode. It calls
+`GET /api/reports/replenishment-cost`, shows the TrustedParts attribution badge,
+renders sourcing status as an inline banner, and leaves rows visible when
+replacement pricing is unavailable.
+
+The table uses `DataTable` with columns for part, MPN, on-hand quantity,
+historical cost, replacement cost, absolute delta, percent delta, reason, and
+source. Historical costs can contain more than one currency; the cell joins
+those amounts without FX conversion.
+
 ## Sourcing Risk
 
 The sourcing-risk page uses TanStack Query with
 `useWsKey("report", "sourcing-risk", onlyWithFlags)`, renders the shared
 `DataTable`, and keeps the default list sorted by flag count before handing rows
-to the table. The page uses `PoweredByTrustedParts` and
-`SourcingSourceLabel` for TrustedParts attribution.
+to the table. The page uses `PoweredByTrustedParts` and `SourcingSourceLabel`
+for TrustedParts attribution.
 
 The page renders a status banner from `data.sourcing_status` instead of relying
 on thrown API errors for normal provider states. The "Show only flagged"
 checkbox maps directly to the API `only_with_flags` query parameter.
+
+## Routing
+
+Sourcing-specific report pages are lazy-loaded from `web/src/App.tsx` and linked
+from the shared reports nav in `web/src/routes/reports/Reports.tsx`.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -96,6 +96,7 @@ const ExpiringLotsReport = lazy(() =>
   import("@/routes/reports/Reports").then(m => ({ default: m.ExpiringLotsReport }))
 );
 const SourcingRiskReport = lazy(() => import("@/routes/reports/SourcingRiskReport"));
+const ReplenishmentCostReport = lazy(() => import("@/routes/reports/ReplenishmentCostReport"));
 
 const ProjectsList = lazy(() => import("@/routes/projects/ProjectsList"));
 const ProjectCreate = lazy(() => import("@/routes/projects/ProjectCreate"));
@@ -270,6 +271,7 @@ export default function App() {
             <Route path="/reports" element={<LazyRoute><ReportsLayout /></LazyRoute>}>
               <Route index element={<LazyRoute><LowStockReport /></LazyRoute>} />
               <Route path="value" element={<LazyRoute><StockValueReport /></LazyRoute>} />
+              <Route path="replenishment-cost" element={<LazyRoute><ReplenishmentCostReport /></LazyRoute>} />
               <Route path="bom" element={<LazyRoute><BomShortageReport /></LazyRoute>} />
               <Route path="buyability" element={<LazyRoute><BomBuyabilityReport /></LazyRoute>} />
               <Route path="expiring" element={<LazyRoute><ExpiringLotsReport /></LazyRoute>} />

--- a/web/src/routes/reports/ReplenishmentCostReport.tsx
+++ b/web/src/routes/reports/ReplenishmentCostReport.tsx
@@ -1,0 +1,246 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { BarChart3 } from "lucide-react";
+import { PoweredByTrustedParts } from "@/components/PoweredByTrustedParts";
+import { SourcingSourceLabel } from "@/components/SourcingSourceLabel";
+import { DataTable } from "@/components/DataTable";
+import EmptyState from "@/components/EmptyState";
+import { api, ApiError } from "@/lib/api";
+import { formatDateTime, formatMoney } from "@/lib/format";
+import { useWsKey } from "@/lib/queryKeys";
+
+type SortMode = "delta_pct" | "delta_abs" | "name";
+
+type CurrencyAmount = {
+  currency: string | null;
+  value: string;
+};
+
+type ReplenishmentCostRow = {
+  part_id: string;
+  name: string;
+  manufacturer: string | null;
+  mpn: string;
+  on_hand: number;
+  currency: string | null;
+  historical_costs: CurrencyAmount[];
+  historical_cost: string | null;
+  replacement_unit_price: string | null;
+  replacement_cost: string | null;
+  replacement_currency: string | null;
+  delta_abs: string | null;
+  delta_pct: string | null;
+  reason: "no_offer" | "currency_mismatch" | "sourcing_not_configured" | "sourcing_unavailable" | null;
+  source: "trustedparts" | null;
+};
+
+type ReplenishmentCostReport = {
+  rows: ReplenishmentCostRow[];
+  totals: {
+    currency: string | null;
+    historical_cost: string;
+    replacement_cost: string;
+    delta_abs: string | null;
+  }[];
+  sourcing_status: {
+    state: "ok" | "not_configured" | "degraded" | "error";
+    message: string | null;
+    fetched_at: string | null;
+    cache_hit: boolean | null;
+    partial: boolean;
+    powered_by: "TrustedParts";
+    links: { primary: string; attribution: string } | null;
+  };
+};
+
+const SORT_OPTIONS: { value: SortMode; label: string }[] = [
+  { value: "delta_pct", label: "Delta % desc" },
+  { value: "delta_abs", label: "Delta desc" },
+  { value: "name", label: "Name asc" },
+];
+
+function moneyValue(value: string | null, currency: string | null | undefined): string {
+  if (value == null) return "-";
+  return formatMoney(Number(value), currency);
+}
+
+function percentValue(value: string | null): string {
+  if (value == null) return "-";
+  return `${Number(value).toFixed(2)}%`;
+}
+
+function reasonLabel(reason: ReplenishmentCostRow["reason"]): string {
+  switch (reason) {
+    case "currency_mismatch":
+      return "Currency mismatch";
+    case "no_offer":
+      return "No offer";
+    case "sourcing_not_configured":
+      return "Not configured";
+    case "sourcing_unavailable":
+      return "Sourcing unavailable";
+    default:
+      return "";
+  }
+}
+
+function historicalSummary(row: ReplenishmentCostRow): string {
+  if (row.historical_costs.length === 0) return "-";
+  return row.historical_costs
+    .map(item => moneyValue(item.value, item.currency))
+    .join(" / ");
+}
+
+function StatusBanner({ report }: { report: ReplenishmentCostReport }) {
+  const status = report.sourcing_status;
+  const primaryUrl = status.links?.primary;
+  if (status.state === "ok") {
+    return (
+      <div className="flex flex-wrap items-center gap-2 text-xs text-muted">
+        <PoweredByTrustedParts primaryUrl={primaryUrl ?? undefined} />
+        <span>{status.cache_hit ? "Served from cache" : "Fresh pricing"}</span>
+        {status.fetched_at && <span>{formatDateTime(status.fetched_at)}</span>}
+      </div>
+    );
+  }
+
+  const tone = status.state === "not_configured" ? "border-warning/40 text-warning" : "border-danger/40 text-danger";
+  return (
+    <div className={`border rounded-md px-3 py-2 text-sm flex flex-wrap items-center gap-2 ${tone}`}>
+      <PoweredByTrustedParts primaryUrl={primaryUrl ?? undefined} />
+      <span>{status.message ?? "TrustedParts sourcing unavailable"}</span>
+    </div>
+  );
+}
+
+export default function ReplenishmentCostReport() {
+  const [sort, setSort] = useState<SortMode>("delta_pct");
+  const { data, isError, isLoading, error } = useQuery({
+    queryKey: useWsKey("report", "replenishment-cost", sort),
+    queryFn: () => api.get<ReplenishmentCostReport>(`/reports/replenishment-cost?sort=${sort}`),
+  });
+
+  if (isError) {
+    return (
+      <div className="text-red-600 text-sm p-4">
+        Failed to load replenishment cost report. {error instanceof ApiError ? error.userMessage : ""}
+      </div>
+    );
+  }
+  if (isLoading) return <div className="text-muted">Loading...</div>;
+  if (!data) return null;
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <StatusBanner report={data} />
+        <div className="w-full sm:w-56">
+          <label className="label" htmlFor="report-replenishment-sort">Sort</label>
+          <select
+            id="report-replenishment-sort"
+            className="input"
+            value={sort}
+            onChange={event => setSort(event.target.value as SortMode)}
+          >
+            {SORT_OPTIONS.map(option => (
+              <option key={option.value} value={option.value}>{option.label}</option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <DataTable
+        rows={data.rows}
+        rowKey={row => row.part_id}
+        tableId="report-replenishment-cost"
+        empty={
+          <EmptyState
+            icon={BarChart3}
+            title="No data"
+            description="No on-hand MPN-tagged stock is available for replenishment pricing."
+          />
+        }
+        exportFilename="replenishment-cost"
+        columns={[
+          {
+            key: "name",
+            header: "Part",
+            accessor: row => row.name,
+            render: row => <Link className="text-accent" to={`/parts/${row.part_id}/info`}>{row.name}</Link>,
+          },
+          { key: "mpn", header: "MPN", accessor: row => row.mpn },
+          { key: "on_hand", header: "On hand", accessor: row => row.on_hand, width: "90px" },
+          { key: "currency", header: "Currency", accessor: row => row.currency ?? "-", width: "100px" },
+          {
+            key: "historical_cost",
+            header: "Historical cost",
+            accessor: row => row.historical_cost ?? historicalSummary(row),
+            render: row => <span className="tabular-nums">{historicalSummary(row)}</span>,
+          },
+          {
+            key: "replacement_cost",
+            header: "Replacement cost",
+            accessor: row => row.replacement_cost ?? "",
+            render: row => <span className="tabular-nums">{moneyValue(row.replacement_cost, row.replacement_currency)}</span>,
+          },
+          {
+            key: "delta_abs",
+            header: "Delta",
+            accessor: row => row.delta_abs ?? "",
+            render: row => (
+              <span className={`tabular-nums ${Number(row.delta_abs ?? 0) > 0 ? "text-warning" : ""}`}>
+                {moneyValue(row.delta_abs, row.replacement_currency)}
+              </span>
+            ),
+          },
+          {
+            key: "delta_pct",
+            header: "Delta %",
+            accessor: row => row.delta_pct ?? "",
+            width: "100px",
+            render: row => <span className="tabular-nums">{percentValue(row.delta_pct)}</span>,
+          },
+          {
+            key: "reason",
+            header: "Reason",
+            accessor: row => reasonLabel(row.reason),
+            render: row => row.reason ? <span className="pill bg-panel2 text-muted">{reasonLabel(row.reason)}</span> : <span className="text-muted">-</span>,
+          },
+          {
+            key: "source",
+            header: "Source",
+            accessor: row => row.source ?? "",
+            width: "110px",
+            render: row => row.source === "trustedparts" ? <SourcingSourceLabel source="trustedparts" /> : <span className="text-muted">-</span>,
+          },
+        ]}
+      />
+
+      {data.totals.length > 0 && (
+        <div className="overflow-x-auto">
+          <table className="table">
+            <thead>
+              <tr>
+                <th>Currency</th>
+                <th>Historical cost</th>
+                <th>Replacement cost</th>
+                <th>Delta</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.totals.map(total => (
+                <tr key={total.currency ?? "none"}>
+                  <td>{total.currency ?? <span className="text-muted">-</span>}</td>
+                  <td className="tabular-nums">{moneyValue(total.historical_cost, total.currency)}</td>
+                  <td className="tabular-nums">{moneyValue(total.replacement_cost, total.currency)}</td>
+                  <td className="tabular-nums">{moneyValue(total.delta_abs, total.currency)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/routes/reports/Reports.tsx
+++ b/web/src/routes/reports/Reports.tsx
@@ -177,6 +177,7 @@ export default function ReportsLayout() {
       <div className="flex items-center gap-1">
         <NavLink end to="/reports" className={({ isActive }) => "btn " + (isActive ? "border-accent/50 text-accent" : "")}>Low stock</NavLink>
         <NavLink to="/reports/value" className={({ isActive }) => "btn " + (isActive ? "border-accent/50 text-accent" : "")}>Stock value</NavLink>
+        <NavLink to="/reports/replenishment-cost" className={({ isActive }) => "btn " + (isActive ? "border-accent/50 text-accent" : "")}>Replenishment cost</NavLink>
         <NavLink to="/reports/bom" className={({ isActive }) => "btn " + (isActive ? "border-accent/50 text-accent" : "")}>BOM shortage</NavLink>
         <NavLink to="/reports/buyability" className={({ isActive }) => "btn " + (isActive ? "border-accent/50 text-accent" : "")}>BOM buyability</NavLink>
         <NavLink to="/reports/expiring" className={({ isActive }) => "btn " + (isActive ? "border-accent/50 text-accent" : "")}>Expiring lots</NavLink>

--- a/web/src/routes/reports/__tests__/ReplenishmentCostReport.test.tsx
+++ b/web/src/routes/reports/__tests__/ReplenishmentCostReport.test.tsx
@@ -1,0 +1,131 @@
+// @vitest-environment jsdom
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { api } from "@/lib/api";
+import ReplenishmentCostReport from "../ReplenishmentCostReport";
+
+vi.mock("@/lib/auth", () => ({
+  useAuth: () => ({ workspaceId: "ws-1" }),
+}));
+
+function reportResponse(overrides: Record<string, unknown> = {}) {
+  return {
+    rows: [
+      {
+        part_id: "part-1",
+        name: "Capacitor",
+        manufacturer: "Murata",
+        mpn: "CAP-10UF",
+        on_hand: 10,
+        currency: "EUR",
+        historical_costs: [{ currency: "EUR", value: "5.000000" }],
+        historical_cost: "5.000000",
+        replacement_unit_price: "0.75",
+        replacement_cost: "7.50",
+        replacement_currency: "EUR",
+        delta_abs: "2.500000",
+        delta_pct: "50.00",
+        reason: null,
+        source: "trustedparts" as const,
+      },
+      {
+        part_id: "part-2",
+        name: "Regulator",
+        manufacturer: "TI",
+        mpn: "REG-3V3",
+        on_hand: 8,
+        currency: "EUR",
+        historical_costs: [{ currency: "USD", value: "4.000000" }],
+        historical_cost: null,
+        replacement_unit_price: "1.00",
+        replacement_cost: "8.00",
+        replacement_currency: "EUR",
+        delta_abs: null,
+        delta_pct: null,
+        reason: "currency_mismatch" as const,
+        source: "trustedparts" as const,
+      },
+    ],
+    totals: [
+      {
+        currency: "EUR",
+        historical_cost: "5.000000",
+        replacement_cost: "15.50",
+        delta_abs: "10.500000",
+      },
+    ],
+    sourcing_status: {
+      state: "ok",
+      message: null,
+      fetched_at: "2026-05-08T12:00:00+00:00",
+      cache_hit: false,
+      partial: false,
+      powered_by: "TrustedParts" as const,
+      links: {
+        primary: "https://www.trustedparts.com/",
+        attribution: "https://www.trustedparts.com/en/about",
+      },
+    },
+    ...overrides,
+  };
+}
+
+function renderReport() {
+  const client = new QueryClient({
+    defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+  });
+  render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <ReplenishmentCostReport />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  cleanup();
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe("ReplenishmentCostReport", () => {
+  it("renders rows", async () => {
+    vi.spyOn(api, "get").mockResolvedValue(reportResponse());
+
+    renderReport();
+
+    expect(await screen.findByText("Capacitor")).toBeDefined();
+    expect(screen.getByText("CAP-10UF")).toBeDefined();
+    expect(screen.getByText("Powered by TrustedParts")).toBeDefined();
+    expect(screen.getAllByText("TrustedParts").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("EUR").length).toBeGreaterThan(0);
+  });
+
+  it("currency mismatch row shows reason chip", async () => {
+    vi.spyOn(api, "get").mockResolvedValue(reportResponse());
+
+    renderReport();
+
+    const row = await screen.findByText("Regulator");
+    const tableRow = row.closest("tr");
+    expect(tableRow).not.toBeNull();
+    expect(within(tableRow as HTMLTableRowElement).getByText("Currency mismatch")).toBeDefined();
+  });
+
+  it("sort dropdown rerenders", async () => {
+    const getSpy = vi.spyOn(api, "get").mockResolvedValue(reportResponse());
+    const user = userEvent.setup();
+
+    renderReport();
+    await screen.findByText("Capacitor");
+    await user.selectOptions(screen.getByLabelText("Sort"), "name");
+
+    expect(await screen.findByText("Name asc")).toBeDefined();
+    expect(getSpy).toHaveBeenCalledWith("/reports/replenishment-cost?sort=delta_pct");
+    expect(getSpy).toHaveBeenCalledWith("/reports/replenishment-cost?sort=name");
+  });
+});


### PR DESCRIPTION
## Summary
- Added transient `GET /api/reports/replenishment-cost` with a reports-domain service/schema, workspace-scoped stock aggregation via stock helpers, 4-hour sourcing cache TTL, Decimal cost math, currency mismatch reasons, and graceful sourcing status instead of sourcing 409/503 responses.
- Added the Replenishment Cost report UI, route, sort control, TrustedParts attribution/source labels, status banner, totals table, and Vitest coverage.
- Documented the API/frontend behavior and added ADR-0020 section `Reports policy: no persistent price history`.

## Validation
- `docker compose -f docker-compose.dev.yml exec backend pytest -k replenishment_cost_report` not run: Docker is unavailable in this environment (`docker: command not found`).
- `cd backend && uv sync --frozen --extra dev`
- `cd backend && uv run python -m pytest -q -k replenishment_cost_report` -> `8 passed, 884 deselected, 1 warning`
- `cd backend && uv run ruff check app/domain/reports tests/test_replenishment_cost_report.py` -> `All checks passed!`
- `cd backend && uv run ruff check --select I,F401,F821 app/api/routes/reports.py` -> `All checks passed!`
- `cd web && npm install` -> completed with Node 18 engine warnings for transitive packages and existing `npm audit` moderate findings
- `cd web && npm run typecheck` -> passed
- `cd web && npm test -- ReplenishmentCostReport` -> `1 passed (1), 3 passed (3)`
- `cd web && npx eslint src/routes/reports/ReplenishmentCostReport.tsx src/routes/reports/__tests__/ReplenishmentCostReport.test.tsx` -> passed
- `git -C /mnt/data/WORK/stockManager-1/.codex/worktrees/tp-507-382 diff --check` -> passed

## No persistent history confirmation
No migration, table, or column was added for TrustedParts-derived replenishment/price history. The integration assertion is:

```python
assert not any(
    fragment in name
    for name in schema_names
    for fragment in forbidden_fragments
)
```

## ADR section
ADR-0020 now includes `Reports policy: no persistent price history`, documenting that replenishment-cost prices are recomputed from existing lot costs plus the short-lived sourcing cache on each request: `docs/adr/0020-trustedparts-sourcing-provider-split.md`.

## Deviations / CI risk
- Full `cd backend && uv run ruff check` is still blocked by existing repository lint baseline violations outside this PR; scoped Ruff checks for new/touched report code pass.
- Full `cd web && npm run lint` is still blocked by existing repository ESLint issues outside this PR (`bagCode.ts`, scanner/order/parts/storage warnings); scoped ESLint for the new report UI/tests passes.
- Separate workspace-isolation checker agent was not available in this environment; workspace isolation is pinned by `test_workspace_isolation` in `backend/tests/test_replenishment_cost_report.py`.

Refs #382
