### PR TITLE
FB-005: Apache maintenance toggle + outage fallback + maintenance.html polish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -418,6 +418,43 @@ jobs:
             -v "$PWD/deploy/nginx-web.conf:/etc/nginx/conf.d/default.conf:ro" \
             nginx:alpine nginx -t
 
+      # FB-005: lint the Apache vhosts and maintenance drop-in before they
+      # reach /etc/apache2 on the VPS. Enable the modules referenced by the
+      # checked-in configs so apache2ctl validates the same directive set.
+      - name: Lint Apache configs
+        run: |
+          docker run --rm \
+            -v "$PWD/deploy:/work/deploy:ro" \
+            debian:bookworm-slim sh -ec '
+              apt-get update >/dev/null
+              DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends apache2 ca-certificates openssl >/dev/null
+              a2enmod headers proxy proxy_http rewrite ssl >/dev/null
+              mkdir -p /etc/letsencrypt/live/parts.matescb.cz
+              openssl req -x509 -nodes -newkey rsa:2048 \
+                -keyout /etc/letsencrypt/live/parts.matescb.cz/privkey.pem \
+                -out /etc/letsencrypt/live/parts.matescb.cz/fullchain.pem \
+                -subj /CN=parts.matescb.cz -days 1 >/dev/null 2>&1
+              touch /etc/letsencrypt/options-ssl-apache.conf
+              cp /work/deploy/parts.matescb.cz.conf /etc/apache2/sites-available/parts.matescb.cz.conf
+              cp /work/deploy/parts.matescb.cz-le-ssl.conf /etc/apache2/sites-available/parts.matescb.cz-le-ssl.conf
+              cp /work/deploy/parts.matescb.cz.maintenance.conf /etc/apache2/conf-available/parts-maintenance.conf
+              a2ensite parts.matescb.cz parts.matescb.cz-le-ssl >/dev/null
+              a2enconf parts-maintenance >/dev/null
+              apache2ctl configtest
+            '
+
+      # FB-005: the outage page is served directly by Apache, outside the SPA
+      # stack, so catch malformed HTML in the deploy validation gate.
+      - name: Lint maintenance HTML
+        run: |
+          docker run --rm \
+            -v "$PWD/deploy/maintenance.html:/work/maintenance.html:ro" \
+            debian:bookworm-slim sh -ec '
+              apt-get update >/dev/null
+              DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tidy >/dev/null
+              tidy -q -e /work/maintenance.html
+            '
+
       # INFRA-005 (issue #46) smoke tests — verify the built images actually
       # start and have the expected entrypoint files. Catches missing modules
       # / wrong WORKDIR / broken bundles that pure `build` doesn't surface.
@@ -646,6 +683,13 @@ jobs:
             # deploys.
             export SENTRY_RELEASE
             SENTRY_RELEASE=$(git rev-parse --short=12 HEAD)
+
+            # FB-005: keep users on the static Apache page during the deploy
+            # window. The trap is deliberately registered before the first
+            # deploy-side effect so failed dumps, builds, migrations, or health
+            # gates do not leave maintenance mode enabled indefinitely.
+            trap 'sudo a2disconf parts-maintenance && sudo systemctl reload apache2 || true' EXIT
+            sudo a2enconf parts-maintenance && sudo systemctl reload apache2
 
             # Pre-deploy DB snapshot (INFRA2-001 / Infra CRIT-1).
             # Runs before `docker compose up` so the pre-migration state

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,6 +235,9 @@ them, that's the bug.
 - **Periodic jobs run through one scheduler path.** ADR-0021 chooses a
   `backend-cron` sidecar + CLI entry point; don't add parallel APScheduler,
   FastAPI lifespan, host cron, or systemd-timer jobs for app maintenance.
+- **Maintenance mode is toggled by the deploy script via
+  `a2enconf parts-maintenance`.** Do not bypass the deploy path without
+  also disabling it with `a2disconf parts-maintenance`.
 
 ## Frontend conventions worth preserving
 

--- a/deploy/maintenance.html
+++ b/deploy/maintenance.html
@@ -1,23 +1,39 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Maintenance — Parts Inventory</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="refresh" content="30">
+  <title>Maintenance - Parts Inventory</title>
   <style>
