### PR TITLE
TP-504: sourcing alerts evaluator + email notification

### DIFF
--- a/backend/app/core/mail.py
+++ b/backend/app/core/mail.py
@@ -15,7 +15,9 @@ Two backends are available:
   are populated.
 
 Call :func:`send_verification_email` from route code — it picks the
-right backend automatically based on the current settings.
+right backend automatically based on the current settings. Background
+jobs that need transactional mail call :func:`send` so they stay on the
+same stdout/dev and SMTP/prod path.
 
 Design notes:
 - All functions are synchronous; FastAPI routes calling them must use
@@ -65,6 +67,54 @@ def _build_verification_email(to: str, verification_link: str) -> MIMEMultipart:
     msg.attach(MIMEText(plain, "plain"))
     msg.attach(MIMEText(html, "html"))
     return msg
+
+
+def _build_email(
+    *,
+    to: str,
+    subject: str,
+    text_body: str,
+    html_body: str | None = None,
+) -> MIMEMultipart:
+    """Build a generic MIME multipart message."""
+    cfg = settings()
+    msg = MIMEMultipart("alternative")
+    msg["Subject"] = subject
+    msg["From"] = cfg.MAIL_FROM
+    msg["To"] = to
+    msg.attach(MIMEText(text_body, "plain"))
+    if html_body is not None:
+        msg.attach(MIMEText(html_body, "html"))
+    return msg
+
+
+def send(
+    *,
+    to: str,
+    subject: str,
+    text_body: str,
+    html_body: str | None = None,
+) -> None:
+    """Send a transactional email on the configured mail backend.
+
+    Dev logs only recipient + subject, never the body. Prod uses the same
+    STARTTLS SMTP path as verification mail and raises on failure so
+    callers can decide whether to fail closed or continue.
+    """
+    cfg = settings()
+    if cfg.APP_ENV == "prod":
+        _send_smtp_message(
+            to=to,
+            subject=subject,
+            text_body=text_body,
+            html_body=html_body,
+        )
+        return
+    _log.warning(
+        "dev mail backend (SMTP not configured): message to %s subject=%s",
+        to,
+        subject,
+    )
 
 
 def send_verification_email(*, to: str, verification_link: str) -> None:
@@ -127,3 +177,27 @@ def _send_smtp(*, to: str, verification_link: str) -> None:
     except Exception as exc:
         _log.error("SMTP send failed to %s: %s", to, exc)
         raise
+
+
+def _send_smtp_message(
+    *,
+    to: str,
+    subject: str,
+    text_body: str,
+    html_body: str | None = None,
+) -> None:
+    """Prod backend: send a generic message via SMTP with STARTTLS."""
+    cfg = settings()
+    msg = _build_email(
+        to=to,
+        subject=subject,
+        text_body=text_body,
+        html_body=html_body,
+    )
+    with smtplib.SMTP(cfg.SMTP_HOST, cfg.SMTP_PORT, timeout=10) as smtp:
+        smtp.ehlo()
+        smtp.starttls()
+        smtp.ehlo()
+        if cfg.SMTP_USER:
+            smtp.login(cfg.SMTP_USER, cfg.SMTP_PASSWORD)
+        smtp.sendmail(cfg.MAIL_FROM, [to], msg.as_string())

