### PR TITLE
TP-501: sourcing_alerts migration

### DIFF
--- a/backend/alembic/versions/0044_sourcing_alerts.py
+++ b/backend/alembic/versions/0044_sourcing_alerts.py
@@ -1,0 +1,143 @@
+"""Add sourcing alerts.
+
+Revision ID: 0044
+Revises: 0043
+Create Date: 2026-05-10
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+from alembic import op
+
+revision = "0044"
+down_revision = "0043"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "sourcing_alerts",
+        sa.Column(
+            "id",
+            sa.UUID(as_uuid=True),
+            nullable=False,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("workspace_id", sa.UUID(as_uuid=True), nullable=False),
+        sa.Column("part_id", sa.UUID(as_uuid=True), nullable=True),
+        sa.Column("project_id", sa.UUID(as_uuid=True), nullable=True),
+        sa.Column("alert_type", sa.String(length=40), nullable=False),
+        sa.Column("threshold", JSONB, nullable=False),
+        sa.Column("country_code", sa.String(length=2), nullable=True),
+        sa.Column("currency_code", sa.String(length=3), nullable=True),
+        sa.Column("distributor_filter", JSONB, nullable=True),
+        sa.Column("notify_user_ids", JSONB, nullable=True),
+        sa.Column(
+            "cooldown_seconds",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("86400"),
+        ),
+        sa.Column(
+            "enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.true(),
+        ),
+        sa.Column("last_checked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_notified_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_evaluation_state", JSONB, nullable=True),
+        sa.Column("created_by", sa.UUID(as_uuid=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("archived_at", sa.DateTime(timezone=True), nullable=True),
+        sa.CheckConstraint(
+            "alert_type IN ("
+            "'stock_below', "
+            "'stock_above', "
+            "'back_in_stock', "
+            "'out_of_authorized_stock', "
+            "'price_changed', "
+            "'bom_buyable'"
+            ")",
+            name="sourcing_alerts_alert_type_check",
+        ),
+        sa.CheckConstraint(
+            "cooldown_seconds >= 60",
+            name="sourcing_alerts_cooldown_seconds_min",
+        ),
+        sa.CheckConstraint(
+            "(part_id IS NOT NULL) <> (project_id IS NOT NULL)",
+            name="sourcing_alerts_part_project_xor",
+        ),
+        sa.ForeignKeyConstraint(
+            ["created_by"],
+            ["users.id"],
+            ondelete="SET NULL",
+        ),
+        sa.ForeignKeyConstraint(
+            ["part_id"],
+            ["parts.id"],
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["project_id"],
+            ["projects.id"],
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["workspace_id"],
+            ["workspaces.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "uq_sourcing_alerts_active_target_threshold",
+        "sourcing_alerts",
+        [
+            "workspace_id",
+            "alert_type",
+            sa.text("COALESCE(part_id, project_id)"),
+            "threshold",
+        ],
+        unique=True,
+        postgresql_where=sa.text("archived_at IS NULL"),
+    )
+    op.create_index(
+        "ix_sourcing_alerts_ws_enabled_archived",
+        "sourcing_alerts",
+        ["workspace_id", "enabled", "archived_at"],
+    )
+    op.create_index(
+        "ix_sourcing_alerts_last_checked_at",
+        "sourcing_alerts",
+        ["last_checked_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_sourcing_alerts_last_checked_at", table_name="sourcing_alerts")
+    op.drop_index(
+        "ix_sourcing_alerts_ws_enabled_archived",
+        table_name="sourcing_alerts",
+    )
+    op.drop_index(
+        "uq_sourcing_alerts_active_target_threshold",
+        table_name="sourcing_alerts",
+    )
+    op.drop_table("sourcing_alerts")

--- a/backend/app/domain/all_models.py
+++ b/backend/app/domain/all_models.py
@@ -42,7 +42,12 @@ from app.domain.projects.models import (  # noqa: F401
     Project,
     ProjectEntry,
 )
-from app.domain.sourcing.models import PurchasePlan, PurchasePlanLine, SourcingCache  # noqa: F401
+from app.domain.sourcing.models import (  # noqa: F401
+    PurchasePlan,
+    PurchasePlanLine,
+    SourcingAlert,
+    SourcingCache,
+)
 from app.domain.stock.models import StockEntry  # noqa: F401
 from app.domain.storage.models import StorageLocation  # noqa: F401
 from app.domain.tags.models import Tag, TagLink  # noqa: F401

--- a/backend/app/domain/sourcing/models.py
+++ b/backend/app/domain/sourcing/models.py
@@ -10,6 +10,7 @@ from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import relationship
 
 from app.core.time import utcnow
+from app.domain._mixins import WorkspaceOwned
 from app.infra.db import Base
 
 
@@ -218,3 +219,110 @@ class PurchasePlanLine(Base):
     )
 
     purchase_plan = relationship("PurchasePlan", back_populates="lines")
+
+
+class SourcingAlert(WorkspaceOwned, Base):
+    """Workspace-scoped alert definition evaluated by the sourcing jobs."""
+
+    __tablename__ = "sourcing_alerts"
+    __table_args__ = (
+        CheckConstraint(
+            "alert_type IN ("
+            "'stock_below', "
+            "'stock_above', "
+            "'back_in_stock', "
+            "'out_of_authorized_stock', "
+            "'price_changed', "
+            "'bom_buyable'"
+            ")",
+            name="sourcing_alerts_alert_type_check",
+        ),
+        CheckConstraint(
+            "cooldown_seconds >= 60",
+            name="sourcing_alerts_cooldown_seconds_min",
+        ),
+        CheckConstraint(
+            "(part_id IS NOT NULL) <> (project_id IS NOT NULL)",
+            name="sourcing_alerts_part_project_xor",
+        ),
+        Index(
+            "uq_sourcing_alerts_active_target_threshold",
+            "workspace_id",
+            "alert_type",
+            sa.text("COALESCE(part_id, project_id)"),
+            "threshold",
+            unique=True,
+            postgresql_where=sa.text("archived_at IS NULL"),
+        ),
+        Index(
+            "ix_sourcing_alerts_ws_enabled_archived",
+            "workspace_id",
+            "enabled",
+            "archived_at",
+        ),
+        Index("ix_sourcing_alerts_last_checked_at", "last_checked_at"),
+    )
+
+    updated_by = None
+
+    id = Column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+        server_default=sa.text("gen_random_uuid()"),
+    )
+    workspace_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("workspaces.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    part_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("parts.id", ondelete="CASCADE"),
+        nullable=True,
+    )
+    project_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("projects.id", ondelete="CASCADE"),
+        nullable=True,
+    )
+    alert_type = Column(sa.String(40), nullable=False)
+    threshold = Column(JSONB, nullable=False)
+    country_code = Column(sa.String(2), nullable=True)
+    currency_code = Column(sa.String(3), nullable=True)
+    distributor_filter = Column(JSONB, nullable=True)
+    notify_user_ids = Column(JSONB, nullable=True)
+    cooldown_seconds = Column(
+        sa.Integer,
+        nullable=False,
+        default=86400,
+        server_default=sa.text("86400"),
+    )
+    enabled = Column(
+        sa.Boolean,
+        nullable=False,
+        default=True,
+        server_default=sa.true(),
+    )
+    last_checked_at = Column(DateTime(timezone=True), nullable=True)
+    last_notified_at = Column(DateTime(timezone=True), nullable=True)
+    last_evaluation_state = Column(JSONB, nullable=True)
+    created_by = Column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    created_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=utcnow,
+        server_default=sa.func.now(),
+    )
+    updated_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=utcnow,
+        onupdate=utcnow,
+        server_default=sa.func.now(),
+    )
+    archived_at = Column(DateTime(timezone=True), nullable=True)

--- a/backend/tests/test_sourcing_alert_models.py
+++ b/backend/tests/test_sourcing_alert_models.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import uuid
+from datetime import timedelta
+
+import pytest
+from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.core.time import utcnow
+from app.domain.parts.models import Part
+from app.domain.projects.models import Project
+from app.domain.sourcing.models import SourcingAlert
+from app.domain.users.models import User
+from app.domain.workspaces.models import Workspace
+
+
+def _workspace_user(db: Session) -> tuple[Workspace, User]:
+    user = User(
+        email=f"sourcing-alert-{uuid.uuid4().hex[:8]}@example.com",
+        name="Sourcing Alert Tester",
+        password_hash="test",
+    )
+    db.add(user)
+    db.flush()
+    workspace = Workspace(
+        name=f"sourcing-alert-ws-{uuid.uuid4().hex[:8]}",
+        kind="organization",
+        owner_user_id=user.id,
+    )
+    db.add(workspace)
+    db.flush()
+    return workspace, user
+
+
+def _part(db: Session, workspace: Workspace, user: User, *, name: str = "STM32") -> Part:
+    part = Part(
+        workspace_id=workspace.id,
+        name=f"{name} {uuid.uuid4().hex[:8]}",
+        part_type="local",
+        mpn=f"{name}-{uuid.uuid4().hex[:8]}",
+        created_by=user.id,
+        updated_by=user.id,
+    )
+    db.add(part)
+    db.flush()
+    return part
+
+
+def _project(db: Session, workspace: Workspace, user: User) -> Project:
+    project = Project(
+        workspace_id=workspace.id,
+        name=f"Alert BOM {uuid.uuid4().hex[:8]}",
+        created_by=user.id,
+        updated_by=user.id,
+    )
+    db.add(project)
+    db.flush()
+    return project
+
+
+def _alert(
+    workspace: Workspace,
+    user: User,
+    *,
+    part: Part | None = None,
+    project: Project | None = None,
+    alert_type: str = "stock_below",
+    threshold: dict | None = None,
+    archived: bool = False,
+    cooldown_seconds: int = 86400,
+) -> SourcingAlert:
+    return SourcingAlert(
+        workspace_id=workspace.id,
+        part_id=part.id if part is not None else None,
+        project_id=project.id if project is not None else None,
+        alert_type=alert_type,
+        threshold=threshold if threshold is not None else {"qty": 10},
+        cooldown_seconds=cooldown_seconds,
+        archived_at=utcnow() - timedelta(minutes=1) if archived else None,
+        created_by=user.id,
+    )
+
+
+def test_check_constraint_rejects_invalid_alert_type(db: Session) -> None:
+    workspace, user = _workspace_user(db)
+    part = _part(db, workspace, user)
+    db.add(_alert(workspace, user, part=part, alert_type="bogus"))
+
+    with pytest.raises(IntegrityError):
+        db.flush()
+    db.rollback()
+
+
+def test_check_constraint_rejects_short_cooldown(db: Session) -> None:
+    workspace, user = _workspace_user(db)
+    part = _part(db, workspace, user)
+    db.add(_alert(workspace, user, part=part, cooldown_seconds=10))
+
+    with pytest.raises(IntegrityError):
+        db.flush()
+    db.rollback()
+
+
+def test_xor_part_id_project_id_check(db: Session) -> None:
+    workspace, user = _workspace_user(db)
+    part = _part(db, workspace, user)
+    project = _project(db, workspace, user)
+    db.add(_alert(workspace, user, part=part, project=project))
+
+    with pytest.raises(IntegrityError):
+        db.flush()
+    db.rollback()
+
+    workspace, user = _workspace_user(db)
+    db.add(_alert(workspace, user))
+
+    with pytest.raises(IntegrityError):
+        db.flush()
+    db.rollback()
+
+    workspace, user = _workspace_user(db)
+    part = _part(db, workspace, user)
+    project = _project(db, workspace, user)
+    db.add_all(
+        [
+            _alert(workspace, user, part=part),
+            _alert(
+                workspace,
+                user,
+                project=project,
+                alert_type="bom_buyable",
+                threshold={"build_quantity": 10},
+            ),
+        ]
+    )
+    db.flush()
+
+
+def test_partial_unique_active_alert(db: Session) -> None:
+    workspace, user = _workspace_user(db)
+    part = _part(db, workspace, user)
+    db.add_all(
+        [
+            _alert(workspace, user, part=part, threshold={"qty": 25}),
+            _alert(workspace, user, part=part, threshold={"qty": 25}),
+        ]
+    )
+
+    with pytest.raises(IntegrityError):
+        db.flush()
+    db.rollback()
+
+
+def test_partial_unique_allows_archived_duplicate(db: Session) -> None:
+    workspace, user = _workspace_user(db)
+    part = _part(db, workspace, user)
+    db.add_all(
+        [
+            _alert(workspace, user, part=part, threshold={"qty": 25}, archived=True),
+            _alert(workspace, user, part=part, threshold={"qty": 25}),
+        ]
+    )
+    db.flush()
+
+    assert db.execute(select(func.count()).select_from(SourcingAlert)).scalar_one() == 2
+
+
+def test_cascade_delete_workspace(db: Session) -> None:
+    workspace, user = _workspace_user(db)
+    part = _part(db, workspace, user)
+    db.add(_alert(workspace, user, part=part))
+    db.flush()
+
+    db.delete(workspace)
+    db.flush()
+
+    assert db.execute(select(func.count()).select_from(SourcingAlert)).scalar_one() == 0
+
+
+def test_cascade_delete_project(db: Session) -> None:
+    workspace, user = _workspace_user(db)
+    project = _project(db, workspace, user)
+    db.add(
+        _alert(
+            workspace,
+            user,
+            project=project,
+            alert_type="bom_buyable",
+            threshold={"build_quantity": 10},
+        )
+    )
+    db.flush()
+
+    db.delete(project)
+    db.flush()
+
+    assert db.execute(select(func.count()).select_from(SourcingAlert)).scalar_one() == 0
+
+
+def test_cascade_delete_part_nulls_other_alerts(db: Session) -> None:
+    workspace, user = _workspace_user(db)
+    part = _part(db, workspace, user, name="DeleteMe")
+    other_part = _part(db, workspace, user, name="KeepMe")
+    db.add_all(
+        [
+            _alert(workspace, user, part=part, threshold={"qty": 5}),
+            _alert(workspace, user, part=other_part, threshold={"qty": 7}),
+        ]
+    )
+    db.flush()
+
+    db.delete(part)
+    db.flush()
+
+    remaining = db.execute(select(SourcingAlert)).scalar_one()
+    assert remaining.part_id == other_part.id
+    assert remaining.threshold == {"qty": 7}

--- a/docs/adr/0020-trustedparts-sourcing-provider-split.md
+++ b/docs/adr/0020-trustedparts-sourcing-provider-split.md
@@ -25,6 +25,9 @@ snapshots while users review optimizer output. `purchase_plans` enforces
 expired plan rows alongside cache rows (`backend/alembic/versions/0039_purchase_plans.py:68`,
 `backend/app/domain/sourcing/cache.py:95`).
 
+Phase 5b sourcing alerts use the same domain boundary; see
+[sourcing alerts](../domain/sourcing.md#alerts).
+
 TrustedParts results must stay visibly distinct from catalog-provider data. Public or UI surfaces that combine distributor data from multiple origins need an explicit future decision before launch.
 
 ## Reports policy: no persistent price history

--- a/docs/domain/sourcing.md
+++ b/docs/domain/sourcing.md
@@ -97,6 +97,29 @@ on `purchase_plan_lines.selected_url` and are not persisted into `orders.comment
 
 Source: `backend/app/domain/sourcing/service.py:57`
 
+## Alerts
+
+`sourcing_alerts` stores workspace-scoped, soft-deletable alert definitions for the
+Phase 5b evaluator. Each row targets exactly one part or one project and uses
+`threshold` as opaque JSONB; the API validates the per-type shape before insert.
+
+| `alert_type` | Scope | Threshold shape |
+|---|---|---|
+| `stock_below` | part | `{ "qty": int }` |
+| `stock_above` | part | `{ "qty": int }` |
+| `back_in_stock` | part | `{}` |
+| `out_of_authorized_stock` | part | `{}` |
+| `price_changed` | part | `{ "delta_pct": Decimal }` |
+| `bom_buyable` | project | `{ "build_quantity": int }` |
+
+The database pins the six MVP alert types with a CHECK constraint, enforces one active
+target via `(part_id IS NOT NULL) <> (project_id IS NOT NULL)`, and prevents duplicate
+active alerts with a partial unique index over workspace, type, target, and threshold.
+`cooldown_seconds` defaults to 24 hours and has a 60-second minimum. Evaluator state
+lives on `last_checked_at`, `last_notified_at`, and `last_evaluation_state`.
+
+Source: `backend/alembic/versions/0044_sourcing_alerts.py:20`
+
 ## Workspace Isolation
 
 Reads filter by both `workspace_id` and `query_hash`, so identical canonical queries in


### PR DESCRIPTION
## Summary
- Adds migration `0044_sourcing_alerts.py` after current head `0043`, creating the workspace-scoped `sourcing_alerts` table.
- Adds CHECK constraints for the six MVP alert types, cooldown minimum, and part/project XOR target rule.
- Adds the partial active-alert uniqueness index plus evaluator lookup/sort indexes.
- Registers `SourcingAlert` in SQLAlchemy metadata and documents the alert schema in sourcing docs / ADR-0020.

## Validation
- `gh issue view 417 --comments -R matescb/stockManager`
- `gh issue view 416 --comments -R matescb/stockManager`
- `uv run alembic heads` -> `0044 (head)`
- `DATABASE_URL=postgresql+psycopg://stockmgr:stockmgr@127.0.0.1:5432/stockmgr_test uv run alembic upgrade head && ... downgrade -1 && ... upgrade head` -> passed; downgrade `0044 -> 0043`, upgrade `0043 -> 0044`.
- `uv run --extra dev pytest -q -k sourcing_alert_models` -> `8 passed, 1029 deselected, 1 warning`.
- `uv run --extra dev pytest -q tests/test_all_models.py` -> `1 passed, 1 warning`.
- `uv run --extra dev ruff check app/domain/sourcing/models.py app/domain/all_models.py tests/test_sourcing_alert_models.py` -> passed.
- `git diff --check` -> passed.

## Not Run / Blocked
- Docker validation commands from #417 could not run because this environment has no `docker` binary (`docker: command not found`).
- Local full `uv run --extra dev ruff check` was attempted and fails on existing repo-wide baseline violations outside this PR; touched Python files pass targeted Ruff.
- `alembic-migration-reviewer` agent was not available in this environment; migration was manually reviewed for linear head, reversible downgrade, constraints, indexes, and DB round-trip.

## Residual Risks
- CI should confirm the exact Docker compose validation commands in the project container.
- This PR intentionally does not implement CRUD routes, evaluator, run_job wiring, or frontend work from #418/#420/#419/#421.

## Merge Order
This PR is first in Phase 5b and must merge before #418/#420/#419/#421.

Closes #417
Refs #416
