### PR TITLE
FB-002: Bulk-import unmatched BOM rows from configured provider

### DIFF
--- a/backend/app/api/routes/parts_scan.py
+++ b/backend/app/api/routes/parts_scan.py
@@ -25,14 +25,12 @@ from app.core.deps import CurrentUser, CurrentWorkspace, DbSession
 from app.core.ratelimit import limiter, workspace_key
 from app.core.responses import ok
 from app.core.secrets import decrypt
-from app.core.time import utcnow
-from app.domain.custom_fields.models import CustomField
 from app.domain.parts.models import BulkImportIdempotency, Part
 from app.domain.parts.providers import make_provider
 from app.domain.parts.schemas import QuickRemoveBagIn, ScanImportIn, ScanImportRow
-from app.domain.parts.services.assets import fetch_provider_asset
 from app.domain.parts.services.bag_signature import compute_bag_signature
 from app.domain.parts.services.provider_cache import lookup_with_cache
+from app.domain.parts.services.provider_import import create_from_provider_lookup
 from app.domain.stock.models import StockEntry
 from app.domain.stock.schemas import AddStockIn, LotInput
 from app.domain.stock.service import StockError, add_stock
@@ -446,78 +444,15 @@ def _import_one_scan_row(
     failure — the caller's `with db.begin_nested():` rolls back this
     row only.
     """
-    r = lookup_result
-    name = (r.get("description") or "").strip() or mpn
-    if len(name) > 300:
-        name = name[:300]
-
-    p = Part(
+    p = create_from_provider_lookup(
+        db,
         workspace_id=ws.id,
-        part_type="linked",
-        name=name,
-        manufacturer=(r.get("manufacturer") or None),
-        mpn=(r.get("mpn") or mpn),
-        description=(r.get("description") or None),
-        footprint=(r.get("footprint") or None),
-        attrition_percentage=0,
-        attrition_min_quantity=0,
+        user_id=user.id,
+        provider_name=provider_name,
+        mpn=mpn,
+        lookup_result=lookup_result,
         default_storage_location_id=row.storage_location_id,
-        default_storage_mandatory=False,
-        serialized=False,
-        linked_provider=provider_name,
-        linked_external_id=(r.get("mpn") or mpn),
-        last_refresh_at=utcnow(),
-        description_locally_edited=False,
-        created_by=user.id,
-        updated_by=user.id,
     )
-    db.add(p)
-    db.flush()  # assign p.id for the custom_fields below
-
-    # Materialise spec rows + image/datasheet as `source='provider'`,
-    # mirroring the refresh-from-provider path. Skip empties.
-    for s in (r.get("specs") or []):
-        key = (s.get("key") or "").strip()
-        value = (s.get("value") or "").strip()
-        if not key or not value:
-            continue
-        db.add(CustomField(
-            workspace_id=ws.id,
-            object_type="part",
-            object_id=p.id,
-            key=key,
-            value=value,
-            source="provider",
-            created_by=user.id,
-            updated_by=user.id,
-        ))
-    # Download image + datasheet locally so we don't depend on the
-    # provider's CDN at render time. Failed downloads fall back to
-    # the original URL so the worst case is unchanged from before.
-    if r.get("image_url"):
-        local = fetch_provider_asset(r["image_url"], str(ws.id), "image")
-        db.add(CustomField(
-            workspace_id=ws.id,
-            object_type="part",
-            object_id=p.id,
-            key="image_url",
-            value=local or r["image_url"],
-            source="provider",
-            created_by=user.id,
-            updated_by=user.id,
-        ))
-    if r.get("datasheet_url"):
-        local = fetch_provider_asset(r["datasheet_url"], str(ws.id), "datasheet")
-        db.add(CustomField(
-            workspace_id=ws.id,
-            object_type="part",
-            object_id=p.id,
-            key="datasheet_url",
-            value=local or r["datasheet_url"],
-            source="provider",
-            created_by=user.id,
-            updated_by=user.id,
-        ))
 
     # Initial stock entry — when the bag's Q field carries a count
     # (or the operator entered one), the part lands on-hand right

--- a/backend/app/api/routes/projects.py
+++ b/backend/app/api/routes/projects.py
@@ -3,22 +3,26 @@ from __future__ import annotations
 import logging
 from uuid import UUID
 
-from fastapi import APIRouter, Query, status
+from fastapi import APIRouter, Query, Request, status
 from sqlalchemy import or_, select
 
 from app.api._helpers import assert_child_in_parent, assert_in_workspace, require_resource_access
 from app.core.deps import CurrentUser, CurrentWorkspace, DbSession
 from app.core.errors import ErrorCodes, raise_http
+from app.core.ratelimit import limiter, workspace_key
 from app.core.responses import ok
 from app.core.time import utcnow
 from app.domain.parts.models import Part
 from app.domain.projects import bom_import as bom
+from app.domain.projects import bom_import_provider
 from app.domain.projects.models import Project, ProjectEntry
 from app.domain.projects.schemas import (
     BomEntryIn,
     BomEntryPatch,
     BomImportCommitIn,
     BomImportPreviewIn,
+    BomProviderImportChoiceIn,
+    BomProviderImportIn,
     MatchEntryIn,
     ProjectCreateIn,
     ProjectPatchIn,
@@ -267,6 +271,48 @@ def commit_bom(project_id: UUID, payload: BomImportCommitIn, db: DbSession, ws: 
     # the dep handle it.
     result = bom.commit(db, workspace_id=ws.id, user_id=user.id, project=project, payload=payload)
     return ok(result.model_dump())
+
+
+@router.post("/{project_id}/bom/import-from-provider")
+@limiter.limit("30/minute", key_func=workspace_key)
+def import_bom_from_provider(
+    request: Request,
+    project_id: UUID,
+    payload: BomProviderImportIn,
+    db: DbSession,
+    ws: CurrentWorkspace,
+    user: CurrentUser,
+):
+    project = assert_in_workspace(db, Project, project_id, ws.id, label="project")
+    result = bom_import_provider.import_unmatched_from_provider(
+        db,
+        workspace=ws,
+        user_id=user.id,
+        project=project,
+        entry_ids=payload.entry_ids,
+    )
+    return ok(result.model_dump(mode="json"))
+
+
+@router.post("/{project_id}/bom/import-from-provider/commit-choices")
+@limiter.limit("30/minute", key_func=workspace_key)
+def commit_bom_provider_choices(
+    request: Request,
+    project_id: UUID,
+    payload: BomProviderImportChoiceIn,
+    db: DbSession,
+    ws: CurrentWorkspace,
+    user: CurrentUser,
+):
+    project = assert_in_workspace(db, Project, project_id, ws.id, label="project")
+    result = bom_import_provider.commit_provider_import_choices(
+        db,
+        workspace=ws,
+        user_id=user.id,
+        project=project,
+        choices=payload.choices,
+    )
+    return ok(result.model_dump(mode="json"))
 
 
 @router.post("/{project_id}/entries/{entry_id}/match")

--- a/backend/app/domain/parts/providers/base.py
+++ b/backend/app/domain/parts/providers/base.py
@@ -13,6 +13,7 @@ class MpnLookupResult(TypedDict, total=False):
     """The shape returned by every provider's `lookup_mpn`."""
     found: bool
     result: Optional[dict]  # see schema below
+    candidates: list[dict]
     message: Optional[str]
 
 

--- a/backend/app/domain/parts/providers/mouser.py
+++ b/backend/app/domain/parts/providers/mouser.py
@@ -161,6 +161,24 @@ class MouserProvider:
         if not parts:
             return {"found": False, "result": None, "message": "no match for MPN"}
 
+        exact_parts = [
+            part for part in parts
+            if (part.get("ManufacturerPartNumber") or "").strip().casefold() == mpn.casefold()
+        ]
+        exact_manufacturers = {
+            (part.get("Manufacturer") or "").strip().casefold()
+            for part in exact_parts
+            if (part.get("Manufacturer") or "").strip()
+        }
+        if len(exact_manufacturers) > 1:
+            candidates = [_candidate_record_from_part(part, mpn) for part in exact_parts]
+            return {
+                "found": True,
+                "result": candidates[0],
+                "candidates": candidates,
+                "message": None,
+            }
+
         # Take the first match — for partial-match search this is the
         # closest stocked variant.
         p = parts[0]
@@ -374,3 +392,43 @@ class MouserProvider:
             },
             "message": None,
         }