--- a/backend/app/domain/sourcing/alerts_evaluator.py
+++ b/backend/app/domain/sourcing/alerts_evaluator.py
@@ -1,0 +1,519 @@
+"""Evaluate sourcing alerts and dispatch email notifications."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.core import mail
+from app.core.config import settings
+from app.core.time import utcnow
+from app.domain.parts.models import Part
+from app.domain.projects.models import Project
+from app.domain.sourcing import service as sourcing_service
+from app.domain.sourcing.pricing import best_unit_price_at_qty
+from app.domain.stock import service as stock_service
+from app.domain.users.models import User
+from app.domain.workspaces.models import Workspace, WorkspaceMember
+
+from .models import SourcingAlert
+
+log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class AlertVerdict:
+    triggered: bool
+    summary: str
+    detail: dict[str, Any]
+    new_state: dict[str, Any]
+
+
+EvaluatorFn = Callable[[Session, Workspace, SourcingAlert], AlertVerdict]
+
+
+def evaluate_all_alerts(db: Session) -> int:
+    """Evaluate every enabled, non-archived sourcing alert.
+
+    Returns the number of alert rows attempted. Each row commits
+    independently so a bad alert cannot roll back earlier bookkeeping.
+    """
+    rows = db.execute(
+        select(SourcingAlert, Workspace)
+        .join(Workspace, Workspace.id == SourcingAlert.workspace_id)
+        .where(SourcingAlert.enabled.is_(True))
+        .where(SourcingAlert.archived_at.is_(None))
+        .order_by(SourcingAlert.workspace_id, SourcingAlert.created_at, SourcingAlert.id)
+    ).all()
+
+    evaluated = 0
+    for alert, workspace in rows:
+        evaluated += 1
+        try:
+            evaluator = EVALUATORS[alert.alert_type]
+            verdict = evaluator(db, workspace, alert)
+            checked_at = utcnow()
+            alert.last_checked_at = checked_at
+            alert.last_evaluation_state = verdict.new_state
+            sent = False
+            if verdict.triggered and _cooldown_elapsed(alert):
+                sent = _send_alert_email(db, workspace, alert, verdict)
+                if sent:
+                    alert.last_notified_at = checked_at
+            db.commit()
+            log.info(
+                "sourcing_alert.evaluated workspace_id=%s alert_id=%s type=%s "
+                "triggered=%s notified=%s",
+                workspace.id,
+                alert.id,
+                alert.alert_type,
+                verdict.triggered,
+                sent,
+            )
+        except Exception:
+            db.rollback()
+            log.exception(
+                "sourcing_alert.evaluation_failed workspace_id=%s alert_id=%s type=%s",
+                getattr(workspace, "id", None),
+                getattr(alert, "id", None),
+                getattr(alert, "alert_type", None),
+            )
+    return evaluated
+
+
+def _evaluate_stock_below(
+    db: Session,
+    workspace: Workspace,
+    alert: SourcingAlert,
+) -> AlertVerdict:
+    part = _part_for_alert(db, workspace, alert)
+    qty = stock_service.current_quantity(
+        db,
+        workspace_id=workspace.id,
+        part_id=part.id,
+    )
+    threshold = _threshold_int(alert, "qty")
+    previous_qty = _previous_int(alert.last_evaluation_state, "qty")
+    triggered = previous_qty is not None and previous_qty >= threshold and qty < threshold
+    return AlertVerdict(
+        triggered=triggered,
+        summary=f"{part.name} stock below {threshold}",
+        detail={
+            "part_id": str(part.id),
+            "part_name": part.name,
+            "mpn": part.mpn,
+            "current_qty": qty,
+            "threshold_qty": threshold,
+        },
+        new_state={"qty": qty},
+    )
+
+
+def _evaluate_stock_above(
+    db: Session,
+    workspace: Workspace,
+    alert: SourcingAlert,
+) -> AlertVerdict:
+    part = _part_for_alert(db, workspace, alert)
+    qty = stock_service.current_quantity(
+        db,
+        workspace_id=workspace.id,
+        part_id=part.id,
+    )
+    threshold = _threshold_int(alert, "qty")
+    previous_qty = _previous_int(alert.last_evaluation_state, "qty")
+    triggered = previous_qty is not None and previous_qty <= threshold and qty > threshold
+    return AlertVerdict(
+        triggered=triggered,
+        summary=f"{part.name} stock above {threshold}",
+        detail={
+            "part_id": str(part.id),
+            "part_name": part.name,
+            "mpn": part.mpn,
+            "current_qty": qty,
+            "threshold_qty": threshold,
+        },
+        new_state={"qty": qty},
+    )
+
+
+def _evaluate_back_in_stock(
+    db: Session,
+    workspace: Workspace,
+    alert: SourcingAlert,
+) -> AlertVerdict:
+    part = _part_for_alert(db, workspace, alert)
+    authorized_stock = _authorized_stock_for_part(db, workspace, alert, part)
+    had_stock = authorized_stock > 0
+    previous_had_stock = _previous_bool(alert.last_evaluation_state, "had_stock")
+    triggered = previous_had_stock is False and had_stock
+    return AlertVerdict(
+        triggered=triggered,
+        summary=f"{part.name} is back in authorized stock",
+        detail={
+            "part_id": str(part.id),
+            "part_name": part.name,
+            "mpn": part.mpn,
+            "authorized_stock": authorized_stock,
+        },
+        new_state={"had_stock": had_stock},
+    )
+
+
+def _evaluate_out_of_authorized_stock(
+    db: Session,
+    workspace: Workspace,
+    alert: SourcingAlert,
+) -> AlertVerdict:
+    part = _part_for_alert(db, workspace, alert)
+    authorized_stock = _authorized_stock_for_part(db, workspace, alert, part)
+    had_stock = authorized_stock > 0
+    previous_had_stock = _previous_bool(alert.last_evaluation_state, "had_stock")
+    triggered = previous_had_stock is True and not had_stock
+    return AlertVerdict(
+        triggered=triggered,
+        summary=f"{part.name} is out of authorized stock",
+        detail={
+            "part_id": str(part.id),
+            "part_name": part.name,
+            "mpn": part.mpn,
+            "authorized_stock": authorized_stock,
+        },
+        new_state={"had_stock": had_stock},
+    )
+
+
+def _evaluate_price_changed(
+    db: Session,
+    workspace: Workspace,
+    alert: SourcingAlert,
+) -> AlertVerdict:
+    part = _part_for_alert(db, workspace, alert)
+    best_price = _best_price_for_part(db, workspace, alert, part)
+    if best_price is None:
+        return AlertVerdict(
+            triggered=False,
+            summary=f"{part.name} has no authorized price",
+            detail={
+                "part_id": str(part.id),
+                "part_name": part.name,
+                "mpn": part.mpn,
+                "current_price": None,
+                "currency": None,
+            },
+            new_state={"last_price": None, "last_currency": None},
+        )
+
+    current_price, current_currency = best_price
+    previous = alert.last_evaluation_state or {}
+    previous_price = _decimal_or_none(previous.get("last_price"))
+    previous_currency = previous.get("last_currency")
+    delta_pct = _threshold_decimal(alert, "delta_pct")
+    triggered = False
+    observed_delta: Decimal | None = None
+    if (
+        previous_price is not None
+        and previous_price != 0
+        and previous_currency == current_currency
+    ):
+        observed_delta = abs((current_price - previous_price) / previous_price) * 100
+        triggered = observed_delta >= delta_pct
+
+    return AlertVerdict(
+        triggered=triggered,
+        summary=f"{part.name} authorized price changed",
+        detail={
+            "part_id": str(part.id),
+            "part_name": part.name,
+            "mpn": part.mpn,
+            "previous_price": str(previous_price) if previous_price is not None else None,
+            "current_price": str(current_price),
+            "currency": current_currency,
+            "delta_pct": str(observed_delta) if observed_delta is not None else None,
+            "threshold_delta_pct": str(delta_pct),
+        },
+        new_state={
+            "last_price": str(current_price),
+            "last_currency": current_currency,
+        },
+    )
+
+
+def _evaluate_bom_buyable(
+    db: Session,
+    workspace: Workspace,
+    alert: SourcingAlert,
+) -> AlertVerdict:
+    project = _project_for_alert(db, workspace, alert)
+    build_quantity = _threshold_int(alert, "build_quantity")
+    bom = sourcing_service.source_bom(
+        db,
+        workspace=workspace,
+        project=project,
+        build_quantity=build_quantity,
+        country=alert.country_code,
+        currency=alert.currency_code,
+        distributors=_distributor_filter(alert),
+        use_cached_data=True,
+    )
+    is_buyable = bom.capacity.can_build_after_purchase >= build_quantity
+    previous_is_buyable = _previous_bool(alert.last_evaluation_state, "is_buyable")
+    triggered = previous_is_buyable is False and is_buyable
+    return AlertVerdict(
+        triggered=triggered,
+        summary=f"{project.name} BOM is buyable",
+        detail={
+            "project_id": str(project.id),
+            "project_name": project.name,
+            "build_quantity": build_quantity,
+            "can_build_after_purchase": bom.capacity.can_build_after_purchase,
+        },
+        new_state={"is_buyable": is_buyable},
+    )
+
+
+EVALUATORS: dict[str, EvaluatorFn] = {
+    "stock_below": _evaluate_stock_below,
+    "stock_above": _evaluate_stock_above,
+    "back_in_stock": _evaluate_back_in_stock,
+    "out_of_authorized_stock": _evaluate_out_of_authorized_stock,
+    "price_changed": _evaluate_price_changed,
+    "bom_buyable": _evaluate_bom_buyable,
+}
+
+
+def _cooldown_elapsed(alert: SourcingAlert) -> bool:
+    if alert.last_notified_at is None:
+        return True
+    return (utcnow() - alert.last_notified_at).total_seconds() >= alert.cooldown_seconds
+
+
+def _send_alert_email(
+    db: Session,
+    workspace: Workspace,
+    alert: SourcingAlert,
+    verdict: AlertVerdict,
+) -> bool:
+    recipients = _recipient_emails(db, workspace, alert)
+    if not recipients:
+        log.warning(
+            "sourcing_alert.no_recipients workspace_id=%s alert_id=%s",
+            workspace.id,
+            alert.id,
+        )
+        return False
+
+    subject = f"[stockManager] {verdict.summary}"
+    body = _render_email_body(workspace, alert, verdict)
+    sent_any = False
+    for recipient in recipients:
+        try:
+            mail.send(to=recipient, subject=subject, text_body=body)
+            sent_any = True
+        except Exception as exc:
+            log.warning(
+                "sourcing_alert.smtp_failed workspace_id=%s alert_id=%s to=%s error=%s",
+                workspace.id,
+                alert.id,
+                recipient,
+                exc,
+            )
+    return sent_any
+
+
+def _recipient_emails(
+    db: Session,
+    workspace: Workspace,
+    alert: SourcingAlert,
+) -> list[str]:
+    base = (
+        select(User.email)
+        .join(WorkspaceMember, WorkspaceMember.user_id == User.id)
+        .where(WorkspaceMember.workspace_id == workspace.id)
+        .where(WorkspaceMember.status == "active")
+    )
+    if alert.notify_user_ids is None:
+        query = base.where(WorkspaceMember.role.in_(("owner", "admin")))
+    else:
+        user_ids = [UUID(str(item)) for item in alert.notify_user_ids]
+        if not user_ids:
+            return []
+        query = base.where(User.id.in_(user_ids))
+    return list(db.execute(query.order_by(User.email)).scalars())
+
+
+def _render_email_body(
+    workspace: Workspace,
+    alert: SourcingAlert,
+    verdict: AlertVerdict,
+) -> str:
+    cfg = settings()
+    target_path = (
+        f"/parts/{alert.part_id}" if alert.part_id is not None else f"/projects/{alert.project_id}"
+    )
+    manage_path = f"/sourcing/alerts?alert_id={alert.id}"
+    detail_lines = "\n".join(
+        f"- {key}: {value}" for key, value in sorted(verdict.detail.items())
+    )
+    return (
+        f"{verdict.summary}\n\n"
+        f"Workspace: {workspace.name}\n"
+        f"Alert type: {alert.alert_type}\n\n"
+        f"Details:\n{detail_lines}\n\n"
+        f"Open target: {cfg.APP_BASE_URL}{target_path}\n"
+        f"Manage this alert: {cfg.APP_BASE_URL}{manage_path}\n\n"
+        f"You are receiving this because you are configured as a recipient "
+        f"for this stockManager sourcing alert."
+    )
+
+
+def _part_for_alert(db: Session, workspace: Workspace, alert: SourcingAlert) -> Part:
+    if alert.part_id is None:
+        raise ValueError(f"alert {alert.id} has no part_id")
+    part = db.execute(
+        select(Part)
+        .where(Part.workspace_id == workspace.id)
+        .where(Part.id == alert.part_id)
+        .where(Part.archived_at.is_(None))
+    ).scalar_one_or_none()
+    if part is None:
+        raise ValueError(f"alert {alert.id} part is missing from workspace {workspace.id}")
+    return part
+
+
+def _project_for_alert(db: Session, workspace: Workspace, alert: SourcingAlert) -> Project:
+    if alert.project_id is None:
+        raise ValueError(f"alert {alert.id} has no project_id")
+    project = db.execute(
+        select(Project)
+        .where(Project.workspace_id == workspace.id)
+        .where(Project.id == alert.project_id)
+        .where(Project.archived_at.is_(None))
+    ).scalar_one_or_none()
+    if project is None:
+        raise ValueError(f"alert {alert.id} project is missing from workspace {workspace.id}")
+    return project
+
+
+def _authorized_stock_for_part(
+    db: Session,
+    workspace: Workspace,
+    alert: SourcingAlert,
+    part: Part,
+) -> int:
+    if not part.mpn:
+        return 0
+    result = sourcing_service.search(
+        db,
+        workspace=workspace,
+        mpns=[part.mpn],
+        country=alert.country_code,
+        currency=alert.currency_code,
+        distributors=_distributor_filter(alert),
+        use_cached_data=True,
+    )
+    return sum(
+        max(0, int(distributor.stock or 0))
+        for item in result.results
+        for offer in item.offers
+        for distributor in offer.distributors
+    )
+
+
+def _best_price_for_part(
+    db: Session,
+    workspace: Workspace,
+    alert: SourcingAlert,
+    part: Part,
+) -> tuple[Decimal, str | None] | None:
+    if not part.mpn:
+        return None
+    result = sourcing_service.search(
+        db,
+        workspace=workspace,
+        mpns=[part.mpn],
+        country=alert.country_code,
+        currency=alert.currency_code,
+        distributors=_distributor_filter(alert),
+        use_cached_data=True,
+    )
+    best: tuple[Decimal, str | None] | None = None
+    for item in result.results:
+        for offer in item.offers:
+            for distributor in offer.distributors:
+                candidate = _unit_price_for_distributor(distributor)
+                if candidate is None:
+                    continue
+                price, currency = candidate
+                if best is None or price < best[0]:
+                    best = (price, currency)
+    return best
+
+
+def _unit_price_for_distributor(distributor: Any) -> tuple[Decimal, str | None] | None:
+    price_breaks = distributor.price_breaks_converted or distributor.price_breaks
+    best = best_unit_price_at_qty(price_breaks, 1)
+    if best is not None:
+        return best[0], distributor.currency_displayed or distributor.currency
+    price = distributor.unit_price_converted
+    currency = distributor.currency_displayed
+    if price is None:
+        price = distributor.unit_price
+        currency = distributor.currency
+    if price is None:
+        return None
+    return Decimal(str(price)), currency
+
+
+def _distributor_filter(alert: SourcingAlert) -> list[str] | None:
+    if alert.distributor_filter is None:
+        return None
+    return [str(item).strip() for item in alert.distributor_filter if str(item).strip()]
+
+
+def _threshold_int(alert: SourcingAlert, key: str) -> int:
+    try:
+        return int(alert.threshold[key])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ValueError(f"alert {alert.id} threshold.{key} must be an integer") from exc
+
+
+def _threshold_decimal(alert: SourcingAlert, key: str) -> Decimal:
+    try:
+        return Decimal(str(alert.threshold[key]))
+    except (KeyError, InvalidOperation) as exc:
+        raise ValueError(f"alert {alert.id} threshold.{key} must be numeric") from exc
+
+
+def _previous_int(state: dict[str, Any] | None, key: str) -> int | None:
+    if not state or state.get(key) is None:
+        return None
+    try:
+        return int(state[key])
+    except (TypeError, ValueError):
+        return None
+
+
+def _previous_bool(state: dict[str, Any] | None, key: str) -> bool | None:
+    if not state or state.get(key) is None:
+        return None
+    value = state[key]
+    if isinstance(value, bool):
+        return value
+    return None
+
+
+def _decimal_or_none(value: Any) -> Decimal | None:
+    if value is None:
+        return None
+    try:
+        return Decimal(str(value))
+    except InvalidOperation:
+        return None

--- a/backend/tests/test_sourcing_alerts_evaluator.py
+++ b/backend/tests/test_sourcing_alerts_evaluator.py
@@ -1,0 +1,733 @@
+from __future__ import annotations
+
+import uuid
+from datetime import timedelta
+from types import SimpleNamespace
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.core.time import utcnow
+from app.domain.parts.models import Part
+from app.domain.projects.models import Project
+from app.domain.sourcing import alerts_evaluator
+from app.domain.sourcing.alerts_evaluator import AlertVerdict, evaluate_all_alerts
+from app.domain.sourcing.models import SourcingAlert
+from app.domain.stock.models import StockEntry
+from app.domain.users.models import User
+from app.domain.workspaces.models import Workspace, WorkspaceMember
+
+
+def _workspace(db: Session, *, role: str = "owner") -> tuple[Workspace, User]:
+    user = User(
+        email=f"alerts-{uuid.uuid4().hex[:8]}@example.com",
+        name="Alert Tester",
+        password_hash="test",
+    )
+    db.add(user)
+    db.flush()
+    workspace = Workspace(
+        name=f"alerts-ws-{uuid.uuid4().hex[:8]}",
+        kind="organization",
+        owner_user_id=user.id,
+    )
+    db.add(workspace)
+    db.flush()
+    db.add(
+        WorkspaceMember(
+            workspace_id=workspace.id,
+            user_id=user.id,
+            role=role,
+            status="active",
+        )
+    )
+    db.flush()
+    return workspace, user
+
+
+def _part(db: Session, workspace: Workspace, user: User, *, mpn: str | None = None) -> Part:
+    part = Part(
+        workspace_id=workspace.id,
+        name=f"Part {uuid.uuid4().hex[:8]}",
+        part_type="local",
+        mpn=mpn or f"MPN-{uuid.uuid4().hex[:8]}",
+        created_by=user.id,
+        updated_by=user.id,
+    )
+    db.add(part)
+    db.flush()
+    return part
+
+
+def _project(db: Session, workspace: Workspace, user: User) -> Project:
+    project = Project(
+        workspace_id=workspace.id,
+        name=f"Project {uuid.uuid4().hex[:8]}",
+        created_by=user.id,
+        updated_by=user.id,
+    )
+    db.add(project)
+    db.flush()
+    return project
+
+
+def _stock(db: Session, workspace: Workspace, part: Part, qty: int, user: User) -> None:
+    db.add(
+        StockEntry(
+            workspace_id=workspace.id,
+            part_id=part.id,
+            quantity_delta=qty,
+            status="on_hand",
+            operation_type="test",
+            created_by=user.id,
+        )
+    )
+    db.flush()
+
+
+def _alert(
+    db: Session,
+    workspace: Workspace,
+    user: User,
+    *,
+    alert_type: str,
+    threshold: dict[str, Any],
+    part: Part | None = None,
+    project: Project | None = None,
+    last_state: dict[str, Any] | None = None,
+    last_notified_offset: timedelta | None = None,
+    notify_user_ids: list[str] | None | object = ...,
+    enabled: bool = True,
+    archived: bool = False,
+    cooldown_seconds: int = 60,
+) -> SourcingAlert:
+    if notify_user_ids is ...:
+        notify_user_ids = [str(user.id)]
+    alert = SourcingAlert(
+        workspace_id=workspace.id,
+        part_id=part.id if part is not None else None,
+        project_id=project.id if project is not None else None,
+        alert_type=alert_type,
+        threshold=threshold,
+        notify_user_ids=notify_user_ids,
+        cooldown_seconds=cooldown_seconds,
+        enabled=enabled,
+        archived_at=utcnow() if archived else None,
+        last_evaluation_state=last_state,
+        last_notified_at=(
+            utcnow() - last_notified_offset if last_notified_offset is not None else None
+        ),
+        created_by=user.id,
+    )
+    db.add(alert)
+    db.flush()
+    return alert
+
+
+def _capture_mail(monkeypatch) -> list[dict[str, Any]]:
+    sent: list[dict[str, Any]] = []
+
+    def fake_send(**kwargs: Any) -> None:
+        sent.append(kwargs)
+
+    monkeypatch.setattr(alerts_evaluator.mail, "send", fake_send)
+    return sent
+
+
+def _search_out(
+    *,
+    stock: int,
+    price: str | None = None,
+    currency: str | None = "USD",
+) -> Any:
+    distributor = SimpleNamespace(
+        stock=stock,
+        unit_price=float(price) if price is not None else None,
+        currency=currency,
+        unit_price_converted=None,
+        currency_displayed=None,
+        price_breaks=[],
+        price_breaks_converted=None,
+    )
+    return SimpleNamespace(
+        results=[
+            SimpleNamespace(
+                offers=[
+                    SimpleNamespace(
+                        distributors=[distributor],
+                    )
+                ]
+            )
+        ]
+    )
+
+
+def test_stock_below_triggers_when_qty_drops(db: Session, monkeypatch) -> None:
+    workspace, user = _workspace(db)
+    part = _part(db, workspace, user)
+    _stock(db, workspace, part, 4, user)
+    alert = _alert(
+        db,
+        workspace,
+        user,
+        part=part,
+        alert_type="stock_below",
+        threshold={"qty": 5},
+        last_state={"qty": 5},
+    )
+    sent = _capture_mail(monkeypatch)
+
+    assert evaluate_all_alerts(db) == 1
+
+    db.refresh(alert)
+    assert len(sent) == 1
+    assert alert.last_checked_at is not None
+    assert alert.last_notified_at is not None
+    assert alert.last_evaluation_state == {"qty": 4}
+
+
+def test_stock_above_triggers_when_qty_rises(db: Session, monkeypatch) -> None:
+    workspace, user = _workspace(db)
+    part = _part(db, workspace, user)
+    _stock(db, workspace, part, 6, user)
+    _alert(
+        db,
+        workspace,
+        user,
+        part=part,
+        alert_type="stock_above",
+        threshold={"qty": 5},
+        last_state={"qty": 5},
+    )
+    sent = _capture_mail(monkeypatch)
+
+    assert evaluate_all_alerts(db) == 1
+
+    assert len(sent) == 1
+
+
+def test_back_in_stock_initial_run_records_state_without_triggering(
+    db: Session,
+    monkeypatch,
+) -> None:
+    workspace, user = _workspace(db)
+    part = _part(db, workspace, user)
+    alert = _alert(
+        db,
+        workspace,
+        user,
+        part=part,
+        alert_type="back_in_stock",
+        threshold={},
+        last_state=None,
+    )
+    monkeypatch.setattr(
+        alerts_evaluator.sourcing_service,
+        "search",
+        lambda *args, **kwargs: _search_out(stock=0),
+    )
+    sent = _capture_mail(monkeypatch)
+
+    assert evaluate_all_alerts(db) == 1
+
+    db.refresh(alert)
+    assert sent == []
+    assert alert.last_notified_at is None
+    assert alert.last_evaluation_state == {"had_stock": False}
+
+
+def test_back_in_stock_triggers_on_zero_to_positive_transition(
+    db: Session,
+    monkeypatch,
+) -> None:
+    workspace, user = _workspace(db)
+    part = _part(db, workspace, user)
+    _alert(
+        db,
+        workspace,
+        user,
+        part=part,
+        alert_type="back_in_stock",
+        threshold={},
+        last_state={"had_stock": False},
+    )
+    monkeypatch.setattr(
+        alerts_evaluator.sourcing_service,
+        "search",
+        lambda *args, **kwargs: _search_out(stock=22),
+    )
+    sent = _capture_mail(monkeypatch)
+
+    assert evaluate_all_alerts(db) == 1
+
+    assert len(sent) == 1
+
+
+def test_back_in_stock_does_not_re_trigger_while_still_in_stock(
+    db: Session,
+    monkeypatch,
+) -> None:
+    workspace, user = _workspace(db)
+    part = _part(db, workspace, user)
+    alert = _alert(
+        db,
+        workspace,
+        user,
+        part=part,
+        alert_type="back_in_stock",
+        threshold={},
+        last_state={"had_stock": True},
+        last_notified_offset=timedelta(hours=2),
+    )
+    monkeypatch.setattr(
+        alerts_evaluator.sourcing_service,
+        "search",
+        lambda *args, **kwargs: _search_out(stock=22),
+    )
+    sent = _capture_mail(monkeypatch)
+
+    assert evaluate_all_alerts(db) == 1
+
+    db.refresh(alert)
+    assert sent == []
+    assert alert.last_evaluation_state == {"had_stock": True}
+
+
+def test_out_of_authorized_stock_triggers_on_positive_to_zero(
+    db: Session,
+    monkeypatch,
+) -> None:
+    workspace, user = _workspace(db)
+    part = _part(db, workspace, user)
+    _alert(
+        db,
+        workspace,
+        user,
+        part=part,
+        alert_type="out_of_authorized_stock",
+        threshold={},
+        last_state={"had_stock": True},
+    )
+    monkeypatch.setattr(
+        alerts_evaluator.sourcing_service,
+        "search",
+        lambda *args, **kwargs: _search_out(stock=0),
+    )
+    sent = _capture_mail(monkeypatch)
+
+    assert evaluate_all_alerts(db) == 1
+
+    assert len(sent) == 1
+
+
+def test_price_changed_triggers_on_delta_pct_breach(db: Session, monkeypatch) -> None:
+    workspace, user = _workspace(db)
+    part = _part(db, workspace, user)
+    _alert(
+        db,
+        workspace,
+        user,
+        part=part,
+        alert_type="price_changed",
+        threshold={"delta_pct": 10},
+        last_state={"last_price": "1.00", "last_currency": "USD"},
+    )
+    monkeypatch.setattr(
+        alerts_evaluator.sourcing_service,
+        "search",
+        lambda *args, **kwargs: _search_out(stock=10, price="1.25"),
+    )
+    sent = _capture_mail(monkeypatch)
+
+    assert evaluate_all_alerts(db) == 1
+
+    assert len(sent) == 1
+
+
+def test_price_changed_currency_mismatch_resets_state_no_trigger(
+    db: Session,
+    monkeypatch,
+) -> None:
+    workspace, user = _workspace(db)
+    part = _part(db, workspace, user)
+    alert = _alert(
+        db,
+        workspace,
+        user,
+        part=part,
+        alert_type="price_changed",
+        threshold={"delta_pct": 10},
+        last_state={"last_price": "1.00", "last_currency": "USD"},
+    )
+    monkeypatch.setattr(
+        alerts_evaluator.sourcing_service,
+        "search",
+        lambda *args, **kwargs: _search_out(stock=10, price="1.25", currency="EUR"),
+    )
+    sent = _capture_mail(monkeypatch)
+
+    assert evaluate_all_alerts(db) == 1
+
+    db.refresh(alert)
+    assert sent == []
+    assert alert.last_evaluation_state == {"last_price": "1.25", "last_currency": "EUR"}
+
+
+def test_bom_buyable_triggers_on_not_buyable_to_buyable_transition(
+    db: Session,
+    monkeypatch,
+) -> None:
+    workspace, user = _workspace(db)
+    project = _project(db, workspace, user)
+    _alert(
+        db,
+        workspace,
+        user,
+        project=project,
+        alert_type="bom_buyable",
+        threshold={"build_quantity": 3},
+        last_state={"is_buyable": False},
+    )
+
+    def fake_source_bom(*args: Any, **kwargs: Any) -> Any:
+        return SimpleNamespace(
+            capacity=SimpleNamespace(can_build_after_purchase=3),
+        )
+
+    monkeypatch.setattr(alerts_evaluator.sourcing_service, "source_bom", fake_source_bom)
+    sent = _capture_mail(monkeypatch)
+
+    assert evaluate_all_alerts(db) == 1
+
+    assert len(sent) == 1
+
+
+def test_cooldown_suppresses_second_notification(db: Session, monkeypatch) -> None:
+    workspace, user = _workspace(db)
+    part = _part(db, workspace, user)
+    _alert(
+        db,
+        workspace,
+        user,
+        part=part,
+        alert_type="stock_below",
+        threshold={"qty": 5},
+        last_notified_offset=timedelta(seconds=10),
+        cooldown_seconds=60,
+    )
+    monkeypatch.setitem(
+        alerts_evaluator.EVALUATORS,
+        "stock_below",
+        lambda _db, _ws, _alert: AlertVerdict(True, "Triggered", {}, {"qty": 1}),
+    )
+    sent = _capture_mail(monkeypatch)
+
+    assert evaluate_all_alerts(db) == 1
+
+    assert sent == []
+
+
+def test_cooldown_elapsed_re_triggers(db: Session, monkeypatch) -> None:
+    workspace, user = _workspace(db)
+    part = _part(db, workspace, user)
+    _alert(
+        db,
+        workspace,
+        user,
+        part=part,
+        alert_type="stock_below",
+        threshold={"qty": 5},
+        last_notified_offset=timedelta(seconds=120),
+        cooldown_seconds=60,
+    )
+    monkeypatch.setitem(
+        alerts_evaluator.EVALUATORS,
+        "stock_below",
+        lambda _db, _ws, _alert: AlertVerdict(True, "Triggered", {}, {"qty": 1}),
+    )
+    sent = _capture_mail(monkeypatch)
+
+    assert evaluate_all_alerts(db) == 1
+
+    assert len(sent) == 1
+
+
+def test_smtp_failure_does_not_crash_loop(db: Session, monkeypatch, caplog) -> None:
+    workspace, user = _workspace(db)
+    part = _part(db, workspace, user)
+    _alert(
+        db,
+        workspace,
+        user,
+        part=part,
+        alert_type="stock_below",
+        threshold={"qty": 5},
+    )
+    monkeypatch.setitem(
+        alerts_evaluator.EVALUATORS,
+        "stock_below",
+        lambda _db, _ws, _alert: AlertVerdict(True, "Triggered", {}, {"qty": 1}),
+    )
+
+    def fail_send(**_kwargs: Any) -> None:
+        raise RuntimeError("smtp down")
+
+    monkeypatch.setattr(alerts_evaluator.mail, "send", fail_send)
+
+    assert evaluate_all_alerts(db) == 1
+
+    assert "sourcing_alert.smtp_failed" in caplog.text
+
+
+def test_recipients_default_to_workspace_admins_when_notify_user_ids_null(
+    db: Session,
+    monkeypatch,
+) -> None:
+    workspace, user = _workspace(db, role="admin")
+    part = _part(db, workspace, user)
+    _alert(
+        db,
+        workspace,
+        user,
+        part=part,
+        alert_type="stock_below",
+        threshold={"qty": 5},
+        notify_user_ids=None,
+    )
+    monkeypatch.setitem(
+        alerts_evaluator.EVALUATORS,
+        "stock_below",
+        lambda _db, _ws, _alert: AlertVerdict(True, "Triggered", {}, {"qty": 1}),
+    )
+    sent = _capture_mail(monkeypatch)
+
+    assert evaluate_all_alerts(db) == 1
+
+    assert [item["to"] for item in sent] == [user.email]
+
+
+def test_no_recipients_logs_warning_and_continues(
+    db: Session,
+    monkeypatch,
+    caplog,
+) -> None:
+    workspace, user = _workspace(db)
+    part = _part(db, workspace, user)
+    alert = _alert(
+        db,
+        workspace,
+        user,
+        part=part,
+        alert_type="stock_below",
+        threshold={"qty": 5},
+        notify_user_ids=[],
+    )
+    monkeypatch.setitem(
+        alerts_evaluator.EVALUATORS,
+        "stock_below",
+        lambda _db, _ws, _alert: AlertVerdict(True, "Triggered", {}, {"qty": 1}),
+    )
+    sent = _capture_mail(monkeypatch)
+
+    assert evaluate_all_alerts(db) == 1
+
+    db.refresh(alert)
+    assert sent == []
+    assert alert.last_notified_at is None
+    assert "sourcing_alert.no_recipients" in caplog.text
+
+
+def test_evaluator_uses_cache_default_true_for_sourcing_alerts(
+    db: Session,
+    monkeypatch,
+) -> None:
+    workspace, user = _workspace(db)
+    part = _part(db, workspace, user)
+    project = _project(db, workspace, user)
+    _alert(
+        db,
+        workspace,
+        user,
+        part=part,
+        alert_type="back_in_stock",
+        threshold={},
+        last_state={"had_stock": False},
+    )
+    _alert(
+        db,
+        workspace,
+        user,
+        project=project,
+        alert_type="bom_buyable",
+        threshold={"build_quantity": 2},
+        last_state={"is_buyable": False},
+    )
+    search_cached: list[bool | None] = []
+    bom_cached: list[bool | None] = []
+
+    def fake_search(*args: Any, **kwargs: Any) -> Any:
+        search_cached.append(kwargs.get("use_cached_data"))
+        return _search_out(stock=1)
+
+    def fake_source_bom(*args: Any, **kwargs: Any) -> Any:
+        bom_cached.append(kwargs.get("use_cached_data"))
+        return SimpleNamespace(
+            capacity=SimpleNamespace(can_build_after_purchase=2),
+        )
+
+    monkeypatch.setattr(alerts_evaluator.sourcing_service, "search", fake_search)
+    monkeypatch.setattr(alerts_evaluator.sourcing_service, "source_bom", fake_source_bom)
+    _capture_mail(monkeypatch)
+
+    assert evaluate_all_alerts(db) == 2
+
+    assert search_cached == [True]
+    assert bom_cached == [True]
+
+
+def test_workspace_isolation_two_alerts_same_mpn_different_workspaces(
+    db: Session,
+    monkeypatch,
+) -> None:
+    workspace_a, user_a = _workspace(db)
+    workspace_b, user_b = _workspace(db)
+    part_a = _part(db, workspace_a, user_a, mpn="SHARED-MPN")
+    part_b = _part(db, workspace_b, user_b, mpn="SHARED-MPN")
+    _alert(
+        db,
+        workspace_a,
+        user_a,
+        part=part_a,
+        alert_type="back_in_stock",
+        threshold={},
+        last_state={"had_stock": False},
+    )
+    _alert(
+        db,
+        workspace_b,
+        user_b,
+        part=part_b,
+        alert_type="back_in_stock",
+        threshold={},
+        last_state={"had_stock": False},
+    )
+    seen: list[uuid.UUID] = []
+
+    def fake_search(*args: Any, **kwargs: Any) -> Any:
+        seen.append(kwargs["workspace"].id)
+        return _search_out(stock=1)
+
+    monkeypatch.setattr(alerts_evaluator.sourcing_service, "search", fake_search)
+    sent = _capture_mail(monkeypatch)
+
+    assert evaluate_all_alerts(db) == 2
+
+    assert set(seen) == {workspace_a.id, workspace_b.id}
+    assert len(sent) == 2
+
+
+def test_archived_alerts_skipped(db: Session, monkeypatch) -> None:
+    workspace, user = _workspace(db)
+    part = _part(db, workspace, user)
+    _alert(
+        db,
+        workspace,
+        user,
+        part=part,
+        alert_type="stock_below",
+        threshold={"qty": 5},
+        archived=True,
+    )
+    monkeypatch.setitem(
+        alerts_evaluator.EVALUATORS,
+        "stock_below",
+        lambda _db, _ws, _alert: AlertVerdict(True, "Triggered", {}, {"qty": 1}),
+    )
+    sent = _capture_mail(monkeypatch)
+
+    assert evaluate_all_alerts(db) == 0
+
+    assert sent == []
+
+
+def test_disabled_alerts_skipped(db: Session, monkeypatch) -> None:
+    workspace, user = _workspace(db)
+    part = _part(db, workspace, user)
+    _alert(
+        db,
+        workspace,
+        user,
+        part=part,
+        alert_type="stock_below",
+        threshold={"qty": 5},
+        enabled=False,
+    )
+    monkeypatch.setitem(
+        alerts_evaluator.EVALUATORS,
+        "stock_below",
+        lambda _db, _ws, _alert: AlertVerdict(True, "Triggered", {}, {"qty": 1}),
+    )
+    sent = _capture_mail(monkeypatch)
+
+    assert evaluate_all_alerts(db) == 0
+
+    assert sent == []
+
+
+def test_last_notified_at_updates_only_on_actual_email_send(
+    db: Session,
+    monkeypatch,
+) -> None:
+    workspace, user = _workspace(db)
+    part = _part(db, workspace, user)
+    alert = _alert(
+        db,
+        workspace,
+        user,
+        part=part,
+        alert_type="stock_below",
+        threshold={"qty": 5},
+        notify_user_ids=[],
+    )
+    monkeypatch.setitem(
+        alerts_evaluator.EVALUATORS,
+        "stock_below",
+        lambda _db, _ws, _alert: AlertVerdict(True, "Triggered", {}, {"qty": 1}),
+    )
+    _capture_mail(monkeypatch)
+
+    assert evaluate_all_alerts(db) == 1
+
+    db.refresh(alert)
+    assert alert.last_checked_at is not None
+    assert alert.last_notified_at is None
+
+
+def test_no_persistent_alert_history_table() -> None:
+    assert "sourcing_alert_history" not in SourcingAlert.metadata.tables
+    assert "sourcing_alert_events" not in SourcingAlert.metadata.tables
+
+
+def test_all_alerts_are_persisted_as_json_state(db: Session, monkeypatch) -> None:
+    workspace, user = _workspace(db)
+    part = _part(db, workspace, user)
+    alert = _alert(
+        db,
+        workspace,
+        user,
+        part=part,
+        alert_type="stock_below",
+        threshold={"qty": 5},
+    )
+    monkeypatch.setitem(
+        alerts_evaluator.EVALUATORS,
+        "stock_below",
+        lambda _db, _ws, _alert: AlertVerdict(False, "State", {}, {"opaque": "value"}),
+    )
+    _capture_mail(monkeypatch)
+
+    assert evaluate_all_alerts(db) == 1
+
+    stored = db.execute(select(SourcingAlert).where(SourcingAlert.id == alert.id)).scalar_one()
+    assert stored.last_evaluation_state == {"opaque": "value"}

--- a/backend/tests/test_workspace_isolation.py
+++ b/backend/tests/test_workspace_isolation.py
@@ -569,7 +569,6 @@ def test_no_cross_workspace_default_storage_in_existing_rows():
     `default_storage_location_id` references a `storage_locations` row
     in a different workspace. Doubles as the form of the prod audit
     query the issue suggests running once on `main`."""
