### PR TITLE
TP-405: Convert purchase plan to draft orders

### DIFF
--- a/backend/app/api/routes/sourcing.py
+++ b/backend/app/api/routes/sourcing.py
@@ -325,6 +325,39 @@ def refresh_purchase_plan(
     return ok(sourcing_service.purchase_plan_to_out(refreshed).model_dump(mode="json"))
 
 
+@search_router.post(
+    "/purchase-plans/{plan_id}/orders",
+    dependencies=[Depends(require_role("member"))],
+)
+def convert_purchase_plan_to_orders(
+    request: Request,
+    plan_id: UUID,
+    ws: CurrentWorkspace,
+    user: CurrentUser,
+    db: Session = Depends(get_db),
+):
+    plan = assert_in_workspace(db, PurchasePlan, plan_id, ws.id, label="purchase plan")
+    try:
+        orders = sourcing_service.convert_plan_to_orders(
+            db,
+            workspace=ws,
+            plan=plan,
+            user_id=user.id,
+        )
+    except sourcing_service.PurchasePlanStaleError as exc:
+        return _error_response(request, 409, "conflict", str(exc))
+    except sourcing_service.PurchasePlanCurrencyError as exc:
+        return _error_response(request, 422, "validation_error", str(exc))
+
+    return ok(
+        sourcing_service.purchase_plan_orders_to_out(
+            db,
+            workspace_id=ws.id,
+            orders=orders,
+        ).model_dump(mode="json")
+    )
+
+
 @parts_router.get(
     "/{part_id}/sourcing",
     dependencies=[Depends(require_role("member"))],

--- a/backend/app/domain/sourcing/schemas.py
+++ b/backend/app/domain/sourcing/schemas.py
@@ -313,6 +313,35 @@ class PurchasePlanOut(BaseModel):
     unfilled_count: int
 
 
+class PurchasePlanCreatedOrderEntryOut(BaseModel):
+    model_config = ConfigDict(extra="forbid", from_attributes=True)
+
+    id: UUID
+    part_id: UUID | None = None
+    quantity_ordered: int
+    unit_price: Decimal | None = None
+    currency: str | None = None
+    comments: str | None = None
+
+
+class PurchasePlanCreatedOrderOut(BaseModel):
+    model_config = ConfigDict(extra="forbid", from_attributes=True)
+
+    id: UUID
+    name: str
+    supplier: str | None = None
+    status: str
+    currency: str | None = None
+    comments: str | None = None
+    entries: list[PurchasePlanCreatedOrderEntryOut]
+
+
+class PurchasePlanOrdersOut(BaseModel):
+    model_config = ConfigDict(extra="forbid", from_attributes=True)
+
+    orders: list[PurchasePlanCreatedOrderOut]
+
+
 class SourcingBomLineOut(BaseModel):
     model_config = ConfigDict(extra="forbid")
 

--- a/backend/app/domain/sourcing/service.py
+++ b/backend/app/domain/sourcing/service.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import Session
 
 from app.core.time import utcnow
 from app.domain.builds.service import shortage_analysis
+from app.domain.orders.models import Order, OrderEntry
 from app.domain.parts.models import Part
 from app.domain.projects.models import Project
 from app.domain.sourcing import cache
@@ -25,6 +26,7 @@ from app.domain.sourcing.pricing import best_unit_price_at_qty
 from app.domain.sourcing.schemas import (
     BuildCapacityOut,
     DistributorCoverageMatrixOut,
+    PurchasePlanOrdersOut,
     PurchasePlanOut,
     SourcingAttributionLinks,
     SourcingBomLineOut,
@@ -40,6 +42,7 @@ from app.domain.sourcing.schemas import (
 TTL_SECONDS = 30 * 60
 BOM_TTL_SECONDS = 10 * 60
 PURCHASE_PLAN_TTL = timedelta(days=7)
+MAX_PLAN_STALENESS_SECONDS = 600
 TRUSTEDPARTS_LINKS = SourcingAttributionLinks(
     primary="https://www.trustedparts.com/",
     attribution="https://www.trustedparts.com/en/about",
@@ -52,6 +55,14 @@ class SourcingNotConfigured(Exception):
 
 class SourcingBudgetBlocked(Exception):
     """Workspace exceeded the hard TrustedParts parts-count budget."""
+
+
+class PurchasePlanStaleError(Exception):
+    """Purchase plan must be refreshed before conversion."""
+
+
+class PurchasePlanCurrencyError(Exception):
+    """Purchase plan has incompatible currencies in one distributor group."""
 
 
 def build_purchase_plan(
@@ -136,6 +147,55 @@ def build_purchase_plan(
     return plan
 
 
+def convert_plan_to_orders(
+    db: Session,
+    *,
+    workspace: Any,
+    plan: PurchasePlan,
+    user_id: UUID | None,
+) -> list[Order]:
+    if plan.status != "refreshed":
+        raise PurchasePlanStaleError(
+            "plan must be refreshed before conversion; call /refresh first"
+        )
+    if plan.last_refreshed_at is None:
+        raise PurchasePlanStaleError(
+            "plan must be refreshed before conversion; call /refresh first"
+        )
+    if plan.last_refreshed_at < utcnow() - timedelta(seconds=MAX_PLAN_STALENESS_SECONDS):
+        raise PurchasePlanStaleError("plan refresh is stale; refresh again before conversion")
+
+    lines_by_distributor: dict[str, list[PurchasePlanLine]] = {}
+    display_names: dict[str, str] = {}
+    for line in plan.lines:
+        if line.selected_distributor is None:
+            continue
+        key = line.selected_distributor.casefold()
+        lines_by_distributor.setdefault(key, []).append(line)
+        display_names.setdefault(key, line.selected_distributor)
+
+    orders: list[Order] = []
+    for distributor_key in sorted(display_names, key=lambda key: display_names[key].casefold()):
+        lines = sorted(
+            lines_by_distributor[distributor_key],
+            key=lambda line: (str(line.project_entry_id or ""), str(line.id)),
+        )
+        orders.append(
+            _create_order_for_distributor(
+                db,
+                workspace_id=workspace.id,
+                plan=plan,
+                distributor=display_names[distributor_key],
+                lines=lines,
+                user_id=user_id,
+            )
+        )
+
+    plan.status = "converted"
+    db.flush()
+    return orders
+
+
 def refresh_purchase_plan(
     db: Session,
     *,
@@ -196,6 +256,42 @@ def refresh_purchase_plan(
     plan.last_refreshed_at = utcnow()
     db.flush()
     return plan
+
+
+def purchase_plan_orders_to_out(
+    db: Session,
+    *,
+    workspace_id: UUID,
+    orders: list[Order],
+) -> PurchasePlanOrdersOut:
+    return PurchasePlanOrdersOut.model_validate({
+        "orders": [
+            {
+                "id": order.id,
+                "name": order.name,
+                "supplier": order.supplier,
+                "status": order.status,
+                "currency": order.currency,
+                "comments": order.comments,
+                "entries": [
+                    {
+                        "id": entry.id,
+                        "part_id": entry.part_id,
+                        "quantity_ordered": entry.quantity_ordered,
+                        "unit_price": entry.unit_price,
+                        "currency": entry.currency,
+                        "comments": entry.comments,
+                    }
+                    for entry in _order_entries(
+                        db,
+                        workspace_id=workspace_id,
+                        order_id=order.id,
+                    )
+                ],
+            }
+            for order in orders
+        ]
+    })
 
 
 def purchase_plan_to_out(plan: PurchasePlan) -> PurchasePlanOut:
@@ -462,6 +558,89 @@ def search(
         cache_hit=all(result.cache_hit for result in results),
         links=TRUSTEDPARTS_LINKS,
     )
+
+
+def _create_order_for_distributor(
+    db: Session,
+    *,
+    workspace_id: UUID,
+    plan: PurchasePlan,
+    distributor: str,
+    lines: list[PurchasePlanLine],
+    user_id: UUID | None,
+) -> Order:
+    currencies = {
+        line.selected_currency
+        for line in lines
+        if line.selected_currency is not None
+    }
+    if len(currencies) > 1:
+        raise PurchasePlanCurrencyError(
+            f"mixed currencies for distributor {distributor}"
+        )
+
+    today = utcnow().date()
+    currency = next(iter(currencies), None)
+    order = Order(
+        workspace_id=workspace_id,
+        name=f"TrustedParts purchase — {distributor} — {today.isoformat()}",
+        order_type="purchase",
+        supplier=distributor,
+        currency=currency,
+        status="draft",
+        comments=(
+            f"TrustedParts purchase plan #{plan.id} — distributor={distributor} "
+            f"— generated={today.isoformat()} — strategy={plan.strategy}"
+        ),
+        created_by=user_id,
+        updated_by=user_id,
+    )
+    db.add(order)
+    db.flush()
+    for index, line in enumerate(lines):
+        db.add(
+            OrderEntry(
+                workspace_id=workspace_id,
+                order_id=order.id,
+                part_id=line.part_id,
+                quantity_ordered=line.selected_qty or 0,
+                unit_price=line.selected_unit_price,
+                currency=line.selected_currency,
+                comments=(
+                    f"TrustedParts: distributor={distributor}, "
+                    f"packaging={line.selected_packaging or 'unknown'}, "
+                    f"lead_time={_lead_time_label(line.selected_lead_time_days)}, "
+                    f"plan={str(plan.id)[:8]}"
+                ),
+                order_index=index,
+                created_by=user_id,
+                updated_by=user_id,
+            )
+        )
+    db.flush()
+    return order
+
+
+def _order_entries(
+    db: Session,
+    *,
+    workspace_id: UUID,
+    order_id: UUID,
+) -> list[OrderEntry]:
+    return list(
+        db.execute(
+            select(OrderEntry)
+            .where(OrderEntry.workspace_id == workspace_id)
+            .where(OrderEntry.order_id == order_id)
+            .order_by(OrderEntry.order_index)
+        ).scalars()
+    )
+
+
+def _lead_time_label(value: int | None) -> str:
+    if value is None:
+        return "unknown"
+    return f"{value}d"
 
 
 def _canonical_query(

--- a/backend/tests/test_purchase_plan_convert_route.py
+++ b/backend/tests/test_purchase_plan_convert_route.py
@@ -1,0 +1,295 @@
+from __future__ import annotations
+
+import uuid
+from datetime import timedelta
+from decimal import Decimal
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import func, select
+
+import app.core.ratelimit as _ratelimit_mod
+from app.core.time import utcnow
+from app.domain.orders.models import Order, OrderEntry
+from app.domain.sourcing.budget import BUDGET
+from app.domain.sourcing.models import PurchasePlan
+from app.main import app
+from tests._factories import create_part, create_project_with_bom, signup_user
+from tests.test_purchase_plan_route import (
+    _configure_sourcing,
+    _FakeTrustedPartsClient,
+    _offer,
+    _post_plan,
+    _single_line_project,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_sourcing_state(monkeypatch):
+    original_limiter_enabled = _ratelimit_mod.limiter.enabled
+    _ratelimit_mod.limiter.enabled = False
+    _FakeTrustedPartsClient.calls = []
+    _FakeTrustedPartsClient.offers_by_mpn = {}
+    BUDGET._events.clear()
+    try:
+        _ratelimit_mod.limiter.reset()
+    except Exception:
+        pass
+    monkeypatch.setattr(
+        "app.domain.sourcing.service.make_sourcing_provider",
+        lambda workspace: _FakeTrustedPartsClient(workspace.id),
+    )
+    yield
+    _ratelimit_mod.limiter.enabled = original_limiter_enabled
+    BUDGET._events.clear()
+    try:
+        _ratelimit_mod.limiter.reset()
+    except Exception:
+        pass
+
+
+def _refresh(client: TestClient, plan_id: str):
+    r = client.post(f"/api/sourcing/purchase-plans/{plan_id}/refresh")
+    assert r.status_code == 200, r.text
+    return r.json()["data"]
+
+
+def _convert(client: TestClient, plan_id: str):
+    return client.post(f"/api/sourcing/purchase-plans/{plan_id}/orders")
+
+
+def _two_line_project(client: TestClient) -> str:
+    part_a = create_part(client, name="Plan A", mpn="PLAN-A")
+    part_b = create_part(client, name="Plan B", mpn="PLAN-B")
+    return create_project_with_bom(
+        client,
+        "Two-line plan",
+        [{"part_id": part_a, "quantity": 5}, {"part_id": part_b, "quantity": 7}],
+    )
+
+
+def _create_refreshed_plan(
+    client: TestClient,
+    *,
+    project_id: str | None = None,
+    offers_by_mpn: dict[str, list[Any]] | None = None,
+):
+    _configure_sourcing(client, preferred=["DigiKey"])
+    if project_id is None:
+        project_id = _two_line_project(client)
+    if offers_by_mpn is not None:
+        _FakeTrustedPartsClient.offers_by_mpn = offers_by_mpn
+    plan_response = _post_plan(client, project_id)
+    assert plan_response.status_code == 200, plan_response.text
+    return _refresh(client, plan_response.json()["data"]["id"])
+
+
+def test_basic_conversion_creates_one_order_per_distributor(authed_client):
+    plan = _create_refreshed_plan(
+        authed_client,
+        offers_by_mpn={
+            "PLAN-A": [_offer("PLAN-A", distributor="DigiKey", stock=100, unit_price=1.0)],
+            "PLAN-B": [_offer("PLAN-B", distributor="Mouser", stock=100, unit_price=2.0)],
+        },
+    )
+
+    r = _convert(authed_client, plan["id"])
+
+    assert r.status_code == 200, r.text
+    orders = r.json()["data"]["orders"]
+    assert [order["supplier"] for order in orders] == ["DigiKey", "Mouser"]
+    assert [len(order["entries"]) for order in orders] == [1, 1]
+    assert orders[0]["entries"][0]["quantity_ordered"] == 5
+    assert orders[1]["entries"][0]["quantity_ordered"] == 7
+
+
+def test_orders_status_is_draft(authed_client):
+    plan = _create_refreshed_plan(authed_client)
+
+    r = _convert(authed_client, plan["id"])
+
+    assert r.status_code == 200, r.text
+    assert {order["status"] for order in r.json()["data"]["orders"]} == {"draft"}
+
+
+def test_order_comments_excludes_raw_url(authed_client, db):
+    raw_url = "https://www.trustedparts.com/PLAN-A/DigiKey"
+    project_id = _single_line_project(authed_client, mpn="PLAN-A", quantity=3)
+    plan = _create_refreshed_plan(
+        authed_client,
+        project_id=project_id,
+        offers_by_mpn={
+            "PLAN-A": [_offer("PLAN-A", distributor="DigiKey", stock=100, unit_price=1.0)]
+        },
+    )
+    assert plan["lines"][0]["selected_url"] == raw_url
+
+    r = _convert(authed_client, plan["id"])
+
+    assert r.status_code == 200, r.text
+    persisted_comments = [
+        *(db.execute(select(Order.comments)).scalars().all()),
+        *(db.execute(select(OrderEntry.comments)).scalars().all()),
+    ]
+    assert all(raw_url not in (comment or "") for comment in persisted_comments)
+
+
+def test_order_comments_contains_compliance_summary(authed_client):
+    plan = _create_refreshed_plan(authed_client)
+
+    r = _convert(authed_client, plan["id"])
+
+    assert r.status_code == 200, r.text
+    order = r.json()["data"]["orders"][0]
+    entry = order["entries"][0]
+    assert "TrustedParts purchase plan" in order["comments"]
+    assert f"strategy={plan['strategy']}" in order["comments"]
+    assert "TrustedParts: distributor=" in entry["comments"]
+    assert f"plan={plan['id'][:8]}" in entry["comments"]
+
+
+def test_plan_status_flips_to_converted(authed_client, db):
+    plan = _create_refreshed_plan(authed_client)
+
+    r = _convert(authed_client, plan["id"])
+
+    assert r.status_code == 200, r.text
+    db_plan = db.get(PurchasePlan, uuid.UUID(plan["id"]))
+    assert db_plan is not None
+    assert db_plan.status == "converted"
+
+
+def test_unrefreshed_plan_returns_409(authed_client):
+    _configure_sourcing(authed_client)
+    project_id = _single_line_project(authed_client, mpn="UNREFRESHED")
+    r_plan = _post_plan(authed_client, project_id)
+    assert r_plan.status_code == 200, r_plan.text
+
+    r = _convert(authed_client, r_plan.json()["data"]["id"])
+
+    assert r.status_code == 409, r.text
+    assert "refresh" in r.json()["status"]["message"]
+
+
+def test_stale_refresh_returns_409(authed_client, db):
+    plan = _create_refreshed_plan(authed_client)
+    db_plan = db.get(PurchasePlan, uuid.UUID(plan["id"]))
+    assert db_plan is not None
+    db_plan.last_refreshed_at = utcnow() - timedelta(minutes=11)
+    db.flush()
+
+    r = _convert(authed_client, plan["id"])
+
+    assert r.status_code == 409, r.text
+    assert r.json()["status"]["message"] == "plan refresh is stale; refresh again before conversion"
+
+
+def test_mixed_currency_in_group_returns_422(authed_client):
+    plan = _create_refreshed_plan(
+        authed_client,
+        offers_by_mpn={
+            "PLAN-A": [
+                _offer(
+                    "PLAN-A",
+                    distributor="DigiKey",
+                    stock=100,
+                    unit_price=1.0,
+                    currency="EUR",
+                )
+            ],
+            "PLAN-B": [
+                _offer(
+                    "PLAN-B",
+                    distributor="DigiKey",
+                    stock=100,
+                    unit_price=2.0,
+                    currency="USD",
+                )
+            ],
+        },
+    )
+
+    r = _convert(authed_client, plan["id"])
+
+    assert r.status_code == 422, r.text
+    assert "mixed currencies" in r.json()["status"]["message"]
+
+
+def test_foreign_plan_returns_404(authed_client):
+    plan = _create_refreshed_plan(authed_client)
+    client_b = TestClient(app)
+    signup_user(client_b)
+    _configure_sourcing(client_b)
+
+    r = _convert(client_b, plan["id"])
+
+    assert r.status_code == 404, r.text
+    assert r.json()["status"]["category"] == "not_found"
+
+
+def test_partial_failure_rolls_back_all_orders(authed_client, db, monkeypatch):
+    plan = _create_refreshed_plan(
+        authed_client,
+        offers_by_mpn={
+            "PLAN-A": [_offer("PLAN-A", distributor="DigiKey", stock=100, unit_price=1.0)],
+            "PLAN-B": [_offer("PLAN-B", distributor="Mouser", stock=100, unit_price=2.0)],
+        },
+    )
+    from app.domain.sourcing import service as sourcing_service
+
+    original = sourcing_service._create_order_for_distributor
+    calls = 0
+
+    def flaky_create(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise RuntimeError("boom")
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(
+        "app.domain.sourcing.service._create_order_for_distributor",
+        flaky_create,
+    )
+
+    with pytest.raises(RuntimeError, match="boom"):
+        _convert(authed_client, plan["id"])
+
+    assert db.execute(select(func.count()).select_from(Order)).scalar_one() == 0
+    assert db.execute(select(func.count()).select_from(OrderEntry)).scalar_one() == 0
+    db_plan = db.get(PurchasePlan, uuid.UUID(plan["id"]))
+    assert db_plan is not None
+    assert db_plan.status == "refreshed"
+
+
+def test_workspace_isolation_two_plans_different_workspaces(authed_client):
+    plan_a = _create_refreshed_plan(authed_client, project_id=None)
+
+    client_b = TestClient(app)
+    signup_user(client_b)
+    plan_b = _create_refreshed_plan(client_b, project_id=None)
+
+    foreign = _convert(client_b, plan_a["id"])
+    own = _convert(client_b, plan_b["id"])
+
+    assert foreign.status_code == 404, foreign.text
+    assert own.status_code == 200, own.text
+    assert own.json()["data"]["orders"]
+
+
+def test_decimal_serialisation_roundtrip(authed_client):
+    plan = _create_refreshed_plan(
+        authed_client,
+        offers_by_mpn={
+            "PLAN-A": [_offer("PLAN-A", distributor="DigiKey", stock=100, unit_price=1.25)],
+            "PLAN-B": [_offer("PLAN-B", distributor="Mouser", stock=100, unit_price=2.5)],
+        },
+    )
+
+    r = _convert(authed_client, plan["id"])
+
+    assert r.status_code == 200, r.text
+    first_price = r.json()["data"]["orders"][0]["entries"][0]["unit_price"]
+    assert isinstance(first_price, str)
+    assert Decimal(first_price) == Decimal("1.25")

--- a/docs/api/sourcing.md
+++ b/docs/api/sourcing.md
@@ -188,6 +188,55 @@ Shape matches `POST /api/projects/{project_id}/purchase-plan`, with `status` set
 - Refresh does not extend `expires_at`; the original 7-day cap stays in force.
 - The service forces a live TrustedParts refresh by using `use_cached_data=false` and bypassing the local cache hit path.
 
+### `POST /api/sourcing/purchase-plans/{plan_id}/orders`
+
+Convert a freshly refreshed purchase plan into draft purchase orders.
+
+**Request**
+
+Path: `plan_id` is a purchase plan UUID in the current workspace. No request body is accepted in this phase.
+
+**Response** — `200 OK` (envelope: `{ data, status }`)
+
+```json
+{
+  "data": {
+    "orders": [
+      {
+        "id": "af28ff2a-33e6-4f6f-9825-7840c37f4440",
+        "name": "TrustedParts purchase — DigiKey — 2026-05-09",
+        "supplier": "DigiKey",
+        "status": "draft",
+        "currency": "EUR",
+        "comments": "TrustedParts purchase plan #... — distributor=DigiKey — generated=2026-05-09 — strategy=preferred_first",
+        "entries": [
+          {
+            "part_id": "012f2f63-3b2c-45c4-a841-682ec681f508",
+            "quantity_ordered": 25,
+            "unit_price": "1.04",
+            "currency": "EUR",
+            "comments": "TrustedParts: distributor=DigiKey, packaging=cut-tape, lead_time=3d, plan=9b7f7d43"
+          }
+        ]
+      }
+    ]
+  },
+  "status": { "category": "ok", "message": "OK" }
+}
+```
+
+**Errors**
+
+- `404 Not Found` — `plan_id` is missing or belongs to another workspace.
+- `409 Conflict` — the plan has not been refreshed or its refresh is older than 10 minutes.
+- `422 Unprocessable Entity` — one distributor group contains mixed currencies.
+
+**Notes**
+
+- The route creates one `Order(status="draft")` per selected distributor and one `OrderEntry` per selected plan line.
+- Conversion flips the plan to `converted` in the same transaction.
+- Permanent order comments are compliance-safe summaries. The raw `selected_url` from ephemeral plan lines is never copied into `orders.comments` or `order_entries.comments`.
+
 ### `GET /api/parts/{part_id}/sourcing`
 
 Return cached TrustedParts offers for one part's MPN.


### PR DESCRIPTION
## Summary
- Rebases TP-405 onto current `main`, which already contains TP-402 through TP-404.
- Keeps this PR scoped to converting refreshed purchase plans into draft orders.
- Resolves the prior merge conflict by dropping duplicate TP-403/TP-404 commits from this branch.

## Validation
- `cd backend && uv run python -m pytest -q tests/test_purchase_plan_convert_route.py` -> 12 passed, 1 warning

## Merge order
1. This PR #401 TP-405 convert plan to draft orders
2. #399 TP-406 plan-review frontend
3. #400 TP-407 integration tests

Refs #377
