### PR TITLE
BOM-001: Opt-in auto-create missing parts on BOM import

### DIFF
--- a/backend/app/api/routes/projects.py
+++ b/backend/app/api/routes/projects.py
@@ -256,7 +256,7 @@ def del_entry(project_id: UUID, entry_id: UUID, db: DbSession, ws: CurrentWorksp
 @router.post("/{project_id}/bom/preview")
 def preview_bom(project_id: UUID, payload: BomImportPreviewIn, db: DbSession, ws: CurrentWorkspace):
     _get(db, ws.id, project_id)
-    return ok(bom.preview(payload).model_dump())
+    return ok(bom.preview(payload, db=db, workspace_id=ws.id).model_dump())
 
 
 @router.post("/{project_id}/bom/import")

--- a/backend/app/domain/projects/bom_import.py
+++ b/backend/app/domain/projects/bom_import.py
@@ -5,12 +5,12 @@ import base64
 import csv
 import io
 from dataclasses import dataclass
-from typing import Iterable
 from uuid import UUID
 
 import chardet
 from fastapi import status
-from sqlalchemy import and_, func, select
+from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.core.errors import ErrorCodes, raise_http
@@ -96,7 +96,16 @@ def _looks_numeric(s: str) -> bool:
         return False
 
 
-def preview(payload: BomImportPreviewIn) -> BomImportPreviewOut:
+class _SkipRow(Exception):
+    """Auto-create cannot materialise a usable Part from this row."""
+
+
+def preview(
+    payload: BomImportPreviewIn,
+    db: Session | None = None,
+    *,
+    workspace_id: UUID | None = None,
+) -> BomImportPreviewOut:
     raw = _decode_b64(payload.text_b64)
     enc = _detect_encoding(raw, payload.encoding)
     text = raw.decode(enc, errors="replace")
@@ -112,15 +121,27 @@ def preview(payload: BomImportPreviewIn) -> BomImportPreviewOut:
             headers=None,
             rows=[],
         )
-    has_header = payload.has_header if payload.has_header is not None else _looks_like_header(all_rows[0])
+    has_header = (
+        payload.has_header
+        if payload.has_header is not None
+        else _looks_like_header(all_rows[0])
+    )
     headers = all_rows[0] if has_header else None
     body = all_rows[1:] if has_header else all_rows
+    would_auto_create_count, would_skip_count = _preview_auto_create_counts(
+        payload,
+        body,
+        db=db,
+        workspace_id=workspace_id,
+    )
     return BomImportPreviewOut(
         detected_separator=sep,
         detected_encoding=enc,
         has_header=has_header,
         headers=headers,
         rows=[BomPreviewRow(cells=r) for r in body[:200]],
+        would_auto_create_count=would_auto_create_count,
+        would_skip_count=would_skip_count,
     )
 
 
@@ -172,7 +193,11 @@ def _split_designators(value: str, sep: str) -> list[str]:
     return [p for p in parts if p]
 
 
-def _apply_mapping(cells: list[str], mapping: list[BomMappingField], designator_sep: str) -> ParsedRow:
+def _apply_mapping(
+    cells: list[str],
+    mapping: list[BomMappingField],
+    designator_sep: str,
+) -> ParsedRow:
     out = ParsedRow()
     for m in mapping:
         idx = m.column_index
