### PR TITLE
TP-406a: Enable purchase-plan offer overrides

### DIFF
--- a/backend/alembic/versions/0041_purchase_plan_line_available_offers.py
+++ b/backend/alembic/versions/0041_purchase_plan_line_available_offers.py
@@ -1,0 +1,34 @@
+"""Add cached offers to purchase plan lines.
+
+Revision ID: 0041
+Revises: 0040
+Create Date: 2026-05-10
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+from alembic import op
+
+revision = "0041"
+down_revision = "0040"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "purchase_plan_lines",
+        sa.Column(
+            "available_offers",
+            JSONB,
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("purchase_plan_lines", "available_offers")

--- a/backend/app/api/routes/sourcing.py
+++ b/backend/app/api/routes/sourcing.py
@@ -26,6 +26,7 @@ from app.domain.sourcing.factory import make_sourcing_provider
 from app.domain.sourcing.models import PurchasePlan
 from app.domain.sourcing.schemas import (
     PurchasePlanIn,
+    PurchasePlanOrdersIn,
     SourcingBomIn,
     SourcingQuery,
     SourcingSearchIn,
@@ -335,6 +336,7 @@ def convert_purchase_plan_to_orders(
     ws: CurrentWorkspace,
     user: CurrentUser,
     db: Session = Depends(get_db),
+    payload: PurchasePlanOrdersIn | None = None,
 ):
     plan = assert_in_workspace(db, PurchasePlan, plan_id, ws.id, label="purchase plan")
     try:
@@ -343,9 +345,12 @@ def convert_purchase_plan_to_orders(
             workspace=ws,
             plan=plan,
             user_id=user.id,
+            overrides=(payload.overrides if payload is not None else None),
         )
     except sourcing_service.PurchasePlanStaleError as exc:
         return _error_response(request, 409, "conflict", str(exc))
+    except sourcing_service.PurchasePlanOverrideError as exc:
+        return _error_response(request, 422, "validation_error", str(exc))
     except sourcing_service.PurchasePlanCurrencyError as exc:
         return _error_response(request, 422, "validation_error", str(exc))
 

--- a/backend/app/domain/sourcing/models.py
+++ b/backend/app/domain/sourcing/models.py
@@ -198,6 +198,12 @@ class PurchasePlanLine(Base):
     selected_moq = Column(sa.Integer, nullable=True)
     selected_lead_time_days = Column(sa.Integer, nullable=True)
     selected_url = Column(sa.Text, nullable=True)
+    available_offers = Column(
+        JSONB,
+        nullable=False,
+        default=list,
+        server_default=sa.text("'[]'::jsonb"),
+    )
     risk_flags = Column(
         JSONB,
         nullable=False,

--- a/backend/app/domain/sourcing/schemas.py
+++ b/backend/app/domain/sourcing/schemas.py
@@ -267,6 +267,37 @@ class PurchasePlanIn(BaseModel):
         return stripped or None
 
 
+class PurchasePlanOrderOverrideIn(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    selected_distributor: str = Field(min_length=1, max_length=120)
+    selected_qty: int = Field(ge=1)
+    selected_unit_price: Decimal
+    selected_currency: str = Field(min_length=3, max_length=3)
+
+    @field_validator("selected_distributor")
+    @classmethod
+    def _strip_distributor(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("selected_distributor must not be empty")
+        return stripped
+
+    @field_validator("selected_currency")
+    @classmethod
+    def _uppercase_currency(cls, value: str) -> str:
+        stripped = value.strip().upper()
+        if len(stripped) != 3:
+            raise ValueError("selected_currency must be a 3-letter code")
+        return stripped
+
+
+class PurchasePlanOrdersIn(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    overrides: dict[UUID, PurchasePlanOrderOverrideIn] = Field(default_factory=dict)
+
+
 class PurchasePlanLineOut(BaseModel):
     model_config = ConfigDict(extra="forbid", from_attributes=True)
 
@@ -285,6 +316,7 @@ class PurchasePlanLineOut(BaseModel):
     selected_moq: int | None = None
     selected_lead_time_days: int | None = None
     selected_url: str | None = None
+    available_offers: list[SourcingBomOfferOut] = Field(default_factory=list)
     risk_flags: list[str] = Field(default_factory=list)
 
 

--- a/backend/app/domain/sourcing/service.py
+++ b/backend/app/domain/sourcing/service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 from decimal import Decimal
 from typing import Any
@@ -26,6 +27,7 @@ from app.domain.sourcing.pricing import best_unit_price_at_qty
 from app.domain.sourcing.schemas import (
     BuildCapacityOut,
     DistributorCoverageMatrixOut,
+    PurchasePlanOrderOverrideIn,
     PurchasePlanOrdersOut,
     PurchasePlanOut,
     SourcingAttributionLinks,
@@ -49,6 +51,19 @@ TRUSTEDPARTS_LINKS = SourcingAttributionLinks(
 )
 
 
+@dataclass(frozen=True)
+class _LineUpdate:
+    line: PurchasePlanLine
+    selected_distributor: str | None
+    selected_qty: int | None
+    selected_unit_price: Decimal | None
+    selected_currency: str | None
+    selected_packaging: str | None
+    selected_moq: int | None
+    selected_lead_time_days: int | None
+    selected_url: str | None
+
+
 class SourcingNotConfigured(Exception):
     """Workspace has no usable TrustedParts sourcing configuration."""
 
@@ -63,6 +78,10 @@ class PurchasePlanStaleError(Exception):
 
 class PurchasePlanCurrencyError(Exception):
     """Purchase plan has incompatible currencies in one distributor group."""
+
+
+class PurchasePlanOverrideError(Exception):
+    """Purchase plan conversion override is not valid for cached line offers."""
 
 
 def build_purchase_plan(
@@ -122,29 +141,49 @@ def build_purchase_plan(
         expires_at=created_at + PURCHASE_PLAN_TTL,
         created_by=requested_by,
     )
-    plan.lines = [
-        PurchasePlanLine(
-            project_entry_id=selection.project_entry_id,
-            part_id=selection.part_id,
-            mpn_searched=selection.mpn_searched,
-            required_qty=selection.required_qty,
-            internal_available_qty=selection.internal_available_qty,
-            shortage_qty=selection.shortage_qty,
-            selected_distributor=selection.selected_distributor,
-            selected_qty=selection.selected_qty,
-            selected_unit_price=selection.selected_unit_price,
-            selected_currency=selection.selected_currency,
-            selected_packaging=selection.selected_packaging,
-            selected_moq=selection.selected_moq,
-            selected_lead_time_days=selection.selected_lead_time_days,
-            selected_url=selection.selected_url,
-            risk_flags=list(selection.risk_flags),
-        )
-        for selection in outcome.selections
-    ]
+    plan.lines = _purchase_plan_lines_from_selections(outcome.selections, bom.rows)
     db.add(plan)
     db.flush()
     return plan
+
+
+def _purchase_plan_lines_from_selections(
+    selections: Iterable[Any],
+    rows: list[SourcingBomLineOut],
+) -> list[PurchasePlanLine]:
+    rows_by_entry_id = {row.project_entry_id: row for row in rows}
+    lines: list[PurchasePlanLine] = []
+    for selection in selections:
+        source_row = rows_by_entry_id.get(selection.project_entry_id)
+        available_offers = (
+            [
+                offer.model_dump(mode="json")
+                for offer in source_row.offers
+            ]
+            if source_row is not None
+            else []
+        )
+        lines.append(
+            PurchasePlanLine(
+                project_entry_id=selection.project_entry_id,
+                part_id=selection.part_id,
+                mpn_searched=selection.mpn_searched,
+                required_qty=selection.required_qty,
+                internal_available_qty=selection.internal_available_qty,
+                shortage_qty=selection.shortage_qty,
+                selected_distributor=selection.selected_distributor,
+                selected_qty=selection.selected_qty,
+                selected_unit_price=selection.selected_unit_price,
+                selected_currency=selection.selected_currency,
+                selected_packaging=selection.selected_packaging,
+                selected_moq=selection.selected_moq,
+                selected_lead_time_days=selection.selected_lead_time_days,
+                selected_url=selection.selected_url,
+                available_offers=available_offers,
+                risk_flags=list(selection.risk_flags),
+            )
+        )
+    return lines
 
 
 def convert_plan_to_orders(
@@ -153,6 +192,7 @@ def convert_plan_to_orders(
     workspace: Any,
     plan: PurchasePlan,
     user_id: UUID | None,
+    overrides: dict[UUID, PurchasePlanOrderOverrideIn] | None = None,
 ) -> list[Order]:
     if plan.status != "refreshed":
         raise PurchasePlanStaleError(
@@ -164,6 +204,10 @@ def convert_plan_to_orders(
         )
     if plan.last_refreshed_at < utcnow() - timedelta(seconds=MAX_PLAN_STALENESS_SECONDS):
         raise PurchasePlanStaleError("plan refresh is stale; refresh again before conversion")
+
+    line_updates = _validated_line_updates(plan, overrides or {})
+    _validate_line_update_currencies(line_updates)
+    _apply_line_updates(line_updates)
 
     lines_by_distributor: dict[str, list[PurchasePlanLine]] = {}
     display_names: dict[str, str] = {}
@@ -194,6 +238,118 @@ def convert_plan_to_orders(
     plan.status = "converted"
     db.flush()
     return orders
+
+
+def _validated_line_updates(
+    plan: PurchasePlan,
+    overrides: dict[UUID, PurchasePlanOrderOverrideIn],
+) -> list[_LineUpdate]:
+    lines_by_id = {line.id: line for line in plan.lines}
+    unknown_line_ids = sorted(set(overrides) - set(lines_by_id), key=str)
+    if unknown_line_ids:
+        raise PurchasePlanOverrideError(
+            "override line does not belong to this purchase plan"
+        )
+
+    updates: list[_LineUpdate] = []
+    for line in plan.lines:
+        override = overrides.get(line.id)
+        if override is None:
+            updates.append(_line_update_from_current_selection(line))
+            continue
+        offer = _matching_cached_offer(line, override)
+        updates.append(
+            _LineUpdate(
+                line=line,
+                selected_distributor=offer.distributor,
+                selected_qty=override.selected_qty,
+                selected_unit_price=override.selected_unit_price,
+                selected_currency=override.selected_currency,
+                selected_packaging=offer.packaging,
+                selected_moq=offer.moq,
+                selected_lead_time_days=offer.lead_time_days,
+                selected_url=offer.url,
+            )
+        )
+    return updates
+
+
+def _line_update_from_current_selection(line: PurchasePlanLine) -> _LineUpdate:
+    return _LineUpdate(
+        line=line,
+        selected_distributor=line.selected_distributor,
+        selected_qty=line.selected_qty,
+        selected_unit_price=line.selected_unit_price,
+        selected_currency=line.selected_currency,
+        selected_packaging=line.selected_packaging,
+        selected_moq=line.selected_moq,
+        selected_lead_time_days=line.selected_lead_time_days,
+        selected_url=line.selected_url,
+    )
+
+
+def _matching_cached_offer(
+    line: PurchasePlanLine,
+    override: PurchasePlanOrderOverrideIn,
+) -> SourcingBomOfferOut:
+    if not line.available_offers:
+        raise PurchasePlanStaleError(
+            "cached offers are unavailable; refresh again before conversion"
+        )
+    for raw_offer in line.available_offers:
+        offer = SourcingBomOfferOut.model_validate(raw_offer)
+        if offer.distributor.casefold() != override.selected_distributor.casefold():
+            continue
+        if offer.stock < override.selected_qty:
+            continue
+        if offer.moq is not None and override.selected_qty < offer.moq:
+            continue
+        if override.selected_qty < line.shortage_qty:
+            continue
+        if (offer.currency or "").upper() != override.selected_currency:
+            continue
+        unit_price = _unit_price_for_offer(offer, override.selected_qty)
+        if unit_price is None or unit_price != override.selected_unit_price:
+            continue
+        return offer
+    raise PurchasePlanOverrideError(
+        "override does not match cached offers for purchase plan line"
+    )
+
+
+def _unit_price_for_offer(offer: SourcingBomOfferOut, qty: int) -> Decimal | None:
+    best = best_unit_price_at_qty(offer.price_breaks, qty)
+    if best is not None:
+        return best[0]
+    return offer.unit_price
+
+
+def _validate_line_update_currencies(updates: list[_LineUpdate]) -> None:
+    currencies_by_distributor: dict[str, set[str]] = {}
+    display_names: dict[str, str] = {}
+    for update in updates:
+        if update.selected_distributor is None or update.selected_currency is None:
+            continue
+        key = update.selected_distributor.casefold()
+        currencies_by_distributor.setdefault(key, set()).add(update.selected_currency)
+        display_names.setdefault(key, update.selected_distributor)
+    for distributor_key, currencies in currencies_by_distributor.items():
+        if len(currencies) > 1:
+            raise PurchasePlanCurrencyError(
+                f"mixed currencies for distributor {display_names[distributor_key]}"
+            )
+
+
+def _apply_line_updates(updates: list[_LineUpdate]) -> None:
+    for update in updates:
+        update.line.selected_distributor = update.selected_distributor
+        update.line.selected_qty = update.selected_qty
+        update.line.selected_unit_price = update.selected_unit_price
+        update.line.selected_currency = update.selected_currency
+        update.line.selected_packaging = update.selected_packaging
+        update.line.selected_moq = update.selected_moq
+        update.line.selected_lead_time_days = update.selected_lead_time_days
+        update.line.selected_url = update.selected_url
 
 
 def refresh_purchase_plan(
@@ -232,26 +388,7 @@ def refresh_purchase_plan(
         price_tolerance_pct=Decimal(plan.price_tolerance_pct or Decimal("5")),
     )
 
-    plan.lines = [
-        PurchasePlanLine(
-            project_entry_id=selection.project_entry_id,
-            part_id=selection.part_id,
-            mpn_searched=selection.mpn_searched,
-            required_qty=selection.required_qty,
-            internal_available_qty=selection.internal_available_qty,
-            shortage_qty=selection.shortage_qty,
-            selected_distributor=selection.selected_distributor,
-            selected_qty=selection.selected_qty,
-            selected_unit_price=selection.selected_unit_price,
-            selected_currency=selection.selected_currency,
-            selected_packaging=selection.selected_packaging,
-            selected_moq=selection.selected_moq,
-            selected_lead_time_days=selection.selected_lead_time_days,
-            selected_url=selection.selected_url,
-            risk_flags=list(selection.risk_flags),
-        )
-        for selection in outcome.selections
-    ]
+    plan.lines = _purchase_plan_lines_from_selections(outcome.selections, bom.rows)
     plan.status = "refreshed"
     plan.last_refreshed_at = utcnow()
     db.flush()

--- a/backend/tests/test_purchase_plan_convert_route.py
+++ b/backend/tests/test_purchase_plan_convert_route.py
@@ -55,8 +55,10 @@ def _refresh(client: TestClient, plan_id: str):
     return r.json()["data"]
 
 
-def _convert(client: TestClient, plan_id: str):
-    return client.post(f"/api/sourcing/purchase-plans/{plan_id}/orders")
+def _convert(client: TestClient, plan_id: str, payload: dict[str, Any] | None = None):
+    if payload is None:
+        return client.post(f"/api/sourcing/purchase-plans/{plan_id}/orders")
+    return client.post(f"/api/sourcing/purchase-plans/{plan_id}/orders", json=payload)
 
 
 def _two_line_project(client: TestClient) -> str:
@@ -102,6 +104,186 @@ def test_basic_conversion_creates_one_order_per_distributor(authed_client):
     assert [len(order["entries"]) for order in orders] == [1, 1]
     assert orders[0]["entries"][0]["quantity_ordered"] == 5
     assert orders[1]["entries"][0]["quantity_ordered"] == 7
+
+
+def test_plan_line_output_includes_cached_offers(authed_client):
+    project_id = _single_line_project(authed_client, mpn="OVERRIDE-OFFERS", quantity=4)
+    plan = _create_refreshed_plan(
+        authed_client,
+        project_id=project_id,
+        offers_by_mpn={
+            "OVERRIDE-OFFERS": [
+                _offer("OVERRIDE-OFFERS", distributor="DigiKey", stock=100, unit_price=1.0),
+                _offer("OVERRIDE-OFFERS", distributor="Mouser", stock=100, unit_price=1.1),
+            ]
+        },
+    )
+
+    offers = plan["lines"][0]["available_offers"]
+    assert [offer["distributor"] for offer in offers] == ["DigiKey", "Mouser"]
+    assert offers[0]["url"] == "https://www.trustedparts.com/OVERRIDE-OFFERS/DigiKey"
+
+
+def test_conversion_override_uses_cached_offer_selection(authed_client, db):
+    project_id = _single_line_project(authed_client, mpn="OVERRIDE-OK", quantity=4)
+    plan = _create_refreshed_plan(
+        authed_client,
+        project_id=project_id,
+        offers_by_mpn={
+            "OVERRIDE-OK": [
+                _offer("OVERRIDE-OK", distributor="DigiKey", stock=100, unit_price=1.0),
+                _offer("OVERRIDE-OK", distributor="Mouser", stock=100, unit_price=1.1),
+            ]
+        },
+    )
+    line = plan["lines"][0]
+    assert line["selected_distributor"] == "DigiKey"
+    override_url = "https://www.trustedparts.com/OVERRIDE-OK/Mouser"
+
+    r = _convert(
+        authed_client,
+        plan["id"],
+        {
+            "overrides": {
+                line["id"]: {
+                    "selected_distributor": "Mouser",
+                    "selected_qty": 4,
+                    "selected_unit_price": "1.1",
+                    "selected_currency": "EUR",
+                }
+            }
+        },
+    )
+
+    assert r.status_code == 200, r.text
+    assert "selected_url" not in r.text
+    assert override_url not in r.text
+    order = r.json()["data"]["orders"][0]
+    assert order["supplier"] == "Mouser"
+    assert order["entries"][0]["quantity_ordered"] == 4
+    assert Decimal(order["entries"][0]["unit_price"]) == Decimal("1.100000")
+    persisted_comments = [
+        *(db.execute(select(Order.comments)).scalars().all()),
+        *(db.execute(select(OrderEntry.comments)).scalars().all()),
+    ]
+    assert all(override_url not in (comment or "") for comment in persisted_comments)
+
+
+def test_invalid_conversion_override_persists_no_orders(authed_client, db):
+    project_id = _single_line_project(authed_client, mpn="OVERRIDE-BAD", quantity=4)
+    plan = _create_refreshed_plan(
+        authed_client,
+        project_id=project_id,
+        offers_by_mpn={
+            "OVERRIDE-BAD": [
+                _offer("OVERRIDE-BAD", distributor="DigiKey", stock=100, unit_price=1.0),
+            ]
+        },
+    )
+    line = plan["lines"][0]
+
+    r = _convert(
+        authed_client,
+        plan["id"],
+        {
+            "overrides": {
+                line["id"]: {
+                    "selected_distributor": "Mouser",
+                    "selected_qty": 4,
+                    "selected_unit_price": "1.1",
+                    "selected_currency": "EUR",
+                }
+            }
+        },
+    )
+
+    assert r.status_code == 422, r.text
+    assert "cached offers" in r.json()["status"]["message"]
+    assert db.execute(select(func.count()).select_from(Order)).scalar_one() == 0
+    assert db.execute(select(func.count()).select_from(OrderEntry)).scalar_one() == 0
+
+
+def test_override_line_from_other_workspace_persists_no_orders(authed_client, db):
+    plan_a = _create_refreshed_plan(
+        authed_client,
+        project_id=_single_line_project(authed_client, mpn="OVERRIDE-WS-A", quantity=4),
+        offers_by_mpn={
+            "OVERRIDE-WS-A": [
+                _offer("OVERRIDE-WS-A", distributor="DigiKey", stock=100, unit_price=1.0)
+            ]
+        },
+    )
+    client_b = TestClient(app)
+    signup_user(client_b)
+    plan_b = _create_refreshed_plan(
+        client_b,
+        project_id=_single_line_project(client_b, mpn="OVERRIDE-WS-B", quantity=4),
+        offers_by_mpn={
+            "OVERRIDE-WS-B": [
+                _offer("OVERRIDE-WS-B", distributor="Mouser", stock=100, unit_price=2.0)
+            ]
+        },
+    )
+
+    r = _convert(
+        client_b,
+        plan_b["id"],
+        {
+            "overrides": {
+                plan_a["lines"][0]["id"]: {
+                    "selected_distributor": "Mouser",
+                    "selected_qty": 4,
+                    "selected_unit_price": "2.0",
+                    "selected_currency": "EUR",
+                }
+            }
+        },
+    )
+
+    assert r.status_code == 422, r.text
+    assert "purchase plan" in r.json()["status"]["message"]
+    assert db.execute(select(func.count()).select_from(Order)).scalar_one() == 0
+    assert db.execute(select(func.count()).select_from(OrderEntry)).scalar_one() == 0
+
+
+def test_override_mixed_currency_guard_persists_no_orders(authed_client, db):
+    plan = _create_refreshed_plan(
+        authed_client,
+        offers_by_mpn={
+            "PLAN-A": [_offer("PLAN-A", distributor="DigiKey", stock=100, unit_price=1.0)],
+            "PLAN-B": [
+                _offer("PLAN-B", distributor="DigiKey", stock=100, unit_price=2.0),
+                _offer(
+                    "PLAN-B",
+                    distributor="DigiKey",
+                    stock=100,
+                    unit_price=3.0,
+                    currency="USD",
+                ),
+            ],
+        },
+    )
+    line_b = next(line for line in plan["lines"] if line["mpn_searched"] == "PLAN-B")
+
+    r = _convert(
+        authed_client,
+        plan["id"],
+        {
+            "overrides": {
+                line_b["id"]: {
+                    "selected_distributor": "DigiKey",
+                    "selected_qty": 7,
+                    "selected_unit_price": "3.0",
+                    "selected_currency": "USD",
+                }
+            }
+        },
+    )
+
+    assert r.status_code == 422, r.text
+    assert "mixed currencies" in r.json()["status"]["message"]
+    assert db.execute(select(func.count()).select_from(Order)).scalar_one() == 0
+    assert db.execute(select(func.count()).select_from(OrderEntry)).scalar_one() == 0
 
 
 def test_orders_status_is_draft(authed_client):

--- a/docs/domain/sourcing.md
+++ b/docs/domain/sourcing.md
@@ -40,7 +40,8 @@ Sources: `backend/alembic/versions/0038_sourcing_cache.py:42`,
 build quantity, strategy, country/currency hints, optional preferred distributors, and
 status. `purchase_plan_lines` stores the per-BOM-line shortage and the selected offer
 snapshot the user is reviewing, including distributor, quantity, unit price, MOQ, lead
-time, and offer URL.
+time, offer URL, and the cached `available_offers` list used to validate user
+overrides during conversion.
 
 Plans inherit the TrustedParts seven-day retention cap:
 
@@ -60,8 +61,11 @@ Sources: `backend/alembic/versions/0039_purchase_plans.py:68`,
 
 Phase 4 keeps TrustedParts data ephemeral until the user converts a freshly refreshed
 purchase plan into draft purchase orders. Conversion creates one draft order per selected
-distributor and one order entry per selected plan line. It does not receive stock, create
-lots, or copy provider URLs into order comments.
+distributor and one order entry per selected plan line. Optional line overrides are
+accepted only when the requested distributor, quantity, unit price, and currency match an
+offer cached on that `purchase_plan_lines` row. Invalid overrides fail before any order
+rows are written. The flow does not receive stock, create lots, or copy provider URLs
+into order comments.
 
 ```text
 BOM entries
@@ -78,6 +82,7 @@ BOM entries
   -> convert
        require status=refreshed
        require last_refreshed_at within 10 minutes
+       validate overrides against cached available_offers
        group selected lines by distributor
        create draft purchase orders
        create draft order entries

--- a/web/src/routes/projects/sourcing/OverrideOfferModal.tsx
+++ b/web/src/routes/projects/sourcing/OverrideOfferModal.tsx
@@ -1,35 +1,161 @@
-import type { PurchasePlanLine } from "./purchasePlanTypes";
+import type { PurchasePlanLine, PurchasePlanOffer } from "./purchasePlanTypes";
 
 type Props = {
   line: PurchasePlanLine | null;
+  onSelect: (line: PurchasePlanLine, offer: PurchasePlanOffer) => void;
   onClose: () => void;
 };
 
-export default function OverrideOfferModal({ line, onClose }: Props) {
+function formatValue(value: string | number | null | undefined): string {
+  if (value == null || value === "") return "-";
+  return String(value);
+}
+
+function formatMoney(value: string | number | null | undefined, currency?: string | null): string {
+  if (value == null || value === "") return "-";
+  const numeric = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(numeric)) return currency ? `${value} ${currency}` : String(value);
+  const formatted = numeric.toLocaleString(undefined, {
+    maximumFractionDigits: 4,
+    minimumFractionDigits: numeric % 1 === 0 ? 0 : 2,
+  });
+  return currency ? `${formatted} ${currency}` : formatted;
+}
+
+function formatLeadTime(days: number | null | undefined): string {
+  if (days == null) return "-";
+  return days === 1 ? "1 day" : `${days.toLocaleString()} days`;
+}
+
+function numericValue(value: string | number | null | undefined): number | null {
+  if (value == null || value === "") return null;
+  const parsed = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function isCurrentOffer(line: PurchasePlanLine, offer: PurchasePlanOffer): boolean {
+  const sameDistributor =
+    (offer.distributor ?? "").toLowerCase() === (line.selected_distributor ?? "").toLowerCase();
+  if (!sameDistributor) return false;
+  if (offer.url && line.selected_url) return offer.url === line.selected_url;
+  return (
+    numericValue(offer.unit_price) === numericValue(line.selected_unit_price) &&
+    (offer.currency ?? "").toUpperCase() === (line.selected_currency ?? "").toUpperCase()
+  );
+}
+
+function selectedQtyForOffer(line: PurchasePlanLine, offer: PurchasePlanOffer): number {
+  const shortage = Math.max(0, line.shortage_qty);
+  const moq = Math.max(0, numericValue(offer.moq) ?? 0);
+  return Math.max(shortage, moq, 1);
+}
+
+function canSelectOffer(line: PurchasePlanLine, offer: PurchasePlanOffer): boolean {
+  const qty = selectedQtyForOffer(line, offer);
+  const stock = numericValue(offer.stock);
+  return Boolean(
+    offer.distributor &&
+    offer.unit_price != null &&
+    offer.currency &&
+    stock != null &&
+    stock >= qty,
+  );
+}
+
+export default function OverrideOfferModal({ line, onSelect, onClose }: Props) {
   if (!line) return null;
+
+  const offers = (line.available_offers ?? []).filter(offer => !isCurrentOffer(line, offer));
 
   return (
     <div className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4">
       <div
-        className="card max-w-md w-full p-4 space-y-4"
+        className="card max-w-5xl w-full max-h-[85vh] overflow-hidden flex flex-col"
         role="dialog"
         aria-modal="true"
         aria-labelledby="override-offer-title"
       >
-        <div className="flex items-start justify-between gap-3">
-          <h2 id="override-offer-title" className="text-lg font-semibold">
-            Override offer
-          </h2>
+        <div className="flex items-start justify-between gap-3 p-4 border-b border-border">
+          <div>
+            <h2 id="override-offer-title" className="text-lg font-semibold">
+              Override offer
+            </h2>
+            <div className="text-sm text-muted">
+              {line.mpn_searched} - current: {line.selected_distributor ?? "Unfilled"}
+            </div>
+          </div>
           <button type="button" className="btn" onClick={onClose}>
             Close
           </button>
         </div>
-        <div className="text-sm text-muted">
-          Override requires backend validation support and is disabled for this phase.
-        </div>
-        <div className="rounded border border-border p-3 text-sm">
-          <div className="font-medium">{line.mpn_searched}</div>
-          <div className="text-muted">{line.selected_distributor ?? "Unfilled"}</div>
+
+        <div className="overflow-auto">
+          {offers.length === 0 ? (
+            <div className="p-4 text-sm text-muted">
+              No cached alternate offers are available for this line.
+            </div>
+          ) : (
+            <table className="table text-sm">
+              <thead>
+                <tr>
+                  <th>Distributor</th>
+                  <th>MPN</th>
+                  <th className="text-right">Stock</th>
+                  <th className="text-right">Unit price</th>
+                  <th>Packaging</th>
+                  <th className="text-right">MOQ</th>
+                  <th className="text-right">Lead time</th>
+                  <th>Offer</th>
+                  <th className="text-right">Action</th>
+                </tr>
+              </thead>
+              <tbody>
+                {offers.map((offer, index) => {
+                  const key = `${offer.distributor ?? "unknown"}-${offer.mpn ?? "mpn"}-${index}`;
+                  const isCurrent =
+                    offer.distributor === line.selected_distributor &&
+                    offer.unit_price === line.selected_unit_price &&
+                    offer.currency === line.selected_currency;
+                  return (
+                    <tr key={key}>
+                      <td>
+                        <div className="font-medium">{offer.distributor ?? "-"}</div>
+                        {isCurrent && <div className="text-xs text-muted">Current selection</div>}
+                      </td>
+                      <td>{offer.mpn ?? line.mpn_searched}</td>
+                      <td className="text-right tabular-nums">{formatValue(offer.stock)}</td>
+                      <td className="text-right tabular-nums">{formatMoney(offer.unit_price, offer.currency)}</td>
+                      <td>{formatValue(offer.packaging)}</td>
+                      <td className="text-right tabular-nums">{formatValue(offer.moq)}</td>
+                      <td className="text-right tabular-nums">{formatLeadTime(offer.lead_time_days)}</td>
+                      <td>
+                        {offer.url ? (
+                          <a
+                            className="text-accent hover:underline"
+                            href={offer.url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                          >
+                            Open
+                          </a>
+                        ) : "-"}
+                      </td>
+                      <td className="text-right">
+                        <button
+                          type="button"
+                          className="btn"
+                          disabled={!canSelectOffer(line, offer)}
+                          onClick={() => onSelect(line, offer)}
+                        >
+                          Select
+                        </button>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          )}
         </div>
       </div>
     </div>

--- a/web/src/routes/projects/sourcing/PurchasePlanReviewPage.tsx
+++ b/web/src/routes/projects/sourcing/PurchasePlanReviewPage.tsx
@@ -8,7 +8,14 @@ import { SourcingSourceLabel } from "@/components/SourcingSourceLabel";
 import { api } from "@/lib/api";
 import type { Project } from "@/types";
 import OverrideOfferModal from "./OverrideOfferModal";
-import type { ConvertOrdersResponse, PurchasePlan, PurchasePlanLine } from "./purchasePlanTypes";
+import type {
+  ConvertOrdersRequest,
+  ConvertOrdersResponse,
+  PurchasePlan,
+  PurchasePlanLine,
+  PurchasePlanOffer,
+  PurchasePlanOrderOverride,
+} from "./purchasePlanTypes";
 
 type LocationState = {
   plan?: PurchasePlan;
@@ -56,6 +63,71 @@ function extendedCost(line: PurchasePlanLine): number | null {
   return unit * line.selected_qty;
 }
 
+function selectedQtyForOffer(line: PurchasePlanLine, offer: PurchasePlanOffer): number {
+  const shortage = Math.max(0, line.shortage_qty);
+  const moq = Math.max(0, numberOrNull(offer.moq) ?? 0);
+  return Math.max(shortage, moq, 1);
+}
+
+function unitPriceForOffer(offer: PurchasePlanOffer, qty: number): string | number | null {
+  const breaks = (offer.price_breaks ?? [])
+    .map(priceBreak => ({
+      quantity: numberOrNull(priceBreak.quantity),
+      unitPrice: priceBreak.unit_price,
+    }))
+    .filter((priceBreak): priceBreak is { quantity: number; unitPrice: string | number } =>
+      priceBreak.quantity != null &&
+      priceBreak.quantity >= 1 &&
+      priceBreak.unitPrice != null &&
+      priceBreak.unitPrice !== "",
+    )
+    .sort((a, b) => a.quantity - b.quantity);
+
+  if (breaks.length === 0) return offer.unit_price ?? null;
+
+  let selected = breaks[0];
+  for (const candidate of breaks) {
+    if (candidate.quantity > qty) break;
+    selected = candidate;
+  }
+  return selected.unitPrice;
+}
+
+function recomputePlanFromLines(plan: PurchasePlan, lines: PurchasePlanLine[]): PurchasePlan {
+  const distributors = new Set<string>();
+  let estTotal = 0;
+  let hasCost = false;
+  let worstLeadTime: number | null = null;
+  let unfilledCount = 0;
+
+  for (const line of lines) {
+    if (line.selected_distributor) {
+      distributors.add(line.selected_distributor);
+    } else {
+      unfilledCount += 1;
+    }
+
+    const cost = extendedCost(line);
+    if (cost != null) {
+      estTotal += cost;
+      hasCost = true;
+    }
+
+    if (line.selected_lead_time_days != null) {
+      worstLeadTime = Math.max(worstLeadTime ?? 0, line.selected_lead_time_days);
+    }
+  }
+
+  return {
+    ...plan,
+    lines,
+    distributors_used: [...distributors].sort((a, b) => a.localeCompare(b)),
+    est_total_cost: hasCost ? estTotal : plan.est_total_cost,
+    worst_lead_time_days: worstLeadTime,
+    unfilled_count: unfilledCount,
+  };
+}
+
 function groupLines(lines: PurchasePlanLine[]) {
   const groups = new Map<string, PurchasePlanLine[]>();
   for (const line of lines) {
@@ -80,11 +152,16 @@ export default function PurchasePlanReviewPage() {
   const [project] = useState<Project | undefined>(locationState.project);
   const [busyAction, setBusyAction] = useState<"refresh" | "convert" | null>(null);
   const [overrideLine, setOverrideLine] = useState<PurchasePlanLine | null>(null);
+  const [overrides, setOverrides] = useState<Record<string, PurchasePlanOrderOverride>>({});
 
   const grouped = useMemo(() => groupLines(plan?.lines ?? []), [plan]);
   const unfilled = useMemo(
     () => (plan?.lines ?? []).filter(line => !line.selected_distributor),
     [plan],
+  );
+  const activeOverrideLine = useMemo(
+    () => overrideLine ? plan?.lines.find(line => line.id === overrideLine.id) ?? overrideLine : null,
+    [overrideLine, plan],
   );
 
   if (!projectId || !planId) return null;
@@ -161,9 +238,7 @@ export default function PurchasePlanReviewPage() {
       render: line => (
         <button
           type="button"
-          className="btn"
-          title="Override will land in TP-406a"
-          disabled
+          className={overrides[line.id] ? "btn-primary" : "btn"}
           onClick={() => setOverrideLine(line)}
         >
           Override
@@ -178,19 +253,62 @@ export default function PurchasePlanReviewPage() {
     try {
       const next = await api.post<PurchasePlan>(`/sourcing/purchase-plans/${plan.id}/refresh`);
       setPlan(next);
+      setOverrides({});
       toast.success("Prices refreshed");
     } finally {
       setBusyAction(null);
     }
   }
 
+  function selectOffer(line: PurchasePlanLine, offer: PurchasePlanOffer) {
+    if (!offer.distributor || offer.unit_price == null || !offer.currency) return;
+
+    const selected_qty = selectedQtyForOffer(line, offer);
+    const selected_unit_price = unitPriceForOffer(offer, selected_qty);
+    if (selected_unit_price == null) return;
+
+    const override: PurchasePlanOrderOverride = {
+      selected_distributor: offer.distributor,
+      selected_qty,
+      selected_unit_price,
+      selected_currency: offer.currency,
+    };
+
+    setPlan(current => {
+      if (!current) return current;
+      const nextLines = current.lines.map(currentLine =>
+        currentLine.id === line.id
+          ? {
+              ...currentLine,
+              selected_distributor: offer.distributor,
+              selected_qty,
+              selected_unit_price,
+              selected_currency: offer.currency,
+              selected_packaging: offer.packaging ?? null,
+              selected_moq: offer.moq ?? null,
+              selected_lead_time_days: offer.lead_time_days ?? null,
+              selected_url: offer.url ?? null,
+            }
+          : currentLine,
+      );
+      return recomputePlanFromLines(current, nextLines);
+    });
+    setOverrides(current => ({ ...current, [line.id]: override }));
+    setOverrideLine(null);
+  }
+
   async function convert() {
     if (!plan) return;
     setBusyAction("convert");
     try {
-      const result = await api.post<ConvertOrdersResponse>(`/sourcing/purchase-plans/${plan.id}/orders`);
+      const result = await api.post<ConvertOrdersResponse, ConvertOrdersRequest>(
+        `/sourcing/purchase-plans/${plan.id}/orders`,
+        { overrides },
+      );
       toast.success(`Created ${result.orders.length} draft orders`);
       navigate("/orders");
+    } catch {
+      toast.error("Could not create draft orders");
     } finally {
       setBusyAction(null);
     }
@@ -264,7 +382,7 @@ export default function PurchasePlanReviewPage() {
           <h2 className="text-md font-semibold text-danger">Unfilled lines</h2>
           <DataTable
             rows={unfilled}
-            columns={columns.filter(column => column.key !== "override")}
+            columns={columns}
             rowKey={line => line.id}
             tableId={`purchase-plan-${plan.id}-unfilled`}
           />
@@ -282,7 +400,7 @@ export default function PurchasePlanReviewPage() {
         </button>
       </div>
 
-      <OverrideOfferModal line={overrideLine} onClose={() => setOverrideLine(null)} />
+      <OverrideOfferModal line={activeOverrideLine} onSelect={selectOffer} onClose={() => setOverrideLine(null)} />
     </div>
   );
 }

--- a/web/src/routes/projects/sourcing/__tests__/PurchasePlanReviewPage.test.tsx
+++ b/web/src/routes/projects/sourcing/__tests__/PurchasePlanReviewPage.test.tsx
@@ -49,6 +49,32 @@ function plan(overrides: Partial<PurchasePlan> = {}): PurchasePlan {
         selected_moq: 1,
         selected_lead_time_days: 3,
         selected_url: "https://www.trustedparts.com/stm32",
+        available_offers: [
+          {
+            mpn: "STM32",
+            distributor: "DigiKey",
+            stock: 200,
+            unit_price: "1.25",
+            currency: "USD",
+            packaging: "cut-tape",
+            moq: 1,
+            lead_time_days: 3,
+            price_breaks: [],
+            url: "https://www.trustedparts.com/stm32",
+          },
+          {
+            mpn: "STM32",
+            distributor: "Arrow",
+            stock: 50,
+            unit_price: "2.05",
+            currency: "USD",
+            packaging: "tray",
+            moq: 5,
+            lead_time_days: 2,
+            price_breaks: [],
+            url: "https://www.trustedparts.com/stm32-arrow",
+          },
+        ],
         risk_flags: ["single_source"],
       },
       {
@@ -67,6 +93,7 @@ function plan(overrides: Partial<PurchasePlan> = {}): PurchasePlan {
         selected_moq: 1,
         selected_lead_time_days: 7,
         selected_url: "https://www.trustedparts.com/lm1117",
+        available_offers: [],
         risk_flags: [],
       },
       {
@@ -85,6 +112,7 @@ function plan(overrides: Partial<PurchasePlan> = {}): PurchasePlan {
         selected_moq: null,
         selected_lead_time_days: null,
         selected_url: null,
+        available_offers: [],
         risk_flags: ["no_authorized_stock"],
       },
     ],
@@ -119,6 +147,14 @@ function renderPage(initialPlan: PurchasePlan = plan()) {
       </Routes>
     </MemoryRouter>,
   );
+}
+
+async function selectArrowOffer() {
+  await userEvent.click(screen.getAllByRole("button", { name: "Override" })[0]);
+  const dialog = screen.getByRole("dialog", { name: "Override offer" });
+  const arrowRow = within(dialog).getByText("Arrow").closest("tr");
+  expect(arrowRow).not.toBeNull();
+  await userEvent.click(within(arrowRow as HTMLElement).getByRole("button", { name: "Select" }));
 }
 
 beforeEach(() => {
@@ -204,6 +240,64 @@ describe("PurchasePlanReviewPage", () => {
     await userEvent.click(screen.getByRole("button", { name: /Create draft orders/ }));
 
     await waitFor(() => expect(screen.getByTestId("location").textContent).toBe("/orders"));
+    expect(api.post).toHaveBeenCalledWith("/sourcing/purchase-plans/plan-12345678/orders", { overrides: {} });
     expect(toast.success).toHaveBeenCalledWith("Created 1 draft orders");
+  });
+
+  it("selects an alternate cached offer and sends it as a conversion override", async () => {
+    vi.spyOn(api, "post").mockResolvedValueOnce({
+      orders: [{ id: "order-1", name: "Draft", supplier: "Arrow", status: "draft", entries: [] }],
+    });
+    renderPage();
+
+    await selectArrowOffer();
+
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+    expect(screen.getByText("Arrow")).toBeDefined();
+    expect(screen.getByText("2.05 USD")).toBeDefined();
+    expect(screen.getByText("2 days")).toBeDefined();
+
+    await userEvent.click(screen.getByRole("button", { name: /Create draft orders/ }));
+
+    await waitFor(() => expect(screen.getByTestId("location").textContent).toBe("/orders"));
+    expect(api.post).toHaveBeenCalledWith("/sourcing/purchase-plans/plan-12345678/orders", {
+      overrides: {
+        "line-1": {
+          selected_distributor: "Arrow",
+          selected_qty: 16,
+          selected_unit_price: "2.05",
+          selected_currency: "USD",
+        },
+      },
+    });
+  });
+
+  it("preserves selected overrides after a failed conversion", async () => {
+    const post = vi.spyOn(api, "post")
+      .mockRejectedValueOnce(new Error("conversion failed"))
+      .mockResolvedValueOnce({
+        orders: [{ id: "order-1", name: "Draft", supplier: "Arrow", status: "draft", entries: [] }],
+      });
+    renderPage();
+
+    await selectArrowOffer();
+    await userEvent.click(screen.getByRole("button", { name: /Create draft orders/ }));
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith("Could not create draft orders"));
+    expect(screen.getByText("Arrow")).toBeDefined();
+
+    await userEvent.click(screen.getByRole("button", { name: /Create draft orders/ }));
+
+    await waitFor(() => expect(screen.getByTestId("location").textContent).toBe("/orders"));
+    expect(post).toHaveBeenLastCalledWith("/sourcing/purchase-plans/plan-12345678/orders", {
+      overrides: {
+        "line-1": {
+          selected_distributor: "Arrow",
+          selected_qty: 16,
+          selected_unit_price: "2.05",
+          selected_currency: "USD",
+        },
+      },
+    });
   });
 });

--- a/web/src/routes/projects/sourcing/purchasePlanTypes.ts
+++ b/web/src/routes/projects/sourcing/purchasePlanTypes.ts
@@ -1,3 +1,20 @@
+export type PurchasePlanOffer = {
+  mpn?: string | null;
+  distributor?: string | null;
+  stock?: number | null;
+  unit_price?: string | number | null;
+  currency?: string | null;
+  packaging?: string | null;
+  moq?: number | null;
+  lead_time_days?: number | null;
+  price_breaks?: {
+    quantity?: number | null;
+    unit_price?: string | number | null;
+    currency?: string | null;
+  }[] | null;
+  url?: string | null;
+};
+
 export type PurchasePlanLine = {
   id: string;
   project_entry_id?: string | null;
@@ -14,6 +31,7 @@ export type PurchasePlanLine = {
   selected_moq?: number | null;
   selected_lead_time_days?: number | null;
   selected_url?: string | null;
+  available_offers?: PurchasePlanOffer[] | null;
   risk_flags: string[];
 };
 
@@ -69,4 +87,15 @@ export type CreatedOrder = {
 
 export type ConvertOrdersResponse = {
   orders: CreatedOrder[];
+};
+
+export type PurchasePlanOrderOverride = {
+  selected_distributor: string;
+  selected_qty: number;
+  selected_unit_price: string | number;
+  selected_currency: string;
+};
+
+export type ConvertOrdersRequest = {
+  overrides: Record<string, PurchasePlanOrderOverride>;
 };


### PR DESCRIPTION
## Summary
- Adds `purchase_plan_lines.available_offers` as the cached offer snapshot used for override validation.
- Extends `POST /api/sourcing/purchase-plans/{id}/orders` to accept an `overrides` map keyed by plan-line id.
- Validates override distributor, selected quantity, unit price, and currency against cached offers before creating any draft-order rows.
- Preserves existing 10-minute refresh gate, mixed-currency guard, single-transaction rollback behavior, and TrustedParts URL exclusion from order comments/output.
- Enables the plan-review Override flow in the frontend and sends selected overrides during draft-order conversion.
- Updates sourcing domain docs for cached offers and override conversion.

## Validation
- `cd backend && uv run --extra dev ruff check app/domain/sourcing/models.py app/domain/sourcing/schemas.py app/domain/sourcing/service.py app/api/routes/sourcing.py tests/test_purchase_plan_convert_route.py tests/test_phase4_integration.py` -> passed
- `cd backend && uv run --extra dev python -m pytest tests/test_purchase_plan_convert_route.py tests/test_phase4_integration.py tests/test_workspace_isolation.py -q` -> 69 passed, 2 warnings
- `cd backend && uv run --extra dev alembic heads` -> `0041 (head)`
- `cd backend && uv run --extra dev python -m pytest tests/test_migrations.py tests/test_db_schema.py -q` -> 20 passed, 3 deselected, 1 warning
- `cd web && npm test -- --run src/routes/projects/sourcing/__tests__/PurchasePlanReviewPage.test.tsx src/routes/projects/sourcing/__tests__/ProjectSourcingPage.test.tsx src/routes/projects/sourcing/__tests__/PurchasePlanOptionsModal.test.tsx` -> 20 passed
- `cd web && npm test -- --run src/routes/projects/sourcing/__tests__/PurchasePlanReviewPage.test.tsx` -> 9 passed
- `cd web && npm run typecheck` -> passed
- `cd web && npx eslint src/routes/projects/sourcing/OverrideOfferModal.tsx src/routes/projects/sourcing/PurchasePlanReviewPage.tsx src/routes/projects/sourcing/__tests__/PurchasePlanReviewPage.test.tsx src/routes/projects/sourcing/purchasePlanTypes.ts` -> passed
- `cd web && LINT_CMD="npm run lint -- --format unix" BASELINE_FILE="../.eslint-baseline.txt" WORK_DIR="." bash ../scripts/lint-delta.sh` -> no new violations
- `git diff --check` -> passed

## Merge order
1. #402 TP-406 plan-review frontend - already merged
2. #405 TP-407 integration tests - already merged
3. This PR TP-406a override enablement

Refs #404