+
+
+def _candidate_record_from_part(p: dict, mpn: str) -> dict:
+    raw_attrs = p.get("ProductAttributes") or []
+    specs_by_key: dict[str, list[str]] = {}
+    spec_order: list[str] = []
+    footprint: str | None = None
+    for a in raw_attrs:
+        name = (a.get("AttributeName") or "").strip()
+        value = (a.get("AttributeValue") or "").strip()
+        if not name or not value:
+            continue
+        if name not in specs_by_key:
+            spec_order.append(name)
+            specs_by_key[name] = []
+        if value not in specs_by_key[name]:
+            specs_by_key[name].append(value)
+        if footprint is None and name.lower() in (
+            "package / case",
+            "package",
+            "case",
+            "package/case",
+            "footprint",
+        ):
+            footprint = value
+
+    return {
+        "mpn": p.get("ManufacturerPartNumber") or mpn,
+        "manufacturer": p.get("Manufacturer") or None,
+        "description": p.get("Description") or None,
+        "category": p.get("Category") or None,
+        "footprint": footprint,
+        "datasheet_url": p.get("DataSheetUrl") or None,
+        "image_url": p.get("ImagePath") or None,
+        "source_url": p.get("ProductDetailUrl") or "",
+        "specs": [
+            {"key": key, "value": " / ".join(specs_by_key[key])}
+            for key in spec_order
+        ],
+    }

--- a/backend/app/domain/parts/services/provider_import.py
+++ b/backend/app/domain/parts/services/provider_import.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from app.core.time import utcnow
+from app.domain.custom_fields.models import CustomField
+from app.domain.parts.models import Part
+from app.domain.parts.services.assets import fetch_provider_asset
+
+
+def create_from_provider_lookup(
+    db,
+    *,
+    workspace_id: UUID,
+    user_id: UUID | None,
+    provider_name: str,
+    mpn: str,
+    lookup_result: dict,
+    default_storage_location_id: UUID | None = None,
+) -> Part:
+    """Create a linked Part from an existing provider lookup result.
+
+    Caller owns transaction/savepoint boundaries. This helper writes only the
+    Part and provider-backed custom fields; stock movements remain with stock
+    services.
+    """
+    r = lookup_result
+    name = (r.get("description") or "").strip() or mpn
+    if len(name) > 300:
+        name = name[:300]
+
+    p = Part(
+        workspace_id=workspace_id,
+        part_type="linked",
+        name=name,
+        manufacturer=(r.get("manufacturer") or None),
+        mpn=(r.get("mpn") or mpn),
+        description=(r.get("description") or None),
+        footprint=(r.get("footprint") or None),
+        attrition_percentage=0,
+        attrition_min_quantity=0,
+        default_storage_location_id=default_storage_location_id,
+        default_storage_mandatory=False,
+        serialized=False,
+        linked_provider=provider_name,
+        linked_external_id=(r.get("mpn") or mpn),
+        last_refresh_at=utcnow(),
+        description_locally_edited=False,
+        created_by=user_id,
+        updated_by=user_id,
+    )
+    db.add(p)
+    db.flush()
+
+    for s in (r.get("specs") or []):
+        key = (s.get("key") or "").strip()
+        value = (s.get("value") or "").strip()
+        if not key or not value:
+            continue
+        _add_provider_field(
+            db,
+            workspace_id=workspace_id,
+            user_id=user_id,
+            part_id=p.id,
+            key=key,
+            value=value,
+        )
+
+    if r.get("image_url"):
+        local = fetch_provider_asset(r["image_url"], str(workspace_id), "image")
+        _add_provider_field(
+            db,
+            workspace_id=workspace_id,
+            user_id=user_id,
+            part_id=p.id,
+            key="image_url",
+            value=local or r["image_url"],
+        )
+    if r.get("datasheet_url"):
+        local = fetch_provider_asset(r["datasheet_url"], str(workspace_id), "datasheet")
+        _add_provider_field(
+            db,
+            workspace_id=workspace_id,
+            user_id=user_id,
+            part_id=p.id,
+            key="datasheet_url",
+            value=local or r["datasheet_url"],
+        )
+    if r.get("source_url"):
+        _add_provider_field(
+            db,
+            workspace_id=workspace_id,
+            user_id=user_id,
+            part_id=p.id,
+            key="source_url",
+            value=str(r["source_url"])[:1024],
+        )
+
+    return p
+
+
+def _add_provider_field(
+    db,
+    *,
+    workspace_id: UUID,
+    user_id: UUID | None,
+    part_id: UUID,
+    key: str,
+    value: str,
+) -> None:
+    db.add(
+        CustomField(
+            workspace_id=workspace_id,
+            object_type="part",
+            object_id=part_id,
+            key=key,
+            value=value[:1024],
+            source="provider",
+            created_by=user_id,
+            updated_by=user_id,
+        )
+    )