@@ -211,7 +236,10 @@ def _apply_mapping(cells: list[str], mapping: list[BomMappingField], designator_
 
 
 def _match_part(db: Session, *, workspace_id: UUID, row: ParsedRow) -> Part | None:
-    """Spec §16.3 match priority — never auto-create."""
+    """Spec §16.3 match priority — never auto-create.
+
+    Auto-create lives in commit() under the auto_create_missing_parts flag (BOM-001).
+    """
     # 1. internal ID code → we treat the part `id` UUID as the ID code if present.
     if row.id_code:
         try:
@@ -254,12 +282,116 @@ def _match_part(db: Session, *, workspace_id: UUID, row: ParsedRow) -> Part | No
     # 5. exact local name
     if row.part:
         p = db.execute(
-            select(Part).where(Part.workspace_id == workspace_id).where(Part.name == row.part).limit(1)
+            select(Part)
+            .where(Part.workspace_id == workspace_id)
+            .where(Part.name == row.part)
+            .limit(1)
         ).scalars().first()
         if p:
             return p
     # 6. meta-part candidate — out of MVP
     return None
+
+
+def _clean(value: str | None) -> str | None:
+    value = (value or "").strip()
+    return value or None
+
+
+def _auto_create_values(row: ParsedRow) -> dict[str, str | None]:
+    mpn = _clean(row.mpn)
+    name = _clean(row.part) or mpn
+    if not name and not mpn:
+        raise _SkipRow
+    return {
+        "name": name,
+        "mpn": mpn,
+        "manufacturer": _clean(row.manufacturer),
+        "internal_part_number": _clean(row.internal_part_number),
+    }
+
+
+def _auto_create_part(
+    db: Session,
+    *,
+    workspace_id: UUID,
+    user_id: UUID | None,
+    row: ParsedRow,
+) -> Part:
+    values = _auto_create_values(row)
+    part = Part(
+        workspace_id=workspace_id,
+        part_type="local",
+        name=values["name"],
+        mpn=values["mpn"],
+        manufacturer=values["manufacturer"],
+        internal_part_number=values["internal_part_number"],
+        description=None,
+        linked_provider="none",
+        default_storage_location_id=None,
+        created_by=user_id,
+        updated_by=user_id,
+    )
+    db.add(part)
+    db.flush()
+    return part
+
+
+@dataclass
+class _PreviewCreatedKeys:
+    internal_part_numbers: set[str]
+    mpns: set[str]
+    names: set[str]
+
+
+def _preview_row_matches_created(row: ParsedRow, created: _PreviewCreatedKeys) -> bool:
+    if row.internal_part_number and row.internal_part_number in created.internal_part_numbers:
+        return True
+    if row.mpn and row.mpn in created.mpns:
+        return True
+    return bool(row.part and row.part in created.names)
+
+
+def _remember_preview_created(row: ParsedRow, created: _PreviewCreatedKeys) -> None:
+    values = _auto_create_values(row)
+    if values["internal_part_number"]:
+        created.internal_part_numbers.add(values["internal_part_number"])
+    if values["mpn"]:
+        created.mpns.add(values["mpn"])
+    if values["name"]:
+        created.names.add(values["name"])
+
+
+def _preview_auto_create_counts(
+    payload: BomImportPreviewIn,
+    rows: list[list[str]],
+    *,
+    db: Session | None,
+    workspace_id: UUID | None,
+) -> tuple[int, int]:
+    if not payload.auto_create_missing_parts or not payload.mapping:
+        return 0, 0
+
+    would_auto_create = 0
+    would_skip = 0
+    created = _PreviewCreatedKeys(internal_part_numbers=set(), mpns=set(), names=set())
+    for cells in rows:
+        parsed = _apply_mapping(cells, payload.mapping, payload.designator_separator)
+        if _preview_row_matches_created(parsed, created):
+            continue
+        if (
+            db is not None
+            and workspace_id is not None
+            and _match_part(db, workspace_id=workspace_id, row=parsed)
+        ):
+            continue
+        try:
+            _remember_preview_created(parsed, created)
+        except _SkipRow:
+            would_skip += 1
+            continue
+        would_auto_create += 1
+    return would_auto_create, would_skip
 
 
 def commit(
@@ -304,38 +436,67 @@ def commit(
             fractional_rows=fractional_rows,
         )
 
-    inserted = matched = unmatched = 0
-    for parsed in parsed_rows:
-        if parsed.designators is None:
-            parsed.designators = []
-        # quantity default from designator count if not set
-        if parsed.quantity == 1 and parsed.designators:
-            parsed.quantity = len(parsed.designators)
-        candidate = _match_part(db, workspace_id=workspace_id, row=parsed)
-        entry_type = "part" if candidate else "unmatched"
-        entry = ProjectEntry(
-            workspace_id=workspace_id,
-            project_id=project.id,
-            entry_type=entry_type,
-            part_id=candidate.id if candidate else None,
-            name=parsed.part or (candidate.name if candidate else parsed.mpn) or "",
-            quantity=parsed.quantity,
-            comments=parsed.comments,
-            designators=parsed.designators,
-            cad_footprint=parsed.footprint,
-            cad_key=parsed.cad_key,
-            dnp=parsed.dnp,
-            order_index=next_idx,
-            created_by=user_id,
-            updated_by=user_id,
-        )
-        db.add(entry)
-        next_idx += 1
-        inserted += 1
-        if candidate:
-            matched += 1
-        else:
-            unmatched += 1
-    db.flush()
-    return BomImportCommitOut(inserted=inserted, matched=matched, unmatched=unmatched)
+    inserted = matched = unmatched = auto_created = skipped = 0
+    try:
+        for parsed in parsed_rows:
+            if parsed.designators is None:
+                parsed.designators = []
+            # quantity default from designator count if not set
+            if parsed.quantity == 1 and parsed.designators:
+                parsed.quantity = len(parsed.designators)
+            candidate = _match_part(db, workspace_id=workspace_id, row=parsed)
+            created_for_row = False
+            if candidate is None and payload.auto_create_missing_parts:
+                try:
+                    candidate = _auto_create_part(
+                        db,
+                        workspace_id=workspace_id,
+                        user_id=user_id,
+                        row=parsed,
+                    )
+                except _SkipRow:
+                    skipped += 1
+                    continue
+                created_for_row = True
+                auto_created += 1
 
+            entry_type = "part" if candidate else "unmatched"
+            entry = ProjectEntry(
+                workspace_id=workspace_id,
+                project_id=project.id,
+                entry_type=entry_type,
+                part_id=candidate.id if candidate else None,
+                name=parsed.part or (candidate.name if candidate else parsed.mpn) or "",
+                quantity=parsed.quantity,
+                comments=parsed.comments,
+                designators=parsed.designators,
+                cad_footprint=parsed.footprint,
+                cad_key=parsed.cad_key,
+                dnp=parsed.dnp,
+                order_index=next_idx,
+                created_by=user_id,
+                updated_by=user_id,
+            )
+            db.add(entry)
+            next_idx += 1
+            inserted += 1
+            if created_for_row:
+                continue
+            if candidate:
+                matched += 1
+            else:
+                unmatched += 1
+        db.flush()
+    except IntegrityError:
+        raise_http(
+            status.HTTP_409_CONFLICT,
+            "part.mpn_conflict",
+            "MPN already used by another part",
+        )
+    return BomImportCommitOut(
+        inserted=inserted,
+        matched=matched,
+        unmatched=unmatched,
+        auto_created=auto_created,
+        skipped=skipped,
+    )

--- a/backend/app/domain/projects/bom_import.py
+++ b/backend/app/domain/projects/bom_import.py
@@ -327,7 +327,7 @@ def _auto_create_part(
         manufacturer=values["manufacturer"],
         internal_part_number=values["internal_part_number"],
         description=None,
-        linked_provider="none",
+        linked_provider=None,
         default_storage_location_id=None,
         created_by=user_id,
         updated_by=user_id,

--- a/backend/app/domain/projects/schemas.py
+++ b/backend/app/domain/projects/schemas.py
@@ -67,23 +67,6 @@ class BomEntryPatch(BaseModel):
     dnp: bool | None = None
 
 
-class BomImportPreviewIn(BaseModel):
-    """Step 1: parse the upload, return preview rows + suggested separator."""
-    model_config = ConfigDict(extra="forbid")
-
-    # Cap base64 input at 6 MB (≈4.5 MB raw after decode). The importer
-    # asserts the decoded size separately at 4 MB so a payload that
-    # squeaks under this Field limit but decodes past the runtime cap
-    # still trips the post-decode 413 guard. The 6 MB / 4 MB pairing
-    # is deliberate: Field validation must allow a payload large enough
-    # for the runtime check to fire, otherwise the layered defence
-    # collapses to just the Pydantic 422. SEC2-007 / BE2-006.
-    text_b64: str = Field(..., max_length=6_000_000)
-    separator: str | None = None  # auto-detect if None
-    encoding: str | None = None
-    has_header: bool | None = None
-
-
 class BomMappingField(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -104,6 +87,26 @@ class BomMappingField(BaseModel):
     ]
 
 
+class BomImportPreviewIn(BaseModel):
+    """Step 1: parse the upload, return preview rows + suggested separator."""
+    model_config = ConfigDict(extra="forbid")
+
+    # Cap base64 input at 6 MB (≈4.5 MB raw after decode). The importer
+    # asserts the decoded size separately at 4 MB so a payload that
+    # squeaks under this Field limit but decodes past the runtime cap
+    # still trips the post-decode 413 guard. The 6 MB / 4 MB pairing
+    # is deliberate: Field validation must allow a payload large enough
+    # for the runtime check to fire, otherwise the layered defence
+    # collapses to just the Pydantic 422. SEC2-007 / BE2-006.
+    text_b64: str = Field(..., max_length=6_000_000)
+    separator: str | None = None  # auto-detect if None
+    encoding: str | None = None
+    has_header: bool | None = None
+    auto_create_missing_parts: bool = Field(default=False)
+    mapping: list[BomMappingField] | None = None
+    designator_separator: str = ","
+
+
 class BomImportCommitIn(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -114,6 +117,7 @@ class BomImportCommitIn(BaseModel):
     has_header: bool
     mapping: list[BomMappingField]
     designator_separator: str = ","
+    auto_create_missing_parts: bool = Field(default=False)
 
 
 class BomPreviewRow(BaseModel):
@@ -126,12 +130,16 @@ class BomImportPreviewOut(BaseModel):
     has_header: bool
     headers: list[str] | None
     rows: list[BomPreviewRow]
+    would_auto_create_count: int = 0
+    would_skip_count: int = 0
 
 
 class BomImportCommitOut(BaseModel):
     inserted: int
     matched: int
     unmatched: int
+    auto_created: int = 0
+    skipped: int = 0
 
 
 # BOM presets (#252 — lifted from app/api/routes/bom_presets.py)

--- a/backend/tests/test_bom_import_auto_create.py
+++ b/backend/tests/test_bom_import_auto_create.py
@@ -109,7 +109,7 @@ def test_auto_create_with_mpn(db):
     part = _parts(db, ws)[0]
     assert part.name == "NEW-MPN"
     assert part.mpn == "NEW-MPN"
-    assert part.linked_provider == "none"
+    assert part.linked_provider is None
     assert part.description is None
     assert part.default_storage_location_id is None
     assert part.created_by == user.id

--- a/backend/tests/test_bom_import_auto_create.py
+++ b/backend/tests/test_bom_import_auto_create.py
@@ -1,0 +1,350 @@
+from __future__ import annotations
+
+import base64
+import uuid
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.exc import IntegrityError
+
+from app.domain.parts.models import Part
+from app.domain.projects import bom_import as bom
+from app.domain.projects.models import Project, ProjectEntry
+from app.domain.projects.schemas import BomImportCommitIn, BomImportPreviewIn, BomMappingField
+from app.domain.stock.models import StockEntry
+from app.domain.users.models import User
+from app.domain.workspaces.models import Workspace, WorkspaceMember
+
+
+def _setup_ws(db, name: str = "W") -> tuple[Workspace, User]:
+    user = User(email=f"u-{uuid.uuid4().hex[:6]}@x.com", name="t", password_hash="x")
+    db.add(user)
+    db.flush()
+    ws = Workspace(name=name, kind="organization", owner_user_id=user.id)
+    db.add(ws)
+    db.flush()
+    db.add(WorkspaceMember(workspace_id=ws.id, user_id=user.id, status="active"))
+    db.commit()
+    return ws, user
+
+
+def _project(db, ws: Workspace, user: User, name: str = "Widget") -> Project:
+    project = Project(workspace_id=ws.id, name=name, created_by=user.id, updated_by=user.id)
+    db.add(project)
+    db.commit()
+    return project
+
+
+def _b64(csv_text: str) -> str:
+    return base64.b64encode(csv_text.encode()).decode()
+
+
+def _mapping(*targets: str) -> list[BomMappingField]:
+    return [BomMappingField(column_index=i, target=target) for i, target in enumerate(targets)]
+
+
+def _commit_payload(
+    csv_text: str,
+    *,
+    mapping: list[BomMappingField],
+    auto_create_missing_parts: bool = True,
+) -> BomImportCommitIn:
+    return BomImportCommitIn(
+        text_b64=_b64(csv_text),
+        separator=",",
+        encoding="utf-8",
+        has_header=True,
+        mapping=mapping,
+        designator_separator=",",
+        auto_create_missing_parts=auto_create_missing_parts,
+    )
+
+
+def _parts(db, ws: Workspace) -> list[Part]:
+    return db.query(Part).filter(Part.workspace_id == ws.id).order_by(Part.name).all()
+
+
+def _entries(db, project: Project) -> list[ProjectEntry]:
+    return (
+        db.query(ProjectEntry)
+        .filter(ProjectEntry.project_id == project.id)
+        .order_by(ProjectEntry.order_index)
+        .all()
+    )
+
+
+def test_default_behaviour_unchanged_no_auto_create(db):
+    ws, user = _setup_ws(db)
+    project = _project(db, ws, user)
+    payload = _commit_payload(
+        "qty,mpn\n2,NEW-MPN\n",
+        mapping=_mapping("quantity", "mpn"),
+        auto_create_missing_parts=False,
+    )
+
+    result = bom.commit(db, workspace_id=ws.id, user_id=user.id, project=project, payload=payload)
+    db.commit()
+
+    assert result.inserted == 1
+    assert result.matched == 0
+    assert result.unmatched == 1
+    assert result.auto_created == 0
+    assert result.skipped == 0
+    assert _parts(db, ws) == []
+    entry = _entries(db, project)[0]
+    assert entry.entry_type == "unmatched"
+    assert entry.part_id is None
+
+
+def test_auto_create_with_mpn(db):
+    ws, user = _setup_ws(db)
+    project = _project(db, ws, user)
+    payload = _commit_payload("qty,mpn\n4,NEW-MPN\n", mapping=_mapping("quantity", "mpn"))
+
+    result = bom.commit(db, workspace_id=ws.id, user_id=user.id, project=project, payload=payload)
+    db.commit()
+
+    assert result.inserted == 1
+    assert result.auto_created == 1
+    part = _parts(db, ws)[0]
+    assert part.name == "NEW-MPN"
+    assert part.mpn == "NEW-MPN"
+    assert part.linked_provider == "none"
+    assert part.description is None
+    assert part.default_storage_location_id is None
+    assert part.created_by == user.id
+    assert db.query(StockEntry).filter(StockEntry.part_id == part.id).count() == 0
+    entry = _entries(db, project)[0]
+    assert entry.entry_type == "part"
+    assert entry.part_id == part.id
+
+
+def test_auto_create_with_name_only(db):
+    ws, user = _setup_ws(db)
+    project = _project(db, ws, user)
+    payload = _commit_payload("qty,part\n3,Local resistor\n", mapping=_mapping("quantity", "part"))
+
+    result = bom.commit(db, workspace_id=ws.id, user_id=user.id, project=project, payload=payload)
+    db.commit()
+
+    assert result.auto_created == 1
+    part = _parts(db, ws)[0]
+    assert part.name == "Local resistor"
+    assert part.mpn is None
+
+
+def test_auto_create_falls_back_to_mpn_for_name(db):
+    ws, user = _setup_ws(db)
+    project = _project(db, ws, user)
+    payload = _commit_payload(
+        "qty,mpn,part\n1,MPN-ONLY,\n",
+        mapping=_mapping("quantity", "mpn", "part"),
+    )
+
+    result = bom.commit(db, workspace_id=ws.id, user_id=user.id, project=project, payload=payload)
+    db.commit()
+
+    assert result.auto_created == 1
+    part = _parts(db, ws)[0]
+    assert part.name == "MPN-ONLY"
+    assert part.mpn == "MPN-ONLY"
+
+
+def test_skip_row_with_neither_name_nor_mpn(db):
+    ws, user = _setup_ws(db)
+    project = _project(db, ws, user)
+    payload = _commit_payload("qty,mpn,part\n5,,\n", mapping=_mapping("quantity", "mpn", "part"))
+
+    result = bom.commit(db, workspace_id=ws.id, user_id=user.id, project=project, payload=payload)
+    db.commit()
+
+    assert result.inserted == 0
+    assert result.auto_created == 0
+    assert result.skipped == 1
+    assert _parts(db, ws) == []
+    assert _entries(db, project) == []
+
+
+def test_two_rows_same_new_mpn_merge_into_one_part(db):
+    ws, user = _setup_ws(db)
+    project = _project(db, ws, user)
+    payload = _commit_payload(
+        "qty,mpn\n1,MERGE-MPN\n2,MERGE-MPN\n",
+        mapping=_mapping("quantity", "mpn"),
+    )
+
+    result = bom.commit(db, workspace_id=ws.id, user_id=user.id, project=project, payload=payload)
+    db.commit()
+
+    parts = _parts(db, ws)
+    entries = _entries(db, project)
+    assert result.auto_created == 1
+    assert len(parts) == 1
+    assert [entry.part_id for entry in entries] == [parts[0].id, parts[0].id]
+
+
+def test_two_rows_same_name_no_mpn_merge_into_one_part(db):
+    ws, user = _setup_ws(db)
+    project = _project(db, ws, user)
+    payload = _commit_payload(
+        "qty,part\n1,Same local name\n2,Same local name\n",
+        mapping=_mapping("quantity", "part"),
+    )
+
+    result = bom.commit(db, workspace_id=ws.id, user_id=user.id, project=project, payload=payload)
+    db.commit()
+
+    parts = _parts(db, ws)
+    entries = _entries(db, project)
+    assert result.auto_created == 1
+    assert len(parts) == 1
+    assert [entry.part_id for entry in entries] == [parts[0].id, parts[0].id]
+
+
+def test_existing_part_with_same_mpn_is_reused_not_recreated(db):
+    ws, user = _setup_ws(db)
+    part = Part(
+        workspace_id=ws.id,
+        name="Existing",
+        mpn="EXISTING-MPN",
+        created_by=user.id,
+        updated_by=user.id,
+    )
+    db.add(part)
+    project = _project(db, ws, user)
+    payload = _commit_payload("qty,mpn\n2,EXISTING-MPN\n", mapping=_mapping("quantity", "mpn"))
+
+    result = bom.commit(db, workspace_id=ws.id, user_id=user.id, project=project, payload=payload)
+    db.commit()
+
+    assert result.matched == 1
+    assert result.auto_created == 0
+    assert (
+        db.query(Part)
+        .filter(Part.workspace_id == ws.id, Part.mpn == "EXISTING-MPN")
+        .count()
+        == 1
+    )
+    assert _entries(db, project)[0].part_id == part.id
+
+
+def test_integrity_error_rolls_back_full_import(db, monkeypatch):
+    ws, user = _setup_ws(db)
+    project = _project(db, ws, user)
+    payload = _commit_payload(
+        "qty,mpn\n1,FIRST-MPN\n1,SECOND-MPN\n",
+        mapping=_mapping("quantity", "mpn"),
+    )
+    real_flush = db.flush
+    flush_calls = 0
+
+    def flaky_flush(*args, **kwargs):
+        nonlocal flush_calls
+        flush_calls += 1
+        if flush_calls == 2:
+            raise IntegrityError("boom", {}, Exception("boom"))
+        return real_flush(*args, **kwargs)
+
+    monkeypatch.setattr(db, "flush", flaky_flush)
+
+    with pytest.raises(HTTPException) as exc:
+        bom.commit(db, workspace_id=ws.id, user_id=user.id, project=project, payload=payload)
+    assert exc.value.status_code == 409
+
+    db.rollback()
+    assert db.query(Part).filter(Part.workspace_id == ws.id).count() == 0
+    assert db.query(ProjectEntry).filter(ProjectEntry.project_id == project.id).count() == 0
+
+
+def test_workspace_isolation_two_workspaces_same_mpn(db):
+    ws_a, user_a = _setup_ws(db, "A")
+    ws_b, user_b = _setup_ws(db, "B")
+    db.add(
+        Part(
+            workspace_id=ws_b.id,
+            name="Workspace B",
+            mpn="SHARED-MPN",
+            created_by=user_b.id,
+            updated_by=user_b.id,
+        )
+    )
+    project_a = _project(db, ws_a, user_a)
+    payload = _commit_payload("qty,mpn\n1,SHARED-MPN\n", mapping=_mapping("quantity", "mpn"))
+
+    result = bom.commit(
+        db,
+        workspace_id=ws_a.id,
+        user_id=user_a.id,
+        project=project_a,
+        payload=payload,
+    )
+    db.commit()
+
+    assert result.auto_created == 1
+    part_a = db.query(Part).filter(Part.workspace_id == ws_a.id, Part.mpn == "SHARED-MPN").one()
+    part_b = db.query(Part).filter(Part.workspace_id == ws_b.id, Part.mpn == "SHARED-MPN").one()
+    assert part_a.id != part_b.id
+    assert _entries(db, project_a)[0].part_id == part_a.id
+
+
+def test_preview_would_auto_create_count_matches_commit(db):
+    ws, user = _setup_ws(db)
+    db.add(
+        Part(
+            workspace_id=ws.id,
+            name="Existing",
+            mpn="EXISTING-MPN",
+            created_by=user.id,
+            updated_by=user.id,
+        )
+    )
+    project = _project(db, ws, user)
+    csv_text = "qty,mpn\n1,EXISTING-MPN\n1,NEW-MPN\n2,NEW-MPN\n"
+    mapping = _mapping("quantity", "mpn")
+    preview_payload = BomImportPreviewIn(
+        text_b64=_b64(csv_text),
+        separator=",",
+        encoding="utf-8",
+        has_header=True,
+        auto_create_missing_parts=True,
+        mapping=mapping,
+    )
+
+    preview = bom.preview(preview_payload, db=db, workspace_id=ws.id)
+    commit_payload = _commit_payload(csv_text, mapping=mapping)
+    result = bom.commit(
+        db,
+        workspace_id=ws.id,
+        user_id=user.id,
+        project=project,
+        payload=commit_payload,
+    )
+
+    assert preview.would_auto_create_count == result.auto_created == 1
+
+
+def test_preview_would_skip_count_matches_commit(db):
+    ws, user = _setup_ws(db)
+    project = _project(db, ws, user)
+    csv_text = "qty,mpn,part\n1,,\n2,NEW-MPN,\n"
+    mapping = _mapping("quantity", "mpn", "part")
+    preview_payload = BomImportPreviewIn(
+        text_b64=_b64(csv_text),
+        separator=",",
+        encoding="utf-8",
+        has_header=True,
+        auto_create_missing_parts=True,
+        mapping=mapping,
+    )
+
+    preview = bom.preview(preview_payload, db=db, workspace_id=ws.id)
+    commit_payload = _commit_payload(csv_text, mapping=mapping)
+    result = bom.commit(
+        db,
+        workspace_id=ws.id,
+        user_id=user.id,
+        project=project,
+        payload=commit_payload,
+    )
+
+    assert preview.would_skip_count == result.skipped == 1

--- a/docs/api/projects.md
+++ b/docs/api/projects.md
@@ -223,7 +223,7 @@ Commit the preview into `project_entries` rows.
 
 - The dep rolls back on any raise, so no explicit try/except is needed (`projects.py:265-267`).
 - Auto-create preserves the import match priority in `bom_import.py::_match_part`; creation happens only after no candidate is found.
-- Created parts use the import workspace, `linked_provider='none'`, no default storage location, and no stock entries or lots.
+- Created parts use the import workspace, have no linked provider, no default storage location, and no stock entries or lots.
 - Source: `backend/app/api/routes/projects.py:262-269`.
 - Service: `backend/app/domain/projects/bom_import.py::commit`.
 

--- a/docs/api/projects.md
+++ b/docs/api/projects.md
@@ -158,9 +158,31 @@ The frontend invokes `preview` to render a diff, then `commit` to apply it. Both
 
 Parse a CSV / paste against a column-mapping config and return the proposed entries (no DB writes). The response model is whatever `bom.preview` returns (`BomImportPreview`).
 
-**Request** — `BomImportPreviewIn`. TODO(verify): exact field shape (CSV bytes vs rows; column-mapping config; preset reference).
+**Request** — `BomImportPreviewIn`
 
-**Response** — `200 OK` — `model_dump()` of the preview result.
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `text_b64` | string | yes | Base64 CSV/TSV/plain text payload. Runtime decoded cap is 4 MB. |
+| `separator` | string \| null | no | Auto-detected when omitted. |
+| `encoding` | string \| null | no | Auto-detected when omitted. |
+| `has_header` | bool \| null | no | Auto-detected when omitted. |
+| `auto_create_missing_parts` | bool | no | Default `false`. When `true`, preview reports auto-create and skip counters. |
+| `mapping` | `BomMappingField[]` \| null | no | Required for meaningful auto-create counters because MPN/name columns must be known. |
+| `designator_separator` | string | no | Default `,`. Used when `mapping` contains `designators`. |
+
+**Response** — `200 OK` — envelope: `{ data, status }`
+
+```json
+{
+  "detected_separator": ",",
+  "detected_encoding": "utf-8",
+  "has_header": true,
+  "headers": ["qty", "mpn"],
+  "rows": [{ "cells": ["1", "NEW-MPN"] }],
+  "would_auto_create_count": 1,
+  "would_skip_count": 0
+}
+```
 
 **Notes**
 
@@ -171,13 +193,37 @@ Parse a CSV / paste against a column-mapping config and return the proposed entr
 
 Commit the preview into `project_entries` rows.
 
-**Request** — `BomImportCommitIn`. TODO(verify): exact field shape and preview→commit handoff (token? full payload?).
+**Request** — `BomImportCommitIn`
 
-**Response** — `200 OK` — `model_dump()` of the commit result (counts, conflicts, skipped rows).
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `text_b64` | string | yes | Same base64 payload used for preview. |
+| `separator` | string | yes | Delimiter to parse with. |
+| `encoding` | string | yes | Text encoding to decode with. |
+| `has_header` | bool | yes | Whether to skip the first row. |
+| `mapping` | `BomMappingField[]` | yes | Column-to-field mapping. Targets include `quantity`, `part`, `mpn`, `manufacturer`, `internal_part_number`, `designators`, `comments`, `footprint`, `id_code`, `cad_key`, `dnp`, `ignore`. |
+| `designator_separator` | string | no | Default `,`. |
+| `auto_create_missing_parts` | bool | no | Default `false`. When `true`, rows that do not match but have MPN or part/name create a zero-stock `Part`. Rows with neither MPN nor part/name are skipped. |
+
+**Response** — `200 OK` — envelope: `{ data, status }`
+
+```json
+{
+  "inserted": 1,
+  "matched": 0,
+  "unmatched": 0,
+  "auto_created": 1,
+  "skipped": 0
+}
+```
+
+`auto_created` counts new `Part` rows, not repeated BOM rows that merge onto a part created earlier in the same import.
 
 **Notes**
 
 - The dep rolls back on any raise, so no explicit try/except is needed (`projects.py:265-267`).
+- Auto-create preserves the import match priority in `bom_import.py::_match_part`; creation happens only after no candidate is found.
+- Created parts use the import workspace, `linked_provider='none'`, no default storage location, and no stock entries or lots.
 - Source: `backend/app/api/routes/projects.py:262-269`.
 - Service: `backend/app/domain/projects/bom_import.py::commit`.
 
@@ -242,5 +288,4 @@ Hard-delete (`db.delete`).
 ## TODOs
 
 - TODO(verify): `BomEntryIn`/`BomEntryPatch` — exhaustive field list, `entry_type` allowed values (`domain/projects/schemas.py`).
-- TODO(verify): `BomImportPreviewIn`/`BomImportCommitIn` shape and the preview→commit handoff (`domain/projects/bom_import.py`, `domain/projects/schemas.py`).
 - TODO(verify): `PresetIn`/`PresetPatch` exact shape and whether `config` is validated server-side (`domain/projects/schemas.py`).

--- a/docs/domain/builds-and-bom.md
+++ b/docs/domain/builds-and-bom.md
@@ -29,6 +29,8 @@ Project ─< ProjectEntry  (the BOM)
 
 `ProjectEntry.dnp` (`backend/app/domain/projects/models.py:78`) — "do not place". Skipped during reservation and consume.
 
+BOM import match priority remains spec §16.3: internal ID, CAD key, internal part number, MPN, local name, then meta-part candidate. BOM-001 amends the failed-match outcome only: when `auto_create_missing_parts=true`, a row with MPN or part/name creates a zero-stock `Part` and becomes `entry_type='part'`; a row with neither MPN nor part/name is skipped. Default imports still create `entry_type='unmatched'` rows on failed match (`backend/app/domain/projects/bom_import.py::commit`).
+
 ## Required-quantity formula
 
 `builds/service.py::_required(entry, part, build_qty)` (`backend/app/domain/builds/service.py:34-43`):

--- a/docs/user/projects-and-bom.md
+++ b/docs/user/projects-and-bom.md
@@ -53,6 +53,20 @@ The fastest way to populate a BOM is to import the export your CAD tool produced
 
 Click **Open BOM** to view the result.
 
+### Auto-create missing parts
+
+If your import screen or integration enables **Auto-create missing parts**, unmatched rows are turned into new parts during import instead of placeholder BOM lines.
+
+The import still tries to match existing parts first. It only creates a part after it fails to match by internal ID, CAD key, internal part number, MPN, or part name.
+
+Auto-created parts start with zero stock. They do not create stock entries or lots. The new part gets:
+
+- **Name** from the BOM's part/name column, or the MPN if the name is blank.
+- **MPN**, **Manufacturer**, and **Internal part number** from the mapped columns when present.
+- **Provider** set to `none`, so you can enrich it later.
+
+Rows with neither an MPN nor a part/name are skipped when auto-create is enabled. They do not create a part or a BOM line.
+
 ### Save your mapping as a preset
 
 If you import BOMs from the same CAD tool repeatedly, save the column mapping:
@@ -86,6 +100,6 @@ Open the project, click **Other**, click **Archive**. The project disappears fro
 ## What to do if it doesn't work
 
 - **Import says "BOM file too large — max 4 MB"** — split the file or strip unused columns.
-- **Lines come back as Unmatched** — the file's MPN or part name didn't match anything in your workspace. Either create the missing parts (via [scan-to-import](scan-import.md) or **+ Part**), then click **Match…** on each row, or re-import after creating the parts.
+- **Lines come back as Unmatched** — the file's MPN or part name didn't match anything in your workspace. Either create the missing parts (via [scan-to-import](scan-import.md) or **+ Part**), then click **Match…** on each row, re-import after creating the parts, or enable auto-create where available.
 - **Designators show up in one cell instead of split** — your **Designator separator** is wrong. Re-import with the right separator (often `,` or `;`).
 - **Imported quantities are off** — your **Separator** or **Has header** detection was wrong. Re-import with the correct values.

--- a/docs/user/projects-and-bom.md
+++ b/docs/user/projects-and-bom.md
@@ -63,7 +63,7 @@ Auto-created parts start with zero stock. They do not create stock entries or lo
 
 - **Name** from the BOM's part/name column, or the MPN if the name is blank.
 - **MPN**, **Manufacturer**, and **Internal part number** from the mapped columns when present.
-- **Provider** set to `none`, so you can enrich it later.
+- **Provider** unset, so you can enrich it later.
 
 Rows with neither an MPN nor a part/name are skipped when auto-create is enabled. They do not create a part or a BOM line.
 


### PR DESCRIPTION
## Summary

- Add `auto_create_missing_parts` to BOM import preview/commit schemas and return preview/commit counters for auto-created and skipped rows.
- Preserve the existing six-step match priority; only create a zero-stock local `Part` after no match is found, using the import workspace and `linked_provider='none'`.
- Skip auto-create rows with neither MPN nor part/name, merge same-MPN/name rows through flushed in-transaction parts, and surface `IntegrityError` as a rollback-triggering 409.
- Add focused BOM auto-create tests and update user, API, and domain docs.

## Validation

Docker validation was unavailable in this environment: `docker: command not found`. Closest local validation was run against local Postgres after `uv sync --frozen --extra dev`.

- `.venv/bin/python -m pytest -q tests/test_bom_import.py tests/test_bom_import_auto_create.py`
  - `17 passed, 3 warnings in 1.80s`
  - Existing `test_bom_import.py` behavior passes unchanged as part of this run.
- `.venv/bin/python -m pytest -q -k "bom_import or workspace_isolation"`
  - `68 passed, 851 deselected, 5 warnings in 18.33s`
- `.venv/bin/ruff check app/domain/projects/bom_import.py app/domain/projects/schemas.py tests/test_bom_import_auto_create.py`
  - `All checks passed!`
- `LINT_CMD="ruff check app --output-format=concise" BASELINE_FILE="../.ruff-baseline.txt" WORK_DIR="." bash ../scripts/lint-delta.sh`
  - `lint-delta: no new violations (baseline: 159, current: 149, fixed since baseline: 10)`
- `git diff --check`
  - no output

Workspace-isolation review: `_match_part` remains workspace-filtered, every inserted `Part` uses the import `workspace_id`, and `test_workspace_isolation_two_workspaces_same_mpn` covers same-MPN imports across workspaces.

## Sample CSV and Counters

```csv
qty,mpn,part
1,EXISTING-MPN,
2,NEW-MPN,
3,,Local only
4,,
```

Before, with `auto_create_missing_parts=false`:

```json
{ "inserted": 4, "matched": 1, "unmatched": 3, "auto_created": 0, "skipped": 0 }
```

After, with `auto_create_missing_parts=true`:

```json
{ "inserted": 3, "matched": 1, "unmatched": 0, "auto_created": 2, "skipped": 1 }
```

Preview with the same mapping reports:

```json
{ "would_auto_create_count": 2, "would_skip_count": 1 }
```

## Deviations

- Preview needed the existing route DB/workspace context to compute real match-aware counters, so the preview route now passes `db` and `workspace_id` into `bom.preview`; the API envelope remains unchanged.
- Unscoped local `uv run pytest` initially hit an Alembic import issue before `uv sync --frozen --extra dev`; the final local validation used `.venv/bin/python -m pytest`.

## Merge Order

No known merge-order dependency. I inspected open PRs #389, #387, #386, and #241 before publishing; their changed files do not overlap this PR's BOM import, projects API, or projects/BOM docs files.

Refs #384