-    /* Mirrors the brand palette from web/src/index.css */
+    /* Mirrors the brand palette from web/src/index.css. */
     :root {
-      --bg:      #f8fafc;
+      --bg: #f8fafc;
       --surface: #ffffff;
-      --border:  #e2e8f0;
-      --text:    #1e293b;
-      --muted:   #64748b;
-      --accent:  #3b82f6;
+      --border: #dbeafe;
+      --text: #1e293b;
+      --muted: #64748b;
+      --accent: #2563eb;
+      --accent-soft: #eff6ff;
+      --ok: #16a34a;
+      --shadow: rgba(15, 23, 42, 0.10);
     }
-    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    html,
     body {
-      font-family: system-ui, -apple-system, sans-serif;
-      background: var(--bg);
+      min-height: 100%;
+    }
+
+    body {
+      margin: 0;
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background:
+        linear-gradient(180deg, rgba(239, 246, 255, 0.78), rgba(248, 250, 252, 0.96)),
+        var(--bg);
       color: var(--text);
       min-height: 100vh;
       display: flex;
@@ -25,52 +41,111 @@
       justify-content: center;
       padding: 2rem;
     }
-    .card {
+
+    main {
+      width: min(100%, 34rem);
       background: var(--surface);
       border: 1px solid var(--border);
       border-radius: 0.75rem;
-      padding: 2.5rem 3rem;
-      max-width: 480px;
-      width: 100%;
+      box-shadow: 0 18px 50px var(--shadow);
+      padding: clamp(2rem, 5vw, 3.25rem);
       text-align: center;
-      box-shadow: 0 1px 3px rgba(0,0,0,.08);
     }
-    .icon {
-      font-size: 2.5rem;
-      margin-bottom: 1rem;
-    }
-    h1 {
-      font-size: 1.5rem;
-      font-weight: 600;
-      margin-bottom: 0.75rem;
-    }
-    p {
-      color: var(--muted);
-      line-height: 1.6;
-      font-size: 0.95rem;
-    }
-    .badge {
-      display: inline-block;
-      margin-top: 1.5rem;
-      padding: 0.35rem 0.9rem;
-      border-radius: 9999px;
-      background: #eff6ff;
+
+    .brand {
       color: var(--accent);
-      font-size: 0.8rem;
-      font-weight: 500;
+      font-size: 0.78rem;
+      font-weight: 700;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      margin-bottom: 1.25rem;
+    }
+
+    .status {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.6rem;
+      color: var(--ok);
+      background: #f0fdf4;
+      border: 1px solid #bbf7d0;
+      border-radius: 999px;
+      padding: 0.42rem 0.9rem;
+      font-size: 0.88rem;
+      font-weight: 600;
+      margin-bottom: 1.5rem;
+    }
+
+    .dot {
+      width: 0.7rem;
+      height: 0.7rem;
+      border-radius: 999px;
+      background: currentColor;
+      box-shadow: 0 0 0 0 rgba(22, 163, 74, 0.42);
+      animation: pulse 1.7s ease-out infinite;
+    }
+
+    h1 {
+      margin: 0;
+      color: var(--text);
+      font-size: clamp(1.75rem, 4vw, 2.35rem);
+      line-height: 1.14;
+      font-weight: 700;
+    }
+
+    p {
+      margin: 1rem auto 0;
+      color: var(--muted);
+      line-height: 1.65;
+      font-size: 1rem;
+      max-width: 27rem;
+    }
+
+    .retry {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      margin-top: 1.75rem;
+      padding: 0.55rem 1rem;
       border: 1px solid #bfdbfe;
+      border-radius: 999px;
+      background: var(--accent-soft);
+      color: var(--accent);
+      font-size: 0.9rem;
+      font-weight: 600;
+    }
+
+    @keyframes pulse {
+      0% {
+        box-shadow: 0 0 0 0 rgba(22, 163, 74, 0.42);
+      }
+      70% {
+        box-shadow: 0 0 0 0.7rem rgba(22, 163, 74, 0);
+      }
+      100% {
+        box-shadow: 0 0 0 0 rgba(22, 163, 74, 0);
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .dot {
+        animation: none;
+      }
     }
   </style>
 </head>
 <body>
-  <div class="card">
-    <div class="icon">&#128295;</div>
-    <h1>Scheduled Maintenance</h1>
+  <main>
+    <div class="brand">Parts Inventory</div>
+    <div class="status">
+      <span class="dot" aria-hidden="true"></span>
+      <span>Maintenance in progress</span>
+    </div>
+    <h1>We'll be back in a moment</h1>
     <p>
-      Parts Inventory is temporarily offline for a planned update.
-      We'll be back in a few minutes — no data has been lost.
+      Parts Inventory is temporarily offline while we finish an update or recover
+      the backend service. Thanks for your patience - your data is safe.
     </p>
-    <span class="badge">Back shortly</span>
-  </div>
+    <div class="retry">This page retries automatically every 30 seconds</div>
+  </main>
 </body>
 </html>

--- a/deploy/parts.matescb.cz-le-ssl.conf
+++ b/deploy/parts.matescb.cz-le-ssl.conf
@@ -40,6 +40,19 @@
     ProxyPass / http://127.0.0.1:8091/ retry=2 timeout=300 connectiontimeout=5
     ProxyPassReverse / http://127.0.0.1:8091/
 
+    # Serve the static maintenance page for backend outage responses while
+    # leaving application-owned 4xx/5xx bodies untouched.
+    ProxyErrorOverride On 502 503 504
+    ErrorDocument 502 /maintenance.html
+    ErrorDocument 503 /maintenance.html
+    ErrorDocument 504 /maintenance.html
+    Alias /maintenance.html /srv/stockmanager/deploy/maintenance.html
+    <Directory "/srv/stockmanager/deploy">
+        <Files "maintenance.html">
+            Require all granted
+        </Files>
+    </Directory>
+
     # Tell clients to retry in ~10s on any 5xx.
     Header always set Retry-After "10" "expr=%{REQUEST_STATUS} == 502 || %{REQUEST_STATUS} == 503 || %{REQUEST_STATUS} == 504"
 

--- a/deploy/parts.matescb.cz.conf
+++ b/deploy/parts.matescb.cz.conf
@@ -28,6 +28,19 @@
     ProxyPass / http://127.0.0.1:8091/ retry=2 timeout=300 connectiontimeout=5
     ProxyPassReverse / http://127.0.0.1:8091/
 
+    # Serve the static maintenance page for backend outage responses while
+    # leaving application-owned 4xx/5xx bodies untouched.
+    ProxyErrorOverride On 502 503 504
+    ErrorDocument 502 /maintenance.html
+    ErrorDocument 503 /maintenance.html
+    ErrorDocument 504 /maintenance.html
+    Alias /maintenance.html /srv/stockmanager/deploy/maintenance.html
+    <Directory "/srv/stockmanager/deploy">
+        <Files "maintenance.html">
+            Require all granted
+        </Files>
+    </Directory>
+
     # Tell clients (especially mobile webviews) to retry in ~10s on any 5xx.
     Header always set Retry-After "10" "expr=%{REQUEST_STATUS} == 502 || %{REQUEST_STATUS} == 503 || %{REQUEST_STATUS} == 504"
 

--- a/deploy/parts.matescb.cz.maintenance.conf
+++ b/deploy/parts.matescb.cz.maintenance.conf
@@ -8,8 +8,6 @@
 # INSTALL (enter drain mode):
 #   sudo cp /srv/stockmanager/deploy/parts.matescb.cz.maintenance.conf \
 #            /etc/apache2/conf-available/parts-maintenance.conf
-#   sudo cp /srv/stockmanager/deploy/maintenance.html \
-#            /var/www/html/maintenance.html
 #   sudo a2enconf parts-maintenance
 #   sudo apache2ctl configtest && sudo systemctl reload apache2
 #
@@ -20,7 +18,8 @@
 # See docs/deployment.md#drain-mode-for-destructive-migrations for the
 # full procedure including a pre-migration pg_dump step.
 #
-# REQUIRED Apache modules: mod_rewrite (already enabled for other vhosts).
+# REQUIRED Apache modules: mod_rewrite + mod_headers. The active vhost owns
+# the /maintenance.html Alias to /srv/stockmanager/deploy/maintenance.html.
 
 <IfModule mod_rewrite.c>
   RewriteEngine On

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -21,6 +21,7 @@ How to handle ops scenarios. Each runbook follows the template in [STYLE.md](../
 | [backup-restore](backup-restore.md) | Routine / SEV-1 | Verify backups, manually trigger, restore from a daily/weekly/monthly snapshot |
 | [prod-rollback](prod-rollback.md) | SEV-1 | Roll back a bad deploy via revert-and-redeploy or emergency `git reset --hard` on the VPS |
 | [migration-recovery](migration-recovery.md) | SEV-1 | Recover from a failed alembic migration; drain mode, point-in-time restore |
+| [maintenance-mode](maintenance-mode.md) | Routine / SEV-1 | Toggle Apache maintenance mode and verify the backend outage fallback |
 | [sentry-triage](sentry-triage.md) | SEV-2/3 | Issue → release → sourcemap workflow for resolving production exceptions |
 | [on-call-quickstart](on-call-quickstart.md) | n/a | Alerts, dashboards, escalation, what to do in the first 5 minutes of a page |
 | [incident-response](incident-response.md) | SEV-1/2 | Severity triage, comms cadence, post-mortem template |

--- a/docs/runbooks/maintenance-mode.md
+++ b/docs/runbooks/maintenance-mode.md
@@ -1,0 +1,121 @@
+# Runbook: maintenance mode
+
+Audience: engineer / on-call
+
+Use Apache maintenance mode for planned deploys and backend outages. The
+deploy job now toggles it automatically; operators only run these commands
+for manual maintenance or incident recovery.
+
+- **When to run**: planned maintenance outside the GitHub deploy path, or
+  a production backend outage where users should see the static page.
+- **Severity**: Routine for planned work; SEV-1 when the backend is down.
+- **Time-to-recovery target**: < 5 min to show or remove the page once SSH
+  access is available.
+- **Owner**: `<TODO(verify): on-call rotation>`
+
+## Pre-flight
+
+- SSH access to the VPS as the deploy operator.
+- `sudo` is allowed for `a2enconf`, `a2disconf`, `apache2ctl configtest`,
+  and `systemctl reload apache2`. If not, add the sudoers rule in a separate
+  INFRA issue; do not weaken the deploy script.
+- `/etc/apache2/conf-available/parts-maintenance.conf` exists and was copied
+  from `deploy/parts.matescb.cz.maintenance.conf`.
+- The regular vhosts include the outage fallback for 502/503/504 responses
+  (`deploy/parts.matescb.cz.conf:31`, `deploy/parts.matescb.cz-le-ssl.conf:43`).
+
+## Steps
+
+1. Install or refresh the checked-in maintenance config.
+   ```bash
+   cd /srv/stockmanager
+   sudo cp deploy/parts.matescb.cz.maintenance.conf \
+       /etc/apache2/conf-available/parts-maintenance.conf
+   sudo apache2ctl configtest
+   ```
+2. Enter maintenance mode.
+   ```bash
+   sudo a2enconf parts-maintenance
+   sudo systemctl reload apache2
+   ```
+3. Confirm users see the static page while `/api/health` still reaches the
+   backend health gate exemption.
+   ```bash
+   curl -i https://parts.matescb.cz/
+   curl -fsS https://parts.matescb.cz/api/health
+   ```
+4. Do the planned maintenance or incident recovery.
+5. Exit maintenance mode.
+   ```bash
+   sudo a2disconf parts-maintenance
+   sudo systemctl reload apache2
+   ```
+
+## Automatic deploy toggle
+
+The GitHub Actions deploy script registers this trap before the pre-deploy
+dump and then enables maintenance mode:
+
+```bash
+trap 'sudo a2disconf parts-maintenance && sudo systemctl reload apache2 || true' EXIT
+sudo a2enconf parts-maintenance && sudo systemctl reload apache2
+```
+
+Source: `.github/workflows/ci.yml:691`. The trap must stay ahead of
+`deploy/predeploy-dump.sh`; failed dumps, failed builds, failed migrations,
+and failed post-deploy health gates must all disable maintenance on exit.
+
+## Outage fallback
+
+When the maintenance drop-in is disabled but the backend is unreachable,
+Apache handles upstream 502/503/504 responses with the same static page:
+
+```bash
+curl -i https://parts.matescb.cz/
+```
+
+Expected: the response body is `deploy/maintenance.html`, not Apache's
+default proxy error. The fallback is scoped to 502/503/504 so application
+error envelopes are not replaced during normal request flow. Sources:
+`deploy/parts.matescb.cz.conf:33` and
+`deploy/parts.matescb.cz-le-ssl.conf:45`.
+
+## Verification
+
+- `sudo apache2ctl configtest` returns `Syntax OK`.
+- Planned toggle smoke:
+  ```bash
+  sudo a2enconf parts-maintenance && sudo systemctl reload apache2
+  curl -i https://parts.matescb.cz/
+  sudo a2disconf parts-maintenance && sudo systemctl reload apache2
+  curl -i https://parts.matescb.cz/
+  ```
+- Outage smoke:
+  ```bash
+  ssh vps "docker compose -f /srv/stockmanager/docker-compose.prod.yml stop backend"
+  curl -i https://parts.matescb.cz/
+  ssh vps "docker compose -f /srv/stockmanager/docker-compose.prod.yml start backend"
+  ```
+- `deploy/maintenance.html` includes a 30-second refresh and CSS pulse
+  animation (`deploy/maintenance.html:6`, `deploy/maintenance.html:78`).
+
+## Rollback
+
+If maintenance mode sticks after the deploy or an operator command:
+
+```bash
+sudo a2disconf parts-maintenance
+sudo apache2ctl configtest
+sudo systemctl reload apache2
+curl -fsS https://parts.matescb.cz/api/health
+```
+
+If the outage fallback itself causes trouble, remove the copied vhost change
+from `/etc/apache2/sites-available/parts.matescb.cz*.conf`, run
+`sudo apache2ctl configtest`, reload Apache, and open a revert PR.
+
+## Post-mortem prompts
+
+- Did the deploy trap run, or was maintenance left enabled manually?
+- Did the fallback serve `maintenance.html` for backend 502/503/504?
+- Was the Apache config installed from the checked-in deploy files?


### PR DESCRIPTION
## Summary

- Wrap the deploy SSH script in Apache maintenance mode and register the required EXIT trap before the pre-deploy dump.
- Add selective Apache outage fallback for upstream 502/503/504 responses on both HTTP and HTTPS vhosts, serving the checked-in `deploy/maintenance.html` without replacing normal app error envelopes.
- Polish `deploy/maintenance.html` with brand styling, a subtle pulse animation, and a 30-second refresh.
- Add CI deploy-validation steps for Apache config syntax and maintenance HTML linting, plus an operator runbook and CLAUDE.md invariant.

## Rendered preview

Rendered locally through `python3 -m http.server` and opened with Playwright at `/deploy/maintenance.html`; page title was `Maintenance - Parts Inventory`, the branded maintenance message rendered, and the only console error was the expected local `/favicon.ico` 404 from the temporary static server.

## Validation

- `git diff --check` passed.
- Parsed `.github/workflows/ci.yml` with Python/YAML; `prod-validate` includes `Lint Apache configs` and `Lint maintenance HTML`.
- Parsed `deploy/maintenance.html` with Python `html.parser`.
- Confirmed the exact trap line is present:
  `trap 'sudo a2disconf parts-maintenance && sudo systemctl reload apache2 || true' EXIT`

## Manual smoke limitations

- Local runner does not have `docker`, `apache2ctl`, or `tidy`, so I could not execute the new Docker-backed Apache config lint, local `apache2ctl -t`, or tidy check here. Those checks are now wired into `prod-validate` for CI.
- No VPS/sudo access from this environment, so I did not run the live maintenance toggle or backend outage smoke commands.
- Operator smoke still required after merge/deploy: planned toggle, failed-deploy trap behavior, and backend-stop outage fallback from the runbook.

## Merge order

Merge after the operator confirms the VPS has `/etc/apache2/conf-available/parts-maintenance.conf` installed from the checked-in maintenance config and the deploy user has sudo rights for `a2enconf`, `a2disconf`, and `systemctl reload apache2`. No other code PR dependency.

Refs #415
