### PR TITLE
TP-406: Plan-review page + grouping + override

### DIFF
--- a/docs/frontend/projects.md
+++ b/docs/frontend/projects.md
@@ -13,3 +13,9 @@ Project detail and build detail both render the shared `SourceBomButton`. It rea
 The populated response renders three `DataTable`-backed areas: the capacity banner, distributor coverage matrix, and enriched BOM rows. Coverage highlights the best single distributor and best two-distributor combo; BOM rows render authorized stock, best offer, distributor, estimated cost, one risk pill per `risk_flag`, and a `SourcingSourceLabel` column for TrustedParts attribution. Sources: `web/src/routes/projects/sourcing/ProjectSourcingPage.tsx:208-252`, `web/src/routes/projects/sourcing/ProjectSourcingPage.tsx:254-307`, `web/src/routes/projects/sourcing/ProjectSourcingPage.tsx:309-379`.
 
 Status handling is local to the route: loading skeletons, 409 not-configured settings link, 503 budget pause, 502 retry/toast, empty-BOM call to action, and `partial=true` badge are all rendered before the populated tables. Sources: `web/src/routes/projects/sourcing/ProjectSourcingPage.tsx:160-206`, `web/src/routes/projects/sourcing/ProjectSourcingPage.tsx:429-547`.
+
+## Purchase Plan Review
+
+The sourcing page can create a purchase plan from the current build quantity, country, currency, and distributor filters. The "Generate purchase plan" modal posts strategy options to `POST /api/projects/{project_id}/purchase-plan`, then opens `/projects/:projectId/purchase-plans/:planId` with the returned plan in route state. The review route renders distributor-grouped plan lines, unfilled rows, TrustedParts attribution, and summary totals from the server response.
+
+The sticky action bar keeps refresh and order conversion together. Refresh calls `POST /api/sourcing/purchase-plans/{plan_id}/refresh`; conversion calls `POST /api/sourcing/purchase-plans/{plan_id}/orders` and is disabled until the plan has been refreshed within the server's 10-minute freshness window. Manual offer override controls are visible but disabled until backend override support lands.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -107,6 +107,7 @@ const ProjectImport = lazy(() => import("@/routes/projects/detail/ProjectImport"
 const ProjectBuilds = lazy(() => import("@/routes/projects/detail/ProjectBuilds"));
 const ProjectOther = lazy(() => import("@/routes/projects/detail/ProjectOther"));
 const ProjectSourcingPage = lazy(() => import("@/routes/projects/sourcing/ProjectSourcingPage"));
+const PurchasePlanReviewPage = lazy(() => import("@/routes/projects/sourcing/PurchasePlanReviewPage"));
 
 const Account = lazy(() => import("@/routes/settings/Account"));
 const WorkspaceSettings = lazy(() => import("@/routes/settings/Workspace"));