-    import pytest as _pytest  # local import — module-level pytest is unused
     from sqlalchemy import text
 
     from app.infra.db import SessionLocal
@@ -1098,7 +1097,7 @@ def test_catalog_token_404s_on_wrong_workspace_token():
     # A enables their catalog
     r = a.patch("/api/workspaces/current", json={"catalog_enabled": True})
     assert r.status_code == 200, r.text
-    me = a.get("/api/auth/me").json()["data"]
+    assert a.get("/api/auth/me").status_code == 200
     # Fetching with a fake token must 404 — and we never authenticated
     # the call to /catalog so this is the unauthenticated probe.
     fresh = TestClient(app)
@@ -1162,8 +1161,6 @@ def test_order_entry_foreign_entry_id_is_404():
     Without assert_child_in_parent, db.get(OrderEntry, id) returned the
     cross-workspace row and let it be mutated."""
     a, b = _two_workspaces()
-    part_a = _create_part(a, "A-Part")
-
     # A creates an order + entry.
     order_a = a.post("/api/orders", json={"name": "OA"}).json()["data"]["id"]
     entry_a = a.post(
@@ -1227,3 +1224,95 @@ def test_audit_log_does_not_leak_cross_workspace_rows():
     assert a_part_ids_in_b == [], (
         f"Workspace A's audit rows leaked into workspace B's log: {a_part_ids_in_b}"
     )
+
+
+def test_sourcing_alert_evaluator_isolated_by_workspace(db, monkeypatch):
+    """Alert evaluation must call sourcing with each alert's own workspace."""
+    from app.domain.parts.models import Part
+    from app.domain.sourcing import alerts_evaluator
+    from app.domain.sourcing.models import SourcingAlert
+    from app.domain.users.models import User
+    from app.domain.workspaces.models import Workspace, WorkspaceMember
+
+    def make_workspace() -> tuple[Workspace, User]:
+        user = User(
+            email=f"alert-isolation-{uuid.uuid4().hex[:8]}@example.com",
+            name="Alert Isolation",
+            password_hash="test",
+        )
+        db.add(user)
+        db.flush()
+        workspace = Workspace(
+            name=f"alert-isolation-{uuid.uuid4().hex[:8]}",
+            kind="organization",
+            owner_user_id=user.id,
+        )
+        db.add(workspace)
+        db.flush()
+        db.add(
+            WorkspaceMember(
+                workspace_id=workspace.id,
+                user_id=user.id,
+                role="owner",
+                status="active",
+            )
+        )
+        db.flush()
+        return workspace, user
+
+    def make_part(workspace: Workspace, user: User) -> Part:
+        part = Part(
+            workspace_id=workspace.id,
+            name=f"Shared MPN {uuid.uuid4().hex[:8]}",
+            part_type="local",
+            mpn="ALERT-SHARED-MPN",
+            created_by=user.id,
+            updated_by=user.id,
+        )
+        db.add(part)
+        db.flush()
+        return part
+
+    workspace_a, user_a = make_workspace()
+    workspace_b, user_b = make_workspace()
+    part_a = make_part(workspace_a, user_a)
+    part_b = make_part(workspace_b, user_b)
+    db.add_all(
+        [
+            SourcingAlert(
+                workspace_id=workspace_a.id,
+                part_id=part_a.id,
+                alert_type="back_in_stock",
+                threshold={},
+                notify_user_ids=[str(user_a.id)],
+                last_evaluation_state={"had_stock": False},
+                created_by=user_a.id,
+            ),
+            SourcingAlert(
+                workspace_id=workspace_b.id,
+                part_id=part_b.id,
+                alert_type="back_in_stock",
+                threshold={},
+                notify_user_ids=[str(user_b.id)],
+                last_evaluation_state={"had_stock": False},
+                created_by=user_b.id,
+            ),
+        ]
+    )
+    db.flush()
+
+    seen_workspace_ids = []
+
+    def fake_search(*args, **kwargs):
+        seen_workspace_ids.append(kwargs["workspace"].id)
+        distributor = type("Distributor", (), {"stock": 1})()
+        offer = type("Offer", (), {"distributors": [distributor]})()
+        result = type("Result", (), {"offers": [offer]})()
+        return type("SearchOut", (), {"results": [result]})()
+
+    monkeypatch.setattr(alerts_evaluator.sourcing_service, "search", fake_search)
+    monkeypatch.setattr(alerts_evaluator.mail, "send", lambda **kwargs: None)
+
+    assert alerts_evaluator.evaluate_all_alerts(db) == 2
+
+    assert set(seen_workspace_ids) == {workspace_a.id, workspace_b.id}

