### PR TITLE
FB-004: Workspace-currency display + ECB FX conversion

### DIFF
--- a/backend/alembic/versions/0043_fx_rate_snapshots.py
+++ b/backend/alembic/versions/0043_fx_rate_snapshots.py
@@ -1,0 +1,47 @@
+"""Add global ECB FX rate snapshots.
+
+Revision ID: 0043
+Revises: 0042
+Create Date: 2026-05-10
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+from alembic import op
+
+revision = "0043"
+down_revision = "0042"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Global public reference data: intentionally no workspace_id column.
+    op.create_table(
+        "fx_rate_snapshots",
+        sa.Column(
+            "id",
+            UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("fetched_date", sa.Date(), nullable=False),
+        sa.Column("rates", JSONB, nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.UniqueConstraint(
+            "fetched_date",
+            name="uq_fx_rate_snapshots_fetched_date",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("fx_rate_snapshots")

--- a/backend/app/api/routes/sourcing.py
+++ b/backend/app/api/routes/sourcing.py
@@ -1,6 +1,7 @@
 """Sourcing provider endpoints."""
 from __future__ import annotations
 
+from decimal import Decimal
 from time import perf_counter
 from uuid import UUID
 
@@ -13,6 +14,7 @@ from app.core.deps import CurrentUser, CurrentWorkspace, require_role
 from app.core.ratelimit import limiter, workspace_key
 from app.core.responses import err, ok
 from app.core.time import utcnow
+from app.domain.fx import rates as fx_rates
 from app.domain.parts.models import Part
 from app.domain.projects.models import Project
 from app.domain.sourcing import (
@@ -28,6 +30,7 @@ from app.domain.sourcing.schemas import (
     PurchasePlanIn,
     PurchasePlanOrdersIn,
     SourcingBomIn,
+    SourcingConvertedPriceBreak,
     SourcingQuery,
     SourcingSearchIn,
 )
@@ -41,6 +44,13 @@ projects_router = APIRouter()
 
 _TEST_PROBE_TOKEN = "TEST_PROBE_DO_NOT_BUY"
 _PART_SOURCING_TTL_SECONDS = 1800
+
+
+def _clean_currency(value: str | None) -> str | None:
+    if value is None:
+        return None
+    cleaned = value.strip().upper()
+    return cleaned or None
 
 
 def _elapsed_ms(started_at: float) -> int:
@@ -430,19 +440,7 @@ def get_part_sourcing(
             "TrustedParts sourcing request failed",
         )
 
-    result = out.results[0]
-    return ok(
-        {
-            "mpn": result.mpn,
-            "offers": [offer.model_dump(mode="json") for offer in result.offers],
-            "request_id": result.request_id,
-            "powered_by": out.powered_by,
-            "fetched_at": result.fetched_at.isoformat(),
-            "cache_hit": result.cache_hit,
-            "links": out.links.model_dump(mode="json"),
-            "reason": "ok",
-        }
-    )
+    return ok(_part_sourcing_payload(out, db=db, requested_currency=currency))
 
 
 @parts_router.post(
@@ -508,8 +506,18 @@ def refresh_part_sourcing(
     return ok(_part_sourcing_payload(out))
 
 
-def _part_sourcing_payload(out):
+def _part_sourcing_payload(
+    out,
+    *,
+    db: Session | None = None,
+    requested_currency: str | None = None,
+):
     result = out.results[0]
+    fx_status = _apply_fx_conversion(
+        db,
+        result.offers,
+        requested_currency=_clean_currency(requested_currency),
+    )
     return {
         "mpn": result.mpn,
         "offers": [offer.model_dump(mode="json") for offer in result.offers],
@@ -519,7 +527,91 @@ def _part_sourcing_payload(out):
         "cache_hit": result.cache_hit,
         "links": out.links.model_dump(mode="json"),
         "reason": "ok",
+        "fx_status": fx_status,
     }
+
+
+def _apply_fx_conversion(
+    db: Session | None,
+    offers,
+    *,
+    requested_currency: str | None,
+) -> str | None:
+    if db is None or requested_currency is None:
+        return None
+
+    rates: dict[str, Decimal] | None = None
+    rate_date = utcnow().date()
+    fx_status: str | None = None
+    fetch_failed = False
+
+    for offer in offers:
+        for distributor in offer.distributors:
+            original_currency = _clean_currency(distributor.currency)
+            if original_currency is None:
+                continue
+            distributor.currency_displayed = distributor.currency
+            if original_currency == requested_currency:
+                distributor.currency_displayed = requested_currency
+                continue
+            if distributor.unit_price is None:
+                continue
+            if fetch_failed:
+                fx_status = "unavailable"
+                distributor.fx_converted = None
+                continue
+            if rates is None:
+                try:
+                    rates = fx_rates.get_or_fetch_today(db, on_date=rate_date)
+                except fx_rates.FxRateError:
+                    fetch_failed = True
+                    fx_status = "unavailable"
+                    distributor.fx_converted = None
+                    continue
+
+            converted = fx_rates.convert(
+                Decimal(str(distributor.unit_price)),
+                from_currency=original_currency,
+                to_currency=requested_currency,
+                rates=rates,
+                on_date=rate_date,
+            )
+            if converted is None:
+                fx_status = "unavailable"
+                distributor.fx_converted = None
+                continue
+
+            converted_breaks: list[SourcingConvertedPriceBreak] = []
+            missing_break = False
+            for price_break in distributor.price_breaks:
+                converted_break = fx_rates.convert(
+                    Decimal(str(price_break.unit_price)),
+                    from_currency=original_currency,
+                    to_currency=requested_currency,
+                    rates=rates,
+                    on_date=rate_date,
+                )
+                if converted_break is None:
+                    missing_break = True
+                    break
+                converted_breaks.append(
+                    SourcingConvertedPriceBreak(
+                        quantity=price_break.quantity,
+                        unit_price=converted_break,
+                    )
+                )
+            if missing_break:
+                fx_status = "unavailable"
+                distributor.fx_converted = None
+                continue
+
+            distributor.unit_price_converted = converted
+            distributor.currency_displayed = requested_currency
+            distributor.fx_converted = True
+            distributor.fx_rate_date = rate_date
+            distributor.price_breaks_converted = converted_breaks
+
+    return fx_status
 
 
 def _clean_query_distributors(value: list[str] | None) -> list[str] | None:

--- a/backend/app/domain/all_models.py
+++ b/backend/app/domain/all_models.py
@@ -27,6 +27,7 @@ from app.domain.attachments.models import Attachment  # noqa: F401
 from app.domain.audit.models import AuditLog  # noqa: F401
 from app.domain.builds.models import Build  # noqa: F401
 from app.domain.custom_fields.models import CustomField  # noqa: F401
+from app.domain.fx.models import FxRateSnapshot  # noqa: F401
 from app.domain.lots.models import Lot  # noqa: F401
 from app.domain.orders.models import Order, OrderEntry  # noqa: F401
 from app.domain.parts.models import (  # noqa: F401

--- a/backend/app/domain/fx/README.md
+++ b/backend/app/domain/fx/README.md
@@ -1,0 +1,7 @@
+# FX
+
+ECB daily reference-rate snapshots for display-only currency conversion.
+
+- `models.py` owns the global `fx_rate_snapshots` table.
+- `rates.py` fetches the ECB daily XML, caches one JSONB snapshot per UTC date, and converts through EUR cross-rates.
+- Snapshots are not workspace-owned because ECB rates are public reference data; see `docs/domain/sourcing.md`.

--- a/backend/app/domain/fx/__init__.py
+++ b/backend/app/domain/fx/__init__.py
@@ -1,0 +1,2 @@
+"""ECB daily FX rate helpers."""
+

--- a/backend/app/domain/fx/models.py
+++ b/backend/app/domain/fx/models.py
@@ -1,0 +1,41 @@
+"""Global FX reference-rate snapshots."""
+
+from __future__ import annotations
+
+import uuid
+
+import sqlalchemy as sa
+from sqlalchemy import Column, Date, DateTime
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+from app.core.time import utcnow
+from app.infra.db import Base
+
+
+class FxRateSnapshot(Base):
+    """One ECB daily reference-rate snapshot per UTC date.
+
+    ECB reference rates are public global data, so this table deliberately
+    does not carry workspace_id.
+    """
+
+    __tablename__ = "fx_rate_snapshots"
+    __table_args__ = (
+        sa.UniqueConstraint("fetched_date", name="uq_fx_rate_snapshots_fetched_date"),
+    )
+
+    id = Column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+        server_default=sa.text("gen_random_uuid()"),
+    )
+    fetched_date = Column(Date, nullable=False)
+    rates = Column(JSONB, nullable=False)
+    created_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=utcnow,
+        server_default=sa.func.now(),
+    )
+

--- a/backend/app/domain/fx/rates.py
+++ b/backend/app/domain/fx/rates.py
@@ -1,0 +1,140 @@
+"""ECB daily FX rate fetch and conversion helpers."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import ROUND_HALF_UP, Decimal, InvalidOperation
+from typing import Mapping
+from xml.etree import ElementTree
+
+import httpx
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.core.time import utcnow
+from app.domain.fx.models import FxRateSnapshot
+
+ECB_DAILY_RATES_URL = "https://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml"
+ECB_TIMEOUT_SECONDS = 8.0
+EUR = "EUR"
+MIN_QUANT = Decimal("0.0001")
+
+
+class FxRateError(Exception):
+    """Base error for ECB reference-rate failures."""
+
+
+class FxRateFetchError(FxRateError):
+    """ECB daily XML could not be fetched."""
+
+
+class FxRateParseError(FxRateError):
+    """ECB daily XML could not be parsed into rates."""
+
+
+def _get_ecb_daily_xml() -> str:
+    """Network seam for tests."""
+    try:
+        with httpx.Client(timeout=ECB_TIMEOUT_SECONDS) as client:
+            response = client.get(ECB_DAILY_RATES_URL)
+            response.raise_for_status()
+    except httpx.HTTPError as exc:
+        raise FxRateFetchError("ECB daily rates fetch failed") from exc
+    return response.text
+
+
+def fetch_ecb_daily_rates() -> dict[str, Decimal]:
+    """Fetch and parse today's ECB daily reference rates.
+
+    The returned rates are base-EUR: 1 EUR equals ``rates[code]`` units of
+    that currency. EUR is always included as ``Decimal("1")``.
+    """
+    xml_text = _get_ecb_daily_xml()
+    try:
+        root = ElementTree.fromstring(xml_text)
+    except ElementTree.ParseError as exc:
+        raise FxRateParseError("ECB daily rates XML is invalid") from exc
+
+    rates: dict[str, Decimal] = {EUR: Decimal("1")}
+    for element in root.iter():
+        currency = element.attrib.get("currency")
+        raw_rate = element.attrib.get("rate")
+        if not currency or not raw_rate:
+            continue
+        code = currency.strip().upper()
+        try:
+            rates[code] = Decimal(raw_rate)
+        except InvalidOperation as exc:
+            raise FxRateParseError(f"ECB daily rate for {code} is invalid") from exc
+
+    if len(rates) == 1:
+        raise FxRateParseError("ECB daily rates XML contained no currency rates")
+    return rates
+
+
+def get_or_fetch_today(db: Session, *, on_date: date | None = None) -> dict[str, Decimal]:
+    """Return the cached ECB snapshot for one UTC date, fetching on miss."""
+    fetched_date = on_date or utcnow().date()
+    existing = db.execute(
+        select(FxRateSnapshot).where(FxRateSnapshot.fetched_date == fetched_date)
+    ).scalar_one_or_none()
+    if existing is not None:
+        return _deserialize_rates(existing.rates)
+
+    rates = fetch_ecb_daily_rates()
+    db.add(
+        FxRateSnapshot(
+            fetched_date=fetched_date,
+            rates={code: str(rate) for code, rate in rates.items()},
+        )
+    )
+    db.flush()
+    return rates
+
+
+def convert(
+    amount: Decimal,
+    *,
+    from_currency: str,
+    to_currency: str,
+    rates: Mapping[str, Decimal | str],
+    on_date: date | None = None,
+) -> Decimal | None:
+    """Convert ``amount`` across ECB base-EUR rates.
+
+    ``on_date`` is accepted for call-site readability; the caller supplies the
+    already-selected snapshot through ``rates``.
+    """
+    del on_date
+    source = from_currency.strip().upper()
+    target = to_currency.strip().upper()
+    if not source or not target:
+        return None
+
+    normalized = _deserialize_rates(rates)
+    source_rate = _rate_for(normalized, source)
+    target_rate = _rate_for(normalized, target)
+    if source_rate is None or target_rate is None:
+        return None
+
+    converted = (amount / source_rate) * target_rate
+    return converted.quantize(MIN_QUANT, rounding=ROUND_HALF_UP)
+
+
+def _rate_for(rates: Mapping[str, Decimal], currency: str) -> Decimal | None:
+    if currency == EUR:
+        return Decimal("1")
+    return rates.get(currency)
+
+
+def _deserialize_rates(raw_rates: Mapping[str, Decimal | str]) -> dict[str, Decimal]:
+    rates: dict[str, Decimal] = {}
+    for currency, raw_rate in raw_rates.items():
+        code = currency.strip().upper()
+        try:
+            rates[code] = raw_rate if isinstance(raw_rate, Decimal) else Decimal(str(raw_rate))
+        except InvalidOperation as exc:
+            raise FxRateParseError(f"cached ECB daily rate for {code} is invalid") from exc
+    rates.setdefault(EUR, Decimal("1"))
+    return rates
+

