### PR TITLE
FB-001: BOM card buttons + parts-style table

### DIFF
--- a/docs/frontend/components.md
+++ b/docs/frontend/components.md
@@ -11,6 +11,10 @@ that live under `routes/**` are out of scope — when in doubt, grep.
 component for every page that shows rows. Use it before rolling your own
 table (CLAUDE.md → "Frontend conventions worth preserving").
 
+Current route-level consumers include `/parts` and the project BOM table.
+The BOM table uses `rowCanClick` so matched rows navigate to the part detail
+page while unmatched rows stay visually muted and inert.
+
 ### Feature catalog
 
 | Feature | Source | Test |
@@ -21,6 +25,7 @@ table (CLAUDE.md → "Frontend conventions worth preserving").
 | Persist hidden columns + density to localStorage | `DataTable.tsx:114-126`, key = `dt:${tableId}` | — |
 | CSV export with formula-injection hardening | `DataTable.tsx:20-41`, `:258-274` | `DataTable.test.tsx:14-78` |
 | Multi-select with select-all-visible header checkbox | `DataTable.tsx:160-167`, `:276-291`, `:411-426` | `DataTable.dom.test.tsx:165-211` |
+| Per-row click gating and row class hooks | `DataTable.tsx` `rowCanClick`, `rowClassName` props | `ProjectBOM.test.tsx` matched/unmatched row navigation |
 | Density toggle (comfortable / compact) | `DataTable.tsx:230-231`, `:307-315` | — |
 | Keyboard navigation (Enter / Space activates row) | `DataTable.tsx:391-403` | `DataTable.keyboard.dom.test.tsx:50-86` |
 | Row aria-label built from first textual column | `DataTable.tsx:43-63`, `:395-396` | — |

--- a/docs/user/projects-and-bom.md
+++ b/docs/user/projects-and-bom.md
@@ -83,11 +83,9 @@ Open the project and click the **BOM** tab.
 
 > _Screenshot: the BOM table with one matched row and one unmatched row showing a Match dropdown._
 
-Each row shows the quantity, the part (linked in green if matched), designators, comments, and a DNP flag. Unmatched rows have a red "unmatched" pill — click **Match…** on the row, pick a part from the dropdown, and click **Match**.
+The BOM tab has **Source BOM**, **Import BOM**, and **Add Part** buttons above the table. **Import BOM** opens the same CSV/TSV import flow as the tab, while **Add Part** lets you search existing library parts by name or MPN and add selected parts as BOM rows. The table shows thumbnails, part details, quantity, designators, and matched/unmatched status. Matched rows open the part's info page when clicked; unmatched rows stay inactive until you match them. Use the row checkboxes to select multiple BOM rows and delete them together.
 
 To remove a line, click **Delete** on its row.
-
-TODO(verify-ui): adding a brand-new BOM line from the BOM tab — there's no "+ Line" button visible in the read-only BOM viewer; manual additions appear to require either editing the imported CSV and re-importing, or another route. Verify before relying on this.
 
 ## Use meta-parts for "any 10k 0402 1%"
 