--- a/docs/domain/sourcing.md
+++ b/docs/domain/sourcing.md
@@ -120,6 +120,43 @@ lives on `last_checked_at`, `last_notified_at`, and `last_evaluation_state`.
 
 Source: `backend/alembic/versions/0044_sourcing_alerts.py:20`
 
+### Evaluator Behaviour
+
+`evaluate_all_alerts(db)` scans enabled, non-archived rows across workspaces, dispatches
+by `alert_type`, persists `last_checked_at` and `last_evaluation_state`, and commits
+per alert row. Evaluator failures roll back only the current row and are logged so later
+alerts still run. Source: `backend/app/domain/sourcing/alerts_evaluator.py:42-88`
+
+All evaluator queries stay workspace-scoped. Part and project targets are loaded with
+`workspace_id == workspace.id`, recipient lookup joins `workspace_members` on the same
+workspace, and sourcing calls receive the current alert workspace. Sources:
+`backend/app/domain/sourcing/alerts_evaluator.py:331-349`,
+`backend/app/domain/sourcing/alerts_evaluator.py:377-402`
+
+| `alert_type` | Trigger rule | Persisted state |
+|---|---|---|
+| `stock_below` | current stock crosses from `>= threshold.qty` to `< threshold.qty` | `{ "qty": int }` |
+| `stock_above` | current stock crosses from `<= threshold.qty` to `> threshold.qty` | `{ "qty": int }` |
+| `back_in_stock` | authorized stock crosses from zero to positive | `{ "had_stock": bool }` |
+| `out_of_authorized_stock` | authorized stock crosses from positive to zero | `{ "had_stock": bool }` |
+| `price_changed` | same-currency best authorized unit price changes by at least `threshold.delta_pct` percent | `{ "last_price": str, "last_currency": str }` |
+| `bom_buyable` | `can_build_after_purchase >= threshold.build_quantity` after a prior not-buyable state | `{ "is_buyable": bool }` |
+
+First evaluation records state and does not notify because no prior state exists.
+Stock alerts read quantity only through `domain/stock/service.py::current_quantity`.
+Sourcing-typed part alerts call `sourcing.service.search(..., use_cached_data=True)`;
+BOM buyability calls `sourcing.service.source_bom(..., use_cached_data=True)` and uses
+the returned capacity computed by `compute_build_capacity`. Sources:
+`backend/app/domain/sourcing/alerts_evaluator.py:91-279`,
+`backend/app/domain/sourcing/alerts_evaluator.py:405-457`
+
+Cooldown is DB-backed: notification is allowed when `last_notified_at IS NULL` or when
+the elapsed wall time is at least `cooldown_seconds`. `last_notified_at` updates only
+after a successful email send. SMTP failures and missing recipients are logged at
+warning level and do not stop the evaluator loop. Sources:
+`backend/app/domain/sourcing/alerts_evaluator.py:292-328`,
+`backend/app/core/mail.py:70-102`
+
 ## Workspace Isolation
 
 Reads filter by both `workspace_id` and `query_hash`, so identical canonical queries in

