### PR TITLE
TP-404: Plan refresh endpoint

### DIFF
--- a/backend/alembic/versions/0040_purchase_plan_refresh_metadata.py
+++ b/backend/alembic/versions/0040_purchase_plan_refresh_metadata.py
@@ -1,0 +1,73 @@
+"""Add purchase plan refresh metadata.
+
+Revision ID: 0040
+Revises: 0039
+Create Date: 2026-05-09
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "0040"
+down_revision = "0039"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "purchase_plans",
+        sa.Column("last_refreshed_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "purchase_plans",
+        sa.Column("max_distributors", sa.Integer(), nullable=True),
+    )
+    op.add_column(
+        "purchase_plans",
+        sa.Column("moq_overbuy_cap", sa.Integer(), nullable=True),
+    )
+    op.add_column(
+        "purchase_plans",
+        sa.Column("price_tolerance_pct", sa.Numeric(8, 4), nullable=True),
+    )
+    op.create_check_constraint(
+        "purchase_plans_max_distributors_positive",
+        "purchase_plans",
+        "max_distributors IS NULL OR max_distributors >= 1",
+    )
+    op.create_check_constraint(
+        "purchase_plans_moq_overbuy_cap_positive",
+        "purchase_plans",
+        "moq_overbuy_cap IS NULL OR moq_overbuy_cap >= 1",
+    )
+    op.create_check_constraint(
+        "purchase_plans_price_tolerance_pct_nonnegative",
+        "purchase_plans",
+        "price_tolerance_pct IS NULL OR price_tolerance_pct >= 0",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "purchase_plans_price_tolerance_pct_nonnegative",
+        "purchase_plans",
+        type_="check",
+    )
+    op.drop_constraint(
+        "purchase_plans_moq_overbuy_cap_positive",
+        "purchase_plans",
+        type_="check",
+    )
+    op.drop_constraint(
+        "purchase_plans_max_distributors_positive",
+        "purchase_plans",
+        type_="check",
+    )
+    op.drop_column("purchase_plans", "price_tolerance_pct")
+    op.drop_column("purchase_plans", "moq_overbuy_cap")
+    op.drop_column("purchase_plans", "max_distributors")
+    op.drop_column("purchase_plans", "last_refreshed_at")

--- a/backend/app/api/routes/sourcing.py
+++ b/backend/app/api/routes/sourcing.py
@@ -12,6 +12,7 @@ from app.api._helpers import assert_in_workspace
 from app.core.deps import CurrentUser, CurrentWorkspace, require_role
 from app.core.ratelimit import limiter, workspace_key
 from app.core.responses import err, ok
+from app.core.time import utcnow
 from app.domain.parts.models import Part
 from app.domain.projects.models import Project
 from app.domain.sourcing import (
@@ -22,6 +23,7 @@ from app.domain.sourcing import (
 )
 from app.domain.sourcing import service as sourcing_service
 from app.domain.sourcing.factory import make_sourcing_provider
+from app.domain.sourcing.models import PurchasePlan
 from app.domain.sourcing.schemas import (
     PurchasePlanIn,
     SourcingBomIn,
@@ -262,6 +264,65 @@ def create_project_purchase_plan(
         )
 
     return ok(sourcing_service.purchase_plan_to_out(plan).model_dump(mode="json"))
+
+
+@search_router.post(
+    "/purchase-plans/{plan_id}/refresh",
+    dependencies=[Depends(require_role("member"))],
+)
+@limiter.limit("15/minute", key_func=workspace_key)
+def refresh_purchase_plan(
+    request: Request,
+    plan_id: UUID,
+    ws: CurrentWorkspace,
+    user: CurrentUser,
+    db: Session = Depends(get_db),
+):
+    plan = assert_in_workspace(db, PurchasePlan, plan_id, ws.id, label="purchase plan")
+    if plan.expires_at <= utcnow():
+        return _error_response(request, 409, "conflict", "plan expired")
+
+    try:
+        refreshed = sourcing_service.refresh_purchase_plan(
+            db,
+            workspace=ws,
+            plan=plan,
+            requested_by=user.id,
+        )
+    except SourcingNotConfigured:
+        return _error_response(request, 409, "conflict", "sourcing not configured")
+    except SourcingBudgetBlocked:
+        return _error_response(request, 503, "server_error", "sourcing budget exhausted")
+    except SourcingAuthError:
+        return _error_response(
+            request,
+            502,
+            "server_error",
+            "TrustedParts rejected sourcing credentials",
+        )
+    except SourcingRateLimitError:
+        return _error_response(
+            request,
+            502,
+            "server_error",
+            "TrustedParts rate limit reached",
+        )
+    except SourcingTimeoutError:
+        return _error_response(
+            request,
+            502,
+            "server_error",
+            "TrustedParts request timed out",
+        )
+    except SourcingClientError:
+        return _error_response(
+            request,
+            502,
+            "server_error",
+            "TrustedParts sourcing request failed",
+        )
+
+    return ok(sourcing_service.purchase_plan_to_out(refreshed).model_dump(mode="json"))
 
 
 @parts_router.get(

--- a/backend/app/api/routes/sourcing.py
+++ b/backend/app/api/routes/sourcing.py
@@ -22,7 +22,12 @@ from app.domain.sourcing import (
 )
 from app.domain.sourcing import service as sourcing_service
 from app.domain.sourcing.factory import make_sourcing_provider
-from app.domain.sourcing.schemas import SourcingBomIn, SourcingQuery, SourcingSearchIn
+from app.domain.sourcing.schemas import (
+    PurchasePlanIn,
+    SourcingBomIn,
+    SourcingQuery,
+    SourcingSearchIn,
+)
 from app.domain.sourcing.service import SourcingBudgetBlocked, SourcingNotConfigured
 from app.infra.db import get_db
 
@@ -192,6 +197,71 @@ def source_project_bom(
         )
 
     return ok(out.model_dump(mode="json"))
+
+
+@projects_router.post(
+    "/{project_id}/purchase-plan",
+    dependencies=[Depends(require_role("member"))],
+)
+@limiter.limit("15/minute", key_func=workspace_key)
+def create_project_purchase_plan(
+    request: Request,
+    project_id: UUID,
+    payload: PurchasePlanIn,
+    ws: CurrentWorkspace,
+    user: CurrentUser,
+    db: Session = Depends(get_db),
+):
+    project = assert_in_workspace(db, Project, project_id, ws.id, label="project")
+    try:
+        plan = sourcing_service.build_purchase_plan(
+            db,
+            workspace=ws,
+            project=project,
+            build_quantity=payload.build_quantity,
+            strategy=payload.strategy,
+            country=payload.country,
+            currency=payload.currency,
+            distributors=payload.distributors,
+            max_distributors=payload.max_distributors,
+            moq_overbuy_cap=payload.moq_overbuy_cap,
+            price_tolerance_pct=payload.price_tolerance_pct,
+            requested_by=user.id,
+        )
+    except SourcingNotConfigured:
+        return _error_response(request, 409, "conflict", "sourcing not configured")
+    except SourcingBudgetBlocked:
+        return _error_response(request, 503, "server_error", "sourcing budget exhausted")
+    except SourcingAuthError:
+        return _error_response(
+            request,
+            502,
+            "server_error",
+            "TrustedParts rejected sourcing credentials",
+        )
+    except SourcingRateLimitError:
+        return _error_response(
+            request,
+            502,
+            "server_error",
+            "TrustedParts rate limit reached",
+        )
+    except SourcingTimeoutError:
+        return _error_response(
+            request,
+            502,
+            "server_error",
+            "TrustedParts request timed out",
+        )
+    except SourcingClientError:
+        return _error_response(
+            request,
+            502,
+            "server_error",
+            "TrustedParts sourcing request failed",
+        )
+
+    return ok(sourcing_service.purchase_plan_to_out(plan).model_dump(mode="json"))
 
 
 @parts_router.get(

--- a/backend/app/domain/sourcing/models.py
+++ b/backend/app/domain/sourcing/models.py
@@ -76,6 +76,18 @@ class PurchasePlan(Base):
             "expires_at <= created_at + interval '7 days'",
             name="purchase_plans_max_7_day_ttl",
         ),
+        CheckConstraint(
+            "max_distributors IS NULL OR max_distributors >= 1",
+            name="purchase_plans_max_distributors_positive",
+        ),
+        CheckConstraint(
+            "moq_overbuy_cap IS NULL OR moq_overbuy_cap >= 1",
+            name="purchase_plans_moq_overbuy_cap_positive",
+        ),
+        CheckConstraint(
+            "price_tolerance_pct IS NULL OR price_tolerance_pct >= 0",
+            name="purchase_plans_price_tolerance_pct_nonnegative",
+        ),
         Index("ix_purchase_plans_expires_at", "expires_at"),
         Index("ix_purchase_plans_ws_project", "workspace_id", "project_id"),
         Index("ix_purchase_plans_ws_status", "workspace_id", "status"),
@@ -102,6 +114,9 @@ class PurchasePlan(Base):
     country_code = Column(sa.String(2), nullable=True)
     currency_code = Column(sa.String(3), nullable=True)
     preferred_distributors = Column(JSONB, nullable=True)
+    max_distributors = Column(sa.Integer, nullable=True)
+    moq_overbuy_cap = Column(sa.Integer, nullable=True)
+    price_tolerance_pct = Column(sa.Numeric(8, 4), nullable=True)
     status = Column(
         sa.String(20),
         nullable=False,
@@ -115,6 +130,7 @@ class PurchasePlan(Base):
         server_default=sa.func.now(),
     )
     expires_at = Column(DateTime(timezone=True), nullable=False)
+    last_refreshed_at = Column(DateTime(timezone=True), nullable=True)
     created_by = Column(UUID(as_uuid=True), nullable=True)
 
     lines = relationship(

--- a/backend/app/domain/sourcing/schemas.py
+++ b/backend/app/domain/sourcing/schemas.py
@@ -298,9 +298,13 @@ class PurchasePlanOut(BaseModel):
     country_code: str | None = None
     currency_code: str | None = None
     preferred_distributors: list[str] | None = None
+    max_distributors: int | None = None
+    moq_overbuy_cap: int | None = None
+    price_tolerance_pct: Decimal | None = None
     status: str
     created_at: datetime
     expires_at: datetime
+    last_refreshed_at: datetime | None = None
     created_by: UUID | None = None
     lines: list[PurchasePlanLineOut]
     distributors_used: list[str]

--- a/backend/app/domain/sourcing/schemas.py
+++ b/backend/app/domain/sourcing/schemas.py
@@ -234,6 +234,81 @@ class OptimizerOutcomeOut(BaseModel):
     worst_lead_time_days: int | None = None
 
 
+class PurchasePlanIn(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    build_quantity: int = Field(ge=1)
+    strategy: Literal[
+        "lowest_total_price",
+        "fewest_distributors",
+        "fastest_availability",
+        "preferred_first",
+    ] = "preferred_first"
+    country: str | None = Field(default=None, min_length=2, max_length=2)
+    currency: str | None = Field(default=None, min_length=3, max_length=3)
+    distributors: list[str] | None = None
+    max_distributors: int | None = Field(default=None, ge=1)
+    moq_overbuy_cap: int | None = Field(default=None, ge=1)
+    price_tolerance_pct: Decimal = Field(default=Decimal("5"), ge=0)
+
+    @field_validator("country", "currency")
+    @classmethod
+    def _uppercase_codes(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return value.strip().upper()
+
+    @field_validator("distributors")
+    @classmethod
+    def _strip_distributors(cls, value: list[str] | None) -> list[str] | None:
+        if value is None:
+            return None
+        stripped = [item.strip() for item in value if item.strip()]
+        return stripped or None
+
+
+class PurchasePlanLineOut(BaseModel):
+    model_config = ConfigDict(extra="forbid", from_attributes=True)
+
+    id: UUID
+    project_entry_id: UUID | None
+    part_id: UUID
+    mpn_searched: str
+    required_qty: int
+    internal_available_qty: int
+    shortage_qty: int
+    selected_distributor: str | None = None
+    selected_qty: int | None = None
+    selected_unit_price: Decimal | None = None
+    selected_currency: str | None = None
+    selected_packaging: str | None = None
+    selected_moq: int | None = None
+    selected_lead_time_days: int | None = None
+    selected_url: str | None = None
+    risk_flags: list[str] = Field(default_factory=list)
+
+
+class PurchasePlanOut(BaseModel):
+    model_config = ConfigDict(extra="forbid", from_attributes=True)
+
+    id: UUID
+    project_id: UUID
+    build_quantity: int
+    strategy: str
+    country_code: str | None = None
+    currency_code: str | None = None
+    preferred_distributors: list[str] | None = None
+    status: str
+    created_at: datetime
+    expires_at: datetime
+    created_by: UUID | None = None
+    lines: list[PurchasePlanLineOut]
+    distributors_used: list[str]
+    est_total_cost: Decimal | None = None
+    worst_lead_time_days: int | None = None
+    unfilled_count: int
+
+
 class SourcingBomLineOut(BaseModel):
     model_config = ConfigDict(extra="forbid")
 

--- a/backend/app/domain/sourcing/service.py
+++ b/backend/app/domain/sourcing/service.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Sequence
-from datetime import datetime
+from datetime import datetime, timedelta
 from decimal import Decimal
 from typing import Any
 from uuid import UUID
@@ -18,10 +18,13 @@ from app.domain.sourcing import cache
 from app.domain.sourcing.budget import BUDGET
 from app.domain.sourcing.coverage import compute_build_capacity, compute_coverage
 from app.domain.sourcing.factory import make_sourcing_provider
+from app.domain.sourcing.models import PurchasePlan, PurchasePlanLine
+from app.domain.sourcing.optimizer import Strategy, optimize
 from app.domain.sourcing.pricing import best_unit_price_at_qty
 from app.domain.sourcing.schemas import (
     BuildCapacityOut,
     DistributorCoverageMatrixOut,
+    PurchasePlanOut,
     SourcingAttributionLinks,
     SourcingBomLineOut,
     SourcingBomOfferOut,
@@ -35,6 +38,7 @@ from app.domain.sourcing.schemas import (
 
 TTL_SECONDS = 30 * 60
 BOM_TTL_SECONDS = 10 * 60
+PURCHASE_PLAN_TTL = timedelta(days=7)
 TRUSTEDPARTS_LINKS = SourcingAttributionLinks(
     primary="https://www.trustedparts.com/",
     attribution="https://www.trustedparts.com/en/about",
@@ -47,6 +51,140 @@ class SourcingNotConfigured(Exception):
 
 class SourcingBudgetBlocked(Exception):
     """Workspace exceeded the hard TrustedParts parts-count budget."""
+
+
+def build_purchase_plan(
+    db: Session,
+    *,
+    workspace: Any,
+    project: Any,
+    build_quantity: int,
+    strategy: Strategy = "preferred_first",
+    country: str | None = None,
+    currency: str | None = None,
+    distributors: list[str] | None = None,
+    max_distributors: int | None = None,
+    moq_overbuy_cap: int | None = None,
+    price_tolerance_pct: Decimal = Decimal("5"),
+    requested_by: UUID | None = None,
+) -> PurchasePlan:
+    bom = source_bom(
+        db,
+        workspace=workspace,
+        project=project,
+        build_quantity=build_quantity,
+        country=country,
+        currency=currency,
+        distributors=distributors,
+        in_stock_only=False,
+        use_cached_data=None,
+        requested_by=requested_by,
+    )
+    preferred_distributors = (
+        _clean_distributors(distributors)
+        if distributors is not None
+        else _clean_distributors(workspace.sourcing_preferred_distributors)
+    )
+    outcome = optimize(
+        bom.rows,
+        strategy=strategy,
+        preferred_distributors=preferred_distributors,
+        max_distributors=max_distributors,
+        moq_overbuy_cap=moq_overbuy_cap,
+        price_tolerance_pct=price_tolerance_pct,
+    )
+    created_at = utcnow()
+    plan = PurchasePlan(
+        workspace_id=workspace.id,
+        project_id=project.id,
+        build_quantity=build_quantity,
+        strategy=strategy,
+        country_code=_clean_code(country) or workspace.sourcing_country_code,
+        currency_code=_clean_code(currency) or workspace.sourcing_currency_code,
+        preferred_distributors=preferred_distributors,
+        status="draft",
+        created_at=created_at,
+        expires_at=created_at + PURCHASE_PLAN_TTL,
+        created_by=requested_by,
+    )
+    plan.lines = [
+        PurchasePlanLine(
+            project_entry_id=selection.project_entry_id,
+            part_id=selection.part_id,
+            mpn_searched=selection.mpn_searched,
+            required_qty=selection.required_qty,
+            internal_available_qty=selection.internal_available_qty,
+            shortage_qty=selection.shortage_qty,
+            selected_distributor=selection.selected_distributor,
+            selected_qty=selection.selected_qty,
+            selected_unit_price=selection.selected_unit_price,
+            selected_currency=selection.selected_currency,
+            selected_packaging=selection.selected_packaging,
+            selected_moq=selection.selected_moq,
+            selected_lead_time_days=selection.selected_lead_time_days,
+            selected_url=selection.selected_url,
+            risk_flags=list(selection.risk_flags),
+        )
+        for selection in outcome.selections
+    ]
+    db.add(plan)
+    db.flush()
+    return plan
+
+
+def purchase_plan_to_out(plan: PurchasePlan) -> PurchasePlanOut:
+    lines = sorted(
+        plan.lines,
+        key=lambda line: (
+            str(line.project_entry_id or ""),
+            (line.selected_distributor or "").casefold(),
+            str(line.id),
+        ),
+    )
+    unfilled_count = sum(1 for line in lines if line.selected_distributor is None)
+    if unfilled_count:
+        est_total_cost: Decimal | None = None
+    else:
+        est_total_cost = sum(
+            (
+                line.selected_unit_price * Decimal(line.selected_qty or 0)
+                for line in lines
+                if line.selected_unit_price is not None
+            ),
+            Decimal("0"),
+        )
+    lead_times = [
+        line.selected_lead_time_days
+        for line in lines
+        if line.selected_lead_time_days is not None
+    ]
+    return PurchasePlanOut.model_validate(
+        {
+            "id": plan.id,
+            "project_id": plan.project_id,
+            "build_quantity": plan.build_quantity,
+            "strategy": plan.strategy,
+            "country_code": plan.country_code,
+            "currency_code": plan.currency_code,
+            "preferred_distributors": plan.preferred_distributors,
+            "status": plan.status,
+            "created_at": plan.created_at,
+            "expires_at": plan.expires_at,
+            "created_by": plan.created_by,
+            "lines": lines,
+            "distributors_used": sorted(
+                {
+                    line.selected_distributor
+                    for line in lines
+                    if line.selected_distributor is not None
+                },
+                key=str.casefold,
+            ),
+            "est_total_cost": est_total_cost,
+            "worst_lead_time_days": max(lead_times) if lead_times else None,
+            "unfilled_count": unfilled_count,
+        }
+    )
 
 
 def dedupe_mpns(mpns: Iterable[str | None]) -> list[str]:

--- a/backend/app/domain/sourcing/service.py
+++ b/backend/app/domain/sourcing/service.py
@@ -14,6 +14,7 @@ from sqlalchemy.orm import Session
 from app.core.time import utcnow
 from app.domain.builds.service import shortage_analysis
 from app.domain.parts.models import Part
+from app.domain.projects.models import Project
 from app.domain.sourcing import cache
 from app.domain.sourcing.budget import BUDGET
 from app.domain.sourcing.coverage import compute_build_capacity, compute_coverage
@@ -102,6 +103,9 @@ def build_purchase_plan(
         country_code=_clean_code(country) or workspace.sourcing_country_code,
         currency_code=_clean_code(currency) or workspace.sourcing_currency_code,
         preferred_distributors=preferred_distributors,
+        max_distributors=max_distributors,
+        moq_overbuy_cap=moq_overbuy_cap,
+        price_tolerance_pct=price_tolerance_pct,
         status="draft",
         created_at=created_at,
         expires_at=created_at + PURCHASE_PLAN_TTL,
@@ -128,6 +132,68 @@ def build_purchase_plan(
         for selection in outcome.selections
     ]
     db.add(plan)
+    db.flush()
+    return plan
+
+
+def refresh_purchase_plan(
+    db: Session,
+    *,
+    workspace: Any,
+    plan: PurchasePlan,
+    requested_by: UUID | None = None,
+) -> PurchasePlan:
+    project = db.execute(
+        select(Project).where(Project.id == plan.project_id, Project.workspace_id == workspace.id)
+    ).scalar_one_or_none()
+    if project is None:
+        raise ValueError("purchase plan project not found")
+
+    bom = source_bom(
+        db,
+        workspace=workspace,
+        project=project,
+        build_quantity=plan.build_quantity,
+        country=plan.country_code,
+        currency=plan.currency_code,
+        distributors=plan.preferred_distributors,
+        in_stock_only=False,
+        use_cached_data=False,
+        ttl_seconds=0,
+        requested_by=requested_by,
+        force_refresh=True,
+    )
+    outcome = optimize(
+        bom.rows,
+        strategy=plan.strategy,
+        preferred_distributors=plan.preferred_distributors,
+        max_distributors=plan.max_distributors,
+        moq_overbuy_cap=plan.moq_overbuy_cap,
+        price_tolerance_pct=Decimal(plan.price_tolerance_pct or Decimal("5")),
+    )
+
+    plan.lines = [
+        PurchasePlanLine(
+            project_entry_id=selection.project_entry_id,
+            part_id=selection.part_id,
+            mpn_searched=selection.mpn_searched,
+            required_qty=selection.required_qty,
+            internal_available_qty=selection.internal_available_qty,
+            shortage_qty=selection.shortage_qty,
+            selected_distributor=selection.selected_distributor,
+            selected_qty=selection.selected_qty,
+            selected_unit_price=selection.selected_unit_price,
+            selected_currency=selection.selected_currency,
+            selected_packaging=selection.selected_packaging,
+            selected_moq=selection.selected_moq,
+            selected_lead_time_days=selection.selected_lead_time_days,
+            selected_url=selection.selected_url,
+            risk_flags=list(selection.risk_flags),
+        )
+        for selection in outcome.selections
+    ]
+    plan.status = "refreshed"
+    plan.last_refreshed_at = utcnow()
     db.flush()
     return plan
 
@@ -167,9 +233,13 @@ def purchase_plan_to_out(plan: PurchasePlan) -> PurchasePlanOut:
             "country_code": plan.country_code,
             "currency_code": plan.currency_code,
             "preferred_distributors": plan.preferred_distributors,
+            "max_distributors": plan.max_distributors,
+            "moq_overbuy_cap": plan.moq_overbuy_cap,
+            "price_tolerance_pct": plan.price_tolerance_pct,
             "status": plan.status,
             "created_at": plan.created_at,
             "expires_at": plan.expires_at,
+            "last_refreshed_at": plan.last_refreshed_at,
             "created_by": plan.created_by,
             "lines": lines,
             "distributors_used": sorted(
@@ -223,6 +293,7 @@ def source_bom(
     use_cached_data: bool | None = None,
     ttl_seconds: int = BOM_TTL_SECONDS,
     requested_by: UUID | None = None,
+    force_refresh: bool = False,
 ) -> SourcingBomOut:
     shortage = shortage_analysis(
         db,
@@ -255,6 +326,7 @@ def source_bom(
             use_cached_data=use_cached_data,
             ttl_seconds=ttl_seconds,
             requested_by=requested_by,
+            force_refresh=force_refresh,
         )
         fetched_at_values.append(out.fetched_at)
         for result in out.results:

--- a/backend/tests/test_purchase_plan_refresh_route.py
+++ b/backend/tests/test_purchase_plan_refresh_route.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+import uuid
+from datetime import timedelta
+from decimal import Decimal
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+
+import app.core.ratelimit as _ratelimit_mod
+from app.core.time import utcnow
+from app.domain.sourcing.budget import BUDGET
+from app.domain.sourcing.models import PurchasePlan, PurchasePlanLine
+from app.main import app
+from tests._factories import signup_user
+from tests.test_purchase_plan_route import (
+    _configure_sourcing,
+    _FakeTrustedPartsClient,
+    _offer,
+    _post_plan,
+    _single_line_project,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_sourcing_state(monkeypatch):
+    original_limiter_enabled = _ratelimit_mod.limiter.enabled
+    _ratelimit_mod.limiter.enabled = False
+    _FakeTrustedPartsClient.calls = []
+    _FakeTrustedPartsClient.offers_by_mpn = {}
+    BUDGET._events.clear()
+    try:
+        _ratelimit_mod.limiter.reset()
+    except Exception:
+        pass
+    monkeypatch.setattr(
+        "app.domain.sourcing.service.make_sourcing_provider",
+        lambda workspace: _FakeTrustedPartsClient(workspace.id),
+    )
+    yield
+    _ratelimit_mod.limiter.enabled = original_limiter_enabled
+    BUDGET._events.clear()
+    try:
+        _ratelimit_mod.limiter.reset()
+    except Exception:
+        pass
+
+
+def _refresh(client: TestClient, plan_id: str, body: dict | None = None):
+    return client.post(
+        f"/api/sourcing/purchase-plans/{plan_id}/refresh",
+        json=body if body is not None else None,
+    )
+
+
+def _create_plan(client: TestClient, *, mpn: str = "REFRESH", strategy: str = "preferred_first"):
+    _configure_sourcing(client, preferred=["DigiKey"])
+    project_id = _single_line_project(client, mpn=mpn, quantity=5)
+    r = _post_plan(client, project_id, strategy=strategy)
+    assert r.status_code == 200, r.text
+    return r.json()["data"]
+
+
+def test_refresh_replaces_lines_and_sets_status(authed_client, db):
+    _FakeTrustedPartsClient.offers_by_mpn = {
+        "REFRESH": [_offer("REFRESH", distributor="DigiKey", stock=50, unit_price=1.0)]
+    }
+    initial = _create_plan(authed_client)
+    original_line_id = initial["lines"][0]["id"]
+    original_expires_at = initial["expires_at"]
+    _FakeTrustedPartsClient.offers_by_mpn = {
+        "REFRESH": [_offer("REFRESH", distributor="Mouser", stock=50, unit_price=0.5)]
+    }
+
+    r = _refresh(authed_client, initial["id"])
+
+    assert r.status_code == 200, r.text
+    data = r.json()["data"]
+    assert data["status"] == "refreshed"
+    assert data["last_refreshed_at"] is not None
+    assert data["expires_at"] == original_expires_at
+    assert len(data["lines"]) == 1
+    assert data["lines"][0]["id"] != original_line_id
+    assert data["lines"][0]["selected_distributor"] == "Mouser"
+
+    rows = db.execute(
+        select(PurchasePlanLine).where(PurchasePlanLine.purchase_plan_id == uuid.UUID(data["id"]))
+    ).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].selected_distributor == "Mouser"
+
+
+def test_refresh_does_not_extend_expires_at(authed_client, db):
+    initial = _create_plan(authed_client)
+    before = db.get(PurchasePlan, uuid.UUID(initial["id"]))
+    assert before is not None
+    expires_at = before.expires_at
+
+    r = _refresh(authed_client, initial["id"])
+
+    assert r.status_code == 200, r.text
+    after = db.get(PurchasePlan, uuid.UUID(initial["id"]))
+    assert after is not None
+    assert after.expires_at == expires_at
+
+
+def test_refresh_uses_persisted_strategy_not_request_body(authed_client):
+    _FakeTrustedPartsClient.offers_by_mpn = {
+        "STRATEGY": [
+            _offer(
+                "STRATEGY",
+                distributor="SlowCheap",
+                stock=50,
+                unit_price=0.25,
+                lead_time_days=20,
+            ),
+            _offer(
+                "STRATEGY",
+                distributor="FastCostly",
+                stock=50,
+                unit_price=9.0,
+                lead_time_days=2,
+            ),
+        ]
+    }
+    initial = _create_plan(
+        authed_client,
+        mpn="STRATEGY",
+        strategy="fastest_availability",
+    )
+
+    r = _refresh(authed_client, initial["id"], body={"strategy": "lowest_total_price"})
+
+    assert r.status_code == 200, r.text
+    assert r.json()["data"]["lines"][0]["selected_distributor"] == "FastCostly"
+
+
+def test_foreign_plan_returns_404(authed_client):
+    initial = _create_plan(authed_client)
+
+    client_b = TestClient(app)
+    signup_user(client_b)
+    _configure_sourcing(client_b)
+
+    r = _refresh(client_b, initial["id"])
+
+    assert r.status_code == 404, r.text
+    assert r.json()["status"]["category"] == "not_found"
+
+
+def test_expired_plan_returns_conflict(authed_client, db):
+    initial = _create_plan(authed_client)
+    plan = db.get(PurchasePlan, uuid.UUID(initial["id"]))
+    assert plan is not None
+    plan.expires_at = utcnow() - timedelta(minutes=1)
+    db.flush()
+
+    r = _refresh(authed_client, initial["id"])
+
+    assert r.status_code == 409, r.text
+    assert r.json()["status"] == {"category": "conflict", "message": "plan expired"}
+
+
+def test_workspace_isolation_two_plans_different_workspaces(authed_client):
+    plan_a = _create_plan(authed_client, mpn="WS-A")
+
+    client_b = TestClient(app)
+    signup_user(client_b)
+    plan_b = _create_plan(client_b, mpn="WS-B")
+
+    foreign = _refresh(client_b, plan_a["id"])
+    own = _refresh(client_b, plan_b["id"])
+
+    assert foreign.status_code == 404, foreign.text
+    assert own.status_code == 200, own.text
+    assert own.json()["data"]["id"] == plan_b["id"]
+
+
+def test_decimals_as_strings_on_wire(authed_client):
+    _FakeTrustedPartsClient.offers_by_mpn = {
+        "DECIMAL": [_offer("DECIMAL", distributor="DigiKey", stock=50, unit_price=1.25)]
+    }
+    initial = _create_plan(authed_client, mpn="DECIMAL")
+
+    r = _refresh(authed_client, initial["id"])
+
+    assert r.status_code == 200, r.text
+    unit_price = r.json()["data"]["lines"][0]["selected_unit_price"]
+    total = r.json()["data"]["est_total_cost"]
+    assert isinstance(unit_price, str)
+    assert isinstance(total, str)
+    assert Decimal(unit_price) == Decimal("1.25")
+    assert Decimal(total) == Decimal("6.25")

--- a/backend/tests/test_purchase_plan_route.py
+++ b/backend/tests/test_purchase_plan_route.py
@@ -1,0 +1,344 @@
+from __future__ import annotations
+
+import uuid
+from datetime import timedelta
+from decimal import Decimal
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+
+import app.core.ratelimit as _ratelimit_mod
+from app.core.time import utcnow
+from app.domain.sourcing.budget import BUDGET
+from app.domain.sourcing.models import PurchasePlan, PurchasePlanLine
+from app.domain.sourcing.schemas import (
+    SourcingDistributor,
+    SourcingLinks,
+    SourcingOffer,
+    SourcingPriceBreak,
+    SourcingQuery,
+    SourcingSearchRaw,
+)
+from app.main import app
+from tests._factories import create_part, create_project_with_bom, signup_user
+
+
+def _configure_sourcing(
+    client: TestClient,
+    *,
+    preferred: list[str] | None = None,
+) -> None:
+    r = client.patch(
+        "/api/workspaces/current",
+        json={
+            "sourcing_provider": "trustedparts",
+            "sourcing_company_id": "company-123",
+            "sourcing_api_key": "api-key-456",
+            "sourcing_country_code": "CZ",
+            "sourcing_currency_code": "EUR",
+            "sourcing_preferred_distributors": preferred or ["DigiKey"],
+            "sourcing_use_cached_for_dashboards": False,
+        },
+    )
+    assert r.status_code == 200, r.text
+
+
+def _current_workspace_id(client: TestClient) -> uuid.UUID:
+    r = client.get("/api/workspaces/current")
+    assert r.status_code == 200, r.text
+    return uuid.UUID(r.json()["data"]["id"])
+
+
+def _offer(
+    mpn: str,
+    *,
+    distributor: str = "DigiKey",
+    stock: int = 100,
+    unit_price: float = 1.0,
+    moq: int | None = 1,
+    lead_time_days: int | None = 3,
+    currency: str = "EUR",
+) -> SourcingOffer:
+    return SourcingOffer(
+        mpn=mpn,
+        manufacturer="TestCo",
+        description=f"Offer for {mpn}",
+        distributors=[
+            SourcingDistributor(
+                name=distributor,
+                sku=f"{mpn}-{distributor}",
+                stock=stock,
+                unit_price=unit_price,
+                currency=currency,
+                moq=moq,
+                lead_time_days=lead_time_days,
+                price_breaks=[SourcingPriceBreak(quantity=1, unit_price=unit_price)],
+                product_url=f"https://www.trustedparts.com/{mpn}/{distributor}",
+            )
+        ],
+        links=SourcingLinks(primary=f"https://www.trustedparts.com/search/{mpn}"),
+    )
+
+
+class _FakeTrustedPartsClient:
+    calls: list[dict[str, Any]] = []
+    offers_by_mpn: dict[str, list[SourcingOffer]] = {}
+
+    def __init__(self, workspace_id: uuid.UUID | None = None) -> None:
+        self.workspace_id = workspace_id
+        self.country_code = "CZ"
+        self.currency_code = "EUR"
+
+    def search(
+        self,
+        queries: list[SourcingQuery],
+        *,
+        in_stock_only: bool,
+        distributors: list[str] | None,
+        use_cached_data: bool,
+        **_kwargs,
+    ) -> SourcingSearchRaw:
+        query = queries[0]
+        self.calls.append(
+            {
+                "workspace_id": str(self.workspace_id) if self.workspace_id else None,
+                "mpn": query.search_token,
+                "distributors": distributors,
+                "use_cached_data": use_cached_data,
+            }
+        )
+        offers = self.offers_by_mpn.get(query.search_token)
+        if offers is None and self.workspace_id is not None:
+            distributor = f"WS-{str(self.workspace_id)[:8]}"
+            offers = [_offer(query.search_token, distributor=distributor)]
+        return SourcingSearchRaw(
+            offers=offers or [],
+            request_id=f"req-{len(self.calls)}",
+        )
+
+
+@pytest.fixture(autouse=True)
+def reset_sourcing_state(monkeypatch):
+    original_limiter_enabled = _ratelimit_mod.limiter.enabled
+    _ratelimit_mod.limiter.enabled = False
+    _FakeTrustedPartsClient.calls = []
+    _FakeTrustedPartsClient.offers_by_mpn = {}
+    BUDGET._events.clear()
+    try:
+        _ratelimit_mod.limiter.reset()
+    except Exception:
+        pass
+    monkeypatch.setattr(
+        "app.domain.sourcing.service.make_sourcing_provider",
+        lambda workspace: _FakeTrustedPartsClient(workspace.id),
+    )
+    yield
+    _ratelimit_mod.limiter.enabled = original_limiter_enabled
+    BUDGET._events.clear()
+    try:
+        _ratelimit_mod.limiter.reset()
+    except Exception:
+        pass
+
+
+def _single_line_project(
+    client: TestClient,
+    *,
+    mpn: str = "PLAN-MPN",
+    quantity: int = 10,
+) -> str:
+    part_id = create_part(client, name=mpn, mpn=mpn)
+    return create_project_with_bom(
+        client,
+        f"Plan Project {mpn}",
+        [{"part_id": part_id, "quantity": quantity}],
+    )
+
+
+def _post_plan(
+    client: TestClient,
+    project_id: str,
+    *,
+    build_quantity: int = 1,
+    strategy: str = "preferred_first",
+):
+    return client.post(
+        f"/api/projects/{project_id}/purchase-plan",
+        json={"build_quantity": build_quantity, "strategy": strategy},
+    )
+
+
+def test_basic_plan_creation_with_default_strategy(authed_client, db):
+    _configure_sourcing(authed_client, preferred=["DigiKey"])
+    project_id = _single_line_project(authed_client, mpn="BASIC", quantity=4)
+    _FakeTrustedPartsClient.offers_by_mpn = {
+        "BASIC": [
+            _offer("BASIC", distributor="Mouser", stock=50, unit_price=1.0),
+            _offer("BASIC", distributor="DigiKey", stock=50, unit_price=1.04),
+        ]
+    }
+
+    r = authed_client.post(
+        f"/api/projects/{project_id}/purchase-plan",
+        json={"build_quantity": 2},
+    )
+
+    assert r.status_code == 200, r.text
+    data = r.json()["data"]
+    assert data["strategy"] == "preferred_first"
+    assert data["status"] == "draft"
+    assert data["build_quantity"] == 2
+    assert data["distributors_used"] == ["DigiKey"]
+    assert data["unfilled_count"] == 0
+    assert len(data["lines"]) == 1
+    assert data["lines"][0]["selected_distributor"] == "DigiKey"
+    assert Decimal(data["lines"][0]["selected_unit_price"]) == Decimal("1.04")
+
+    plan = db.get(PurchasePlan, uuid.UUID(data["id"]))
+    assert plan is not None
+    assert plan.workspace_id == _current_workspace_id(authed_client)
+    assert plan.expires_at <= plan.created_at + timedelta(days=7)
+
+
+@pytest.mark.parametrize(
+    "strategy",
+    [
+        "lowest_total_price",
+        "fewest_distributors",
+        "fastest_availability",
+        "preferred_first",
+    ],
+)
+def test_each_strategy_produces_a_persisted_plan(authed_client, db, strategy: str):
+    _configure_sourcing(authed_client)
+    project_id = _single_line_project(authed_client, mpn=f"STRAT-{strategy}")
+
+    r = _post_plan(authed_client, project_id, strategy=strategy)
+
+    assert r.status_code == 200, r.text
+    plan_id = uuid.UUID(r.json()["data"]["id"])
+    rows = db.execute(
+        select(PurchasePlanLine).where(PurchasePlanLine.purchase_plan_id == plan_id)
+    ).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].selected_distributor is not None
+
+
+def test_foreign_project_returns_404(authed_client):
+    other = TestClient(app)
+    signup_user(other)
+    _configure_sourcing(authed_client)
+    foreign_project_id = _single_line_project(other, mpn="FOREIGN-MPN")
+
+    r = _post_plan(authed_client, foreign_project_id)
+
+    assert r.status_code == 404, r.text
+    assert r.json()["status"]["category"] == "not_found"
+
+
+def test_invalid_build_quantity_returns_422(authed_client):
+    _configure_sourcing(authed_client)
+    project_id = _single_line_project(authed_client)
+
+    r = authed_client.post(
+        f"/api/projects/{project_id}/purchase-plan",
+        json={"build_quantity": 0},
+    )
+
+    assert r.status_code == 422, r.text
+    assert r.json()["status"]["category"] == "validation_error"
+
+
+def test_invalid_strategy_returns_422(authed_client):
+    _configure_sourcing(authed_client)
+    project_id = _single_line_project(authed_client)
+
+    r = _post_plan(authed_client, project_id, strategy="magic")
+
+    assert r.status_code == 422, r.text
+    assert r.json()["status"]["category"] == "validation_error"
+
+
+def test_unconfigured_returns_409(authed_client, monkeypatch):
+    monkeypatch.setattr(
+        "app.domain.sourcing.service.make_sourcing_provider",
+        lambda _workspace: None,
+    )
+    project_id = _single_line_project(authed_client)
+
+    r = _post_plan(authed_client, project_id)
+
+    assert r.status_code == 409, r.text
+    assert r.json()["status"] == {
+        "category": "conflict",
+        "message": "sourcing not configured",
+    }
+
+
+def test_budget_blocked_returns_503(authed_client):
+    _configure_sourcing(authed_client)
+    project_id = _single_line_project(authed_client)
+    BUDGET.record(_current_workspace_id(authed_client), 250)
+
+    r = _post_plan(authed_client, project_id)
+
+    assert r.status_code == 503, r.text
+    assert r.json()["status"] == {
+        "category": "server_error",
+        "message": "sourcing budget exhausted",
+    }
+
+
+def test_workspace_isolation_two_workspaces_same_project_id(authed_client, db):
+    _configure_sourcing(authed_client)
+    project_a = _single_line_project(authed_client, mpn="SHARED")
+
+    client_b = TestClient(app)
+    signup_user(client_b)
+    _configure_sourcing(client_b)
+
+    r = _post_plan(client_b, project_a)
+
+    assert r.status_code == 404, r.text
+    assert db.execute(select(PurchasePlan)).scalars().all() == []
+
+
+def test_plan_lines_match_optimizer_output(authed_client, db):
+    _configure_sourcing(authed_client)
+    project_id = _single_line_project(authed_client, mpn="MATCH", quantity=3)
+    _FakeTrustedPartsClient.offers_by_mpn = {
+        "MATCH": [
+            _offer("MATCH", distributor="Slow", stock=50, unit_price=0.5, lead_time_days=10),
+            _offer("MATCH", distributor="Fast", stock=50, unit_price=1.5, lead_time_days=2),
+        ]
+    }
+
+    r = _post_plan(authed_client, project_id, strategy="fastest_availability")
+
+    assert r.status_code == 200, r.text
+    line = r.json()["data"]["lines"][0]
+    assert line["selected_distributor"] == "Fast"
+    assert line["selected_qty"] == 3
+    assert line["shortage_qty"] == 3
+    assert Decimal(line["selected_unit_price"]) == Decimal("1.5")
+
+    db_line = db.execute(select(PurchasePlanLine)).scalar_one()
+    assert db_line.selected_distributor == line["selected_distributor"]
+    assert db_line.selected_qty == line["selected_qty"]
+    assert db_line.selected_unit_price == Decimal(line["selected_unit_price"])
+
+
+def test_expires_at_uses_created_at_plus_seven_days(authed_client, db):
+    _configure_sourcing(authed_client)
+    project_id = _single_line_project(authed_client)
+    before = utcnow()
+
+    r = _post_plan(authed_client, project_id)
+
+    assert r.status_code == 200, r.text
+    plan = db.get(PurchasePlan, uuid.UUID(r.json()["data"]["id"]))
+    assert plan is not None
+    assert plan.created_at >= before
+    assert plan.expires_at == plan.created_at + timedelta(days=7)

--- a/backend/tests/test_workspace_isolation.py
+++ b/backend/tests/test_workspace_isolation.py
@@ -16,6 +16,9 @@ from tests._factories import (
     create_part as _create_part,
 )
 from tests._factories import (
+    create_project_with_bom as _create_project_with_bom,
+)
+from tests._factories import (
     create_storage as _create_storage,
 )
 from tests._factories import (
@@ -500,6 +503,32 @@ def test_sourcing_search_uses_caller_workspace_secrets(monkeypatch):
     ]
     assert RecordingTrustedPartsClient.calls[-1]["company_id"] == "company-b"
     assert RecordingTrustedPartsClient.calls[-1]["api_key"] == "api-key-b"
+
+
+def test_purchase_plan_isolated_by_workspace(monkeypatch):
+    a, b = _two_workspaces()
+    part_a = _create_part(a, "A-plan-part")
+    project_a = _create_project_with_bom(
+        a,
+        "A plan",
+        [{"part_id": part_a, "quantity": 1}],
+    )
+
+    def fail_build_purchase_plan(*_args, **_kwargs):
+        pytest.fail("foreign project id reached purchase-plan service")
+
+    monkeypatch.setattr(
+        "app.domain.sourcing.service.build_purchase_plan",
+        fail_build_purchase_plan,
+    )
+
+    r = b.post(
+        f"/api/projects/{project_a}/purchase-plan",
+        json={"build_quantity": 1},
+    )
+
+    assert r.status_code == 404, r.text
+    assert r.json()["status"]["category"] == "not_found"
 
 
 # ---------------------------------------------------------------------------

--- a/docs/api/sourcing.md
+++ b/docs/api/sourcing.md
@@ -146,6 +146,48 @@ Path: `project_id` is a project UUID in the current workspace.
 - `expires_at` is capped to `created_at + 7 days`; refresh and conversion are later Phase-4 endpoints.
 - Decimal monetary fields serialize as strings.
 
+### `POST /api/sourcing/purchase-plans/{plan_id}/refresh`
+
+Re-run a purchase plan with fresh TrustedParts offers and replace its plan lines.
+
+**Request**
+
+Path: `plan_id` is a purchase plan UUID in the current workspace. No request body is accepted; refresh uses the strategy and filters persisted on the plan.
+
+**Response** — `200 OK` (envelope: `{ data, status }`)
+
+Shape matches `POST /api/projects/{project_id}/purchase-plan`, with `status` set to `refreshed` and `last_refreshed_at` populated.
+
+```json
+{
+  "data": {
+    "id": "9b7f7d43-6b5c-4f7d-bc0e-44c6d73f0992",
+    "strategy": "preferred_first",
+    "status": "refreshed",
+    "expires_at": "2026-05-15T12:00:00+00:00",
+    "last_refreshed_at": "2026-05-09T12:00:00+00:00",
+    "lines": []
+  },
+  "status": { "category": "ok", "message": "OK" }
+}
+```
+
+**Errors**
+
+- `404 Not Found` — `plan_id` is missing or belongs to another workspace.
+- `409 Conflict` — the plan has expired, or sourcing is not configured.
+- `422 Unprocessable Entity` — malformed UUID.
+- `429 Too Many Requests` — workspace rate limit: 15 requests/minute.
+- `502 Bad Gateway` — TrustedParts auth, rate-limit, timeout, upstream, or response-shape failure.
+- `503 Service Unavailable` — sourcing budget exhausted.
+
+**Notes**
+
+- Expired plans return `409 Conflict` with `message="plan expired"`.
+- Refresh deletes the old `purchase_plan_lines` and inserts a fresh optimizer outcome.
+- Refresh does not extend `expires_at`; the original 7-day cap stays in force.
+- The service forces a live TrustedParts refresh by using `use_cached_data=false` and bypassing the local cache hit path.
+
 ### `GET /api/parts/{part_id}/sourcing`
 
 Return cached TrustedParts offers for one part's MPN.

--- a/docs/api/sourcing.md
+++ b/docs/api/sourcing.md
@@ -77,6 +77,75 @@ Path: `project_id` is a project UUID in the current workspace.
 - Service: `backend/app/domain/sourcing/service.py:71-135`.
 - Pricing: `backend/app/domain/sourcing/pricing.py:9-40`.
 
+### `POST /api/projects/{project_id}/purchase-plan`
+
+Build and persist a short-lived purchase plan from the current project's sourced BOM.
+
+**Request**
+
+Path: `project_id` is a project UUID in the current workspace.
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `build_quantity` | `integer` | Yes | Must be at least `1`. |
+| `strategy` | `string` | No | One of `lowest_total_price`, `fewest_distributors`, `fastest_availability`, `preferred_first`; defaults to `preferred_first`. |
+| `country` | `string` | No | Two-letter override; persisted on the plan. |
+| `currency` | `string` | No | Three-letter override; persisted on the plan. |
+| `distributors` | `string[]` | No | Distributor filter / preferred order for optimizer decisions. |
+| `max_distributors` | `integer` | No | Positive cap used by `fewest_distributors`. |
+| `moq_overbuy_cap` | `integer` | No | Positive cap; offers requiring more than `shortage * cap` are ignored. |
+| `price_tolerance_pct` | `decimal` | No | Preferred-first tolerance; defaults to `5`. |
+
+**Response** — `200 OK` (envelope: `{ data, status }`)
+
+```json
+{
+  "data": {
+    "id": "9b7f7d43-6b5c-4f7d-bc0e-44c6d73f0992",
+    "project_id": "012f2f63-3b2c-45c4-a841-682ec681f508",
+    "build_quantity": 2,
+    "strategy": "preferred_first",
+    "status": "draft",
+    "expires_at": "2026-05-15T12:00:00+00:00",
+    "distributors_used": ["DigiKey"],
+    "est_total_cost": "20.80",
+    "worst_lead_time_days": 3,
+    "unfilled_count": 0,
+    "lines": [
+      {
+        "mpn_searched": "STM32F103C8T6",
+        "required_qty": 20,
+        "internal_available_qty": 0,
+        "shortage_qty": 20,
+        "selected_distributor": "DigiKey",
+        "selected_qty": 20,
+        "selected_unit_price": "1.04",
+        "selected_currency": "EUR",
+        "selected_moq": 1,
+        "selected_url": "https://www.trustedparts.com/..."
+      }
+    ]
+  },
+  "status": { "category": "ok", "message": "OK" }
+}
+```
+
+**Errors**
+
+- `404 Not Found` — `project_id` is missing or belongs to another workspace.
+- `409 Conflict` — sourcing is not configured for the workspace.
+- `422 Unprocessable Entity` — invalid strategy, invalid quantity, malformed codes, or unknown fields.
+- `429 Too Many Requests` — workspace rate limit: 15 requests/minute.
+- `502 Bad Gateway` — TrustedParts auth, rate-limit, timeout, upstream, or response-shape failure.
+- `503 Service Unavailable` — sourcing budget exhausted.
+
+**Notes**
+
+- The route validates `project_id` with `assert_in_workspace()` before creating any plan rows.
+- Plans are snapshots: each call creates a new `purchase_plans` row and child `purchase_plan_lines` rows.
+- `expires_at` is capped to `created_at + 7 days`; refresh and conversion are later Phase-4 endpoints.
+- Decimal monetary fields serialize as strings.
+
 ### `GET /api/parts/{part_id}/sourcing`
 
 Return cached TrustedParts offers for one part's MPN.


### PR DESCRIPTION
Summary
- Adds migration `0040_purchase_plan_refresh_metadata` for `last_refreshed_at` and the persisted optimizer knobs needed to faithfully rerun refreshes.
- Adds `refresh_purchase_plan()` with live TrustedParts refresh, line replacement, status flip to `refreshed`, and no `expires_at` extension.
- Adds `POST /api/sourcing/purchase-plans/{plan_id}/refresh`, route tests, decimal serialization checks, and API docs.

Expired-plan choice
- Expired plans return `409 Conflict` with `message="plan expired"`.

Validation
- `DATABASE_URL=postgresql+psycopg://stockmgr:stockmgr@127.0.0.1:5432/stockmgr_test uv run alembic upgrade head && ... downgrade -1 && ... upgrade head` -> passed
- `uv run python -m pytest -q -k purchase_plan_refresh` -> 8 passed, 969 deselected
- `uv run python -m pytest -q tests/test_purchase_plan_route.py tests/test_purchase_plan_models.py` -> 22 passed
- `LINT_CMD="ruff check app --output-format=concise" BASELINE_FILE="../.ruff-baseline.txt" WORK_DIR="." bash ../scripts/lint-delta.sh` -> no new violations
- `uv run python scripts/check_no_traceback_leaks.py` -> passed
- `git diff --check` -> passed

Merge order
- Phase 4 stack order: #392 (#374) -> #393 (#375) -> this PR (#376) -> #377 -> #378 -> #379.
- This PR is intentionally based on `codex/tp-403-375-purchase-plan`; rebase/retarget it after #393 merges.

Refs #376