--- a/web/src/components/DataTable.tsx
+++ b/web/src/components/DataTable.tsx
@@ -92,6 +92,8 @@ type Props<T> = {
   columns: Column<T>[];
   rowKey: (row: T) => string;
   onRowClick?: (row: T) => void;
+  rowCanClick?: (row: T) => boolean;
+  rowClassName?: (row: T) => string | undefined;
   searchPlaceholder?: string;
   initialSearch?: string;
   empty?: ReactNode;
@@ -137,6 +139,8 @@ export function DataTable<T>({
   columns,
   rowKey,
   onRowClick,
+  rowCanClick,
+  rowClassName,
   searchPlaceholder,
   initialSearch,
   empty,
@@ -387,25 +391,29 @@ export function DataTable<T>({
             {sorted.map((r, i) => {
               const id = rowKey(r);
               const isSel = selected.has(id);
+              const canClick = !!onRowClick && (rowCanClick ? rowCanClick(r) : true);
               return (
               <tr
                 key={id}
-                tabIndex={onRowClick ? 0 : undefined}
-                onClick={() => onRowClick?.(r)}
-                {...(onRowClick ? {
+                tabIndex={canClick ? 0 : undefined}
+                onClick={() => {
+                  if (canClick) onRowClick?.(r);
+                }}
+                {...(canClick ? {
                   "aria-label": rowAriaLabel(r, visibleCols),
                   onKeyDown: (e: React.KeyboardEvent<HTMLTableRowElement>) => {
                     if (e.key === "Enter" || e.key === " ") {
                       if (e.key === " ") e.preventDefault();
-                      onRowClick(r);
+                      onRowClick?.(r);
                     }
                   },
                 } : {})}
                 className={cn(
-                  onRowClick && "cursor-pointer focus-visible:ring-2 focus-visible:ring-accent/40 focus-visible:outline-none",
+                  canClick && "cursor-pointer focus-visible:ring-2 focus-visible:ring-accent/40 focus-visible:outline-none",
                   // Subtle zebra striping — only odd rows pick up panel2.
                   i % 2 === 1 && "bg-panel2/40",
                   isSel && "bg-accent/10",
+                  rowClassName?.(r),
                 )}
               >
                 {selectable && (

--- a/web/src/routes/projects/detail/AddPartFromLibraryModal.tsx
+++ b/web/src/routes/projects/detail/AddPartFromLibraryModal.tsx
@@ -1,0 +1,235 @@
+import { FormEvent, useEffect, useMemo, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { ImageOff, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import { api, ApiError } from "@/lib/api";
+import { useAuth } from "@/lib/auth";
+import { useApiMutation } from "@/lib/mutations";
+import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
+import type { Part, ProjectEntry } from "@/types";
+
+type Props = {
+  open: boolean;
+  projectId: string;
+  onClose: () => void;
+};
+
+type AddPayload = {
+  parts: Part[];
+};
+
+function partSubtitle(part: Part): string {
+  return [part.mpn, part.manufacturer].filter(Boolean).join(" - ");
+}
+
+export default function AddPartFromLibraryModal({ open, projectId, onClose }: Props) {
+  const qc = useQueryClient();
+  const { workspaceId } = useAuth();
+  const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const [selected, setSelected] = useState<Set<string>>(() => new Set());
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const handle = window.setTimeout(() => setDebouncedSearch(search.trim()), 250);
+    return () => window.clearTimeout(handle);
+  }, [search]);
+
+  const partsQuery = useQuery({
+    queryKey: useWsKey("parts", "library-picker", debouncedSearch),
+    queryFn: () => {
+      const params = new URLSearchParams({ limit: "20" });
+      if (debouncedSearch) {
+        params.set("q", debouncedSearch);
+        params.set("search", debouncedSearch);
+      }
+      return api.get<Part[]>(`/parts?${params.toString()}`);
+    },
+    enabled: open,
+  });
+
+  const parts = useMemo(() => partsQuery.data ?? [], [partsQuery.data]);
+  const selectedParts = useMemo(
+    () => parts.filter(part => selected.has(part.id)),
+    [parts, selected],
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    setSelected(prev => {
+      if (prev.size === 0) return prev;
+      const visible = new Set(parts.map(part => part.id));
+      const next = new Set<string>();
+      for (const id of prev) if (visible.has(id)) next.add(id);
+      return next.size === prev.size ? prev : next;
+    });
+  }, [open, parts]);
+
+  const addMutation = useApiMutation<ProjectEntry[], AddPayload>({
+    mutationKey: ["project", projectId, "add-library-parts"],
+    mutationFn: async ({ parts: picked }) => {
+      const created: ProjectEntry[] = [];
+      for (const part of picked) {
+        created.push(
+          await api.post<ProjectEntry>(`/projects/${projectId}/entries`, {
+            entry_type: "part",
+            part_id: part.id,
+            name: part.name,
+            quantity: 1,
+            designators: [],
+            dnp: false,
+          }),
+        );
+      }
+      return created;
+    },
+    onSuccess: created => {
+      qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "project", projectId, "entries") });
+      setSelected(new Set());
+      toast.success(`Added ${created.length} part${created.length === 1 ? "" : "s"} to BOM.`);
+      onClose();
+    },
+    onError: err => {
+      setError(err instanceof ApiError ? err.userMessage : "Failed to add parts to BOM");
+    },
+  });
+
+  if (!open) return null;
+
+  function toggle(partId: string) {
+    setSelected(prev => {
+      const next = new Set(prev);
+      if (next.has(partId)) next.delete(partId);
+      else next.add(partId);
+      return next;
+    });
+  }
+
+  function submit(event: FormEvent) {
+    event.preventDefault();
+    setError(null);
+    if (selectedParts.length === 0) {
+      setError("Select at least one part.");
+      return;
+    }
+    addMutation.mutate({ parts: selectedParts });
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="add-library-part-title"
+      onMouseDown={event => {
+        if (event.target === event.currentTarget && !addMutation.isPending) onClose();
+      }}
+    >
+      <form className="card w-full max-w-2xl p-4 shadow-lg" onSubmit={submit}>
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <h2 id="add-library-part-title" className="text-base font-semibold text-text">
+              Add part from library
+            </h2>
+            <p className="mt-1 text-sm text-muted">Choose existing workspace parts for this BOM.</p>
+          </div>
+          <button
+            type="button"
+            className="btn-ghost btn-sm"
+            onClick={onClose}
+            disabled={addMutation.isPending}
+          >
+            Close
+          </button>
+        </div>
+
+        {error && (
+          <div className="mt-3 card p-3 text-sm text-danger" role="alert">
+            {error}
+          </div>
+        )}
+
+        <div className="mt-4 space-y-3">
+          <label className="label" htmlFor="library-part-search">
+            Search library
+            <input
+              id="library-part-search"
+              className="input"
+              placeholder="Search MPN or name..."
+              value={search}
+              onChange={event => setSearch(event.currentTarget.value)}
+              disabled={addMutation.isPending}
+              autoFocus
+            />
+          </label>
+
+          <div className="max-h-96 overflow-auto rounded border border-border">
+            {partsQuery.isLoading ? (
+              <div className="flex items-center gap-2 p-4 text-sm text-muted">
+                <Loader2 size={14} className="animate-spin" />
+                Loading parts...
+              </div>
+            ) : parts.length === 0 ? (
+              <div className="p-4 text-sm text-muted">
+                {debouncedSearch ? "No parts match that search." : "No library parts found."}
+              </div>
+            ) : (
+              <ul className="divide-y divide-border">
+                {parts.map(part => {
+                  const checked = selected.has(part.id);
+                  return (
+                    <li key={part.id}>
+                      <label className="flex cursor-pointer items-center gap-3 p-3 hover:bg-panel2/40">
+                        <input
+                          type="checkbox"
+                          checked={checked}
+                          onChange={() => toggle(part.id)}
+                          disabled={addMutation.isPending}
+                          aria-label={checked ? `Deselect ${part.name}` : `Select ${part.name}`}
+                        />
+                        {part.image_url ? (
+                          <img
+                            src={part.image_url}
+                            alt=""
+                            loading="lazy"
+                            className="h-10 w-10 rounded bg-panel object-contain"
+                          />
+                        ) : (
+                          <span className="flex h-10 w-10 items-center justify-center rounded bg-panel2/40 text-muted">
+                            <ImageOff size={16} />
+                          </span>
+                        )}
+                        <span className="min-w-0 flex-1">
+                          <span className="block truncate text-sm font-medium text-text">{part.name}</span>
+                          <span className="block truncate text-xs text-muted">{partSubtitle(part) || "No MPN"}</span>
+                        </span>
+                      </label>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
+        </div>
+
+        <div className="mt-4 flex justify-end gap-2">
+          <button
+            type="button"
+            className="btn"
+            onClick={onClose}
+            disabled={addMutation.isPending}
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            className="btn-primary"
+            disabled={addMutation.isPending || selectedParts.length === 0}
+          >
+            {addMutation.isPending ? "Adding..." : `Add ${selectedParts.length} part${selectedParts.length === 1 ? "" : "s"} to BOM`}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/web/src/routes/projects/detail/ProjectBOM.tsx
+++ b/web/src/routes/projects/detail/ProjectBOM.tsx
@@ -1,7 +1,9 @@
-import { useParams } from "react-router-dom";
+import { Link, useNavigate, useParams } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { FolderKanban } from "lucide-react";
+import { FolderKanban, ImageOff, Trash2 } from "lucide-react";
+import { toast } from "sonner";
 import { api } from "@/lib/api";
+import { useApiMutation } from "@/lib/mutations";
 import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
 import { useAuth } from "@/lib/auth";
 import type { Part, ProjectEntry } from "@/types";
@@ -9,9 +11,12 @@ import { useState } from "react";
 import { DataTable } from "@/components/DataTable";
 import EmptyState from "@/components/EmptyState";
 import QueryStateBoundary from "@/components/QueryStateBoundary";
+import AddPartFromLibraryModal from "./AddPartFromLibraryModal";
+import { SourceBomButton } from "@/routes/projects/sourcing/SourceBomButton";
 
 export default function ProjectBOM() {
   const { projectId } = useParams();
+  const nav = useNavigate();
   const qc = useQueryClient();
   const { workspaceId } = useAuth();
   const entriesQuery = useQuery({
@@ -23,6 +28,22 @@ export default function ProjectBOM() {
   const partsById = new Map(parts?.map(p => [p.id, p]) ?? []);
 
   const [matching, setMatching] = useState<{ entryId: string; pick: string } | null>(null);
+  const [addPartOpen, setAddPartOpen] = useState(false);
+
+  const bulkDeleteMutation = useApiMutation<null[], string[]>({
+    mutationKey: ["project", projectId, "bulk-delete-entries"],
+    mutationFn: async entryIds => {
+      const deleted: null[] = [];
+      for (const entryId of entryIds) {
+        deleted.push(await api.delete<null>(`/projects/${projectId}/entries/${entryId}`));
+      }
+      return deleted;
+    },
+    onSuccess: (_res, entryIds) => {
+      qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "project", projectId, "entries") });
+      toast.success(`Deleted ${entryIds.length} BOM row${entryIds.length === 1 ? "" : "s"}.`);
+    },
+  });
 
   async function match(entryId: string, partId: string) {
     await api.post(`/projects/${projectId}/entries/${entryId}/match`, { part_id: partId });
@@ -36,22 +57,78 @@ export default function ProjectBOM() {
   }
 
   return (
-    <div>
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center justify-end gap-2">
+        <SourceBomButton projectId={projectId} className="btn" />
+        {projectId && (
+          <Link className="btn" to={`/projects/${projectId}/import`}>
+            Import BOM
+          </Link>
+        )}
+        <button
+          type="button"
+          className="btn"
+          onClick={() => setAddPartOpen(true)}
+          disabled={!projectId}
+        >
+          Add Part
+        </button>
+      </div>
       <QueryStateBoundary query={entriesQuery} resourceLabel="BOM entries">
       <DataTable
         rows={entries ?? []}
         rowKey={r => r.id}
         tableId="project-bom"
+        searchPlaceholder="Search BOM..."
+        selectable
+        selectionAccessory={(ids, clear) => (
+          <button
+            type="button"
+            className="btn-danger inline-flex items-center gap-1.5"
+            disabled={bulkDeleteMutation.isPending}
+            onClick={() => {
+              clear();
+              bulkDeleteMutation.mutate(ids);
+            }}
+          >
+            <Trash2 size={14} />
+            Delete ({ids.length})
+          </button>
+        )}
         empty={
           <EmptyState
             icon={FolderKanban}
             title="BOM is empty"
-            description="Use the Import BOM tab to load a CSV/TSV."
+            description="Use Import BOM or Add Part to populate this project."
           />
         }
         exportFilename="bom"
+        onRowClick={r => {
+          if (r.part_id) nav(`/parts/${r.part_id}/info`);
+        }}
+        rowCanClick={r => r.entry_type === "part" && !!r.part_id}
+        rowClassName={r => r.entry_type === "unmatched" || !r.part_id ? "text-muted" : undefined}
         columns={[
-          { key: "qty", header: "Qty", accessor: r => r.quantity, width: "60px" },
+          {
+            key: "image",
+            header: "",
+            width: "44px",
+            render: r => {
+              const part = r.part_id ? partsById.get(r.part_id) : null;
+              return part?.image_url ? (
+                <img
+                  src={part.image_url}
+                  alt=""
+                  loading="lazy"
+                  className="h-8 w-8 rounded bg-panel object-contain"
+                />
+              ) : (
+                <span className="flex h-8 w-8 items-center justify-center rounded bg-panel2/40 text-muted">
+                  <ImageOff size={14} />
+                </span>
+              );
+            },
+          },
           {
             key: "part",
             header: "Part",
@@ -80,18 +157,47 @@ export default function ProjectBOM() {
                 <span>{r.name}</span>
               ),
           },
+          { key: "mpn", header: "MPN", accessor: r => r.part_id ? partsById.get(r.part_id)?.mpn ?? "" : "" },
+          { key: "manufacturer", header: "Manufacturer", accessor: r => r.part_id ? partsById.get(r.part_id)?.manufacturer ?? "" : "" },
+          { key: "qty", header: "Qty", accessor: r => r.quantity, width: "70px" },
           { key: "designators", header: "Designators", accessor: r => (r.designators ?? []).join(", ") },
-          { key: "comments", header: "Comments", accessor: r => r.comments ?? "" },
-          { key: "dnp", header: "DNP", accessor: r => r.dnp ? "yes" : "" },
+          {
+            key: "status",
+            header: "Status",
+            accessor: r => r.entry_type === "part" && r.part_id ? "matched" : "unmatched",
+            render: r => r.entry_type === "part" && r.part_id ? (
+              <span className="pill bg-accent/15 text-accent">matched</span>
+            ) : (
+              <span className="pill bg-danger/20 text-danger">unmatched</span>
+            ),
+            width: "110px",
+          },
           {
             key: "actions",
             header: "",
             accessor: () => "",
-            render: r => <button className="btn-danger text-xs" onClick={() => delEntry(r.id)}>Delete</button>,
+            render: r => (
+              <button
+                className="btn-danger text-xs"
+                onClick={event => {
+                  event.stopPropagation();
+                  delEntry(r.id);
+                }}
+              >
+                Delete
+              </button>
+            ),
           },
         ]}
       />
       </QueryStateBoundary>
+      {projectId && (
+        <AddPartFromLibraryModal
+          open={addPartOpen}
+          projectId={projectId}
+          onClose={() => setAddPartOpen(false)}
+        />
+      )}
     </div>
   );
 }

--- a/web/src/routes/projects/detail/__tests__/AddPartFromLibraryModal.test.tsx
+++ b/web/src/routes/projects/detail/__tests__/AddPartFromLibraryModal.test.tsx
@@ -1,0 +1,169 @@
+// @vitest-environment jsdom
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { api } from "@/lib/api";
+import type { Part, ProjectEntry } from "@/types";
+import AddPartFromLibraryModal from "../AddPartFromLibraryModal";
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({
+  useAuth: () => ({ workspaceId: "ws-1" }),
+}));
+
+const projectId = "project-1";
+
+function part(overrides: Partial<Part>): Part {
+  return {
+    id: "part-1",
+    part_type: "local",
+    name: "STM32",
+    manufacturer: "ST",
+    mpn: "STM32F103C8T6",
+    internal_part_number: null,
+    description: null,
+    footprint: null,
+    notes_markdown: null,
+    low_stock_report_quantity: null,
+    attrition_percentage: 0,
+    attrition_min_quantity: 0,
+    default_storage_location_id: null,
+    default_storage_mandatory: false,
+    serialized: false,
+    published: false,
+    linked_provider: null,
+    linked_external_id: null,
+    last_refresh_at: null,
+    description_locally_edited: false,
+    archived_at: null,
+    on_hand: 0,
+    reserved: 0,
+    available: 0,
+    image_url: null,
+    ...overrides,
+  };
+}
+
+const parts = [
+  part({ id: "part-1", name: "STM32", mpn: "STM32F103C8T6", manufacturer: "ST", image_url: "/img/stm32.png" }),
+  part({ id: "part-2", name: "Regulator", mpn: "LM1117", manufacturer: "TI" }),
+];
+
+function entry(overrides: Partial<ProjectEntry>): ProjectEntry {
+  return {
+    id: "entry-1",
+    project_id: projectId,
+    entry_type: "part",
+    part_id: "part-1",
+    meta_part_id: null,
+    name: "STM32",
+    quantity: 1,
+    comments: null,
+    designators: [],
+    cad_footprint: null,
+    cad_key: null,
+    dnp: false,
+    order_index: 1,
+    ...overrides,
+  };
+}
+
+function renderModal(onClose = vi.fn()) {
+  const client = new QueryClient({
+    defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+  });
+  render(
+    <QueryClientProvider client={client}>
+      <AddPartFromLibraryModal open projectId={projectId} onClose={onClose} />
+    </QueryClientProvider>,
+  );
+  return { onClose };
+}
+
+beforeEach(() => {
+  cleanup();
+  localStorage.clear();
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+});
+
+describe("AddPartFromLibraryModal", () => {
+  it("renders search results from GET /parts", async () => {
+    vi.spyOn(api, "get").mockResolvedValue(parts);
+
+    renderModal();
+
+    expect(await screen.findByText("STM32")).toBeDefined();
+    expect(screen.getByText("STM32F103C8T6 - ST")).toBeDefined();
+    expect(screen.getByText("Regulator")).toBeDefined();
+    expect(api.get).toHaveBeenCalledWith("/parts?limit=20");
+  });
+
+  it("uses the debounced search term in the parts request", async () => {
+    const user = userEvent.setup();
+    vi.spyOn(api, "get").mockResolvedValue(parts);
+
+    renderModal();
+    await user.type(await screen.findByLabelText("Search library"), "STM");
+
+    await waitFor(() => {
+      expect(api.get).toHaveBeenCalledWith(expect.stringContaining("search=STM"));
+    });
+  });
+
+  it("selecting N parts and clicking add posts N BOM rows", async () => {
+    const user = userEvent.setup();
+    vi.spyOn(api, "get").mockResolvedValue(parts);
+    const postSpy = vi.spyOn(api, "post").mockImplementation(async (_path, body) => {
+      const payload = body as { part_id: string; name: string };
+      return entry({
+        id: `entry-${payload.part_id}`,
+        part_id: payload.part_id,
+        name: payload.name,
+      }) as never;
+    });
+
+    renderModal();
+
+    await user.click(await screen.findByLabelText("Select STM32"));
+    await user.click(screen.getByLabelText("Select Regulator"));
+    await user.click(screen.getByRole("button", { name: "Add 2 parts to BOM" }));
+
+    await waitFor(() => expect(postSpy).toHaveBeenCalledTimes(2));
+    expect(postSpy).toHaveBeenNthCalledWith(1, `/projects/${projectId}/entries`, {
+      entry_type: "part",
+      part_id: "part-1",
+      name: "STM32",
+      quantity: 1,
+      designators: [],
+      dnp: false,
+    });
+    expect(postSpy).toHaveBeenNthCalledWith(2, `/projects/${projectId}/entries`, {
+      entry_type: "part",
+      part_id: "part-2",
+      name: "Regulator",
+      quantity: 1,
+      designators: [],
+      dnp: false,
+    });
+  });
+
+  it("closes modal after success", async () => {
+    const user = userEvent.setup();
+    vi.spyOn(api, "get").mockResolvedValue(parts);
+    vi.spyOn(api, "post").mockResolvedValue(entry({}) as never);
+    const { onClose } = renderModal();
+
+    await user.click(await screen.findByLabelText("Select STM32"));
+    await user.click(screen.getByRole("button", { name: "Add 1 part to BOM" }));
+
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+  });
+});

--- a/web/src/routes/projects/detail/__tests__/ProjectBOM.test.tsx
+++ b/web/src/routes/projects/detail/__tests__/ProjectBOM.test.tsx
@@ -1,0 +1,200 @@
+// @vitest-environment jsdom
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { api } from "@/lib/api";
+import type { Part, ProjectEntry } from "@/types";
+import ProjectBOM from "../ProjectBOM";
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({
+  useAuth: () => ({ workspaceId: "ws-1" }),
+}));
+
+const projectId = "project-1";
+
+function LocationProbe() {
+  const location = useLocation();
+  return <div data-testid="location">{location.pathname}</div>;
+}
+
+function part(overrides: Partial<Part>): Part {
+  return {
+    id: "part-1",
+    part_type: "local",
+    name: "STM32",
+    manufacturer: "ST",
+    mpn: "STM32F103C8T6",
+    internal_part_number: null,
+    description: null,
+    footprint: null,
+    notes_markdown: null,
+    low_stock_report_quantity: null,
+    attrition_percentage: 0,
+    attrition_min_quantity: 0,
+    default_storage_location_id: null,
+    default_storage_mandatory: false,
+    serialized: false,
+    published: false,
+    linked_provider: null,
+    linked_external_id: null,
+    last_refresh_at: null,
+    description_locally_edited: false,
+    archived_at: null,
+    on_hand: 0,
+    reserved: 0,
+    available: 0,
+    image_url: null,
+    ...overrides,
+  };
+}
+
+function bomEntry(overrides: Partial<ProjectEntry>): ProjectEntry {
+  return {
+    id: "entry-1",
+    project_id: projectId,
+    entry_type: "part",
+    part_id: "part-1",
+    meta_part_id: null,
+    name: "STM32",
+    quantity: 2,
+    comments: null,
+    designators: ["U1"],
+    cad_footprint: null,
+    cad_key: null,
+    dnp: false,
+    order_index: 1,
+    ...overrides,
+  };
+}
+
+const parts = [
+  part({ id: "part-1", name: "STM32", mpn: "STM32F103C8T6", manufacturer: "ST", image_url: "/img/stm32.png" }),
+  part({ id: "part-2", name: "Regulator", mpn: "LM1117", manufacturer: "TI" }),
+];
+
+function renderPage() {
+  const client = new QueryClient({
+    defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+  });
+  render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={[`/projects/${projectId}/bom`]}>
+        <Routes>
+          <Route path="/projects/:projectId/bom" element={<><LocationProbe /><ProjectBOM /></>} />
+          <Route path="/projects/:projectId/import" element={<LocationProbe />} />
+          <Route path="/parts/:partId/info" element={<LocationProbe />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+function mockApi(entriesRef: { current: ProjectEntry[] }) {
+  vi.spyOn(api, "get").mockImplementation(async path => {
+    if (path === `/projects/${projectId}/entries`) return entriesRef.current as never;
+    if (path === "/parts?limit=200") return parts as never;
+    if (path === "/workspaces/current") {
+      return {
+        sourcing_country_code: "US",
+        sourcing_currency_code: "USD",
+        sourcing_preferred_distributors: [],
+        has_sourcing_company_id: true,
+      } as never;
+    }
+    throw new Error(`unexpected GET ${path}`);
+  });
+  vi.spyOn(api, "delete").mockImplementation(async path => {
+    const id = String(path).split("/").pop();
+    entriesRef.current = entriesRef.current.filter(entry => entry.id !== id);
+    return null as never;
+  });
+}
+
+beforeEach(() => {
+  cleanup();
+  localStorage.clear();
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+});
+
+describe("ProjectBOM", () => {
+  it("renders three action buttons in the toolbar", async () => {
+    mockApi({ current: [] });
+
+    renderPage();
+
+    expect(await screen.findByRole("link", { name: "Source BOM" })).toBeDefined();
+    expect(screen.getByRole("link", { name: "Import BOM" }).getAttribute("href")).toBe(`/projects/${projectId}/import`);
+    expect(screen.getByRole("button", { name: "Add Part" })).toBeDefined();
+  });
+
+  it("matched-row click navigates to part info", async () => {
+    mockApi({ current: [bomEntry({})] });
+    const user = userEvent.setup();
+
+    renderPage();
+
+    await user.click(await screen.findByText("STM32"));
+    await waitFor(() => {
+      expect(screen.getByTestId("location").textContent).toBe("/parts/part-1/info");
+    });
+  });
+
+  it("unmatched-row click does nothing", async () => {
+    mockApi({
+      current: [
+        bomEntry({
+          id: "entry-unmatched",
+          entry_type: "unmatched",
+          part_id: null,
+          name: "Mystery line",
+        }),
+      ],
+    });
+    const user = userEvent.setup();
+
+    renderPage();
+
+    await user.click(await screen.findByText("Mystery line"));
+    expect(screen.getByTestId("location").textContent).toBe(`/projects/${projectId}/bom`);
+  });
+
+  it("multi-select + bulk-delete removes selected rows", async () => {
+    const entriesRef = {
+      current: [
+        bomEntry({ id: "entry-1", part_id: "part-1", name: "STM32" }),
+        bomEntry({ id: "entry-2", part_id: "part-2", name: "Regulator" }),
+      ],
+    };
+    mockApi(entriesRef);
+    const user = userEvent.setup();
+
+    renderPage();
+
+    expect(await screen.findByText("STM32")).toBeDefined();
+    const rowCheckboxes = screen
+      .getAllByRole("checkbox")
+      .filter(input => input.getAttribute("aria-label") === "Select row");
+    await user.click(rowCheckboxes[0]);
+    await user.click(rowCheckboxes[1]);
+    await user.click(screen.getByRole("button", { name: "Delete (2)" }));
+
+    await waitFor(() => {
+      expect(api.delete).toHaveBeenCalledWith(`/projects/${projectId}/entries/entry-1`);
+      expect(api.delete).toHaveBeenCalledWith(`/projects/${projectId}/entries/entry-2`);
+    });
+    await waitFor(() => {
+      expect(screen.queryByText("STM32")).toBeNull();
+      expect(screen.queryByText("Regulator")).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds Source BOM, Import BOM, and Add Part actions directly above the project BOM table.
- Reworks the BOM table around DataTable with thumbnails, matched/unmatched status, per-row click gating, selection checkboxes, and bulk delete.
- Adds AddPartFromLibraryModal for searching existing workspace parts and appending selected parts to the BOM through the existing POST /projects/{project_id}/entries endpoint.
- Documents the new user workflow and the project BOM as a DataTable consumer.

## Import Modal vs Navigation Choice
Import BOM uses navigation to the existing /projects/:projectId/import route. ProjectImport owns its own multi-step file state, preset management, and post-import navigation, so re-mounting it inline would add modal-specific lifecycle work without improving the existing flow.

## Validations
- npm run typecheck: passed.
- npm test -- "ProjectBOM|AddPartFromLibraryModal": did not run any files under this Vitest filter.
- npm test -- src/routes/projects/detail/__tests__/ProjectBOM.test.tsx src/routes/projects/detail/__tests__/AddPartFromLibraryModal.test.tsx: passed, 8 tests.
- npm run lint: failed on pre-existing unrelated baseline issues in ZxingScanner.tsx, bagCode.ts, responsive-grids.test.ts, OrderDetail.tsx, PartsList.tsx, PartLayout.navigation.dom.test.tsx, and StorageDetail.tsx.
- npx eslint on touched files: passed.
- lint-delta for web eslint baseline: passed, no new violations.
- git diff --check: passed.

## Screenshots
Not captured: this isolated worktree does not have an authenticated, seeded frontend/backend session for the project BOM route.

## Merge Order
Merge #408 before #409 because #409 shares the BOM card layout.

Refs #408