--- a/docs/runbooks/on-call-quickstart.md
+++ b/docs/runbooks/on-call-quickstart.md
@@ -103,9 +103,32 @@ sudo -u deploy docker compose -f docker-compose.prod.yml --env-file .env.prod \
 | Sentry issue spike, app still up | [`sentry-triage.md`](sentry-triage.md) |
 | Backups missing, restore needed | [`backup-restore.md`](backup-restore.md) |
 | Email not sending (signup / invitation) | [`smtp-outage.md`](smtp-outage.md) |
+| User reports a sourcing alert did not fire | Alert checks below, then [`smtp-outage.md`](smtp-outage.md) if email dispatch failed |
 | DigiKey or Mouser lookup failing | [`provider-outage.md`](provider-outage.md) |
 | Workspace is unreachable / disabled / suspected isolation leak | [`workspace-recovery.md`](workspace-recovery.md) |
 | Something I can't categorise | [`incident-response.md`](incident-response.md) — declare an incident |
+
+### User Reports a Sourcing Alert Did Not Fire
+
+Check the row state first:
+
+```bash
+sudo -u deploy docker compose -f docker-compose.prod.yml --env-file .env.prod \
+  exec db psql "$DATABASE_URL" -c \
+  "SELECT id, alert_type, enabled, archived_at, last_checked_at, last_notified_at, last_evaluation_state FROM sourcing_alerts WHERE workspace_id = '<WORKSPACE_ID>' ORDER BY created_at DESC LIMIT 20;"
+```
+
+- `last_checked_at` is null or stale: the alert evaluator job did not run; check the
+  backend-cron-alerts container once TP-503 lands.
+- `last_evaluation_state` is null: first evaluation records state and does not notify.
+- `last_notified_at` is recent: cooldown may be suppressing another email; compare with
+  `cooldown_seconds`.
+- Sourcing alert types use cached TrustedParts data by default; a manual fresh refresh
+  may show newer provider state than the evaluator saw.
+- If the row says it notified but the user has no email, check backend logs for
+  `sourcing_alert.smtp_failed` and continue with [`smtp-outage.md`](smtp-outage.md).
+
+Source: `backend/app/domain/sourcing/alerts_evaluator.py:42-88`
 
 ## Where the dashboards live
 