@@ -288,6 +289,7 @@ export default function App() {
               <Route path="import" element={<LazyRoute><ProjectImport /></LazyRoute>} />
               <Route path="builds" element={<LazyRoute><ProjectBuilds /></LazyRoute>} />
               <Route path="sourcing" element={<LazyRoute><ProjectSourcingPage /></LazyRoute>} />
+              <Route path="purchase-plans/:planId" element={<LazyRoute><PurchasePlanReviewPage /></LazyRoute>} />
               <Route path="other" element={<LazyRoute><ProjectOther /></LazyRoute>} />
             </Route>
 

--- a/web/src/routes/projects/sourcing/OverrideOfferModal.tsx
+++ b/web/src/routes/projects/sourcing/OverrideOfferModal.tsx
@@ -1,0 +1,37 @@
+import type { PurchasePlanLine } from "./purchasePlanTypes";
+
+type Props = {
+  line: PurchasePlanLine | null;
+  onClose: () => void;
+};
+
+export default function OverrideOfferModal({ line, onClose }: Props) {
+  if (!line) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4">
+      <div
+        className="card max-w-md w-full p-4 space-y-4"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="override-offer-title"
+      >
+        <div className="flex items-start justify-between gap-3">
+          <h2 id="override-offer-title" className="text-lg font-semibold">
+            Override offer
+          </h2>
+          <button type="button" className="btn" onClick={onClose}>
+            Close
+          </button>
+        </div>
+        <div className="text-sm text-muted">
+          Override requires backend validation support and is disabled for this phase.
+        </div>
+        <div className="rounded border border-border p-3 text-sm">
+          <div className="font-medium">{line.mpn_searched}</div>
+          <div className="text-muted">{line.selected_distributor ?? "Unfilled"}</div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/routes/projects/sourcing/ProjectSourcingPage.tsx
+++ b/web/src/routes/projects/sourcing/ProjectSourcingPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { Link, useParams } from "react-router-dom";
+import { Link, useNavigate, useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { FolderKanban, RefreshCw } from "lucide-react";
 import { toast } from "sonner";
@@ -10,6 +10,8 @@ import { SourcingSourceLabel } from "@/components/SourcingSourceLabel";
 import { ApiError, api } from "@/lib/api";
 import { useWsKey } from "@/lib/queryKeys";
 import type { Project } from "@/types";
+import PurchasePlanOptionsModal from "./PurchasePlanOptionsModal";
+import type { PurchasePlan, PurchasePlanRequest } from "./purchasePlanTypes";
 import type { SourcingWorkspaceSettings } from "./SourceBomButton";
 
 type SourcingBomOffer = {
@@ -380,12 +382,15 @@ function BomRows({ rows }: { rows: SourcingBomLine[] }) {
 
 export default function ProjectSourcingPage() {
   const { projectId } = useParams<{ projectId: string }>();
+  const navigate = useNavigate();
   const [buildQuantity, setBuildQuantity] = useState(1);
   const [country, setCountry] = useState("");
   const [currency, setCurrency] = useState("");
   const [distributors, setDistributors] = useState("");
   const [defaultsApplied, setDefaultsApplied] = useState(false);
   const [budgetDisabledUntil, setBudgetDisabledUntil] = useState<number | null>(null);
+  const [planModalOpen, setPlanModalOpen] = useState(false);
+  const [planPending, setPlanPending] = useState(false);
 
   const { data: workspace } = useQuery({
     queryKey: useWsKey("ws", "current"),
@@ -448,6 +453,23 @@ export default function ProjectSourcingPage() {
   const sourceDisabled = query.isFetching || buildQuantity < 1 || (budgetDisabledUntil != null && Date.now() < budgetDisabledUntil);
   const hasRows = (query.data?.rows.length ?? 0) > 0;
   const primaryUrl = query.data?.links.primary;
+
+  async function generatePurchasePlan(planRequest: PurchasePlanRequest) {
+    if (!projectId) return;
+    setPlanPending(true);
+    try {
+      const plan = await api.post<PurchasePlan, PurchasePlanRequest>(
+        `/projects/${projectId}/purchase-plan`,
+        planRequest,
+      );
+      setPlanModalOpen(false);
+      navigate(`/projects/${projectId}/purchase-plans/${plan.id}`, {
+        state: { plan, project },
+      });
+    } finally {
+      setPlanPending(false);
+    }
+  }
 
   if (!projectId) return null;
 
@@ -514,6 +536,14 @@ export default function ProjectSourcingPage() {
         <div className="mt-3 flex justify-end">
           <button
             type="button"
+            className="btn mr-2"
+            disabled={sourceDisabled || !hasRows}
+            onClick={() => setPlanModalOpen(true)}
+          >
+            Generate purchase plan
+          </button>
+          <button
+            type="button"
             className="btn-primary"
             disabled={sourceDisabled}
             onClick={() => query.refetch()}
@@ -550,6 +580,14 @@ export default function ProjectSourcingPage() {
           </div>
         </>
       )}
+      <PurchasePlanOptionsModal
+        open={planModalOpen}
+        buildQuantity={buildQuantity}
+        baseRequest={requestBody}
+        pending={planPending}
+        onClose={() => setPlanModalOpen(false)}
+        onSubmit={generatePurchasePlan}
+      />
     </div>
   );
 }

--- a/web/src/routes/projects/sourcing/PurchasePlanOptionsModal.tsx
+++ b/web/src/routes/projects/sourcing/PurchasePlanOptionsModal.tsx
@@ -1,0 +1,150 @@
+import { useState, type FormEvent } from "react";
+import type { PurchasePlanRequest } from "./purchasePlanTypes";
+
+type Props = {
+  open: boolean;
+  buildQuantity: number;
+  baseRequest: Omit<PurchasePlanRequest, "strategy">;
+  pending?: boolean;
+  onClose: () => void;
+  onSubmit: (request: PurchasePlanRequest) => void;
+};
+
+const strategies = [
+  ["preferred_first", "Preferred first"],
+  ["lowest_total_price", "Lowest total price"],
+  ["fewest_distributors", "Fewest distributors"],
+  ["fastest_availability", "Fastest availability"],
+] as const;
+
+export default function PurchasePlanOptionsModal({
+  open,
+  buildQuantity,
+  baseRequest,
+  pending = false,
+  onClose,
+  onSubmit,
+}: Props) {
+  const [strategy, setStrategy] = useState("preferred_first");
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+  const [maxDistributors, setMaxDistributors] = useState("");
+  const [moqOverbuyCap, setMoqOverbuyCap] = useState("");
+  const [priceTolerancePct, setPriceTolerancePct] = useState("5");
+
+  if (!open) return null;
+
+  function submit(event: FormEvent) {
+    event.preventDefault();
+    const request: PurchasePlanRequest = {
+      ...baseRequest,
+      build_quantity: Math.max(1, Math.floor(buildQuantity || 1)),
+      strategy,
+    };
+    if (maxDistributors.trim()) request.max_distributors = Number(maxDistributors);
+    if (moqOverbuyCap.trim()) request.moq_overbuy_cap = Number(moqOverbuyCap);
+    if (priceTolerancePct.trim()) request.price_tolerance_pct = priceTolerancePct.trim();
+    onSubmit(request);
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4">
+      <form
+        className="card max-w-lg w-full p-4 space-y-4"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="purchase-plan-options-title"
+        onSubmit={submit}
+      >
+        <div className="flex items-start justify-between gap-3">
+          <h2 id="purchase-plan-options-title" className="text-lg font-semibold">
+            Generate purchase plan
+          </h2>
+          <button type="button" className="btn" onClick={onClose}>
+            Close
+          </button>
+        </div>
+
+        <div>
+          <label className="label" htmlFor="purchase-plan-strategy">
+            Strategy
+          </label>
+          <select
+            id="purchase-plan-strategy"
+            className="input"
+            value={strategy}
+            onChange={event => setStrategy(event.target.value)}
+          >
+            {strategies.map(([value, label]) => (
+              <option key={value} value={value}>
+                {label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <button
+          type="button"
+          className="btn"
+          aria-expanded={advancedOpen}
+          onClick={() => setAdvancedOpen(open => !open)}
+        >
+          Advanced options
+        </button>
+
+        {advancedOpen && (
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            <div>
+              <label className="label" htmlFor="purchase-plan-max-distributors">
+                Max distributors
+              </label>
+              <input
+                id="purchase-plan-max-distributors"
+                className="input"
+                type="number"
+                min={1}
+                value={maxDistributors}
+                onChange={event => setMaxDistributors(event.target.value)}
+              />
+            </div>
+            <div>
+              <label className="label" htmlFor="purchase-plan-moq-cap">
+                MOQ cap
+              </label>
+              <input
+                id="purchase-plan-moq-cap"
+                className="input"
+                type="number"
+                min={1}
+                value={moqOverbuyCap}
+                onChange={event => setMoqOverbuyCap(event.target.value)}
+              />
+            </div>
+            <div>
+              <label className="label" htmlFor="purchase-plan-tolerance">
+                Tolerance %
+              </label>
+              <input
+                id="purchase-plan-tolerance"
+                className="input"
+                type="number"
+                min={0}
+                step="0.1"
+                value={priceTolerancePct}
+                onChange={event => setPriceTolerancePct(event.target.value)}
+              />
+            </div>
+          </div>
+        )}
+
+        <div className="flex justify-end gap-2">
+          <button type="button" className="btn" onClick={onClose}>
+            Cancel
+          </button>
+          <button type="submit" className="btn-primary" disabled={pending}>
+            {pending ? "Generating..." : "Generate"}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/web/src/routes/projects/sourcing/PurchasePlanReviewPage.tsx
+++ b/web/src/routes/projects/sourcing/PurchasePlanReviewPage.tsx
@@ -1,0 +1,288 @@
+import { useMemo, useState } from "react";
+import { useLocation, useNavigate, useParams } from "react-router-dom";
+import { RefreshCw, ShoppingCart } from "lucide-react";
+import { toast } from "sonner";
+import { DataTable, type Column } from "@/components/DataTable";
+import { PoweredByTrustedParts } from "@/components/PoweredByTrustedParts";
+import { SourcingSourceLabel } from "@/components/SourcingSourceLabel";
+import { api } from "@/lib/api";
+import type { Project } from "@/types";
+import OverrideOfferModal from "./OverrideOfferModal";
+import type { ConvertOrdersResponse, PurchasePlan, PurchasePlanLine } from "./purchasePlanTypes";
+
+type LocationState = {
+  plan?: PurchasePlan;
+  project?: Project;
+};
+
+const STALE_MS = 10 * 60 * 1000;
+
+function numberOrNull(value: string | number | null | undefined): number | null {
+  if (value == null || value === "") return null;
+  const parsed = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function formatMoney(value: string | number | null | undefined, currency?: string | null): string {
+  const numeric = numberOrNull(value);
+  if (numeric == null) return "-";
+  const formatted = numeric.toLocaleString(undefined, {
+    maximumFractionDigits: 2,
+    minimumFractionDigits: numeric % 1 === 0 ? 0 : 2,
+  });
+  return currency ? `${formatted} ${currency}` : formatted;
+}
+
+function formatLeadTime(days: number | null | undefined): string {
+  if (days == null) return "-";
+  return days === 1 ? "1 day" : `${days.toLocaleString()} days`;
+}
+
+function refreshedLabel(plan: PurchasePlan): string {
+  if (!plan.last_refreshed_at) return "Not refreshed yet";
+  const ageMs = Date.now() - new Date(plan.last_refreshed_at).getTime();
+  const minutes = Math.max(0, Math.floor(ageMs / 60000));
+  return `Refreshed ${minutes} min ago`;
+}
+
+function isRefreshFresh(plan: PurchasePlan): boolean {
+  if (!plan.last_refreshed_at) return false;
+  return Date.now() - new Date(plan.last_refreshed_at).getTime() <= STALE_MS;
+}
+
+function extendedCost(line: PurchasePlanLine): number | null {
+  const unit = numberOrNull(line.selected_unit_price);
+  if (unit == null || line.selected_qty == null) return null;
+  return unit * line.selected_qty;
+}
+
+function groupLines(lines: PurchasePlanLine[]) {
+  const groups = new Map<string, PurchasePlanLine[]>();
+  for (const line of lines) {
+    if (!line.selected_distributor) continue;
+    const current = groups.get(line.selected_distributor) ?? [];
+    current.push(line);
+    groups.set(line.selected_distributor, current);
+  }
+  return [...groups.entries()].sort(([a], [b]) => a.localeCompare(b));
+}
+
+function summaryCurrency(plan: PurchasePlan): string | null {
+  return plan.lines.find(line => line.selected_currency)?.selected_currency ?? plan.currency_code ?? null;
+}
+
+export default function PurchasePlanReviewPage() {
+  const { projectId, planId } = useParams<{ projectId: string; planId: string }>();
+  const navigate = useNavigate();
+  const { state } = useLocation();
+  const locationState = (state ?? {}) as LocationState;
+  const [plan, setPlan] = useState<PurchasePlan | null>(locationState.plan ?? null);
+  const [project] = useState<Project | undefined>(locationState.project);
+  const [busyAction, setBusyAction] = useState<"refresh" | "convert" | null>(null);
+  const [overrideLine, setOverrideLine] = useState<PurchasePlanLine | null>(null);
+
+  const grouped = useMemo(() => groupLines(plan?.lines ?? []), [plan]);
+  const unfilled = useMemo(
+    () => (plan?.lines ?? []).filter(line => !line.selected_distributor),
+    [plan],
+  );
+
+  if (!projectId || !planId) return null;
+  if (!plan) {
+    return (
+      <div className="card p-4">
+        <div className="font-medium">Purchase plan data is not loaded.</div>
+        <button type="button" className="btn mt-3" onClick={() => navigate(`/projects/${projectId}/sourcing`)}>
+          Back to sourcing
+        </button>
+      </div>
+    );
+  }
+
+  const fresh = isRefreshFresh(plan);
+  const currency = summaryCurrency(plan);
+  const columns: Column<PurchasePlanLine>[] = [
+    { key: "mpn", header: "MPN", accessor: line => line.mpn_searched },
+    { key: "required", header: "Required", accessor: line => line.required_qty, align: "right" },
+    { key: "internal", header: "Internal", accessor: line => line.internal_available_qty, align: "right" },
+    { key: "shortage", header: "Shortage", accessor: line => line.shortage_qty, align: "right" },
+    { key: "qty", header: "Selected qty", accessor: line => line.selected_qty ?? 0, align: "right" },
+    {
+      key: "unit",
+      header: "Unit price",
+      accessor: line => numberOrNull(line.selected_unit_price),
+      render: line => formatMoney(line.selected_unit_price, line.selected_currency),
+      align: "right",
+    },
+    {
+      key: "extended",
+      header: "Extended",
+      accessor: line => extendedCost(line),
+      render: line => formatMoney(extendedCost(line), line.selected_currency),
+      align: "right",
+    },
+    {
+      key: "lead",
+      header: "Lead time",
+      accessor: line => line.selected_lead_time_days,
+      render: line => formatLeadTime(line.selected_lead_time_days),
+      align: "right",
+    },
+    {
+      key: "risk",
+      header: "Risk",
+      accessor: line => line.risk_flags.join(" "),
+      render: line => (
+        <span className="flex flex-wrap gap-1">
+          {line.risk_flags.length === 0 ? (
+            <span className="text-muted">-</span>
+          ) : line.risk_flags.map(flag => (
+            <span key={flag} className="pill bg-warning/10 text-warning">
+              {flag.replaceAll("_", " ")}
+            </span>
+          ))}
+        </span>
+      ),
+    },
+    {
+      key: "link",
+      header: "Offer",
+      accessor: line => line.selected_url ?? "",
+      render: line => line.selected_url ? (
+        <a className="text-accent hover:underline" href={line.selected_url} target="_blank" rel="noopener noreferrer">
+          Open
+        </a>
+      ) : "-",
+    },
+    {
+      key: "override",
+      header: "Override",
+      accessor: () => "",
+      render: line => (
+        <button
+          type="button"
+          className="btn"
+          title="Override will land in TP-406a"
+          disabled
+          onClick={() => setOverrideLine(line)}
+        >
+          Override
+        </button>
+      ),
+    },
+  ];
+
+  async function refresh() {
+    if (!plan) return;
+    setBusyAction("refresh");
+    try {
+      const next = await api.post<PurchasePlan>(`/sourcing/purchase-plans/${plan.id}/refresh`);
+      setPlan(next);
+      toast.success("Prices refreshed");
+    } finally {
+      setBusyAction(null);
+    }
+  }
+
+  async function convert() {
+    if (!plan) return;
+    setBusyAction("convert");
+    try {
+      const result = await api.post<ConvertOrdersResponse>(`/sourcing/purchase-plans/${plan.id}/orders`);
+      toast.success(`Created ${result.orders.length} draft orders`);
+      navigate("/orders");
+    } finally {
+      setBusyAction(null);
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <div className="text-sm text-muted">
+            Projects / {project?.name ?? "Project"} / Purchase plan
+          </div>
+          <div className="mt-1 flex flex-wrap items-center gap-2">
+            <h1 className="text-xl font-semibold">
+              Purchase plan #{plan.id.slice(0, 8)} - {project?.name ?? "Project"} - strategy={plan.strategy}
+            </h1>
+            <span className={`pill ${fresh ? "bg-success/10 text-success" : "bg-warning/10 text-warning"}`}>
+              {refreshedLabel(plan)}
+            </span>
+            {!fresh && plan.last_refreshed_at && (
+              <span className="pill bg-danger/10 text-danger">Refresh stale (&gt;10 min)</span>
+            )}
+          </div>
+        </div>
+        <PoweredByTrustedParts />
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-4 gap-3">
+        <div className="card p-4">
+          <div className="section-title">Distributors</div>
+          <div className="text-2xl font-semibold">{plan.distributors_used.length}</div>
+        </div>
+        <div className="card p-4">
+          <div className="section-title">Est. cost</div>
+          <div className="text-2xl font-semibold">{formatMoney(plan.est_total_cost, currency)}</div>
+        </div>
+        <div className="card p-4">
+          <div className="section-title">Worst lead time</div>
+          <div className="text-2xl font-semibold">{formatLeadTime(plan.worst_lead_time_days)}</div>
+        </div>
+        <div className="card p-4">
+          <div className="section-title">Unfilled</div>
+          <div className="text-2xl font-semibold">{plan.unfilled_count}</div>
+        </div>
+      </div>
+
+      {grouped.map(([distributor, lines]) => {
+        const subtotal = lines.reduce((sum, line) => sum + (extendedCost(line) ?? 0), 0);
+        return (
+          <details key={distributor} className="rounded-md border border-border bg-panel p-4" open>
+            <summary className="cursor-pointer">
+              <span className="font-medium">{distributor}</span>
+              <span className="ml-2 text-sm text-muted">{lines.length} lines - {formatMoney(subtotal, currency)}</span>
+              <span className="ml-2"><SourcingSourceLabel source="trustedparts" /></span>
+            </summary>
+            <div className="mt-3">
+              <DataTable
+                rows={lines}
+                columns={columns}
+                rowKey={line => line.id}
+                tableId={`purchase-plan-${plan.id}-${distributor}`}
+                exportFilename={`purchase-plan-${distributor}`}
+              />
+            </div>
+          </details>
+        );
+      })}
+
+      {unfilled.length > 0 && (
+        <section className="rounded-md border border-danger/40 bg-panel p-4">
+          <h2 className="text-md font-semibold text-danger">Unfilled lines</h2>
+          <DataTable
+            rows={unfilled}
+            columns={columns.filter(column => column.key !== "override")}
+            rowKey={line => line.id}
+            tableId={`purchase-plan-${plan.id}-unfilled`}
+          />
+        </section>
+      )}
+
+      <div className="sticky bottom-0 bg-panel border border-border rounded-md p-3 flex flex-wrap justify-end gap-2">
+        <button type="button" className="btn" onClick={refresh} disabled={busyAction !== null}>
+          <RefreshCw size={14} className={busyAction === "refresh" ? "animate-spin" : ""} />
+          Refresh prices
+        </button>
+        <button type="button" className="btn-primary" onClick={convert} disabled={!fresh || busyAction !== null}>
+          <ShoppingCart size={14} />
+          Create draft orders
+        </button>
+      </div>
+
+      <OverrideOfferModal line={overrideLine} onClose={() => setOverrideLine(null)} />
+    </div>
+  );
+}

--- a/web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.test.tsx
+++ b/web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { toast } from "sonner";
@@ -191,6 +192,7 @@ function renderPage() {
       <MemoryRouter initialEntries={[`/projects/${projectId}/sourcing`]}>
         <Routes>
           <Route path="/projects/:projectId/sourcing" element={<ProjectSourcingPage />} />
+          <Route path="/projects/:projectId/purchase-plans/:planId" element={<div data-testid="plan-route" />} />
         </Routes>
       </MemoryRouter>
     </QueryClientProvider>,
@@ -262,7 +264,8 @@ describe("ProjectSourcingPage", () => {
     renderPage();
 
     expect(await screen.findByText("TrustedParts request budget reached for this hour. Retry is paused for 5 minutes.")).toBeDefined();
-    expect((screen.getByRole("button", { name: "Retry Source BOM" }) as HTMLButtonElement).disabled).toBe(true);
+    const retry = screen.getByRole("button", { name: "Retry Source BOM" }) as HTMLButtonElement;
+    await waitFor(() => expect(retry.disabled).toBe(true));
   });
 
   it("partial flag surfaces the partial badge", async () => {
@@ -272,6 +275,44 @@ describe("ProjectSourcingPage", () => {
     renderPage();
 
     expect(await screen.findByText("Partial — some chunks served from cache")).toBeDefined();
+  });
+
+  it("Generate purchase plan posts default strategy from current sourcing filters", async () => {
+    mockReads();
+    const post = vi.spyOn(api, "post");
+    post.mockResolvedValueOnce(sourcingResponse());
+    post.mockResolvedValueOnce({
+      id: "plan-1",
+      project_id: projectId,
+      build_quantity: 1,
+      strategy: "preferred_first",
+      status: "draft",
+      created_at: "2026-05-09T12:00:00+00:00",
+      expires_at: "2026-05-15T12:00:00+00:00",
+      lines: [],
+      distributors_used: [],
+      unfilled_count: 0,
+    });
+
+    renderPage();
+
+    await screen.findByText("BOM rows");
+    await userEvent.click(screen.getByRole("button", { name: "Generate purchase plan" }));
+    await userEvent.click(screen.getByRole("button", { name: "Generate" }));
+
+    expect(await screen.findByTestId("plan-route")).toBeDefined();
+    await waitFor(() => {
+      expect(post).toHaveBeenLastCalledWith(
+        `/projects/${projectId}/purchase-plan`,
+        expect.objectContaining({
+          build_quantity: 1,
+          strategy: "preferred_first",
+          country: "US",
+          currency: "USD",
+          distributors: ["DigiKey", "Mouser"],
+        }),
+      );
+    });
   });
 
   it("Source BOM button is disabled when workspace lacks sourcing creds", async () => {

--- a/web/src/routes/projects/sourcing/__tests__/PurchasePlanOptionsModal.test.tsx
+++ b/web/src/routes/projects/sourcing/__tests__/PurchasePlanOptionsModal.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import PurchasePlanOptionsModal from "../PurchasePlanOptionsModal";
+
+beforeEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("PurchasePlanOptionsModal", () => {
+  it("submits with default strategy preferred_first", async () => {
+    const onSubmit = vi.fn();
+    render(
+      <PurchasePlanOptionsModal
+        open
+        buildQuantity={3}
+        baseRequest={{ build_quantity: 3, country: "US", currency: "USD" }}
+        onClose={vi.fn()}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Generate" }));
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      build_quantity: 3,
+      country: "US",
+      currency: "USD",
+      strategy: "preferred_first",
+      price_tolerance_pct: "5",
+    });
+  });
+
+  it("advanced options toggle reveals max_distributors and tolerance fields", async () => {
+    render(
+      <PurchasePlanOptionsModal
+        open
+        buildQuantity={1}
+        baseRequest={{ build_quantity: 1 }}
+        onClose={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByLabelText("Max distributors")).toBeNull();
+
+    await userEvent.click(screen.getByRole("button", { name: "Advanced options" }));
+
+    expect(screen.getByLabelText("Max distributors")).toBeDefined();
+    expect(screen.getByLabelText("Tolerance %")).toBeDefined();
+  });
+});

--- a/web/src/routes/projects/sourcing/__tests__/PurchasePlanReviewPage.test.tsx
+++ b/web/src/routes/projects/sourcing/__tests__/PurchasePlanReviewPage.test.tsx
@@ -1,0 +1,209 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { toast } from "sonner";
+import { api } from "@/lib/api";
+import PurchasePlanReviewPage from "../PurchasePlanReviewPage";
+import type { PurchasePlan } from "../purchasePlanTypes";
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+function plan(overrides: Partial<PurchasePlan> = {}): PurchasePlan {
+  return {
+    id: "plan-12345678",
+    project_id: "project-123",
+    build_quantity: 1,
+    strategy: "preferred_first",
+    country_code: "US",
+    currency_code: "USD",
+    preferred_distributors: ["DigiKey"],
+    status: "refreshed",
+    created_at: "2026-05-09T12:00:00+00:00",
+    expires_at: "2026-05-15T12:00:00+00:00",
+    last_refreshed_at: new Date().toISOString(),
+    distributors_used: ["DigiKey", "Mouser"],
+    est_total_cost: "25.00",
+    worst_lead_time_days: 7,
+    unfilled_count: 1,
+    lines: [
+      {
+        id: "line-1",
+        project_entry_id: "entry-1",
+        part_id: "part-1",
+        mpn_searched: "STM32",
+        required_qty: 20,
+        internal_available_qty: 4,
+        shortage_qty: 16,
+        selected_distributor: "DigiKey",
+        selected_qty: 16,
+        selected_unit_price: "1.25",
+        selected_currency: "USD",
+        selected_packaging: "cut-tape",
+        selected_moq: 1,
+        selected_lead_time_days: 3,
+        selected_url: "https://www.trustedparts.com/stm32",
+        risk_flags: ["single_source"],
+      },
+      {
+        id: "line-2",
+        project_entry_id: "entry-2",
+        part_id: "part-2",
+        mpn_searched: "LM1117",
+        required_qty: 10,
+        internal_available_qty: 0,
+        shortage_qty: 10,
+        selected_distributor: "Mouser",
+        selected_qty: 10,
+        selected_unit_price: "0.50",
+        selected_currency: "USD",
+        selected_packaging: "reel",
+        selected_moq: 1,
+        selected_lead_time_days: 7,
+        selected_url: "https://www.trustedparts.com/lm1117",
+        risk_flags: [],
+      },
+      {
+        id: "line-3",
+        project_entry_id: "entry-3",
+        part_id: "part-3",
+        mpn_searched: "NO-STOCK",
+        required_qty: 1,
+        internal_available_qty: 0,
+        shortage_qty: 1,
+        selected_distributor: null,
+        selected_qty: 0,
+        selected_unit_price: null,
+        selected_currency: null,
+        selected_packaging: null,
+        selected_moq: null,
+        selected_lead_time_days: null,
+        selected_url: null,
+        risk_flags: ["no_authorized_stock"],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function LocationProbe() {
+  const location = useLocation();
+  return <div data-testid="location">{location.pathname}</div>;
+}
+
+function renderPage(initialPlan: PurchasePlan = plan()) {
+  render(
+    <MemoryRouter
+      initialEntries={[
+        {
+          pathname: "/projects/project-123/purchase-plans/plan-12345678",
+          state: {
+            plan: initialPlan,
+            project: { id: "project-123", name: "Amplifier" },
+          },
+        },
+      ]}
+    >
+      <Routes>
+        <Route
+          path="/projects/:projectId/purchase-plans/:planId"
+          element={<PurchasePlanReviewPage />}
+        />
+        <Route path="/orders" element={<LocationProbe />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  cleanup();
+  localStorage.clear();
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+});
+
+describe("PurchasePlanReviewPage", () => {
+  it("renders summary cards from server response", () => {
+    renderPage();
+
+    expect(screen.getByRole("heading", { name: /Purchase plan #\s*plan-123/ })).toBeDefined();
+    expect(screen.getByText("Distributors")).toBeDefined();
+    expect(screen.getByText("25 USD")).toBeDefined();
+    expect(screen.getAllByText("7 days").length).toBeGreaterThan(0);
+    expect(screen.getByText("Powered by TrustedParts")).toBeDefined();
+  });
+
+  it("renders one distributor group per distributor", () => {
+    renderPage();
+
+    expect(screen.getByText("DigiKey")).toBeDefined();
+    expect(screen.getByText("Mouser")).toBeDefined();
+    expect(screen.getAllByLabelText("Source: TrustedParts").length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("unfilled lines render in a separate red card", () => {
+    renderPage();
+
+    const section = screen.getByText("Unfilled lines").closest("section");
+    expect(section).not.toBeNull();
+    expect(within(section as HTMLElement).getByText("NO-STOCK")).toBeDefined();
+  });
+
+  it("Refresh prices calls TP-404 and replaces visible state", async () => {
+    const refreshed = plan({
+      est_total_cost: "12.00",
+      distributors_used: ["Arrow"],
+      lines: [
+        {
+          ...plan().lines[0],
+          id: "line-new",
+          selected_distributor: "Arrow",
+          selected_unit_price: "0.75",
+        },
+      ],
+      unfilled_count: 0,
+    });
+    vi.spyOn(api, "post").mockResolvedValueOnce(refreshed);
+    renderPage();
+
+    await userEvent.click(screen.getByRole("button", { name: /Refresh prices/ }));
+
+    await waitFor(() => expect(screen.getByText("Arrow")).toBeDefined());
+    expect(api.post).toHaveBeenCalledWith("/sourcing/purchase-plans/plan-12345678/refresh");
+    expect(toast.success).toHaveBeenCalledWith("Prices refreshed");
+  });
+
+  it("Create draft orders is disabled when last_refreshed_at is null", () => {
+    renderPage(plan({ last_refreshed_at: null }));
+
+    const button = screen.getByRole("button", { name: /Create draft orders/ });
+    expect((button as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("Create draft orders is disabled when last_refreshed_at is > 10 min old", () => {
+    const stale = new Date(Date.now() - 11 * 60 * 1000).toISOString();
+    renderPage(plan({ last_refreshed_at: stale }));
+
+    const button = screen.getByRole("button", { name: /Create draft orders/ });
+    expect((button as HTMLButtonElement).disabled).toBe(true);
+    expect(screen.getByText("Refresh stale (>10 min)")).toBeDefined();
+  });
+
+  it("Successful conversion redirects to /orders with toast", async () => {
+    vi.spyOn(api, "post").mockResolvedValueOnce({
+      orders: [{ id: "order-1", name: "Draft", supplier: "DigiKey", status: "draft", entries: [] }],
+    });
+    renderPage();
+
+    await userEvent.click(screen.getByRole("button", { name: /Create draft orders/ }));
+
+    await waitFor(() => expect(screen.getByTestId("location").textContent).toBe("/orders"));
+    expect(toast.success).toHaveBeenCalledWith("Created 1 draft orders");
+  });
+});

--- a/web/src/routes/projects/sourcing/purchasePlanTypes.ts
+++ b/web/src/routes/projects/sourcing/purchasePlanTypes.ts
@@ -1,0 +1,72 @@
+export type PurchasePlanLine = {
+  id: string;
+  project_entry_id?: string | null;
+  part_id: string;
+  mpn_searched: string;
+  required_qty: number;
+  internal_available_qty: number;
+  shortage_qty: number;
+  selected_distributor?: string | null;
+  selected_qty?: number | null;
+  selected_unit_price?: string | number | null;
+  selected_currency?: string | null;
+  selected_packaging?: string | null;
+  selected_moq?: number | null;
+  selected_lead_time_days?: number | null;
+  selected_url?: string | null;
+  risk_flags: string[];
+};
+
+export type PurchasePlan = {
+  id: string;
+  project_id: string;
+  build_quantity: number;
+  strategy: string;
+  country_code?: string | null;
+  currency_code?: string | null;
+  preferred_distributors?: string[] | null;
+  max_distributors?: number | null;
+  moq_overbuy_cap?: number | null;
+  price_tolerance_pct?: string | number | null;
+  status: string;
+  created_at: string;
+  expires_at: string;
+  last_refreshed_at?: string | null;
+  lines: PurchasePlanLine[];
+  distributors_used: string[];
+  est_total_cost?: string | number | null;
+  worst_lead_time_days?: number | null;
+  unfilled_count: number;
+};
+
+export type PurchasePlanRequest = {
+  build_quantity: number;
+  strategy: string;
+  country?: string;
+  currency?: string;
+  distributors?: string[];
+  max_distributors?: number;
+  moq_overbuy_cap?: number;
+  price_tolerance_pct?: string;
+};
+
+export type CreatedOrder = {
+  id: string;
+  name: string;
+  supplier?: string | null;
+  status: string;
+  currency?: string | null;
+  comments?: string | null;
+  entries: {
+    id: string;
+    part_id?: string | null;
+    quantity_ordered: number;
+    unit_price?: string | number | null;
+    currency?: string | null;
+    comments?: string | null;
+  }[];
+};
+
+export type ConvertOrdersResponse = {
+  orders: CreatedOrder[];
+};


### PR DESCRIPTION
## Summary
- Replaces closed-unmerged #399 with a corrected TP-406-only branch against current `main`.
- Adds the Source-BOM "Generate purchase plan" CTA and strategy/options modal.
- Adds `/projects/:projectId/purchase-plans/:planId` with summary cards, distributor-grouped DataTables, unfilled lines, TrustedParts attribution, refresh, conversion, and the 10-minute stale conversion gate.
- Keeps the per-line Override affordance disabled with the TP-406a tooltip because TP-405 does not accept an override body.
- Updates `docs/frontend/projects.md` for the purchase-plan review flow.

## Validation
- `cd web && npm test -- src/routes/projects/sourcing/__tests__/PurchasePlanReviewPage.test.tsx src/routes/projects/sourcing/__tests__/PurchasePlanOptionsModal.test.tsx src/routes/projects/sourcing/__tests__/ProjectSourcingPage.test.tsx` -> 18 passed
- `cd web && npm run typecheck` -> passed
- `cd web && LINT_CMD="npm run lint -- --format unix" BASELINE_FILE="../.eslint-baseline.txt" WORK_DIR="." bash ../scripts/lint-delta.sh` -> no new violations

## Repair note
#399 was closed unmerged, while #400 was accidentally merged into the TP-406 branch instead of `main`. This PR restores TP-406 as a standalone PR against `main`; TP-407 is split back out into #403 on top of this branch.

## Override note
Override is deferred to TP-406a per the issue fallback path. TP-405 exposes `POST /api/sourcing/purchase-plans/{id}/orders` without an override body, so this PR keeps per-line Override buttons disabled with `Override will land in TP-406a`. Follow-up issue: #404.

## Merge order
1. This PR #402 TP-406 plan-review frontend
2. #403 TP-407 integration tests

Refs #378