--- a/backend/app/domain/projects/bom_import_provider.py
+++ b/backend/app/domain/projects/bom_import_provider.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import select
+
+from app.core.errors import raise_http
+from app.core.secrets import decrypt
+from app.domain.parts.providers import make_provider
+from app.domain.parts.services.provider_cache import lookup_with_cache
+from app.domain.parts.services.provider_import import create_from_provider_lookup
+from app.domain.projects.models import Project, ProjectEntry
+from app.domain.projects.schemas import (
+    BomProviderCandidate,
+    BomProviderFailure,
+    BomProviderImportOut,
+    BomProviderPendingChoice,
+)
+
+
+def import_unmatched_from_provider(
+    db,
+    *,
+    workspace,
+    user_id: UUID | None,
+    project: Project,
+    entry_ids: list[UUID] | None = None,
+) -> BomProviderImportOut:
+    provider = _provider_or_409(workspace)
+    rows = _load_unmatched_entries(
+        db,
+        workspace_id=workspace.id,
+        project_id=project.id,
+        entry_ids=entry_ids,
+    )
+
+    created = 0
+    pending: list[BomProviderPendingChoice] = []
+    failures: list[BomProviderFailure] = []
+
+    for entry in rows:
+        outcome = _lookup_entry(provider, entry)
+        if isinstance(outcome, BomProviderFailure):
+            failures.append(outcome)
+            continue
+        if isinstance(outcome, BomProviderPendingChoice):
+            pending.append(outcome)
+            continue
+
+        try:
+            with db.begin_nested():
+                _create_and_link(
+                    db,
+                    workspace_id=workspace.id,
+                    user_id=user_id,
+                    provider_name=provider.name,
+                    entry=entry,
+                    lookup_result=outcome,
+                )
+        except Exception as exc:
+            failures.append(
+                _failure(entry, _entry_mpn(entry), f"{type(exc).__name__}: {exc}")
+            )
+            continue
+        created += 1
+
+    return BomProviderImportOut(
+        created=created,
+        pending_choices=pending,
+        failures=failures,
+        provider=provider.name,
+    )
+
+
+def commit_provider_import_choices(
+    db,
+    *,
+    workspace,
+    user_id: UUID | None,
+    project: Project,
+    choices: dict[UUID, str],
+) -> BomProviderImportOut:
+    provider = _provider_or_409(workspace)
+    rows = _load_unmatched_entries(
+        db,
+        workspace_id=workspace.id,
+        project_id=project.id,
+        entry_ids=list(choices.keys()),
+    )
+    by_id = {row.id: row for row in rows}
+
+    created = 0
+    failures: list[BomProviderFailure] = []
+    for entry_id, manufacturer in choices.items():
+        entry = by_id.get(entry_id)
+        if entry is None:
+            continue
+
+        mpn = _entry_mpn(entry)
+        lookup = _lookup_raw(provider, mpn)
+        record = _record_for_manufacturer(lookup, manufacturer)
+        if record is None:
+            failures.append(
+                _failure(entry, mpn, f"manufacturer not found: {manufacturer}")
+            )
+            continue
+
+        try:
+            with db.begin_nested():
+                _create_and_link(
+                    db,
+                    workspace_id=workspace.id,
+                    user_id=user_id,
+                    provider_name=provider.name,
+                    entry=entry,
+                    lookup_result=record,
+                )
+        except Exception as exc:
+            failures.append(
+                _failure(entry, mpn, f"{type(exc).__name__}: {exc}")
+            )
+            continue
+        created += 1
+
+    return BomProviderImportOut(
+        created=created,
+        pending_choices=[],
+        failures=failures,
+        provider=provider.name,
+    )
+
+
+def _provider_or_409(workspace):
+    provider = make_provider(
+        workspace.parts_provider,
+        decrypt(workspace.parts_provider_api_key),
+        decrypt(workspace.parts_provider_api_secret),
+    )
+    if provider is None:
+        raise_http(
+            409,
+            "bom_provider.no_provider",
+            "no provider configured",
+        )
+    return provider
+
+
+def _load_unmatched_entries(
+    db,
+    *,
+    workspace_id: UUID,
+    project_id: UUID,
+    entry_ids: list[UUID] | None,
+) -> list[ProjectEntry]:
+    stmt = (
+        select(ProjectEntry)
+        .where(ProjectEntry.workspace_id == workspace_id)
+        .where(ProjectEntry.project_id == project_id)
+        .where(ProjectEntry.entry_type == "unmatched")
+        .where(ProjectEntry.part_id.is_(None))
+        .order_by(ProjectEntry.order_index)
+    )
+    if entry_ids is not None:
+        stmt = stmt.where(ProjectEntry.id.in_(entry_ids))
+    return list(db.execute(stmt).scalars())
+
+
+def _lookup_entry(
+    provider,
+    entry: ProjectEntry,
+) -> dict | BomProviderPendingChoice | BomProviderFailure:
+    mpn = _entry_mpn(entry)
+    if not mpn:
+        return _failure(entry, mpn, "missing MPN")
+
+    lookup = _lookup_raw(provider, mpn)
+    if not lookup.get("found") or not lookup.get("result"):
+        return _failure(entry, mpn, lookup.get("message") or "no match")
+
+    candidates = _candidate_records(lookup)
+    manufacturers = {(_manufacturer(candidate) or "").casefold() for candidate in candidates}
+    manufacturers.discard("")
+    if len(manufacturers) > 1:
+        return BomProviderPendingChoice(
+            entry_id=entry.id,
+            mpn=mpn,
+            candidates=[_candidate_out(candidate) for candidate in candidates],
+        )
+    return lookup["result"]
+
+
+def _lookup_raw(provider, mpn: str) -> dict:
+    try:
+        return lookup_with_cache(provider, mpn)
+    except Exception as exc:
+        return {"found": False, "result": None, "message": f"provider raised {type(exc).__name__}"}
+
+
+def _candidate_records(lookup: dict) -> list[dict]:
+    candidates = lookup.get("candidates") or []
+    if candidates and isinstance(candidates, list):
+        return [candidate for candidate in candidates if isinstance(candidate, dict)]
+    result = lookup.get("result")
+    return [result] if isinstance(result, dict) else []
+
+
+def _record_for_manufacturer(lookup: dict, manufacturer: str) -> dict | None:
+    if not lookup.get("found") or not lookup.get("result"):
+        return None
+    wanted = manufacturer.strip().casefold()
+    for candidate in _candidate_records(lookup):
+        if (_manufacturer(candidate) or "").casefold() == wanted:
+            return candidate
+    result = lookup.get("result")
+    if isinstance(result, dict) and (_manufacturer(result) or "").casefold() == wanted:
+        return result
+    return None
+
+
+def _create_and_link(
+    db,
+    *,
+    workspace_id: UUID,
+    user_id: UUID | None,
+    provider_name: str,
+    entry: ProjectEntry,
+    lookup_result: dict,
+) -> None:
+    mpn = _entry_mpn(entry)
+    part = create_from_provider_lookup(
+        db,
+        workspace_id=workspace_id,
+        user_id=user_id,
+        provider_name=provider_name,
+        mpn=mpn,
+        lookup_result=lookup_result,
+    )
+    entry.part_id = part.id
+    entry.entry_type = "part"
+    entry.updated_by = user_id
+    db.flush()
+
+
+def _entry_mpn(entry: ProjectEntry) -> str:
+    return (entry.name or "").strip()
+
+
+def _manufacturer(record: dict) -> str | None:
+    value = record.get("manufacturer")
+    return str(value).strip() if value else None
+
+
+def _candidate_out(record: dict) -> BomProviderCandidate:
+    return BomProviderCandidate(
+        manufacturer=_manufacturer(record) or "",
+        mpn=(record.get("mpn") or None),
+        description=(record.get("description") or None),
+        source_url=(record.get("source_url") or None),
+        image_url=(record.get("image_url") or None),
+    )
+
+
+def _failure(entry: ProjectEntry, mpn: str, reason: str) -> BomProviderFailure:
+    return BomProviderFailure(entry_id=entry.id, mpn=mpn, reason=reason)

--- a/backend/app/domain/projects/schemas.py
+++ b/backend/app/domain/projects/schemas.py
@@ -142,6 +142,45 @@ class BomImportCommitOut(BaseModel):
     skipped: int = 0
 
 