### PR DESCRIPTION
## Summary

- Adds `app.domain.sourcing.alerts_evaluator.evaluate_all_alerts(db)` with six per-type evaluators, per-alert commits, transition detection, DB-backed cooldown, and JSON state persistence on `sourcing_alerts.last_evaluation_state`.
- Sends alert email through the existing `app.core.mail` path via a generic `mail.send(...)` helper; alert bodies use inline strings rather than Jinja templates to keep this PR scoped.
- Adds focused evaluator tests, a workspace-isolation regression pin, and docs for alert evaluator behavior plus on-call troubleshooting.
- Does not depend on #418 CRUD; tests seed `sourcing_alerts` rows directly.

Closes #420
Refs #416

## Merge Order

- #431 is already merged into `main` and this branch is rebased onto current `origin/main`.
- #419 must follow this PR (#420).

## Email Rendering Choice

This PR uses inline text bodies in `backend/app/domain/sourcing/alerts_evaluator.py` instead of Jinja templates. The bodies are deterministic, testable through the existing mail seam, and include alert detail, target link, manage-alert link, and the recipient footer required by #420.

## Example Emails

`stock_below`

Subject: `[stockManager] 10k resistor stock below 5`

```text
10k resistor stock below 5

Workspace: Lab
Alert type: stock_below

Details:
- current_qty: 4
- mpn: RC0603FR-0710KL
- part_id: <PART_ID>
- part_name: 10k resistor
- threshold_qty: 5

Open target: https://parts.example.test/parts/<PART_ID>
Manage this alert: https://parts.example.test/sourcing/alerts?alert_id=<ALERT_ID>

You are receiving this because you are configured as a recipient for this stockManager sourcing alert.
```