--- a/backend/app/domain/sourcing/schemas.py
+++ b/backend/app/domain/sourcing/schemas.py
@@ -1,7 +1,7 @@
 """Pydantic DTOs for TrustedParts sourcing."""
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime
 from decimal import Decimal
 from typing import Literal
 from uuid import UUID
@@ -23,6 +23,13 @@ class SourcingPriceBreak(BaseModel):
     unit_price: float
 
 
+class SourcingConvertedPriceBreak(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    quantity: int
+    unit_price: Decimal
+
+
 class SourcingBomPriceBreakOut(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -41,7 +48,12 @@ class SourcingDistributor(BaseModel):
     stock: int | None = None
     unit_price: float | None = None
     currency: str | None = None
+    unit_price_converted: Decimal | None = None
+    currency_displayed: str | None = None
+    fx_converted: bool | None = None
+    fx_rate_date: date | None = None
     price_breaks: list[SourcingPriceBreak] = Field(default_factory=list)
+    price_breaks_converted: list[SourcingConvertedPriceBreak] | None = None
     product_url: str | None = None
 
 

--- a/backend/tests/test_fx_rates.py
+++ b/backend/tests/test_fx_rates.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import inspect
+from sqlalchemy.exc import IntegrityError
+
+from app.domain.fx import rates as fx_rates
+from app.domain.fx.models import FxRateSnapshot
+
+ECB_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<gesmes:Envelope xmlns:gesmes="http://www.gesmes.org/xml/2002-08-01"
+    xmlns="http://www.ecb.int/vocabulary/2002-08-01/eurofxref">
+  <Cube>
+    <Cube time="2026-05-08">
+      <Cube currency="USD" rate="1.25"/>
+      <Cube currency="CZK" rate="25.00"/>
+    </Cube>
+  </Cube>
+</gesmes:Envelope>
+"""
+
+
+def test_fetch_ecb_daily_rates_parses_xml(monkeypatch):
+    monkeypatch.setattr(fx_rates, "_get_ecb_daily_xml", lambda: ECB_XML)
+
+    parsed = fx_rates.fetch_ecb_daily_rates()
+
+    assert parsed == {
+        "EUR": Decimal("1"),
+        "USD": Decimal("1.25"),
+        "CZK": Decimal("25.00"),
+    }
+
+
+def test_get_or_fetch_today_caches_per_date(db, monkeypatch):
+    calls = 0
+
+    def fake_fetch():
+        nonlocal calls
+        calls += 1
+        return {"EUR": Decimal("1"), "USD": Decimal("1.25")}
+
+    monkeypatch.setattr(fx_rates, "fetch_ecb_daily_rates", fake_fetch)
+
+    first = fx_rates.get_or_fetch_today(db, on_date=date(2026, 5, 8))
+    second = fx_rates.get_or_fetch_today(db, on_date=date(2026, 5, 8))
+
+    assert first == second
+    assert calls == 1
+
+
+def test_convert_uses_eur_cross_rate():
+    converted = fx_rates.convert(
+        Decimal("100"),
+        from_currency="USD",
+        to_currency="CZK",
+        rates={
+            "EUR": Decimal("1"),
+            "USD": Decimal("1.25"),
+            "CZK": Decimal("25"),
+        },
+    )
+
+    assert converted == Decimal("2000.0000")
+
+
+def test_convert_returns_none_for_unknown_currency():
+    converted = fx_rates.convert(
+        Decimal("100"),
+        from_currency="USD",
+        to_currency="GBP",
+        rates={"EUR": Decimal("1"), "USD": Decimal("1.25")},
+    )
+
+    assert converted is None
+
+
+def test_no_workspace_id_column_on_fx_table(engine):
+    columns = inspect(engine).get_columns("fx_rate_snapshots")
+
+    assert "workspace_id" not in {column["name"] for column in columns}
+
+
+def test_unique_constraint_on_fetched_date(db):
+    db.add(
+        FxRateSnapshot(
+            fetched_date=date(2026, 5, 8),
+            rates={"EUR": "1", "USD": "1.25"},
+        )
+    )
+    db.flush()
+    db.add(
+        FxRateSnapshot(
+            fetched_date=date(2026, 5, 8),
+            rates={"EUR": "1", "USD": "1.25"},
+        )
+    )
+
+    with pytest.raises(IntegrityError):
+        db.flush()
+    db.rollback()
+

--- a/backend/tests/test_sourcing_part_route.py
+++ b/backend/tests/test_sourcing_part_route.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import uuid
-from datetime import datetime
+from datetime import date, datetime
+from decimal import Decimal
 
 import pytest
 from fastapi.testclient import TestClient
@@ -12,6 +13,7 @@ from app.domain.sourcing.schemas import (
     SourcingDistributor,
     SourcingLinks,
     SourcingOffer,
+    SourcingPriceBreak,
     SourcingQuery,
     SourcingSearchRaw,
 )
@@ -19,7 +21,12 @@ from app.main import app
 from tests._factories import create_part, signup_user
 
 
-def _configure_sourcing(client: TestClient, *, use_cached: bool = False) -> None:
+def _configure_sourcing(
+    client: TestClient,
+    *,
+    use_cached: bool = False,
+    currency_code: str | None = "EUR",
+) -> None:
     r = client.patch(
         "/api/workspaces/current",
         json={
@@ -27,7 +34,7 @@ def _configure_sourcing(client: TestClient, *, use_cached: bool = False) -> None
             "sourcing_company_id": "company-123",
             "sourcing_api_key": "api-key-456",
             "sourcing_country_code": "CZ",
-            "sourcing_currency_code": "EUR",
+            "sourcing_currency_code": currency_code,
             "sourcing_preferred_distributors": ["DigiKey"],
             "sourcing_use_cached_for_dashboards": use_cached,
         },
@@ -43,6 +50,9 @@ def _current_workspace_id(client: TestClient) -> str:
 
 class _FakeTrustedPartsClient:
     calls: list[dict] = []
+    returned_currency: str | None = None
+    unit_price: float = 1.23
+    price_breaks: list[SourcingPriceBreak] = []
 
     def __init__(self) -> None:
         self.country_code = "CZ"
@@ -68,6 +78,7 @@ class _FakeTrustedPartsClient:
                 "use_cached_data": use_cached_data,
             }
         )
+        returned_currency = self.returned_currency or self.currency_code
         return SourcingSearchRaw(
             offers=[
                 SourcingOffer(
@@ -79,8 +90,9 @@ class _FakeTrustedPartsClient:
                             name="DigiKey",
                             sku=f"{query.search_token}-DK",
                             stock=42,
-                            unit_price=1.23,
-                            currency=self.currency_code,
+                            unit_price=self.unit_price,
+                            currency=returned_currency,
+                            price_breaks=self.price_breaks,
                             product_url="https://www.trustedparts.com/product",
                         )
                     ],
@@ -98,6 +110,9 @@ def reset_sourcing_state(monkeypatch):
     original_limiter_enabled = _ratelimit_mod.limiter.enabled
     _ratelimit_mod.limiter.enabled = False
     _FakeTrustedPartsClient.calls = []
+    _FakeTrustedPartsClient.returned_currency = None
+    _FakeTrustedPartsClient.unit_price = 1.23
+    _FakeTrustedPartsClient.price_breaks = []
     BUDGET._events.clear()
     try:
         _ratelimit_mod.limiter.reset()
@@ -268,3 +283,76 @@ def test_workspace_isolation_two_parts_same_mpn(authed_client):
     assert first.json()["data"]["cache_hit"] is False
     assert second.json()["data"]["cache_hit"] is False
     assert len(_FakeTrustedPartsClient.calls) == 2
+
+
+def test_sourcing_response_converts_when_distributor_returns_different_currency(
+    authed_client,
+    monkeypatch,
+):
+    _configure_sourcing(authed_client)
+    _FakeTrustedPartsClient.returned_currency = "USD"
+    _FakeTrustedPartsClient.unit_price = 2.5
+    _FakeTrustedPartsClient.price_breaks = [
+        SourcingPriceBreak(quantity=1, unit_price=2.5),
+        SourcingPriceBreak(quantity=10, unit_price=2.0),
+    ]
+    monkeypatch.setattr(
+        "app.domain.fx.rates.get_or_fetch_today",
+        lambda _db, *, on_date: {
+            "EUR": Decimal("1"),
+            "USD": Decimal("2"),
+        },
+    )
+    part_id = create_part(authed_client, name="FX part", mpn="FX-USD")
+
+    r = authed_client.get(f"/api/parts/{part_id}/sourcing", params={"currency": "eur"})
+
+    assert r.status_code == 200, r.text
+    data = r.json()["data"]
+    distributor = data["offers"][0]["distributors"][0]
+    assert data["fx_status"] is None
+    assert distributor["unit_price"] == 2.5
+    assert distributor["currency"] == "USD"
+    assert Decimal(distributor["unit_price_converted"]) == Decimal("1.2500")
+    assert distributor["currency_displayed"] == "EUR"
+    assert distributor["fx_converted"] is True
+    assert distributor["fx_rate_date"] == date.today().isoformat()
+    assert Decimal(distributor["price_breaks_converted"][1]["unit_price"]) == Decimal("1.0000")
+
+
+def test_sourcing_response_skips_conversion_when_workspace_currency_null(authed_client):
+    _configure_sourcing(authed_client, currency_code=None)
+    _FakeTrustedPartsClient.returned_currency = "USD"
+    part_id = create_part(authed_client, name="Native currency", mpn="FX-NATIVE")
+
+    r = authed_client.get(f"/api/parts/{part_id}/sourcing")
+
+    assert r.status_code == 200, r.text
+    data = r.json()["data"]
+    distributor = data["offers"][0]["distributors"][0]
+    assert data["fx_status"] is None
+    assert distributor["currency"] == "USD"
+    assert distributor["unit_price_converted"] is None
+    assert distributor["currency_displayed"] is None
+    assert distributor["fx_converted"] is None
+
+
+def test_sourcing_response_surfaces_fx_status_unavailable(authed_client, monkeypatch):
+    _configure_sourcing(authed_client)
+    _FakeTrustedPartsClient.returned_currency = "USD"
+    monkeypatch.setattr(
+        "app.domain.fx.rates.get_or_fetch_today",
+        lambda _db, *, on_date: {"EUR": Decimal("1")},
+    )
+    part_id = create_part(authed_client, name="Unknown FX", mpn="FX-MISS")
+
+    r = authed_client.get(f"/api/parts/{part_id}/sourcing", params={"currency": "eur"})
+
+    assert r.status_code == 200, r.text
+    data = r.json()["data"]
+    distributor = data["offers"][0]["distributors"][0]
+    assert data["fx_status"] == "unavailable"
+    assert distributor["unit_price"] == 1.23
+    assert distributor["currency"] == "USD"
+    assert distributor["unit_price_converted"] is None
+    assert distributor["fx_converted"] is None

--- a/docs/adr/0020-trustedparts-sourcing-provider-split.md
+++ b/docs/adr/0020-trustedparts-sourcing-provider-split.md
@@ -31,6 +31,12 @@ TrustedParts results must stay visibly distinct from catalog-provider data. Publ
 
 Reports may use TrustedParts prices only as a transient request-time input. The replenishment-cost report recomputes replacement cost from existing on-hand lot costs and the short-lived sourcing cache on each request (`backend/app/domain/reports/service.py:39`); it must not add a report-specific table, column, or long-lived price snapshot because that would turn cached TrustedParts offers into persistent price history.
 
+ECB FX reference rates are separate global public data. `fx_rate_snapshots` stores one
+daily JSONB snapshot per UTC date without `workspace_id`, and the Authorized Supply
+route uses it only to display distributor offers in the requested workspace currency
+(`backend/app/domain/fx/models.py:15`, `backend/app/api/routes/sourcing.py:534`).
+This does not permit persistent TrustedParts price history or historical FX charting.
+
 ## Consequences
 
 - **Good**:

--- a/docs/api/sourcing.md
+++ b/docs/api/sourcing.md
@@ -262,7 +262,19 @@ Path: `part_id` is a part UUID in the current workspace.
       {
         "mpn": "STM32F103C8T6",
         "distributors": [
-          { "name": "DigiKey", "stock": 42, "unit_price": 1.23, "currency": "EUR" }
+          {
+            "name": "DigiKey",
+            "stock": 42,
+            "unit_price": 1.23,
+            "currency": "USD",
+            "unit_price_converted": "1.1070",
+            "currency_displayed": "EUR",
+            "fx_converted": true,
+            "fx_rate_date": "2026-05-08",
+            "price_breaks_converted": [
+              { "quantity": 1, "unit_price": "1.1070" }
+            ]
+          }
         ]
       }
     ],
@@ -274,7 +286,8 @@ Path: `part_id` is a part UUID in the current workspace.
       "primary": "https://www.trustedparts.com/",
       "attribution": "https://www.trustedparts.com/en/about"
     },
-    "reason": "ok"
+    "reason": "ok",
+    "fx_status": null
   },
   "status": { "category": "ok", "message": "OK" }
 }
@@ -302,9 +315,12 @@ Parts without an MPN return a successful no-network response.
 
 - The route validates `part_id` with `assert_in_workspace()` before reading the part MPN.
 - The local cache is scoped by `workspace_id`; the part-detail route calls sourcing search with `ttl_seconds=1800`.
+- When a `currency` query param is supplied, distributor prices that still arrive in another currency are display-converted through the global ECB daily snapshot. Native `unit_price` / `currency` stay unchanged; converted display values are exposed as `unit_price_converted`, `currency_displayed`, `fx_converted`, `fx_rate_date`, and `price_breaks_converted`.
+- `fx_status` is `unavailable` when at least one requested conversion could not be produced; affected rows keep native prices.
 - The route uses member-or-higher role gating and maps the same sourcing exceptions as `POST /api/sourcing/search`.
-- Source: `backend/app/api/routes/sourcing.py:132-220`.
-- Service: `backend/app/domain/sourcing/service.py:62-138`.
+- Source: `backend/app/api/routes/sourcing.py:376`.
+- Service: `backend/app/domain/sourcing/service.py:595`.
+- FX: `backend/app/domain/fx/rates.py:46`.
 
 ### `POST /api/parts/{part_id}/sourcing/refresh`
 

--- a/docs/domain/sourcing.md
+++ b/docs/domain/sourcing.md
@@ -144,3 +144,21 @@ limit build count before and after purchase. Source:
 | Sweep expired rows | `app.domain.sourcing.cache::sweep_expired` | Deletes rows with `expires_at < now()`. |
 
 Source: `backend/app/domain/sourcing/cache.py:23`
+
+## FX Conversion
+
+The part-detail Authorized Supply route can request display conversion into the
+workspace sourcing currency. TrustedParts still owns the native offer payload:
+`unit_price`, `currency`, and native price breaks are preserved. Converted display
+fields are added only for rows whose distributor currency differs from the requested
+currency.
+
+ECB daily reference rates are cached in `fx_rate_snapshots` with one JSONB snapshot
+per UTC date. The table is global, not workspace-owned, because ECB rates are public
+reference data and identical for every workspace. The snapshot stores the current daily
+rate set only; it is not a normalized per-currency history table and is not used for
+price-trend reporting.
+
+Sources: `backend/app/domain/fx/models.py:15`,
+`backend/app/domain/fx/rates.py:46`,
+`backend/app/api/routes/sourcing.py:534`

--- a/web/src/routes/parts/detail/AuthorizedSupplyTab.tsx
+++ b/web/src/routes/parts/detail/AuthorizedSupplyTab.tsx
@@ -19,6 +19,17 @@ import {
 } from "./CreateOrderLineModal";
 
 type SourcingReason = "ok" | "no_mpn";
+type FxStatus = "unavailable";
+type WirePrice = number | string;
+
+type SourcingWorkspaceSettings = {
+  sourcing_currency_code?: string | null;
+};
+
+type SourcingPriceBreakWire = {
+  quantity: number;
+  unit_price: WirePrice;
+};
 
 type SourcingDistributor = {
   name: string;
@@ -27,9 +38,14 @@ type SourcingDistributor = {
   moq?: number | null;
   lead_time_days?: number | null;
   stock?: number | null;
-  unit_price?: number | null;
+  unit_price?: WirePrice | null;
   currency?: string | null;
-  price_breaks?: SourcingPriceBreak[] | null;
+  unit_price_converted?: WirePrice | null;
+  currency_displayed?: string | null;
+  fx_converted?: boolean | null;
+  fx_rate_date?: string | null;
+  price_breaks?: SourcingPriceBreakWire[] | null;
+  price_breaks_converted?: SourcingPriceBreakWire[] | null;
   product_url?: string | null;
 };
 
@@ -57,6 +73,7 @@ type SourcingResponse = {
     attribution?: string | null;
   };
   reason: SourcingReason;
+  fx_status?: FxStatus | null;
 };
 
 type SupplyRow = {
@@ -70,6 +87,10 @@ type SupplyRow = {
   priceBreaks: SourcingPriceBreak[];
   leadTimeDays: number | null;
   link: string | null;
+  originalUnitPrice: number | null;
+  originalCurrency: string | null;
+  fxConverted: boolean;
+  fxRateDate: string | null;
 };
 
 const QUANTITY_PRESETS = [1, 10, 100, 1000] as const;
@@ -91,6 +112,26 @@ function formatPriceValue(value: number, currency: string | null): string {
   return currency ? `${price} ${currency}` : price;
 }
 
+function toFiniteNumber(value: WirePrice | null | undefined): number | null {
+  if (value == null) return null;
+  const parsed = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function normalisePriceBreaks(value: SourcingPriceBreakWire[] | null | undefined): SourcingPriceBreak[] {
+  return (value ?? []).flatMap(priceBreak => {
+    const unitPrice = toFiniteNumber(priceBreak.unit_price);
+    return unitPrice == null ? [] : [{ quantity: priceBreak.quantity, unit_price: unitPrice }];
+  });
+}
+
+function fxTooltip(row: SupplyRow): string {
+  const original = row.originalUnitPrice == null
+    ? row.originalCurrency ?? "native currency"
+    : formatPriceValue(row.originalUnitPrice, row.originalCurrency);
+  return `Converted from ${original} via ECB daily rate (${row.fxRateDate ?? "unknown date"})`;
+}
+
 function formatLeadTime(days: number | null): string {
   if (days == null) return "—";
   return days === 1 ? "1 day" : `${days.toLocaleString()} days`;
@@ -106,24 +147,54 @@ function flattenOffers(data: SourcingResponse | undefined): SupplyRow[] {
   if (!data || data.reason !== "ok") return [];
 
   return data.offers.flatMap((offer, offerIndex) =>
-    offer.distributors.map((distributor, distributorIndex) => ({
-      id: [
-        offer.mpn,
-        distributor.name,
-        distributor.sku ?? "sku",
-        offerIndex,
-        distributorIndex,
-      ].join(":"),
-      distributor: distributor.name,
-      stock: distributor.stock ?? null,
-      moq: distributor.moq ?? null,
-      packaging: distributor.packaging ?? null,
-      unitPrice: distributor.unit_price ?? null,
-      currency: distributor.currency ?? null,
-      priceBreaks: distributor.price_breaks ?? [],
-      leadTimeDays: distributor.lead_time_days ?? null,
-      link: distributor.product_url ?? offer.links?.primary ?? data.links?.primary ?? null,
-    })),
+    offer.distributors.map((distributor, distributorIndex) => {
+      const originalUnitPrice = toFiniteNumber(distributor.unit_price);
+      const convertedUnitPrice = toFiniteNumber(distributor.unit_price_converted);
+      const fxConverted = distributor.fx_converted === true && convertedUnitPrice !== null;
+      return {
+        id: [
+          offer.mpn,
+          distributor.name,
+          distributor.sku ?? "sku",
+          offerIndex,
+          distributorIndex,
+        ].join(":"),
+        distributor: distributor.name,
+        stock: distributor.stock ?? null,
+        moq: distributor.moq ?? null,
+        packaging: distributor.packaging ?? null,
+        unitPrice: fxConverted ? convertedUnitPrice : originalUnitPrice,
+        currency: fxConverted
+          ? distributor.currency_displayed ?? distributor.currency ?? null
+          : distributor.currency ?? null,
+        priceBreaks: fxConverted
+          ? normalisePriceBreaks(distributor.price_breaks_converted)
+          : normalisePriceBreaks(distributor.price_breaks),
+        leadTimeDays: distributor.lead_time_days ?? null,
+        link: distributor.product_url ?? offer.links?.primary ?? data.links?.primary ?? null,
+        originalUnitPrice,
+        originalCurrency: distributor.currency ?? null,
+        fxConverted,
+        fxRateDate: distributor.fx_rate_date ?? null,
+      };
+    }),
+  );
+}
+
+function PriceCell({ row }: { row: SupplyRow }) {
+  return (
+    <span className="inline-flex items-center justify-end gap-1.5">
+      <span>{formatPrice(row)}</span>
+      {row.fxConverted && (
+        <span
+          className="inline-flex h-5 w-5 items-center justify-center rounded border border-accent/40 text-accent"
+          title={fxTooltip(row)}
+          aria-label={fxTooltip(row)}
+        >
+          <RefreshCw size={12} aria-hidden="true" />
+        </span>
+      )}
+    </span>
   );
 }
 
@@ -164,8 +235,16 @@ function rateLimitMessage(seconds: number): string {
 export function AuthorizedSupplyTab({ partId }: { partId: string }) {
   const queryClient = useQueryClient();
   const { workspaceId } = useAuth();
-  const queryKey = useWsKey("part", partId, "sourcing");
-  const invalidateKey = wsKeyOf(workspaceId, "part", partId, "sourcing");
+  const workspaceQuery = useQuery({
+    queryKey: useWsKey("ws", "current"),
+    queryFn: () => api.get<SourcingWorkspaceSettings>("/workspaces/current"),
+  });
+  const workspaceCurrency = workspaceQuery.data?.sourcing_currency_code?.trim().toUpperCase() || null;
+  const sourcingPath = workspaceCurrency
+    ? `/parts/${partId}/sourcing?currency=${encodeURIComponent(workspaceCurrency)}`
+    : `/parts/${partId}/sourcing`;
+  const queryKey = useWsKey("part", partId, "sourcing", workspaceCurrency ?? "native");
+  const invalidateKey = wsKeyOf(workspaceId, "part", partId, "sourcing", workspaceCurrency ?? "native");
   const [selectedDistributors, setSelectedDistributors] = useState<Set<string>>(() => new Set());
   const [quantity, setQuantity] = useState(1);
   const [customQuantity, setCustomQuantity] = useState("1");
@@ -174,7 +253,8 @@ export function AuthorizedSupplyTab({ partId }: { partId: string }) {
   const query = useQuery({
     queryKey,
     queryFn: ({ signal }) =>
-      api.get<SourcingResponse>(`/parts/${partId}/sourcing`, { signal }),
+      api.get<SourcingResponse>(sourcingPath, { signal }),
+    enabled: workspaceQuery.isSuccess,
   });
 
   const refreshMutation = useApiMutation<SourcingResponse, void>({
@@ -285,7 +365,7 @@ export function AuthorizedSupplyTab({ partId }: { partId: string }) {
         key: "price",
         header: "Price",
         accessor: row => row.unitPrice,
-        render: row => formatPrice(row),
+        render: row => <PriceCell row={row} />,
         align: "right",
       },
       ...quantityColumns,
@@ -351,7 +431,11 @@ export function AuthorizedSupplyTab({ partId }: { partId: string }) {
   const retryAfter = retryAfterSeconds(refreshMutation.error) ?? retryAfterSeconds(query.error);
   const primaryUrl = query.data?.links?.primary ?? undefined;
 
-  if (query.isLoading) {
+  if (workspaceQuery.isError) {
+    return <InlineQueryError query={workspaceQuery} label="workspace settings" />;
+  }
+
+  if (workspaceQuery.isLoading || query.isLoading) {
     return (
       <div className="card p-3 text-sm text-muted" role="status">
         Loading authorized supply…
@@ -423,6 +507,12 @@ export function AuthorizedSupplyTab({ partId }: { partId: string }) {
 
       {query.isError && status !== 429 && status !== 502 && status !== 503 && status !== 409 && (
         <InlineQueryError query={query} label="authorized supply" />
+      )}
+
+      {query.data?.fx_status === "unavailable" && (
+        <div className="card p-3 text-sm text-muted" role="status">
+          FX conversion unavailable for some rows — showing native currency.
+        </div>
       )}
 
       {distributors.length > 0 && (

--- a/web/src/routes/parts/detail/__tests__/AuthorizedSupplyTab.test.tsx
+++ b/web/src/routes/parts/detail/__tests__/AuthorizedSupplyTab.test.tsx
@@ -19,7 +19,11 @@ vi.mock("@/lib/auth", () => ({
 }));
 
 const partId = "part-123";
-const sourcingQueryKey = ["ws", "ws-1", "part", partId, "sourcing"];
+const sourcingQueryKey = ["ws", "ws-1", "part", partId, "sourcing", "EUR"];
+
+function workspaceResponse(currency: string | null = "EUR") {
+  return { sourcing_currency_code: currency };
+}
 
 function sourcingResponse() {
   return {
@@ -76,6 +80,42 @@ function sourcingResponse() {
   };
 }
 
+function convertedSourcingResponse() {
+  const response = sourcingResponse();
+  Object.assign(response.offers[0].distributors[0], {
+    unit_price: 2.5,
+    currency: "USD",
+    unit_price_converted: "1.25",
+    currency_displayed: "EUR",
+    fx_converted: true,
+    fx_rate_date: "2026-05-08",
+    price_breaks_converted: [{ quantity: 1, unit_price: "1.25" }],
+  });
+  return response;
+}
+
+function mockApiGet(response: unknown, workspaceCurrency: string | null = "EUR") {
+  return vi.spyOn(api, "get").mockImplementation((path: string) => {
+    if (path === "/workspaces/current") {
+      return Promise.resolve(workspaceResponse(workspaceCurrency));
+    }
+    return Promise.resolve(response);
+  });
+}
+
+function mockApiGetError(error: ApiError, workspaceCurrency: string | null = "EUR") {
+  return vi.spyOn(api, "get").mockImplementation((path: string) => {
+    if (path === "/workspaces/current") {
+      return Promise.resolve(workspaceResponse(workspaceCurrency));
+    }
+    return Promise.reject(error);
+  });
+}
+
+function sourcingGetCalls(spy: ReturnType<typeof mockApiGet>) {
+  return spy.mock.calls.filter(([path]) => String(path).startsWith(`/parts/${partId}/sourcing`));
+}
+
 function apiError(status: number, message: string, extra: Record<string, unknown> = {}) {
   const category =
     status === 409 ? "conflict" : status === 429 ? "rate_limited" : "server_error";
@@ -113,7 +153,7 @@ beforeEach(() => {
 
 describe("AuthorizedSupplyTab", () => {
   it("renders offers and attribution badge for part with MPN", async () => {
-    vi.spyOn(api, "get").mockResolvedValue(sourcingResponse());
+    mockApiGet(sourcingResponse());
 
     renderTab();
 
@@ -128,7 +168,7 @@ describe("AuthorizedSupplyTab", () => {
   });
 
   it("renders no-mpn empty state and never calls the API path with empty mpn", async () => {
-    const getSpy = vi.spyOn(api, "get").mockResolvedValue({
+    const getSpy = mockApiGet({
       offers: [],
       reason: "no_mpn",
       cache_hit: null,
@@ -138,13 +178,13 @@ describe("AuthorizedSupplyTab", () => {
     renderTab();
 
     expect(await screen.findByText("Add an MPN to this part to see authorized-distributor offers.")).toBeDefined();
-    expect(getSpy).toHaveBeenCalledWith(`/parts/${partId}/sourcing`, expect.any(Object));
+    expect(getSpy).toHaveBeenCalledWith(`/parts/${partId}/sourcing?currency=EUR`, expect.any(Object));
     expect(postSpy).not.toHaveBeenCalled();
   });
 
   it("refresh button invalidates the query", async () => {
     const user = userEvent.setup();
-    vi.spyOn(api, "get").mockResolvedValue(sourcingResponse());
+    mockApiGet(sourcingResponse());
     vi.spyOn(api, "post").mockResolvedValue(sourcingResponse());
     const { invalidateSpy } = renderTab();
 
@@ -159,7 +199,7 @@ describe("AuthorizedSupplyTab", () => {
 
   it("distributor filter narrows visible rows", async () => {
     const user = userEvent.setup();
-    const getSpy = vi.spyOn(api, "get").mockResolvedValue(sourcingResponse());
+    const getSpy = mockApiGet(sourcingResponse());
 
     renderTab();
 
@@ -170,11 +210,11 @@ describe("AuthorizedSupplyTab", () => {
     const table = screen.getByRole("table");
     expect(within(table).queryByText("DigiKey")).toBeNull();
     expect(within(table).getByText("Mouser")).toBeDefined();
-    expect(getSpy).toHaveBeenCalledTimes(1);
+    expect(sourcingGetCalls(getSpy)).toHaveLength(1);
   });
 
   it("409 path shows admin-prompt card", async () => {
-    vi.spyOn(api, "get").mockRejectedValue(apiError(409, "sourcing not configured"));
+    mockApiGetError(apiError(409, "sourcing not configured"));
 
     renderTab();
 
@@ -184,7 +224,7 @@ describe("AuthorizedSupplyTab", () => {
   });
 
   it("503 path shows budget banner", async () => {
-    vi.spyOn(api, "get").mockRejectedValue(apiError(503, "sourcing budget exhausted"));
+    mockApiGetError(apiError(503, "sourcing budget exhausted"));
 
     renderTab();
 
@@ -193,7 +233,7 @@ describe("AuthorizedSupplyTab", () => {
 
   it("429 refresh path shows retry-after banner", async () => {
     const user = userEvent.setup();
-    vi.spyOn(api, "get").mockResolvedValue(sourcingResponse());
+    mockApiGet(sourcingResponse());
     vi.spyOn(api, "post").mockRejectedValue(
       apiError(429, "rate limit exceeded", { retry_after_seconds: 17 }),
     );
@@ -210,7 +250,7 @@ describe("AuthorizedSupplyTab", () => {
   });
 
   it("502 path shows unavailable toast with retry action", async () => {
-    vi.spyOn(api, "get").mockRejectedValue(apiError(502, "TrustedParts request timed out"));
+    mockApiGetError(apiError(502, "TrustedParts request timed out"));
 
     renderTab();
 
@@ -226,7 +266,7 @@ describe("AuthorizedSupplyTab", () => {
   });
 
   it("attribution link does not have nofollow", async () => {
-    vi.spyOn(api, "get").mockResolvedValue(sourcingResponse());
+    mockApiGet(sourcingResponse());
 
     renderTab();
 
@@ -239,9 +279,54 @@ describe("AuthorizedSupplyTab", () => {
     expect(offerLink.getAttribute("rel") ?? "").not.toContain("nofollow");
   });
 
+  it("flag rendered on rows with fx_converted=true", async () => {
+    mockApiGet(convertedSourcingResponse());
+
+    renderTab();
+
+    expect(await screen.findByText("1.25 EUR")).toBeDefined();
+    expect(
+      screen.getByLabelText("Converted from 2.5 USD via ECB daily rate (2026-05-08)"),
+    ).toBeDefined();
+  });
+
+  it("tooltip shows original currency and rate date", async () => {
+    mockApiGet(convertedSourcingResponse());
+
+    renderTab();
+
+    const badge = await screen.findByLabelText(
+      "Converted from 2.5 USD via ECB daily rate (2026-05-08)",
+    );
+    expect(badge.getAttribute("title")).toBe(
+      "Converted from 2.5 USD via ECB daily rate (2026-05-08)",
+    );
+  });
+
+  it("fx_status warning rendered at top of table when present", async () => {
+    const response = { ...sourcingResponse(), fx_status: "unavailable" as const };
+    mockApiGet(response);
+
+    renderTab();
+
+    expect(
+      await screen.findByText("FX conversion unavailable for some rows — showing native currency."),
+    ).toBeDefined();
+  });
+
+  it("legacy view when workspace currency is null", async () => {
+    const getSpy = mockApiGet(sourcingResponse(), null);
+
+    renderTab();
+
+    expect(await screen.findByText("1.23 EUR")).toBeDefined();
+    expect(screen.queryByLabelText(/Converted from/)).toBeNull();
+    expect(getSpy).toHaveBeenCalledWith(`/parts/${partId}/sourcing`, expect.any(Object));
+  });
+
   it("quantity preset 100 recomputes unit price across rows", async () => {
     const user = userEvent.setup();
-    vi.spyOn(api, "get").mockResolvedValue(sourcingResponse());
+    mockApiGet(sourcingResponse());
 
     renderTab();
 
@@ -260,7 +345,7 @@ describe("AuthorizedSupplyTab", () => {
 
   it("custom quantity input is applied on blur", async () => {
     const user = userEvent.setup();
-    vi.spyOn(api, "get").mockResolvedValue(sourcingResponse());
+    mockApiGet(sourcingResponse());
 
     renderTab();
 
@@ -280,7 +365,7 @@ describe("AuthorizedSupplyTab", () => {
 
   it("quantity change does not refetch", async () => {
     const user = userEvent.setup();
-    const getSpy = vi.spyOn(api, "get").mockResolvedValue(sourcingResponse());
+    const getSpy = mockApiGet(sourcingResponse());
 
     renderTab();
 
@@ -288,12 +373,12 @@ describe("AuthorizedSupplyTab", () => {
     await user.click(screen.getByRole("button", { name: "1,000" }));
     await user.click(screen.getByRole("button", { name: "10" }));
 
-    expect(getSpy).toHaveBeenCalledTimes(1);
+    expect(sourcingGetCalls(getSpy)).toHaveLength(1);
   });
 
   it("below-MOQ rendering is visible at low quantities", async () => {
     const user = userEvent.setup();
-    vi.spyOn(api, "get").mockResolvedValue(sourcingResponse());
+    mockApiGet(sourcingResponse());
 
     renderTab();
 
@@ -309,7 +394,7 @@ describe("AuthorizedSupplyTab", () => {
 
   it("sorts by unit price at selected quantity", async () => {
     const user = userEvent.setup();
-    vi.spyOn(api, "get").mockResolvedValue(sourcingResponse());
+    mockApiGet(sourcingResponse());
 
     renderTab();
 


### PR DESCRIPTION
## Summary
- Adds a global ECB daily FX snapshot table and `app.domain.fx` helpers for XML parsing, daily caching, and Decimal EUR cross-rate conversion.
- Converts Authorized Supply distributor prices into the requested workspace currency when TrustedParts returns a different native currency, preserving native price fields and adding converted display fields, rate date, and `fx_status`.
- Updates the part Authorized Supply tab to pass `workspace.sourcing_currency_code`, render converted prices/price breaks, show a converted badge tooltip, and warn when FX conversion is unavailable.
- Documents the new sourcing response fields, global FX snapshots, and ADR-0020 global-rate policy.

Closes #414
Refs #407

## Validation
- `docker compose -f docker-compose.dev.yml exec backend alembic upgrade head` / `downgrade -1` / `upgrade head` could not run because `docker` is not installed in this environment.
- Stacked local equivalent run before rebasing this PR branch back to `main`: `DATABASE_URL=postgresql+psycopg://stockmgr:stockmgr@127.0.0.1:5432/stockmgr_test .venv/bin/alembic upgrade head && ... downgrade -1 && ... upgrade head` -> passed (`0042 -> 0043`, `0043 -> 0042`, `0042 -> 0043`).
- `DATABASE_URL=postgresql+psycopg://stockmgr:stockmgr@127.0.0.1:5432/stockmgr_test .venv/bin/python -m pytest -k "fx_rates or sourcing_part_route" -q` -> 17 passed, 1008 deselected, 1 warning.
- `npm test -- AuthorizedSupplyTab --run` -> 18 passed.
- `npm run typecheck` -> passed.
- `npx eslint src/routes/parts/detail/AuthorizedSupplyTab.tsx src/routes/parts/detail/__tests__/AuthorizedSupplyTab.test.tsx` -> passed.
- Touched-file backend lint: `.venv/bin/ruff check app/domain/fx app/domain/all_models.py app/domain/sourcing/schemas.py app/api/routes/sourcing.py tests/test_fx_rates.py tests/test_sourcing_part_route.py` -> passed.
- `alembic heads` on the stacked validation checkout -> `0043 (head)`.
- `git diff --check` -> passed.
- `scripts/lint-delta.sh` for ruff and eslint -> no new violations.

## Residual Risks
- This PR is draft because #425's head branch is no longer available as a GitHub base branch, but migration `0043` must follow #425's `0042`. Merge #425 first, then this branch should be rebased/undrafted or merged after `main` contains `0042_workspace_active_lists.py`.
- Full `ruff check` and full `npm run lint` still report existing baseline violations outside this PR; lint-delta reports no new violations.
- `alembic check` still reports existing model-vs-migration drift around legacy indexes outside this PR after the new migration is applied.
- Screenshot of the converted-row badge was not captured; the behavior is covered by `AuthorizedSupplyTab` DOM tests.
- `npm ci` completed on local Node 18 with package engine warnings for dependencies that request Node 20+, but the targeted frontend tests and typecheck passed.

## Migration Notes
- New migration: `backend/alembic/versions/0043_fx_rate_snapshots.py`.
- `fx_rate_snapshots` is global public reference data and intentionally has no `workspace_id` column; `test_no_workspace_id_column_on_fx_table` verifies this.

## Merge Order
- #425 before this PR (#414).
- This PR's migration `0043` revises #425's `0042_workspace_active_lists.py`; #425's branch could not be selected as the PR base because GitHub reports that branch as missing.