+class BomProviderImportIn(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    entry_ids: list[UUID] | None = Field(default=None, max_length=50)
+
+
+class BomProviderImportChoiceIn(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    choices: dict[UUID, str] = Field(min_length=1, max_length=50)
+
+
+class BomProviderCandidate(BaseModel):
+    manufacturer: str
+    mpn: str | None = None
+    description: str | None = None
+    source_url: str | None = None
+    image_url: str | None = None
+
+
+class BomProviderPendingChoice(BaseModel):
+    entry_id: UUID
+    mpn: str
+    candidates: list[BomProviderCandidate]
+
+
+class BomProviderFailure(BaseModel):
+    entry_id: UUID
+    mpn: str
+    reason: str
+
+
+class BomProviderImportOut(BaseModel):
+    created: int
+    pending_choices: list[BomProviderPendingChoice] = []
+    failures: list[BomProviderFailure] = []
+    provider: str
+
+
 # BOM presets (#252 — lifted from app/api/routes/bom_presets.py)
 
 class PresetIn(BaseModel):

--- a/backend/tests/test_bom_import_provider.py
+++ b/backend/tests/test_bom_import_provider.py
@@ -52,7 +52,7 @@ def _enable_mouser(c: TestClient) -> None:
 
 def _project(c: TestClient, name: str = "P") -> str:
     r = c.post("/api/projects", json={"name": name})
-    assert r.status_code == 200, r.text
+    assert r.status_code == 201, r.text
     return r.json()["data"]["id"]
 
 

--- a/backend/tests/test_bom_import_provider.py
+++ b/backend/tests/test_bom_import_provider.py
@@ -1,0 +1,326 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.core import ratelimit as _ratelimit_mod
+from app.main import app
+
+
+def _signup(c: TestClient, email: str | None = None) -> str:
+    r = c.post(
+        "/api/auth/signup",
+        json={
+            "email": email or f"u-{uuid.uuid4().hex[:8]}@x.com",
+            "name": "u",
+            "password": "TestPass-2026-Stronk",
+        },
+    )
+    assert r.status_code == 200, r.text
+    return r.json()["data"]["workspace_id"]
+
+
+@pytest.fixture
+def authed():
+    c = TestClient(app)
+    _signup(c)
+    _enable_mouser(c)
+    return c
+
+
+@pytest.fixture
+def limiter_enabled():
+    original = _ratelimit_mod.limiter.enabled
+    _ratelimit_mod.limiter.enabled = True
+    yield
+    _ratelimit_mod.limiter.enabled = original
+    try:
+        _ratelimit_mod.limiter.reset()
+    except Exception:
+        pass
+
+
+def _enable_mouser(c: TestClient) -> None:
+    r = c.patch(
+        "/api/workspaces/current",
+        json={"parts_provider": "mouser", "parts_provider_api_key": "fake-key"},
+    )
+    assert r.status_code == 200, r.text
+
+
+def _project(c: TestClient, name: str = "P") -> str:
+    r = c.post("/api/projects", json={"name": name})
+    assert r.status_code == 200, r.text
+    return r.json()["data"]["id"]
+
+
+def _entry(
+    c: TestClient,
+    project_id: str,
+    mpn: str,
+    *,
+    entry_type: str = "unmatched",
+    part_id: str | None = None,
+) -> str:
+    payload = {
+        "entry_type": entry_type,
+        "name": mpn,
+        "quantity": 2,
+    }
+    if part_id is not None:
+        payload["part_id"] = part_id
+    r = c.post(f"/api/projects/{project_id}/entries", json=payload)
+    assert r.status_code == 200, r.text
+    return r.json()["data"]["id"]
+
+
+def _part(c: TestClient, mpn: str = "EXISTING") -> str:
+    r = c.post("/api/parts", json={"part_type": "local", "name": mpn, "mpn": mpn})
+    assert r.status_code == 201, r.text
+    return r.json()["data"]["id"]
+
+
+def _lookup_result(mpn: str, manufacturer: str = "Yageo") -> dict:
+    return {
+        "found": True,
+        "result": {
+            "mpn": mpn,
+            "manufacturer": manufacturer,
+            "description": f"{mpn} resistor",
+            "category": "Resistors",
+            "footprint": "0402",
+            "datasheet_url": "https://example.com/ds.pdf",
+            "image_url": "https://example.com/img.jpg",
+            "source_url": f"https://example.com/{mpn}",
+            "specs": [{"key": "Resistance", "value": "10 kOhms"}],
+        },
+        "message": None,
+    }
+
+
+def test_bulk_import_creates_real_parts_with_specs(authed, monkeypatch):
+    monkeypatch.setattr(
+        "app.domain.projects.bom_import_provider.lookup_with_cache",
+        lambda provider, mpn: _lookup_result(mpn),
+    )
+    project_id = _project(authed)
+    entry_id = _entry(authed, project_id, "RC0402-10K")
+
+    r = authed.post(
+        f"/api/projects/{project_id}/bom/import-from-provider",
+        json={"entry_ids": None},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()["data"]
+    assert body["created"] == 1
+    assert body["pending_choices"] == []
+    assert body["failures"] == []
+
+    entry = authed.get(f"/api/projects/{project_id}/entries").json()["data"][0]
+    assert entry["id"] == entry_id
+    assert entry["entry_type"] == "part"
+    part = authed.get(f"/api/parts/{entry['part_id']}").json()["data"]
+    assert part["linked_provider"] != "none"
+    assert part["linked_provider"] == "mouser"
+
+    cfs = authed.get(f"/api/custom-fields/by-object/part/{part['id']}").json()["data"]
+    provider_specs = [
+        row for row in cfs
+        if row["source"] == "provider" and row["key"] == "Resistance"
+    ]
+    assert len(provider_specs) >= 1
+
+
+def test_bulk_import_skips_already_matched_rows(authed, monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        "app.domain.projects.bom_import_provider.lookup_with_cache",
+        lambda provider, mpn: calls.append(mpn) or _lookup_result(mpn),
+    )
+    project_id = _project(authed)
+    part_id = _part(authed)
+    _entry(authed, project_id, "EXISTING", entry_type="part", part_id=part_id)
+
+    r = authed.post(
+        f"/api/projects/{project_id}/bom/import-from-provider",
+        json={"entry_ids": None},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["data"]["created"] == 0
+    assert calls == []
+
+
+def test_ambiguous_mpn_returns_pending_choices_no_commit(authed, monkeypatch):
+    def ambiguous(_provider, mpn):
+        a = _lookup_result(mpn, "Alpha")["result"]
+        b = _lookup_result(mpn, "Beta")["result"]
+        return {"found": True, "result": a, "candidates": [a, b], "message": None}
+
+    monkeypatch.setattr("app.domain.projects.bom_import_provider.lookup_with_cache", ambiguous)
+    project_id = _project(authed)
+    entry_id = _entry(authed, project_id, "AMB-1")
+
+    r = authed.post(
+        f"/api/projects/{project_id}/bom/import-from-provider",
+        json={"entry_ids": [entry_id]},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()["data"]
+    assert body["created"] == 0
+    assert body["pending_choices"][0]["entry_id"] == entry_id
+    manufacturers = {c["manufacturer"] for c in body["pending_choices"][0]["candidates"]}
+    assert manufacturers == {"Alpha", "Beta"}
+    assert (
+        authed.get(f"/api/projects/{project_id}/entries").json()["data"][0]["entry_type"]
+        == "unmatched"
+    )
+
+
+def test_commit_choices_creates_parts_from_chosen_manufacturer(authed, monkeypatch):
+    def ambiguous(_provider, mpn):
+        a = _lookup_result(mpn, "Alpha")["result"]
+        b = _lookup_result(mpn, "Beta")["result"]
+        return {"found": True, "result": a, "candidates": [a, b], "message": None}
+
+    monkeypatch.setattr("app.domain.projects.bom_import_provider.lookup_with_cache", ambiguous)
+    project_id = _project(authed)
+    entry_id = _entry(authed, project_id, "AMB-2")
+
+    r = authed.post(
+        f"/api/projects/{project_id}/bom/import-from-provider/commit-choices",
+        json={"choices": {entry_id: "Beta"}},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["data"]["created"] == 1
+    entry = authed.get(f"/api/projects/{project_id}/entries").json()["data"][0]
+    part = authed.get(f"/api/parts/{entry['part_id']}").json()["data"]
+    assert part["manufacturer"] == "Beta"
+
+
+def test_failed_lookup_appears_in_failures_not_as_stub(authed, monkeypatch):
+    monkeypatch.setattr(
+        "app.domain.projects.bom_import_provider.lookup_with_cache",
+        lambda provider, mpn: {"found": False, "result": None, "message": "no match for MPN"},
+    )
+    project_id = _project(authed)
+    _entry(authed, project_id, "NOPE")
+
+    r = authed.post(
+        f"/api/projects/{project_id}/bom/import-from-provider",
+        json={"entry_ids": None},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()["data"]
+    assert body["created"] == 0
+    assert body["failures"][0]["mpn"] == "NOPE"
+    assert "no match" in body["failures"][0]["reason"]
+    assert (
+        authed.get(f"/api/projects/{project_id}/entries").json()["data"][0]["entry_type"]
+        == "unmatched"
+    )
+    assert authed.get("/api/parts?limit=200").json()["data"] == []
+
+
+def test_per_row_savepoint_isolates_failures(authed, monkeypatch):
+    monkeypatch.setattr(
+        "app.domain.projects.bom_import_provider.lookup_with_cache",
+        lambda provider, mpn: _lookup_result(mpn),
+    )
+    real_create = __import__(
+        "app.domain.projects.bom_import_provider",
+        fromlist=["create_from_provider_lookup"],
+    ).create_from_provider_lookup
+
+    def maybe_raise(*args, **kwargs):
+        if kwargs["mpn"] == "BAD":
+            raise RuntimeError("boom")
+        return real_create(*args, **kwargs)
+
+    monkeypatch.setattr(
+        "app.domain.projects.bom_import_provider.create_from_provider_lookup",
+        maybe_raise,
+    )
+    project_id = _project(authed)
+    _entry(authed, project_id, "GOOD1")
+    _entry(authed, project_id, "BAD")
+    _entry(authed, project_id, "GOOD2")
+
+    r = authed.post(
+        f"/api/projects/{project_id}/bom/import-from-provider",
+        json={"entry_ids": None},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()["data"]
+    assert body["created"] == 2
+    assert body["failures"][0]["mpn"] == "BAD"
+    rows = authed.get(f"/api/projects/{project_id}/entries").json()["data"]
+    assert [row["entry_type"] for row in rows] == ["part", "unmatched", "part"]
+
+
+def test_foreign_project_returns_404(authed):
+    other = TestClient(app)
+    _signup(other)
+    _enable_mouser(other)
+    project_id = _project(authed)
+
+    r = other.post(
+        f"/api/projects/{project_id}/bom/import-from-provider",
+        json={"entry_ids": None},
+    )
+    assert r.status_code == 404
+    assert r.json()["status"]["category"] == "not_found"
+
+
+def test_workspace_isolation_two_workspaces_same_mpn(monkeypatch):
+    monkeypatch.setattr(
+        "app.domain.projects.bom_import_provider.lookup_with_cache",
+        lambda provider, mpn: _lookup_result(mpn),
+    )
+    a = TestClient(app)
+    b = TestClient(app)
+    _signup(a)
+    _signup(b)
+    _enable_mouser(a)
+    _enable_mouser(b)
+    project_a = _project(a, "A")
+    project_b = _project(b, "B")
+    _entry(a, project_a, "SAME-MPN")
+    _entry(b, project_b, "SAME-MPN")
+
+    rb = b.post(
+        f"/api/projects/{project_b}/bom/import-from-provider",
+        json={"entry_ids": None},
+    )
+    assert rb.status_code == 200, rb.text
+    assert rb.json()["data"]["created"] == 1
+
+    assert (
+        a.get(f"/api/projects/{project_a}/entries").json()["data"][0]["entry_type"]
+        == "unmatched"
+    )
+    assert len(a.get("/api/parts?limit=200").json()["data"]) == 0
+    assert len(b.get("/api/parts?limit=200").json()["data"]) == 1
+
+
+def test_rate_limit_30_per_minute(authed, monkeypatch, limiter_enabled):
+    monkeypatch.setattr(
+        "app.domain.projects.bom_import_provider.lookup_with_cache",
+        lambda provider, mpn: {"found": False, "result": None, "message": "no match"},
+    )
+    project_id = _project(authed)
+
+    for i in range(30):
+        r = authed.post(
+            f"/api/projects/{project_id}/bom/import-from-provider",
+            json={"entry_ids": []},
+        )
+        assert r.status_code == 200, f"call {i}: {r.status_code} {r.text}"
+
+    r = authed.post(
+        f"/api/projects/{project_id}/bom/import-from-provider",
+        json={"entry_ids": []},
+    )
+    assert r.status_code == 429, r.text
+    assert r.json()["status"]["category"] == "rate_limited"

--- a/backend/tests/test_workspace_isolation.py
+++ b/backend/tests/test_workspace_isolation.py
@@ -936,6 +936,23 @@ def test_bom_presets_isolation():
     assert b.delete(f"/api/bom-presets/{preset}").status_code == 404
 
 
+def test_bom_provider_import_foreign_project_404():
+    """Provider-backed unmatched-row import must resolve project_id inside
+    the caller's workspace before it looks at any BOM entries."""
+    a, b = _two_workspaces()
+    b.patch(
+        "/api/workspaces/current",
+        json={"parts_provider": "mouser", "parts_provider_api_key": "x" * 36},
+    )
+    project_a = a.post("/api/projects", json={"name": "A-provider-import"}).json()["data"]["id"]
+
+    r = b.post(
+        f"/api/projects/{project_a}/bom/import-from-provider",
+        json={"entry_ids": None},
+    )
+    assert r.status_code == 404, r.text
+
+
 def test_reports_low_stock_does_not_leak_other_workspace_parts():
     """Reports run as workspace-scoped aggregations. A foreign threshold-
     flagged part must not appear in B's low-stock report."""

--- a/docs/api/projects.md
+++ b/docs/api/projects.md
@@ -227,6 +227,59 @@ Commit the preview into `project_entries` rows.
 - Source: `backend/app/api/routes/projects.py:262-269`.
 - Service: `backend/app/domain/projects/bom_import.py::commit`.
 
+### `POST /api/projects/{project_id}/bom/import-from-provider`
+
+Create real provider-backed parts for unmatched BOM rows, then bind each
+successful row to the new part. The route is workspace-scoped, member-access,
+and rate-limited at 30 calls/minute per workspace.
+
+**Request** — `BomProviderImportIn`
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `entry_ids` | UUID[] \| null | no | `null` imports all unmatched rows in the project. A list imports only those rows. |
+
+**Response** — `200 OK` — envelope: `{ data, status }`
+
+```json
+{
+  "created": 1,
+  "pending_choices": [],
+  "failures": [{ "entry_id": "…", "mpn": "NOPE", "reason": "no match" }],
+  "provider": "mouser"
+}
+```
+
+**Errors** — `404` for a foreign/missing project. `409 bom_provider.no_provider`
+when the workspace has no configured parts provider.
+
+**Notes**
+
+- Uses per-row savepoints; one failed lookup or write does not roll back rows that already created parts.
+- This is not the CSV `auto_create_missing_parts` path. It does not create stub parts; failures stay unmatched.
+- Source: `backend/app/api/routes/projects.py:276-294`.
+- Service: `backend/app/domain/projects/bom_import_provider.py:21-72`.
+
+### `POST /api/projects/{project_id}/bom/import-from-provider/commit-choices`
+
+Commit manufacturer choices returned by `pending_choices`.
+
+**Request** — `BomProviderImportChoiceIn`
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `choices` | object | yes | Map of `entry_id` to chosen manufacturer. |
+
+**Response** — `200 OK` — same shape as `import-from-provider`.
+
+**Errors** — same project/provider errors as `import-from-provider`.
+
+**Notes**
+
+- Re-runs provider lookup for each selected entry and creates the part only when the selected manufacturer is present.
+- Source: `backend/app/api/routes/projects.py:297-315`.
+- Service: `backend/app/domain/projects/bom_import_provider.py:75-130`.
+
 ## BOM import presets (`/api/bom-presets`)
 
 Reusable column-mapping configs for the BOM import wizard.

--- a/docs/user/projects-and-bom.md
+++ b/docs/user/projects-and-bom.md
@@ -67,6 +67,8 @@ Auto-created parts start with zero stock. They do not create stock entries or lo
 
 Rows with neither an MPN nor a part/name are skipped when auto-create is enabled. They do not create a part or a BOM line.
 
+CSV auto-create is an import-time stub fallback. The provider import on the BOM tab creates real provider-backed parts and is the recommended way to turn unmatched rows into library parts.
+
 ### Save your mapping as a preset
 
 If you import BOMs from the same CAD tool repeatedly, save the column mapping:
@@ -86,6 +88,18 @@ Open the project and click the **BOM** tab.
 The BOM tab has **Source BOM**, **Import BOM**, and **Add Part** buttons above the table. **Import BOM** opens the same CSV/TSV import flow as the tab, while **Add Part** lets you search existing library parts by name or MPN and add selected parts as BOM rows. The table shows thumbnails, part details, quantity, designators, and matched/unmatched status. Matched rows open the part's info page when clicked; unmatched rows stay inactive until you match them. Use the row checkboxes to select multiple BOM rows and delete them together.
 
 To remove a line, click **Delete** on its row.
+
+### Import unmatched rows from provider
+
+When your workspace has a Mouser or DigiKey parts provider configured, the BOM tab shows **Import all unmatched from provider** when there are unmatched rows.
+
+1. Click **Import all unmatched from provider** to import every unmatched row, or click **Import from provider** on one row.
+2. The app looks up each row's MPN with the configured provider.
+3. Rows with a single match create a linked library part with provider specs and media, then the BOM row becomes matched.
+4. Rows with more than one manufacturer choice open a picker. Select the right manufacturer and click **Import selected**.
+5. Rows the provider cannot resolve remain unmatched. The failure panel lists the MPN and reason.
+
+This provider flow does not create stub parts. Failed lookups stay on the BOM so you can retry later or match them by hand.
 
 ## Use meta-parts for "any 10k 0402 1%"
 

--- a/web/src/lib/providerCatalog.ts
+++ b/web/src/lib/providerCatalog.ts
@@ -40,7 +40,7 @@ const CATALOG_REGEX_KEYS: RegExp[] = [
   /^Unit price \(\d+\+\)$/,
 ];
 
-const RESERVED_KEYS = new Set<string>(["image_url", "datasheet_url"]);
+const RESERVED_KEYS = new Set<string>(["image_url", "datasheet_url", "source_url"]);
 
 export function isReservedKey(key: string): boolean {
   return RESERVED_KEYS.has(key);

--- a/web/src/routes/projects/detail/BomProviderAmbiguityModal.tsx
+++ b/web/src/routes/projects/detail/BomProviderAmbiguityModal.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useMemo, useState } from "react";
+
+export type BomProviderCandidate = {
+  manufacturer: string;
+  mpn: string | null;
+  description: string | null;
+  source_url: string | null;
+  image_url: string | null;
+};
+
+export type BomProviderPendingChoice = {
+  entry_id: string;
+  mpn: string;
+  candidates: BomProviderCandidate[];
+};
+
+type Props = {
+  open: boolean;
+  choices: BomProviderPendingChoice[];
+  busy?: boolean;
+  onClose: () => void;
+  onConfirm: (choices: Record<string, string>) => void;
+};
+
+export default function BomProviderAmbiguityModal({ open, choices, busy = false, onClose, onConfirm }: Props) {
+  const initial = useMemo(() => {
+    const next: Record<string, string> = {};
+    for (const choice of choices) {
+      const first = choice.candidates[0]?.manufacturer;
+      if (first) next[choice.entry_id] = first;
+    }
+    return next;
+  }, [choices]);
+  const [selected, setSelected] = useState<Record<string, string>>(initial);
+
+  useEffect(() => {
+    if (open) setSelected(initial);
+  }, [initial, open]);
+
+  if (!open) return null;
+
+  const canSubmit = choices.every(choice => selected[choice.entry_id]);
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <div role="dialog" aria-modal="true" aria-labelledby="bom-provider-ambiguity-title" className="w-full max-w-3xl rounded-md border border-border bg-panel p-4 shadow-xl">
+        <div className="mb-3 flex items-start justify-between gap-3">
+          <h2 id="bom-provider-ambiguity-title" className="text-lg font-semibold">Choose manufacturers</h2>
+          <button type="button" className="btn" onClick={onClose} disabled={busy}>Close</button>
+        </div>
+        <div className="max-h-[60vh] space-y-3 overflow-y-auto pr-1">
+          {choices.map(choice => (
+            <section key={choice.entry_id} className="rounded-md border border-border p-3">
+              <div className="mb-2 font-mono text-sm">{choice.mpn}</div>
+              <div className="grid gap-2 sm:grid-cols-2">
+                {choice.candidates.map(candidate => {
+                  const id = `${choice.entry_id}-${candidate.manufacturer}`;
+                  return (
+                    <label key={id} htmlFor={id} className="flex cursor-pointer gap-2 rounded-md border border-border p-2 hover:border-accent">
+                      <input
+                        id={id}
+                        aria-label={candidate.manufacturer}
+                        type="radio"
+                        name={choice.entry_id}
+                        value={candidate.manufacturer}
+                        checked={selected[choice.entry_id] === candidate.manufacturer}
+                        onChange={() => setSelected(current => ({ ...current, [choice.entry_id]: candidate.manufacturer }))}
+                      />
+                      <span className="min-w-0">
+                        <span className="block font-medium">{candidate.manufacturer}</span>
+                        <span className="block truncate text-xs text-muted">{candidate.description || candidate.mpn || ""}</span>
+                      </span>
+                    </label>
+                  );
+                })}
+              </div>
+            </section>
+          ))}
+        </div>
+        <div className="mt-4 flex justify-end gap-2">
+          <button type="button" className="btn" onClick={onClose} disabled={busy}>Cancel</button>
+          <button
+            type="button"
+            className="btn-primary"
+            disabled={busy || !canSubmit}
+            onClick={() => onConfirm(selected)}
+          >
+            {busy ? "Importing..." : "Import selected"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/routes/projects/detail/BomProviderFailuresPanel.tsx
+++ b/web/src/routes/projects/detail/BomProviderFailuresPanel.tsx
@@ -1,0 +1,45 @@
+import { X } from "lucide-react";
+
+export type BomProviderFailure = {
+  entry_id: string;
+  mpn: string;
+  reason: string;
+};
+
+type Props = {
+  failures: BomProviderFailure[];
+  onClose: () => void;
+};
+
+export default function BomProviderFailuresPanel({ failures, onClose }: Props) {
+  if (failures.length === 0) return null;
+
+  return (
+    <div className="rounded-md border border-danger/40 bg-danger/10 p-3">
+      <div className="mb-2 flex items-center justify-between gap-3">
+        <h3 className="text-sm font-semibold text-danger">Provider import failures</h3>
+        <button type="button" className="btn p-1" onClick={onClose} aria-label="Clear provider import failures">
+          <X size={15} />
+        </button>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-left text-xs uppercase text-muted">
+              <th className="py-1 pr-3 font-medium">MPN</th>
+              <th className="py-1 font-medium">Reason</th>
+            </tr>
+          </thead>
+          <tbody>
+            {failures.map(failure => (
+              <tr key={failure.entry_id} className="border-t border-border/70 align-top">
+                <td className="py-1.5 pr-3 font-mono text-xs">{failure.mpn || "—"}</td>
+                <td className="py-1.5">{failure.reason}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/web/src/routes/projects/detail/ProjectBOM.tsx
+++ b/web/src/routes/projects/detail/ProjectBOM.tsx
@@ -1,8 +1,8 @@
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { FolderKanban, ImageOff, Trash2 } from "lucide-react";
+import { CloudDownload, FolderKanban, ImageOff, Loader2, Trash2 } from "lucide-react";
 import { toast } from "sonner";
-import { api } from "@/lib/api";
+import { api, ApiError } from "@/lib/api";
 import { useApiMutation } from "@/lib/mutations";
 import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
 import { useAuth } from "@/lib/auth";
@@ -12,7 +12,30 @@ import { DataTable } from "@/components/DataTable";
 import EmptyState from "@/components/EmptyState";
 import QueryStateBoundary from "@/components/QueryStateBoundary";
 import AddPartFromLibraryModal from "./AddPartFromLibraryModal";
+import BomProviderAmbiguityModal, { type BomProviderPendingChoice } from "./BomProviderAmbiguityModal";
+import BomProviderFailuresPanel, { type BomProviderFailure } from "./BomProviderFailuresPanel";
 import { SourceBomButton } from "@/routes/projects/sourcing/SourceBomButton";
+
+type WorkspaceProviderSettings = {
+  parts_provider: "none" | "mouser" | "digikey";
+};
+
+type BomProviderImportOut = {
+  created: number;
+  pending_choices: BomProviderPendingChoice[];
+  failures: BomProviderFailure[];
+  provider: WorkspaceProviderSettings["parts_provider"];
+};
+
+type BomProviderImportPayload = {
+  entry_ids: string[] | null;
+};
+
+const PROVIDER_LABEL: Record<string, string> = {
+  none: "provider",
+  mouser: "Mouser",
+  digikey: "DigiKey",
+};
 
 export default function ProjectBOM() {
   const { projectId } = useParams();
@@ -25,10 +48,20 @@ export default function ProjectBOM() {
   });
   const { data: entries } = entriesQuery;
   const { data: parts } = useQuery({ queryKey: useWsKey("parts"), queryFn: () => api.get<Part[]>("/parts?limit=200") });
+  const { data: workspace } = useQuery({
+    queryKey: useWsKey("ws", "current"),
+    queryFn: () => api.get<WorkspaceProviderSettings>("/workspaces/current"),
+  });
   const partsById = new Map(parts?.map(p => [p.id, p]) ?? []);
 
   const [matching, setMatching] = useState<{ entryId: string; pick: string } | null>(null);
   const [addPartOpen, setAddPartOpen] = useState(false);
+  const [pendingChoices, setPendingChoices] = useState<BomProviderPendingChoice[]>([]);
+  const [failures, setFailures] = useState<BomProviderFailure[]>([]);
+
+  const provider = workspace?.parts_provider ?? "none";
+  const providerLabel = PROVIDER_LABEL[provider] ?? provider;
+  const unmatchedEntries = (entries ?? []).filter(entry => entry.entry_type === "unmatched" && !entry.part_id);
 
   const bulkDeleteMutation = useApiMutation<null[], string[]>({
     mutationKey: ["project", projectId, "bulk-delete-entries"],
@@ -42,6 +75,41 @@ export default function ProjectBOM() {
     onSuccess: (_res, entryIds) => {
       qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "project", projectId, "entries") });
       toast.success(`Deleted ${entryIds.length} BOM row${entryIds.length === 1 ? "" : "s"}.`);
+    },
+  });
+
+  function handleProviderResult(result: BomProviderImportOut) {
+    if (result.created > 0) {
+      qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "project", projectId, "entries") });
+      qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "parts") });
+      toast.success(`Created ${result.created} part${result.created === 1 ? "" : "s"} from ${PROVIDER_LABEL[result.provider] ?? result.provider}.`);
+    }
+    if (result.pending_choices.length > 0) {
+      setPendingChoices(result.pending_choices);
+    }
+    if (result.failures.length > 0) {
+      setFailures(result.failures);
+    }
+  }
+
+  const importProviderMutation = useApiMutation<BomProviderImportOut, BomProviderImportPayload>({
+    mutationKey: ["project", projectId, "bom-import-provider"],
+    mutationFn: payload => api.post<BomProviderImportOut, BomProviderImportPayload>(`/projects/${projectId}/bom/import-from-provider`, payload),
+    onSuccess: handleProviderResult,
+    onError: error => {
+      toast.error(error instanceof ApiError ? error.userMessage : "Provider import failed");
+    },
+  });
+
+  const commitChoicesMutation = useApiMutation<BomProviderImportOut, { choices: Record<string, string> }>({
+    mutationKey: ["project", projectId, "bom-import-provider-choices"],
+    mutationFn: payload => api.post<BomProviderImportOut, { choices: Record<string, string> }>(`/projects/${projectId}/bom/import-from-provider/commit-choices`, payload),
+    onSuccess: result => {
+      setPendingChoices([]);
+      handleProviderResult(result);
+    },
+    onError: error => {
+      toast.error(error instanceof ApiError ? error.userMessage : "Provider import failed");
     },
   });
 
@@ -60,6 +128,17 @@ export default function ProjectBOM() {
     <div className="space-y-3">
       <div className="flex flex-wrap items-center justify-end gap-2">
         <SourceBomButton projectId={projectId} className="btn" />
+        {projectId && provider !== "none" && unmatchedEntries.length > 0 && (
+          <button
+            type="button"
+            className="btn inline-flex items-center gap-1.5"
+            disabled={importProviderMutation.isPending}
+            onClick={() => importProviderMutation.mutate({ entry_ids: null })}
+          >
+            {importProviderMutation.isPending ? <Loader2 size={14} className="animate-spin" /> : <CloudDownload size={14} />}
+            Import all unmatched from {providerLabel}
+          </button>
+        )}
         {projectId && (
           <Link className="btn" to={`/projects/${projectId}/import`}>
             Import BOM
@@ -151,6 +230,18 @@ export default function ProjectBOM() {
                     <span className="pill bg-danger/20 text-danger mr-2">unmatched</span>
                     <span>{r.name || ""}</span>
                     <button className="btn ml-2 text-xs" onClick={() => setMatching({ entryId: r.id, pick: "" })}>Match…</button>
+                    {provider !== "none" && (
+                      <button
+                        className="btn ml-2 text-xs"
+                        disabled={importProviderMutation.isPending}
+                        onClick={event => {
+                          event.stopPropagation();
+                          importProviderMutation.mutate({ entry_ids: [r.id] });
+                        }}
+                      >
+                        Import from provider
+                      </button>
+                    )}
                   </span>
                 )
               ) : (
@@ -198,6 +289,14 @@ export default function ProjectBOM() {
           onClose={() => setAddPartOpen(false)}
         />
       )}
+      <BomProviderAmbiguityModal
+        open={pendingChoices.length > 0}
+        choices={pendingChoices}
+        busy={commitChoicesMutation.isPending}
+        onClose={() => setPendingChoices([])}
+        onConfirm={choices => commitChoicesMutation.mutate({ choices })}
+      />
+      <BomProviderFailuresPanel failures={failures} onClose={() => setFailures([])} />
     </div>
   );
 }

--- a/web/src/routes/projects/detail/__tests__/BomProviderAmbiguityModal.test.tsx
+++ b/web/src/routes/projects/detail/__tests__/BomProviderAmbiguityModal.test.tsx
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import BomProviderAmbiguityModal from "../BomProviderAmbiguityModal";
+
+beforeEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("BomProviderAmbiguityModal", () => {
+  it("submits the selected manufacturer for each pending choice", async () => {
+    const onConfirm = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <BomProviderAmbiguityModal
+        open
+        busy={false}
+        onClose={vi.fn()}
+        onConfirm={onConfirm}
+        choices={[{
+          entry_id: "entry-1",
+          mpn: "AMB-1",
+          candidates: [
+            { manufacturer: "Alpha", mpn: "AMB-1", description: "Alpha part", source_url: null, image_url: null },
+            { manufacturer: "Beta", mpn: "AMB-1", description: "Beta part", source_url: null, image_url: null },
+          ],
+        }]}
+      />,
+    );
+
+    await user.click(screen.getByLabelText("Beta"));
+    await user.click(screen.getByRole("button", { name: "Import selected" }));
+
+    expect(onConfirm).toHaveBeenCalledWith({ "entry-1": "Beta" });
+  });
+});

--- a/web/src/routes/projects/detail/__tests__/ProjectBOM.test.tsx
+++ b/web/src/routes/projects/detail/__tests__/ProjectBOM.test.tsx
@@ -81,6 +81,23 @@ const parts = [
   part({ id: "part-2", name: "Regulator", mpn: "LM1117", manufacturer: "TI" }),
 ];
 
+type ImportResponse = {
+  created: number;
+  pending_choices: Array<{
+    entry_id: string;
+    mpn: string;
+    candidates: Array<{
+      manufacturer: string;
+      mpn: string | null;
+      description: string | null;
+      source_url: string | null;
+      image_url: string | null;
+    }>;
+  }>;
+  failures: Array<{ entry_id: string; mpn: string; reason: string }>;
+  provider: "none" | "mouser" | "digikey";
+};
+
 function renderPage() {
   const client = new QueryClient({
     defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
@@ -98,12 +115,20 @@ function renderPage() {
   );
 }
 
-function mockApi(entriesRef: { current: ProjectEntry[] }) {
+function mockApi(
+  entriesRef: { current: ProjectEntry[] },
+  options: {
+    partsProvider?: "none" | "mouser" | "digikey";
+    importResponse?: ImportResponse;
+    commitResponse?: ImportResponse;
+  } = {},
+) {
   vi.spyOn(api, "get").mockImplementation(async path => {
     if (path === `/projects/${projectId}/entries`) return entriesRef.current as never;
     if (path === "/parts?limit=200") return parts as never;
     if (path === "/workspaces/current") {
       return {
+        parts_provider: options.partsProvider ?? "none",
         sourcing_country_code: "US",
         sourcing_currency_code: "USD",
         sourcing_preferred_distributors: [],
@@ -116,6 +141,33 @@ function mockApi(entriesRef: { current: ProjectEntry[] }) {
     const id = String(path).split("/").pop();
     entriesRef.current = entriesRef.current.filter(entry => entry.id !== id);
     return null as never;
+  });
+  vi.spyOn(api, "post").mockImplementation(async (path, payload) => {
+    if (path === `/projects/${projectId}/bom/import-from-provider`) {
+      return (options.importResponse ?? {
+        created: 0,
+        pending_choices: [],
+        failures: [],
+        provider: options.partsProvider ?? "none",
+      }) as never;
+    }
+    if (path === `/projects/${projectId}/bom/import-from-provider/commit-choices`) {
+      return (options.commitResponse ?? {
+        created: 0,
+        pending_choices: [],
+        failures: [],
+        provider: options.partsProvider ?? "none",
+      }) as never;
+    }
+    if (String(path).includes("/match")) {
+      const entryId = String(path).split("/entries/")[1]?.split("/")[0];
+      const partId = (payload as { part_id?: string }).part_id;
+      entriesRef.current = entriesRef.current.map(entry =>
+        entry.id === entryId ? { ...entry, entry_type: "part", part_id: partId ?? null } : entry,
+      );
+      return {} as never;
+    }
+    throw new Error(`unexpected POST ${path}`);
   });
 }
 
@@ -195,6 +247,102 @@ describe("ProjectBOM", () => {
     await waitFor(() => {
       expect(screen.queryByText("STM32")).toBeNull();
       expect(screen.queryByText("Regulator")).toBeNull();
+    });
+  });
+
+  it("bulk button hidden when no provider configured", async () => {
+    mockApi({
+      current: [
+        bomEntry({ id: "entry-unmatched", entry_type: "unmatched", part_id: null, name: "RC0402" }),
+      ],
+    });
+
+    renderPage();
+
+    expect(await screen.findByText("RC0402")).toBeDefined();
+    expect(screen.queryByRole("button", { name: /Import all unmatched from/ })).toBeNull();
+  });
+
+  it("bulk button hidden when no unmatched rows", async () => {
+    mockApi({ current: [bomEntry({})] }, { partsProvider: "mouser" });
+
+    renderPage();
+
+    expect(await screen.findByText("STM32")).toBeDefined();
+    expect(screen.queryByRole("button", { name: /Import all unmatched from/ })).toBeNull();
+  });
+
+  it("failures panel renders MPN + reason for each failure", async () => {
+    mockApi(
+      {
+        current: [
+          bomEntry({ id: "entry-unmatched", entry_type: "unmatched", part_id: null, name: "NOPE" }),
+        ],
+      },
+      {
+        partsProvider: "mouser",
+        importResponse: {
+          created: 0,
+          pending_choices: [],
+          failures: [{ entry_id: "entry-unmatched", mpn: "NOPE", reason: "no match for MPN" }],
+          provider: "mouser",
+        },
+      },
+    );
+    const user = userEvent.setup();
+
+    renderPage();
+
+    await user.click(await screen.findByRole("button", { name: "Import all unmatched from Mouser" }));
+    expect(await screen.findByText("Provider import failures")).toBeDefined();
+    expect(screen.getAllByText("NOPE").length).toBeGreaterThan(0);
+    expect(screen.getByText("no match for MPN")).toBeDefined();
+  });
+
+  it("ambiguity modal opens with candidates and posts commit-choices on confirm", async () => {
+    mockApi(
+      {
+        current: [
+          bomEntry({ id: "entry-unmatched", entry_type: "unmatched", part_id: null, name: "AMB-1" }),
+        ],
+      },
+      {
+        partsProvider: "mouser",
+        importResponse: {
+          created: 0,
+          pending_choices: [{
+            entry_id: "entry-unmatched",
+            mpn: "AMB-1",
+            candidates: [
+              { manufacturer: "Alpha", mpn: "AMB-1", description: "Alpha part", source_url: null, image_url: null },
+              { manufacturer: "Beta", mpn: "AMB-1", description: "Beta part", source_url: null, image_url: null },
+            ],
+          }],
+          failures: [],
+          provider: "mouser",
+        },
+        commitResponse: {
+          created: 1,
+          pending_choices: [],
+          failures: [],
+          provider: "mouser",
+        },
+      },
+    );
+    const user = userEvent.setup();
+
+    renderPage();
+
+    await user.click(await screen.findByRole("button", { name: "Import all unmatched from Mouser" }));
+    expect(await screen.findByRole("dialog", { name: "Choose manufacturers" })).toBeDefined();
+    await user.click(screen.getByLabelText("Beta"));
+    await user.click(screen.getByRole("button", { name: "Import selected" }));
+
+    await waitFor(() => {
+      expect(api.post).toHaveBeenCalledWith(
+        `/projects/${projectId}/bom/import-from-provider/commit-choices`,
+        { choices: { "entry-unmatched": "Beta" } },
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary
- Adds provider-backed BOM import endpoints for unmatched rows, with per-row savepoints, failure summaries, pending manufacturer choices, and no stub fallback.
- Extracts shared provider-backed Part creation so BOM import and scan import use the same linked Part/spec/media persistence path.
- Extends the BOM card with bulk/per-row import actions, ambiguity resolution modal, and failure panel, plus focused backend/frontend tests and docs.

## Merge Order
#424 before this PR (#409).

This PR is stacked on `codex/fb-001-408-bom-card` because it overlaps #424's Project BOM card/table flow (`ProjectBOM.tsx` and its tests). Merge #424 first, then this PR.

## Validation
Passed:
- `python3 -m compileall -q backend/app/domain/parts/providers/base.py backend/app/domain/parts/providers/mouser.py backend/app/domain/parts/services/provider_import.py backend/app/domain/projects/bom_import_provider.py backend/app/api/routes/projects.py backend/app/api/routes/parts_scan.py`
- `ruff check backend/app/domain/parts/providers/base.py backend/app/domain/parts/providers/mouser.py backend/app/domain/parts/services/provider_import.py backend/app/domain/projects/bom_import_provider.py backend/tests/test_bom_import_provider.py`
- `cd web && npm run typecheck`
- `cd web && npm test -- src/routes/projects/detail/__tests__/ProjectBOM.test.tsx src/routes/projects/detail/__tests__/BomProviderAmbiguityModal.test.tsx` (2 files, 9 tests)
- `cd web && npx eslint src/routes/projects/detail/ProjectBOM.tsx src/routes/projects/detail/BomProviderAmbiguityModal.tsx src/routes/projects/detail/BomProviderFailuresPanel.tsx src/routes/projects/detail/__tests__/ProjectBOM.test.tsx src/routes/projects/detail/__tests__/BomProviderAmbiguityModal.test.tsx src/lib/providerCatalog.ts`
- `git diff --check`

Attempted but not green in this environment:
- `docker compose -f docker-compose.dev.yml exec backend pytest -k "bom_import_provider or workspace_isolation"` failed: `docker: command not found`.
- `docker compose -f docker-compose.dev.yml exec backend ruff check` failed: `docker: command not found`.
- `cd backend && python3 -m pytest -k "bom_import_provider or workspace_isolation"` failed before tests: `ImportError: cannot import name 'command' from 'alembic'` in local Python env.
- `cd web && npm run typecheck && npm test -- "ProjectBOM|BomProviderAmbiguityModal" && npm run lint` ran typecheck, then Vitest exited with `No test files found` for that exact filter, so lint did not run in the chain.
- `cd web && npm run lint` failed on pre-existing baseline issues in `ZxingScanner.tsx`, `bagCode.ts`, `responsive-grids.test.ts`, `OrderDetail.tsx`, `PartsList.tsx`, `PartLayout.navigation.dom.test.tsx`, and `StorageDetail.tsx`.
- `cd backend && ruff check` failed on existing repository-wide lint baseline issues.

No-stub assertion line: `assert part["linked_provider"] != "none"` in `backend/tests/test_bom_import_provider.py`.

## Screenshots
Not captured: this environment does not have Docker or a seeded/authenticated running app session for the Project BOM route.

## Residual Risks
- Backend integration tests need to run in the normal Docker dev environment/CI because this machine lacks Docker and a working backend dependency environment.
- Mouser ambiguity now surfaces exact-MPN multi-manufacturer candidates; DigiKey's exact product lookup remains single-record unless the provider API itself returns alternate candidate data later.

Closes #409
Refs #407