`stock_above`

Subject: `[stockManager] 10k resistor stock above 50`

```text
10k resistor stock above 50

Workspace: Lab
Alert type: stock_above

Details:
- current_qty: 51
- mpn: RC0603FR-0710KL
- part_id: <PART_ID>
- part_name: 10k resistor
- threshold_qty: 50

Open target: https://parts.example.test/parts/<PART_ID>
Manage this alert: https://parts.example.test/sourcing/alerts?alert_id=<ALERT_ID>

You are receiving this because you are configured as a recipient for this stockManager sourcing alert.
```

`back_in_stock`

Subject: `[stockManager] STM32 is back in authorized stock`

```text
STM32 is back in authorized stock

Workspace: Lab
Alert type: back_in_stock

Details:
- authorized_stock: 22
- mpn: STM32F103C8T6
- part_id: <PART_ID>
- part_name: STM32

Open target: https://parts.example.test/parts/<PART_ID>
Manage this alert: https://parts.example.test/sourcing/alerts?alert_id=<ALERT_ID>

You are receiving this because you are configured as a recipient for this stockManager sourcing alert.
```

`out_of_authorized_stock`

Subject: `[stockManager] STM32 is out of authorized stock`

```text
STM32 is out of authorized stock

Workspace: Lab
Alert type: out_of_authorized_stock

Details:
- authorized_stock: 0
- mpn: STM32F103C8T6
- part_id: <PART_ID>
- part_name: STM32

Open target: https://parts.example.test/parts/<PART_ID>
Manage this alert: https://parts.example.test/sourcing/alerts?alert_id=<ALERT_ID>

You are receiving this because you are configured as a recipient for this stockManager sourcing alert.
```

