### PR TITLE
fix: clean up the three bugs PR #317's audit surfaced (#314, #315, #316)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,9 +167,11 @@ them, that's the bug.
 - **Provider catalog vs spec keys.** `web/src/lib/providerCatalog.ts`
   defines which custom-field keys are catalog metadata (price, stock,
   manufacturer URL, …) vs user-curated specs. The PartSpecs and
-  PartSourcing tabs split on this boundary; the same key list lives
-  server-side in `backend/app/domain/parts/services/provider.py`.
-  Adding a new catalog field needs both sides.
+  PartSourcing tabs split on this boundary; server-side, the catalog
+  field shapes live in `backend/app/domain/parts/providers/base.py`
+  and the asset-side reserved-keys subset is `_PROVIDER_RESERVED_KEYS`
+  in `backend/app/api/routes/parts_assets.py`. Adding a new catalog
+  field needs the FE list AND the relevant server-side touchpoint.
 - **No `verify=False` on httpx clients.** CI greps for `verify=False`,
   `trust_env=False`, `ssl=False` under `backend/app/`. Annotate with
   `# noqa: tls-verify` if intentional (e.g. internal test doubles).

--- a/backend/app/api/routes/tags.py
+++ b/backend/app/api/routes/tags.py
@@ -74,13 +74,12 @@ def link(payload: TagLinkIn, db: DbSession, ws: CurrentWorkspace, user: CurrentU
 
 @router.delete("/links/{link_id}")
 def unlink(link_id: UUID, db: DbSession, ws: CurrentWorkspace):
-    row = db.execute(
-        select(TagLink)
-        .where(TagLink.id == link_id)
-        .where(TagLink.workspace_id == ws.id)
-    ).scalar_one_or_none()
-    if row is not None:
-        db.delete(row)
+    # Per the rest of the API (orders/projects/parts), DELETE on an id
+    # that doesn't exist in this workspace returns 404 — never silently
+    # succeed (would let a caller probe foreign-workspace ids by their
+    # 200/404 split). Use the canonical helper.
+    row = assert_in_workspace(db, TagLink, link_id, ws.id)
+    db.delete(row)
     return ok(None, "deleted")
 
 

--- a/backend/app/domain/audit/models.py
+++ b/backend/app/domain/audit/models.py
@@ -27,7 +27,7 @@ class AuditLog(Base):
     )
     action = Column(Text, nullable=False)
     target_type = Column(Text, nullable=True)
-    # PostgreSQL UUID[] — GIN-indexed in migration 0024 (audit_log).
+    # PostgreSQL UUID[] — GIN-indexed in migration 0030 (audit_log).
     target_ids = Column(ARRAY(UUID(as_uuid=True)), nullable=True)
     comment = Column(Text, nullable=True)
     request_id = Column(Text, nullable=True)

--- a/backend/tests/test_workspace_isolation.py
+++ b/backend/tests/test_workspace_isolation.py
@@ -246,7 +246,7 @@ def test_tag_unlink_rejects_foreign_workspace_id():
 
     # And A's link is still there (negative side of the regression).
     listed = a.get(f"/api/tags/by-object/part/{part_a}").json()["data"]
-    assert any(t["id"] == tag_a for t in listed)
+    assert any(t["id"] == link_a and t["tag"]["id"] == tag_a for t in listed)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_workspace_isolation.py
+++ b/backend/tests/test_workspace_isolation.py
@@ -226,6 +226,29 @@ def test_tags_reject_cross_workspace_object_id_on_link():
     assert r.status_code == 404, r.text
 
 
+def test_tag_unlink_rejects_foreign_workspace_id():
+    """DELETE /api/tags/links/{id} on a foreign-workspace link MUST 404,
+    not silently 200. A naive `select … where ws=mine` + `if row: delete`
+    pattern returns the same body for "doesn't exist" and "exists in
+    another workspace" — that lets B probe A's link ids by their 200 vs.
+    404 split (issue #316)."""
+    a, b = _two_workspaces()
+    part_a = _create_part(a, "A-pn")
+    tag_a = a.post("/api/tags", json={"name": "Mine"}).json()["data"]["id"]
+    link_a = a.post(
+        "/api/tags/links",
+        json={"tag_id": tag_a, "object_type": "part", "object_id": part_a},
+    ).json()["data"]["id"]
+
+    # B tries to delete A's link; must be 404, not 200.
+    r = b.delete(f"/api/tags/links/{link_a}")
+    assert r.status_code == 404, r.text
+
+    # And A's link is still there (negative side of the regression).
+    listed = a.get(f"/api/tags/by-object/part/{part_a}").json()["data"]
+    assert any(t["id"] == tag_a for t in listed)
+
+
 # ---------------------------------------------------------------------------
 # stock service: cross-workspace lot/storage on adjust/remove/move.
 # adjust_stock was the active leak — `delta = actual_qty - 0` persists a


### PR DESCRIPTION
## Summary

Closes the three loose ends from PR #317's audit pass. Each was tracked as its own issue but never followed up by a PR until now.

- **#314** — CLAUDE.md "Provider catalog vs spec keys" pointed at a non-existent path. Updated the invariant to point at the real server-side touchpoints (`providers/base.py` for shapes, `parts_assets.py::_PROVIDER_RESERVED_KEYS` for the asset-side subset).
- **#315** — `audit/models.py` comment cited migration **0024** for the GIN index on `audit_log.target_ids`; actual file is `0030_audit_log.py`. One-character fix.
- **#316** — `DELETE /api/tags/links/{id}` returned 200 silently for foreign-workspace link ids. Every other DELETE returns 404 via `assert_in_workspace`; switched tags to the same. Added a regression test in `test_workspace_isolation.py` that pins both halves (B's DELETE on A's link 404s; A's link survives).

## Test plan

- [x] `pytest test_workspace_isolation.py::test_tag_unlink_rejects_foreign_workspace_id`
- [x] grep CLAUDE.md for the corrected paths exists
- [x] grep `audit/models.py` for "0030" comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)