### PR TITLE
FB-003d: Fix empty per-row leadtime on Sourcing table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ follow that model — it's a continuous flow of product work + production
 hardening landing per-commit. Themes are summarised below; `git log` is
 the canonical record.
 
+## 2026-05 — feedback brief fixes
+
+- **FB-003d / #413** Project Sourcing BOM rows now render the per-row
+  lead time returned by the Source-BOM response.
+
 ## 2026-05 — security follow-ups
 
 - **SEC2-013 / #72** Invitation accept flow switched to constant-time

--- a/web/src/routes/projects/sourcing/ProjectSourcingPage.tsx
+++ b/web/src/routes/projects/sourcing/ProjectSourcingPage.tsx
@@ -343,6 +343,13 @@ function BomRows({ rows }: { rows: SourcingBomLine[] }) {
       align: "right",
     },
     {
+      key: "lead_time",
+      header: "Lead time",
+      accessor: row => row.lead_time_days,
+      render: row => formatLeadTime(row.lead_time_days),
+      align: "right",
+    },
+    {
       key: "risk",
       header: "Risk",
       accessor: row => row.risk_flags.join(" "),

--- a/web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.test.tsx
+++ b/web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.test.tsx
@@ -246,6 +246,41 @@ describe("ProjectSourcingPage", () => {
     expect(screen.getAllByLabelText("Source: TrustedParts").length).toBeGreaterThan(0);
   });
 
+  it("renders per-row lead time values in the BOM rows table", async () => {
+    mockReads();
+    const base = sourcingResponse();
+    vi.spyOn(api, "post").mockResolvedValue(sourcingResponse({
+      rows: [
+        ...base.rows,
+        {
+          ...base.rows[1],
+          project_entry_id: "entry-3",
+          part_id: "part-3",
+          part_name: "Oscillator",
+          mpn: "XO-1",
+          best_offer: {
+            ...base.rows[1].best_offer,
+            lead_time_days: null,
+          },
+          lead_time_days: null,
+          risk_flags: [],
+        },
+      ],
+    }));
+
+    renderPage();
+
+    await screen.findByText("BOM rows");
+    const bomRowsTable = screen.getAllByRole("table")[1];
+    const leadTimeCellText = (rowName: RegExp) =>
+      within(within(bomRowsTable).getByRole("row", { name: rowName })).getAllByRole("cell")[9].textContent;
+
+    expect(within(bomRowsTable).getByRole("columnheader", { name: "Lead time" })).toBeDefined();
+    expect(leadTimeCellText(/STM32/)).toBe("3 days");
+    expect(leadTimeCellText(/Regulator/)).toBe("7 days");
+    expect(leadTimeCellText(/Oscillator/)).toBe("—");
+  });
+
   it("409 path renders not-configured card with settings link", async () => {
     mockReads();
     vi.spyOn(api, "post").mockRejectedValue(apiError(409, "sourcing not configured"));


### PR DESCRIPTION
## Summary
- Add the missing Project Sourcing BOM rows Lead time column.
- Render row-level lead_time_days with the existing formatter, including an em dash for null values.
- Add a ProjectSourcingPage regression test for populated and null per-row lead times.
- Add the required changelog entry.

## Root Cause
Backend diagnosis: source_bom already projects best_offer.lead_time_days into each row as lead_time_days. The bug was frontend-only: BomRows never defined/rendered a Lead time column, so the populated response field was invisible.

## Validations
- PASS: npm test -- ProjectSourcingPage (10 tests)
- PASS: npm run typecheck
- PASS: PYTHONPATH=/mnt/data/WORK/stockManager-1/.codex/worktrees/fb-003d-413/backend/.venv/lib/python3.12/site-packages uv run --project /mnt/data/WORK/stockManager-1/.codex/worktrees/fb-003d-413/backend pytest /mnt/data/WORK/stockManager-1/.codex/worktrees/fb-003d-413/backend/tests -k sourcing_bom_route (14 passed)
- PASS: frontend lint-delta, no new ESLint violations
- PASS: backend lint-delta, no new Ruff violations
- NOTE: docker compose -f docker-compose.dev.yml exec backend pytest -k sourcing_bom_route could not run in this environment because docker is not installed.
- NOTE: npm run lint still fails on existing baseline debt in web/src/lib/bagCode.ts no-control-regex plus unrelated warnings; delta lint is clean for this branch.

## Merge Order
Standalone bug fix from origin/main. No blockers and no dependency on other Feedback Brief PRs; can merge independently when reviewed.

Refs #413