`price_changed`

Subject: `[stockManager] STM32 authorized price changed`

```text
STM32 authorized price changed

Workspace: Lab
Alert type: price_changed

Details:
- currency: USD
- current_price: 1.25
- delta_pct: 25.00
- mpn: STM32F103C8T6
- part_id: <PART_ID>
- part_name: STM32
- previous_price: 1.00
- threshold_delta_pct: 10

Open target: https://parts.example.test/parts/<PART_ID>
Manage this alert: https://parts.example.test/sourcing/alerts?alert_id=<ALERT_ID>

You are receiving this because you are configured as a recipient for this stockManager sourcing alert.
```

`bom_buyable`

Subject: `[stockManager] Controller BOM is buyable`

```text
Controller BOM is buyable

Workspace: Lab
Alert type: bom_buyable

Details:
- build_quantity: 3
- can_build_after_purchase: 3
- project_id: <PROJECT_ID>
- project_name: Controller BOM

Open target: https://parts.example.test/projects/<PROJECT_ID>
Manage this alert: https://parts.example.test/sourcing/alerts?alert_id=<ALERT_ID>

You are receiving this because you are configured as a recipient for this stockManager sourcing alert.
```

## Validation

- `uv run --extra dev pytest -q tests/test_sourcing_alerts_evaluator.py tests/test_workspace_isolation.py::test_sourcing_alert_evaluator_isolated_by_workspace` → `22 passed, 1 warning in 1.96s`.
- `uv run --extra dev pytest -q -k "sourcing_alerts_evaluator or workspace_isolation"` → `82 passed, 977 deselected, 2 warnings in 26.63s`.
- `python3 -m ruff check backend/app/core/mail.py backend/app/domain/sourcing/alerts_evaluator.py backend/tests/test_sourcing_alerts_evaluator.py backend/tests/test_workspace_isolation.py` → `All checks passed!`.
- Exact Docker validation commands from #420 were not runnable in this environment because `docker` is not installed.
- Raw full `uv run --extra dev ruff check` reports existing repository-wide lint debt outside this PR; changed-file ruff is clean.
- Manual smoke `python -m app.cli.run_job sourcing-alerts-evaluate` was not run because #419 is the follow-up that wires the job entry.

## Residual Risks

- CI should run the project’s baseline-aware lint path; raw full ruff on this checkout is not currently a meaningful green signal because of existing violations.
- End-to-end SMTP delivery still needs an environment with configured mail credentials; unit coverage verifies SMTP failure logs and the evaluator continues.
