### PR TITLE
TP-403: POST /api/projects/{id}/purchase-plan

### DIFF
--- a/backend/app/api/routes/sourcing.py
+++ b/backend/app/api/routes/sourcing.py
@@ -22,7 +22,12 @@ from app.domain.sourcing import (
 )
 from app.domain.sourcing import service as sourcing_service
 from app.domain.sourcing.factory import make_sourcing_provider
-from app.domain.sourcing.schemas import SourcingBomIn, SourcingQuery, SourcingSearchIn
+from app.domain.sourcing.schemas import (
+    PurchasePlanIn,
+    SourcingBomIn,
+    SourcingQuery,
+    SourcingSearchIn,
+)
 from app.domain.sourcing.service import SourcingBudgetBlocked, SourcingNotConfigured
 from app.infra.db import get_db
 
@@ -192,6 +197,71 @@ def source_project_bom(
         )
 
     return ok(out.model_dump(mode="json"))
+
+
+@projects_router.post(
+    "/{project_id}/purchase-plan",
+    dependencies=[Depends(require_role("member"))],
+)
+@limiter.limit("15/minute", key_func=workspace_key)
+def create_project_purchase_plan(
+    request: Request,
+    project_id: UUID,
+    payload: PurchasePlanIn,
+    ws: CurrentWorkspace,
+    user: CurrentUser,
+    db: Session = Depends(get_db),
+):
+    project = assert_in_workspace(db, Project, project_id, ws.id, label="project")
+    try:
+        plan = sourcing_service.build_purchase_plan(
+            db,
+            workspace=ws,
+            project=project,
+            build_quantity=payload.build_quantity,
+            strategy=payload.strategy,
+            country=payload.country,
+            currency=payload.currency,
+            distributors=payload.distributors,
+            max_distributors=payload.max_distributors,
+            moq_overbuy_cap=payload.moq_overbuy_cap,
+            price_tolerance_pct=payload.price_tolerance_pct,
+            requested_by=user.id,
+        )
+    except SourcingNotConfigured:
+        return _error_response(request, 409, "conflict", "sourcing not configured")
+    except SourcingBudgetBlocked:
+        return _error_response(request, 503, "server_error", "sourcing budget exhausted")
+    except SourcingAuthError:
+        return _error_response(
+            request,
+            502,
+            "server_error",
+            "TrustedParts rejected sourcing credentials",
+        )
+    except SourcingRateLimitError:
+        return _error_response(
+            request,
+            502,
+            "server_error",
+            "TrustedParts rate limit reached",
+        )
+    except SourcingTimeoutError:
+        return _error_response(
+            request,
+            502,
+            "server_error",
+            "TrustedParts request timed out",
+        )
+    except SourcingClientError:
+        return _error_response(
+            request,
+            502,
+            "server_error",
+            "TrustedParts sourcing request failed",
+        )
+
+    return ok(sourcing_service.purchase_plan_to_out(plan).model_dump(mode="json"))
 
 
 @parts_router.get(

--- a/backend/app/domain/sourcing/schemas.py
+++ b/backend/app/domain/sourcing/schemas.py
@@ -234,6 +234,81 @@ class OptimizerOutcomeOut(BaseModel):
     worst_lead_time_days: int | None = None
 
 
+class PurchasePlanIn(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    build_quantity: int = Field(ge=1)
+    strategy: Literal[
+        "lowest_total_price",
+        "fewest_distributors",
+        "fastest_availability",
+        "preferred_first",
+    ] = "preferred_first"
+    country: str | None = Field(default=None, min_length=2, max_length=2)
+    currency: str | None = Field(default=None, min_length=3, max_length=3)
+    distributors: list[str] | None = None
+    max_distributors: int | None = Field(default=None, ge=1)
+    moq_overbuy_cap: int | None = Field(default=None, ge=1)
+    price_tolerance_pct: Decimal = Field(default=Decimal("5"), ge=0)
+
+    @field_validator("country", "currency")
+    @classmethod
+    def _uppercase_codes(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return value.strip().upper()
+
+    @field_validator("distributors")
+    @classmethod
+    def _strip_distributors(cls, value: list[str] | None) -> list[str] | None:
+        if value is None:
+            return None
+        stripped = [item.strip() for item in value if item.strip()]
+        return stripped or None
+
+
+class PurchasePlanLineOut(BaseModel):
+    model_config = ConfigDict(extra="forbid", from_attributes=True)
+
+    id: UUID
+    project_entry_id: UUID | None
+    part_id: UUID
+    mpn_searched: str
+    required_qty: int
+    internal_available_qty: int
+    shortage_qty: int
+    selected_distributor: str | None = None
+    selected_qty: int | None = None
+    selected_unit_price: Decimal | None = None
+    selected_currency: str | None = None
+    selected_packaging: str | None = None
+    selected_moq: int | None = None
+    selected_lead_time_days: int | None = None
+    selected_url: str | None = None
+    risk_flags: list[str] = Field(default_factory=list)
+
+
+class PurchasePlanOut(BaseModel):
+    model_config = ConfigDict(extra="forbid", from_attributes=True)
+
+    id: UUID
+    project_id: UUID
+    build_quantity: int
+    strategy: str
+    country_code: str | None = None
+    currency_code: str | None = None
+    preferred_distributors: list[str] | None = None
+    status: str
+    created_at: datetime
+    expires_at: datetime
+    created_by: UUID | None = None
+    lines: list[PurchasePlanLineOut]
+    distributors_used: list[str]
+    est_total_cost: Decimal | None = None
+    worst_lead_time_days: int | None = None
+    unfilled_count: int
+
+
 class SourcingBomLineOut(BaseModel):
     model_config = ConfigDict(extra="forbid")
 

--- a/backend/app/domain/sourcing/service.py
+++ b/backend/app/domain/sourcing/service.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Sequence
-from datetime import datetime
+from datetime import datetime, timedelta
 from decimal import Decimal
 from typing import Any
 from uuid import UUID
@@ -18,10 +18,13 @@ from app.domain.sourcing import cache
 from app.domain.sourcing.budget import BUDGET
 from app.domain.sourcing.coverage import compute_build_capacity, compute_coverage
 from app.domain.sourcing.factory import make_sourcing_provider
+from app.domain.sourcing.models import PurchasePlan, PurchasePlanLine
+from app.domain.sourcing.optimizer import Strategy, optimize
 from app.domain.sourcing.pricing import best_unit_price_at_qty
 from app.domain.sourcing.schemas import (
     BuildCapacityOut,
     DistributorCoverageMatrixOut,
+    PurchasePlanOut,
     SourcingAttributionLinks,
     SourcingBomLineOut,
     SourcingBomOfferOut,
@@ -35,6 +38,7 @@ from app.domain.sourcing.schemas import (
 
 TTL_SECONDS = 30 * 60
 BOM_TTL_SECONDS = 10 * 60
+PURCHASE_PLAN_TTL = timedelta(days=7)
 TRUSTEDPARTS_LINKS = SourcingAttributionLinks(
     primary="https://www.trustedparts.com/",
     attribution="https://www.trustedparts.com/en/about",
@@ -47,6 +51,140 @@ class SourcingNotConfigured(Exception):
 
 class SourcingBudgetBlocked(Exception):
     """Workspace exceeded the hard TrustedParts parts-count budget."""
+
+
+def build_purchase_plan(
+    db: Session,
+    *,
+    workspace: Any,
+    project: Any,
+    build_quantity: int,
+    strategy: Strategy = "preferred_first",
+    country: str | None = None,
+    currency: str | None = None,
+    distributors: list[str] | None = None,
+    max_distributors: int | None = None,
+    moq_overbuy_cap: int | None = None,
+    price_tolerance_pct: Decimal = Decimal("5"),
+    requested_by: UUID | None = None,
+) -> PurchasePlan:
+    bom = source_bom(
+        db,
+        workspace=workspace,
+        project=project,
+        build_quantity=build_quantity,
+        country=country,
+        currency=currency,
+        distributors=distributors,
+        in_stock_only=False,
+        use_cached_data=None,
+        requested_by=requested_by,
+    )
+    preferred_distributors = (
+        _clean_distributors(distributors)
+        if distributors is not None
+        else _clean_distributors(workspace.sourcing_preferred_distributors)
+    )
+    outcome = optimize(
+        bom.rows,
+        strategy=strategy,
+        preferred_distributors=preferred_distributors,
+        max_distributors=max_distributors,
+        moq_overbuy_cap=moq_overbuy_cap,
+        price_tolerance_pct=price_tolerance_pct,
+    )
+    created_at = utcnow()
+    plan = PurchasePlan(
+        workspace_id=workspace.id,
+        project_id=project.id,
+        build_quantity=build_quantity,
+        strategy=strategy,
+        country_code=_clean_code(country) or workspace.sourcing_country_code,
+        currency_code=_clean_code(currency) or workspace.sourcing_currency_code,
+        preferred_distributors=preferred_distributors,
+        status="draft",
+        created_at=created_at,
+        expires_at=created_at + PURCHASE_PLAN_TTL,
+        created_by=requested_by,
+    )
+    plan.lines = [
+        PurchasePlanLine(
+            project_entry_id=selection.project_entry_id,
+            part_id=selection.part_id,
+            mpn_searched=selection.mpn_searched,
+            required_qty=selection.required_qty,
+            internal_available_qty=selection.internal_available_qty,
+            shortage_qty=selection.shortage_qty,
+            selected_distributor=selection.selected_distributor,
+            selected_qty=selection.selected_qty,
+            selected_unit_price=selection.selected_unit_price,
+            selected_currency=selection.selected_currency,
+            selected_packaging=selection.selected_packaging,
+            selected_moq=selection.selected_moq,
+            selected_lead_time_days=selection.selected_lead_time_days,
+            selected_url=selection.selected_url,
+            risk_flags=list(selection.risk_flags),
+        )
+        for selection in outcome.selections
+    ]
+    db.add(plan)
+    db.flush()
+    return plan
+
+
+def purchase_plan_to_out(plan: PurchasePlan) -> PurchasePlanOut:
+    lines = sorted(
+        plan.lines,
+        key=lambda line: (
+            str(line.project_entry_id or ""),
+            (line.selected_distributor or "").casefold(),
+            str(line.id),
+        ),
+    )
+    unfilled_count = sum(1 for line in lines if line.selected_distributor is None)
+    if unfilled_count:
+        est_total_cost: Decimal | None = None
+    else:
+        est_total_cost = sum(
+            (
+                line.selected_unit_price * Decimal(line.selected_qty or 0)
+                for line in lines
+                if line.selected_unit_price is not None
+            ),
+            Decimal("0"),
+        )
+    lead_times = [
+        line.selected_lead_time_days
+        for line in lines
+        if line.selected_lead_time_days is not None
+    ]
+    return PurchasePlanOut.model_validate(
+        {
+            "id": plan.id,
+            "project_id": plan.project_id,
+            "build_quantity": plan.build_quantity,
+            "strategy": plan.strategy,
+            "country_code": plan.country_code,
+            "currency_code": plan.currency_code,
+            "preferred_distributors": plan.preferred_distributors,
+            "status": plan.status,
+            "created_at": plan.created_at,
+            "expires_at": plan.expires_at,
+            "created_by": plan.created_by,
+            "lines": lines,
+            "distributors_used": sorted(
+                {
+                    line.selected_distributor
+                    for line in lines
+                    if line.selected_distributor is not None
+                },
+                key=str.casefold,
+            ),
+            "est_total_cost": est_total_cost,
+            "worst_lead_time_days": max(lead_times) if lead_times else None,
+            "unfilled_count": unfilled_count,
+        }
+    )
 
 
 def dedupe_mpns(mpns: Iterable[str | None]) -> list[str]:

--- a/backend/tests/test_purchase_plan_route.py
+++ b/backend/tests/test_purchase_plan_route.py
@@ -1,0 +1,344 @@
+from __future__ import annotations
+
+import uuid
+from datetime import timedelta
+from decimal import Decimal
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+
+import app.core.ratelimit as _ratelimit_mod
+from app.core.time import utcnow
+from app.domain.sourcing.budget import BUDGET
+from app.domain.sourcing.models import PurchasePlan, PurchasePlanLine
+from app.domain.sourcing.schemas import (
+    SourcingDistributor,
+    SourcingLinks,
+    SourcingOffer,
+    SourcingPriceBreak,
+    SourcingQuery,
+    SourcingSearchRaw,
+)
+from app.main import app
+from tests._factories import create_part, create_project_with_bom, signup_user
+
+
+def _configure_sourcing(
+    client: TestClient,
+    *,
+    preferred: list[str] | None = None,
+) -> None:
+    r = client.patch(
+        "/api/workspaces/current",
+        json={
+            "sourcing_provider": "trustedparts",
+            "sourcing_company_id": "company-123",
+            "sourcing_api_key": "api-key-456",
+            "sourcing_country_code": "CZ",
+            "sourcing_currency_code": "EUR",
+            "sourcing_preferred_distributors": preferred or ["DigiKey"],
+            "sourcing_use_cached_for_dashboards": False,
+        },
+    )
+    assert r.status_code == 200, r.text
+
+
+def _current_workspace_id(client: TestClient) -> uuid.UUID:
+    r = client.get("/api/workspaces/current")
+    assert r.status_code == 200, r.text
+    return uuid.UUID(r.json()["data"]["id"])
+
+
+def _offer(
+    mpn: str,
+    *,
+    distributor: str = "DigiKey",
+    stock: int = 100,
+    unit_price: float = 1.0,
+    moq: int | None = 1,
+    lead_time_days: int | None = 3,
+    currency: str = "EUR",
+) -> SourcingOffer:
+    return SourcingOffer(
+        mpn=mpn,
+        manufacturer="TestCo",
+        description=f"Offer for {mpn}",
+        distributors=[
+            SourcingDistributor(
+                name=distributor,
+                sku=f"{mpn}-{distributor}",
+                stock=stock,
+                unit_price=unit_price,
+                currency=currency,
+                moq=moq,
+                lead_time_days=lead_time_days,
+                price_breaks=[SourcingPriceBreak(quantity=1, unit_price=unit_price)],
+                product_url=f"https://www.trustedparts.com/{mpn}/{distributor}",
+            )
+        ],
+        links=SourcingLinks(primary=f"https://www.trustedparts.com/search/{mpn}"),
+    )
+
+
+class _FakeTrustedPartsClient:
+    calls: list[dict[str, Any]] = []
+    offers_by_mpn: dict[str, list[SourcingOffer]] = {}
+
+    def __init__(self, workspace_id: uuid.UUID | None = None) -> None:
+        self.workspace_id = workspace_id
+        self.country_code = "CZ"
+        self.currency_code = "EUR"
+
+    def search(
+        self,
+        queries: list[SourcingQuery],
+        *,
+        in_stock_only: bool,
+        distributors: list[str] | None,
+        use_cached_data: bool,
+        **_kwargs,
+    ) -> SourcingSearchRaw:
+        query = queries[0]
+        self.calls.append(
+            {
+                "workspace_id": str(self.workspace_id) if self.workspace_id else None,
+                "mpn": query.search_token,
+                "distributors": distributors,
+                "use_cached_data": use_cached_data,
+            }
+        )
+        offers = self.offers_by_mpn.get(query.search_token)
+        if offers is None and self.workspace_id is not None:
+            distributor = f"WS-{str(self.workspace_id)[:8]}"
+            offers = [_offer(query.search_token, distributor=distributor)]
+        return SourcingSearchRaw(
+            offers=offers or [],
+            request_id=f"req-{len(self.calls)}",
+        )
+
+
+@pytest.fixture(autouse=True)
+def reset_sourcing_state(monkeypatch):
+    original_limiter_enabled = _ratelimit_mod.limiter.enabled
+    _ratelimit_mod.limiter.enabled = False
+    _FakeTrustedPartsClient.calls = []
+    _FakeTrustedPartsClient.offers_by_mpn = {}
+    BUDGET._events.clear()
+    try:
+        _ratelimit_mod.limiter.reset()
+    except Exception:
+        pass
+    monkeypatch.setattr(
+        "app.domain.sourcing.service.make_sourcing_provider",
+        lambda workspace: _FakeTrustedPartsClient(workspace.id),
+    )
+    yield
+    _ratelimit_mod.limiter.enabled = original_limiter_enabled
+    BUDGET._events.clear()
+    try:
+        _ratelimit_mod.limiter.reset()
+    except Exception:
+        pass
+
+
+def _single_line_project(
+    client: TestClient,
+    *,
+    mpn: str = "PLAN-MPN",
+    quantity: int = 10,
+) -> str:
+    part_id = create_part(client, name=mpn, mpn=mpn)
+    return create_project_with_bom(
+        client,
+        f"Plan Project {mpn}",
+        [{"part_id": part_id, "quantity": quantity}],
+    )
+
+
+def _post_plan(
+    client: TestClient,
+    project_id: str,
+    *,
+    build_quantity: int = 1,
+    strategy: str = "preferred_first",
+):
+    return client.post(
+        f"/api/projects/{project_id}/purchase-plan",
+        json={"build_quantity": build_quantity, "strategy": strategy},
+    )
+
+
+def test_basic_plan_creation_with_default_strategy(authed_client, db):
+    _configure_sourcing(authed_client, preferred=["DigiKey"])
+    project_id = _single_line_project(authed_client, mpn="BASIC", quantity=4)
+    _FakeTrustedPartsClient.offers_by_mpn = {
+        "BASIC": [
+            _offer("BASIC", distributor="Mouser", stock=50, unit_price=1.0),
+            _offer("BASIC", distributor="DigiKey", stock=50, unit_price=1.04),
+        ]
+    }
+
+    r = authed_client.post(
+        f"/api/projects/{project_id}/purchase-plan",
+        json={"build_quantity": 2},
+    )
+
+    assert r.status_code == 200, r.text
+    data = r.json()["data"]
+    assert data["strategy"] == "preferred_first"
+    assert data["status"] == "draft"
+    assert data["build_quantity"] == 2
+    assert data["distributors_used"] == ["DigiKey"]
+    assert data["unfilled_count"] == 0
+    assert len(data["lines"]) == 1
+    assert data["lines"][0]["selected_distributor"] == "DigiKey"
+    assert Decimal(data["lines"][0]["selected_unit_price"]) == Decimal("1.04")
+
+    plan = db.get(PurchasePlan, uuid.UUID(data["id"]))
+    assert plan is not None
+    assert plan.workspace_id == _current_workspace_id(authed_client)
+    assert plan.expires_at <= plan.created_at + timedelta(days=7)
+
+
+@pytest.mark.parametrize(
+    "strategy",
+    [
+        "lowest_total_price",
+        "fewest_distributors",
+        "fastest_availability",
+        "preferred_first",
+    ],
+)
+def test_each_strategy_produces_a_persisted_plan(authed_client, db, strategy: str):
+    _configure_sourcing(authed_client)
+    project_id = _single_line_project(authed_client, mpn=f"STRAT-{strategy}")
+
+    r = _post_plan(authed_client, project_id, strategy=strategy)
+
+    assert r.status_code == 200, r.text
+    plan_id = uuid.UUID(r.json()["data"]["id"])
+    rows = db.execute(
+        select(PurchasePlanLine).where(PurchasePlanLine.purchase_plan_id == plan_id)
+    ).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].selected_distributor is not None
+
+
+def test_foreign_project_returns_404(authed_client):
+    other = TestClient(app)
+    signup_user(other)
+    _configure_sourcing(authed_client)
+    foreign_project_id = _single_line_project(other, mpn="FOREIGN-MPN")
+
+    r = _post_plan(authed_client, foreign_project_id)
+
+    assert r.status_code == 404, r.text
+    assert r.json()["status"]["category"] == "not_found"
+
+
+def test_invalid_build_quantity_returns_422(authed_client):
+    _configure_sourcing(authed_client)
+    project_id = _single_line_project(authed_client)
+
+    r = authed_client.post(
+        f"/api/projects/{project_id}/purchase-plan",
+        json={"build_quantity": 0},
+    )
+
+    assert r.status_code == 422, r.text
+    assert r.json()["status"]["category"] == "validation_error"
+
+
+def test_invalid_strategy_returns_422(authed_client):
+    _configure_sourcing(authed_client)
+    project_id = _single_line_project(authed_client)
+
+    r = _post_plan(authed_client, project_id, strategy="magic")
+
+    assert r.status_code == 422, r.text
+    assert r.json()["status"]["category"] == "validation_error"
+
+
+def test_unconfigured_returns_409(authed_client, monkeypatch):
+    monkeypatch.setattr(
+        "app.domain.sourcing.service.make_sourcing_provider",
+        lambda _workspace: None,
+    )
+    project_id = _single_line_project(authed_client)
+
+    r = _post_plan(authed_client, project_id)
+
+    assert r.status_code == 409, r.text
+    assert r.json()["status"] == {
+        "category": "conflict",
+        "message": "sourcing not configured",
+    }
+
+
+def test_budget_blocked_returns_503(authed_client):
+    _configure_sourcing(authed_client)
+    project_id = _single_line_project(authed_client)
+    BUDGET.record(_current_workspace_id(authed_client), 250)
+
+    r = _post_plan(authed_client, project_id)
+
+    assert r.status_code == 503, r.text
+    assert r.json()["status"] == {
+        "category": "server_error",
+        "message": "sourcing budget exhausted",
+    }
+
+
+def test_workspace_isolation_two_workspaces_same_project_id(authed_client, db):
+    _configure_sourcing(authed_client)
+    project_a = _single_line_project(authed_client, mpn="SHARED")
+
+    client_b = TestClient(app)
+    signup_user(client_b)
+    _configure_sourcing(client_b)
+
+    r = _post_plan(client_b, project_a)
+
+    assert r.status_code == 404, r.text
+    assert db.execute(select(PurchasePlan)).scalars().all() == []
+
+
+def test_plan_lines_match_optimizer_output(authed_client, db):
+    _configure_sourcing(authed_client)
+    project_id = _single_line_project(authed_client, mpn="MATCH", quantity=3)
+    _FakeTrustedPartsClient.offers_by_mpn = {
+        "MATCH": [
+            _offer("MATCH", distributor="Slow", stock=50, unit_price=0.5, lead_time_days=10),
+            _offer("MATCH", distributor="Fast", stock=50, unit_price=1.5, lead_time_days=2),
+        ]
+    }
+
+    r = _post_plan(authed_client, project_id, strategy="fastest_availability")
+
+    assert r.status_code == 200, r.text
+    line = r.json()["data"]["lines"][0]
+    assert line["selected_distributor"] == "Fast"
+    assert line["selected_qty"] == 3
+    assert line["shortage_qty"] == 3
+    assert Decimal(line["selected_unit_price"]) == Decimal("1.5")
+
+    db_line = db.execute(select(PurchasePlanLine)).scalar_one()
+    assert db_line.selected_distributor == line["selected_distributor"]
+    assert db_line.selected_qty == line["selected_qty"]
+    assert db_line.selected_unit_price == Decimal(line["selected_unit_price"])
+
+
+def test_expires_at_uses_created_at_plus_seven_days(authed_client, db):
+    _configure_sourcing(authed_client)
+    project_id = _single_line_project(authed_client)
+    before = utcnow()
+
+    r = _post_plan(authed_client, project_id)
+
+    assert r.status_code == 200, r.text
+    plan = db.get(PurchasePlan, uuid.UUID(r.json()["data"]["id"]))
+    assert plan is not None
+    assert plan.created_at >= before
+    assert plan.expires_at == plan.created_at + timedelta(days=7)

--- a/backend/tests/test_workspace_isolation.py
+++ b/backend/tests/test_workspace_isolation.py
@@ -16,6 +16,9 @@ from tests._factories import (
     create_part as _create_part,
 )
 from tests._factories import (
+    create_project_with_bom as _create_project_with_bom,
+)
+from tests._factories import (
     create_storage as _create_storage,
 )
 from tests._factories import (
@@ -500,6 +503,32 @@ def test_sourcing_search_uses_caller_workspace_secrets(monkeypatch):
     ]
     assert RecordingTrustedPartsClient.calls[-1]["company_id"] == "company-b"
     assert RecordingTrustedPartsClient.calls[-1]["api_key"] == "api-key-b"
+
+
+def test_purchase_plan_isolated_by_workspace(monkeypatch):
+    a, b = _two_workspaces()
+    part_a = _create_part(a, "A-plan-part")
+    project_a = _create_project_with_bom(
+        a,
+        "A plan",
+        [{"part_id": part_a, "quantity": 1}],
+    )
+
+    def fail_build_purchase_plan(*_args, **_kwargs):
+        pytest.fail("foreign project id reached purchase-plan service")
+
+    monkeypatch.setattr(
+        "app.domain.sourcing.service.build_purchase_plan",
+        fail_build_purchase_plan,
+    )
+
+    r = b.post(
+        f"/api/projects/{project_a}/purchase-plan",
+        json={"build_quantity": 1},
+    )
+
+    assert r.status_code == 404, r.text
+    assert r.json()["status"]["category"] == "not_found"
 
 
 # ---------------------------------------------------------------------------

--- a/docs/api/sourcing.md
+++ b/docs/api/sourcing.md
@@ -77,6 +77,75 @@ Path: `project_id` is a project UUID in the current workspace.
 - Service: `backend/app/domain/sourcing/service.py:71-135`.
 - Pricing: `backend/app/domain/sourcing/pricing.py:9-40`.
 
+### `POST /api/projects/{project_id}/purchase-plan`
+
+Build and persist a short-lived purchase plan from the current project's sourced BOM.
+
+**Request**
+
+Path: `project_id` is a project UUID in the current workspace.
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `build_quantity` | `integer` | Yes | Must be at least `1`. |
+| `strategy` | `string` | No | One of `lowest_total_price`, `fewest_distributors`, `fastest_availability`, `preferred_first`; defaults to `preferred_first`. |
+| `country` | `string` | No | Two-letter override; persisted on the plan. |
+| `currency` | `string` | No | Three-letter override; persisted on the plan. |
+| `distributors` | `string[]` | No | Distributor filter / preferred order for optimizer decisions. |
+| `max_distributors` | `integer` | No | Positive cap used by `fewest_distributors`. |
+| `moq_overbuy_cap` | `integer` | No | Positive cap; offers requiring more than `shortage * cap` are ignored. |
+| `price_tolerance_pct` | `decimal` | No | Preferred-first tolerance; defaults to `5`. |
+
+**Response** — `200 OK` (envelope: `{ data, status }`)
+
+```json
+{
+  "data": {
+    "id": "9b7f7d43-6b5c-4f7d-bc0e-44c6d73f0992",
+    "project_id": "012f2f63-3b2c-45c4-a841-682ec681f508",
+    "build_quantity": 2,
+    "strategy": "preferred_first",
+    "status": "draft",
+    "expires_at": "2026-05-15T12:00:00+00:00",
+    "distributors_used": ["DigiKey"],
+    "est_total_cost": "20.80",
+    "worst_lead_time_days": 3,
+    "unfilled_count": 0,
+    "lines": [
+      {
+        "mpn_searched": "STM32F103C8T6",
+        "required_qty": 20,
+        "internal_available_qty": 0,
+        "shortage_qty": 20,
+        "selected_distributor": "DigiKey",
+        "selected_qty": 20,
+        "selected_unit_price": "1.04",
+        "selected_currency": "EUR",
+        "selected_moq": 1,
+        "selected_url": "https://www.trustedparts.com/..."
+      }
+    ]
+  },
+  "status": { "category": "ok", "message": "OK" }
+}
+```
+
+**Errors**
+
+- `404 Not Found` — `project_id` is missing or belongs to another workspace.
+- `409 Conflict` — sourcing is not configured for the workspace.
+- `422 Unprocessable Entity` — invalid strategy, invalid quantity, malformed codes, or unknown fields.
+- `429 Too Many Requests` — workspace rate limit: 15 requests/minute.
+- `502 Bad Gateway` — TrustedParts auth, rate-limit, timeout, upstream, or response-shape failure.
+- `503 Service Unavailable` — sourcing budget exhausted.
+
+**Notes**
+
+- The route validates `project_id` with `assert_in_workspace()` before creating any plan rows.
+- Plans are snapshots: each call creates a new `purchase_plans` row and child `purchase_plan_lines` rows.
+- `expires_at` is capped to `created_at + 7 days`; refresh and conversion are later Phase-4 endpoints.
+- Decimal monetary fields serialize as strings.
+
 ### `GET /api/parts/{part_id}/sourcing`
 
 Return cached TrustedParts offers for one part's MPN.


### PR DESCRIPTION
Summary
- Adds `POST /api/projects/{project_id}/purchase-plan` with member role gating, workspace-scoped project validation, and standard sourcing error envelopes.
- Adds `build_purchase_plan()` to source the BOM, run TP-402 optimizer strategies, and persist `PurchasePlan` plus `PurchasePlanLine` snapshots with a 7-day expiry.
- Adds purchase-plan request/response DTOs, response summary stats, route tests, a workspace-isolation pin, and API docs.

Validation
- `uv run python -m pytest -q tests/test_purchase_plan_route.py tests/test_workspace_isolation.py::test_purchase_plan_isolated_by_workspace` -> 14 passed
- `uv run python -m pytest -q -k "purchase_plan_route or workspace_isolation"` -> 68 passed, 901 deselected
- `LINT_CMD="ruff check app --output-format=concise" BASELINE_FILE="../.ruff-baseline.txt" WORK_DIR="." bash ../scripts/lint-delta.sh` -> no new violations
- `uv run python scripts/check_no_traceback_leaks.py` -> passed
- `git diff --check` -> passed

Example responses
- `preferred_first`: chooses preferred DigiKey at EUR 1.04 over Mouser at EUR 1.00 within the 5% tolerance and persists one draft plan line.
- `lowest_total_price`, `fewest_distributors`, `fastest_availability`, and `preferred_first` are parametrized in `test_each_strategy_produces_a_persisted_plan()` and each creates DB rows.

Workspace isolation
- New route validates `project_id` with `assert_in_workspace()` before service creation.
- Added `test_purchase_plan_isolated_by_workspace`; workspace B gets 404 for workspace A's project and the service is not reached.

Merge order
- Phase 4 stack order: #392 (#374) -> this PR (#375) -> #376 -> #377 -> #378 -> #379.
- This PR is intentionally based on `codex/tp-402-374-optimizer`; rebase/retarget it after #392 merges.

Refs #375
