### PR TITLE
TP-502: sourcing_alerts CRUD endpoints

### DIFF
--- a/backend/app/api/routes/sourcing.py
+++ b/backend/app/api/routes/sourcing.py
@@ -164,6 +164,8 @@ def list_sourcing_alerts(
     part_id: UUID | None = None,
     project_id: UUID | None = None,
     include_archived: bool = False,
+    limit: int = Query(100, ge=1, le=500),
+    offset: int = Query(0, ge=0),
     db: Session = Depends(get_db),
 ):
     alerts = sourcing_service.list_alerts(
@@ -174,6 +176,8 @@ def list_sourcing_alerts(
         part_id=part_id,
         project_id=project_id,
         include_archived=include_archived,
+        limit=limit,
+        offset=offset,
     )
     return ok([_alert_payload(alert) for alert in alerts])
 

--- a/backend/app/api/routes/sourcing.py
+++ b/backend/app/api/routes/sourcing.py
@@ -29,6 +29,10 @@ from app.domain.sourcing.models import PurchasePlan
 from app.domain.sourcing.schemas import (
     PurchasePlanIn,
     PurchasePlanOrdersIn,
+    SourcingAlertIn,
+    SourcingAlertOut,
+    SourcingAlertPatch,
+    SourcingAlertType,
     SourcingBomIn,
     SourcingConvertedPriceBreak,
     SourcingQuery,
@@ -147,6 +151,97 @@ def search_sourcing(
         )
 
     return ok(out.model_dump(mode="json"))
+
+
+@search_router.get(
+    "/alerts",
+    dependencies=[Depends(require_role("member"))],
+)
+def list_sourcing_alerts(
+    ws: CurrentWorkspace,
+    enabled: bool | None = None,
+    alert_type: SourcingAlertType | None = None,
+    part_id: UUID | None = None,
+    project_id: UUID | None = None,
+    include_archived: bool = False,
+    db: Session = Depends(get_db),
+):
+    alerts = sourcing_service.list_alerts(
+        db,
+        workspace=ws,
+        enabled=enabled,
+        alert_type=alert_type,
+        part_id=part_id,
+        project_id=project_id,
+        include_archived=include_archived,
+    )
+    return ok([_alert_payload(alert) for alert in alerts])
+
+
+@search_router.post(
+    "/alerts",
+    dependencies=[Depends(require_role("member"))],
+)
+@limiter.limit("30/minute", key_func=workspace_key)
+def create_sourcing_alert(
+    request: Request,
+    payload: SourcingAlertIn,
+    ws: CurrentWorkspace,
+    user: CurrentUser,
+    db: Session = Depends(get_db),
+):
+    alert = sourcing_service.create_alert(
+        db,
+        workspace=ws,
+        user_id=user.id,
+        payload=payload,
+    )
+    return ok(_alert_payload(alert))
+
+
+@search_router.get(
+    "/alerts/{alert_id}",
+    dependencies=[Depends(require_role("member"))],
+)
+def get_sourcing_alert(
+    alert_id: UUID,
+    ws: CurrentWorkspace,
+    db: Session = Depends(get_db),
+):
+    alert = sourcing_service.get_alert(db, workspace=ws, alert_id=alert_id)
+    return ok(_alert_payload(alert))
+
+
+@search_router.patch(
+    "/alerts/{alert_id}",
+    dependencies=[Depends(require_role("member"))],
+)
+def update_sourcing_alert(
+    alert_id: UUID,
+    payload: SourcingAlertPatch,
+    ws: CurrentWorkspace,
+    db: Session = Depends(get_db),
+):
+    alert = sourcing_service.update_alert(
+        db,
+        workspace=ws,
+        alert_id=alert_id,
+        payload=payload,
+    )
+    return ok(_alert_payload(alert))
+
+
+@search_router.delete(
+    "/alerts/{alert_id}",
+    dependencies=[Depends(require_role("member"))],
+)
+def delete_sourcing_alert(
+    alert_id: UUID,
+    ws: CurrentWorkspace,
+    db: Session = Depends(get_db),
+):
+    alert = sourcing_service.archive_alert(db, workspace=ws, alert_id=alert_id)
+    return ok(_alert_payload(alert))
 
 
 @projects_router.post(
@@ -621,6 +716,10 @@ def _clean_query_distributors(value: list[str] | None) -> list[str] | None:
     for item in value:
         cleaned.extend(part.strip() for part in item.split(",") if part.strip())
     return cleaned or None
+
+
+def _alert_payload(alert) -> dict:
+    return SourcingAlertOut.model_validate(alert).model_dump(mode="json")
 
 
 def _error_response(

--- a/backend/app/domain/sourcing/schemas.py
+++ b/backend/app/domain/sourcing/schemas.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from datetime import date, datetime
 from decimal import Decimal
-from typing import Literal
+from typing import Any, Literal
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
@@ -168,6 +168,121 @@ class SourcingBomIn(BaseModel):
             return None
         stripped = [item.strip() for item in value if item.strip()]
         return stripped or None
+
+
+SourcingAlertType = Literal[
+    "stock_below",
+    "stock_above",
+    "back_in_stock",
+    "out_of_authorized_stock",
+    "price_changed",
+    "bom_buyable",
+]
+
+
+class StockBelowThreshold(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    qty: int = Field(ge=0)
+
+
+class StockAboveThreshold(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    qty: int = Field(ge=0)
+
+
+class BackInStockThreshold(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class OutOfAuthorizedStockThreshold(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class PriceChangedThreshold(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    delta_pct: Decimal = Field(gt=0, le=100)
+
+
+class BomBuyableThreshold(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    build_quantity: int = Field(ge=1)
+
+
+class SourcingAlertIn(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    alert_type: SourcingAlertType
+    part_id: UUID | None = None
+    project_id: UUID | None = None
+    threshold: dict[str, Any]
+    country_code: str | None = Field(default=None, min_length=2, max_length=2)
+    currency_code: str | None = Field(default=None, min_length=3, max_length=3)
+    distributor_filter: list[str] | None = None
+    notify_user_ids: list[UUID] | None = None
+    cooldown_seconds: int = Field(default=86400, ge=60)
+    enabled: bool = True
+
+    @field_validator("country_code", "currency_code")
+    @classmethod
+    def _uppercase_codes(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return value.strip().upper()
+
+    @field_validator("distributor_filter")
+    @classmethod
+    def _strip_distributor_filter(cls, value: list[str] | None) -> list[str] | None:
+        if value is None:
+            return None
+        stripped = [item.strip() for item in value if item.strip()]
+        return stripped or None
+
+
+class SourcingAlertPatch(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    alert_type: SourcingAlertType | None = None
+    part_id: UUID | None = None
+    project_id: UUID | None = None
+    threshold: dict[str, Any] | None = None
+    country_code: str | None = Field(default=None, min_length=2, max_length=2)
+    currency_code: str | None = Field(default=None, min_length=3, max_length=3)
+    distributor_filter: list[str] | None = None
+    notify_user_ids: list[UUID] | None = None
+    cooldown_seconds: int | None = Field(default=None, ge=60)
+    enabled: bool | None = None
+
+    @field_validator("country_code", "currency_code")
+    @classmethod
+    def _uppercase_codes(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return value.strip().upper()
+
+    @field_validator("distributor_filter")
+    @classmethod
+    def _strip_distributor_filter(cls, value: list[str] | None) -> list[str] | None:
+        if value is None:
+            return None
+        stripped = [item.strip() for item in value if item.strip()]
+        return stripped or None
+
+
+class SourcingAlertOut(SourcingAlertIn):
+    model_config = ConfigDict(extra="forbid", from_attributes=True)
+
+    id: UUID
+    workspace_id: UUID
+    last_checked_at: datetime | None = None
+    last_notified_at: datetime | None = None
+    archived_at: datetime | None = None
+    created_by: UUID | None = None
+    created_at: datetime
+    updated_at: datetime
 
 
 class SourcingBomOfferOut(BaseModel):

--- a/backend/app/domain/sourcing/service.py
+++ b/backend/app/domain/sourcing/service.py
@@ -151,6 +151,8 @@ def list_alerts(
     part_id: UUID | None = None,
     project_id: UUID | None = None,
     include_archived: bool = False,
+    limit: int = 100,
+    offset: int = 0,
 ) -> list[SourcingAlert]:
     if part_id is not None:
         assert_in_workspace(db, Part, part_id, workspace.id, label="part")
@@ -169,6 +171,7 @@ def list_alerts(
     if project_id is not None:
         stmt = stmt.where(SourcingAlert.project_id == project_id)
     stmt = stmt.order_by(SourcingAlert.created_at.desc(), SourcingAlert.id)
+    stmt = stmt.limit(limit).offset(offset)
     return list(db.execute(stmt).scalars())
 
 
@@ -182,6 +185,7 @@ def get_alert(
         select(SourcingAlert).where(
             SourcingAlert.id == alert_id,
             SourcingAlert.workspace_id == workspace.id,
+            SourcingAlert.archived_at.is_(None),
         )
     ).scalar_one_or_none()
     if alert is None:

--- a/backend/app/domain/sourcing/service.py
+++ b/backend/app/domain/sourcing/service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timedelta
@@ -9,9 +10,12 @@ from decimal import Decimal
 from typing import Any
 from uuid import UUID
 
+from pydantic import BaseModel, ValidationError
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from app.api._helpers import assert_in_workspace
+from app.core.errors import ErrorCodes, raise_http
 from app.core.time import utcnow
 from app.domain.builds.service import shortage_analysis
 from app.domain.orders.models import Order, OrderEntry
@@ -21,15 +25,22 @@ from app.domain.sourcing import cache
 from app.domain.sourcing.budget import BUDGET
 from app.domain.sourcing.coverage import compute_build_capacity, compute_coverage
 from app.domain.sourcing.factory import make_sourcing_provider
-from app.domain.sourcing.models import PurchasePlan, PurchasePlanLine
+from app.domain.sourcing.models import PurchasePlan, PurchasePlanLine, SourcingAlert
 from app.domain.sourcing.optimizer import Strategy, optimize
 from app.domain.sourcing.pricing import best_unit_price_at_qty
 from app.domain.sourcing.schemas import (
+    BackInStockThreshold,
+    BomBuyableThreshold,
     BuildCapacityOut,
     DistributorCoverageMatrixOut,
+    OutOfAuthorizedStockThreshold,
+    PriceChangedThreshold,
     PurchasePlanOrderOverrideIn,
     PurchasePlanOrdersOut,
     PurchasePlanOut,
+    SourcingAlertIn,
+    SourcingAlertPatch,
+    SourcingAlertType,
     SourcingAttributionLinks,
     SourcingBomLineOut,
     SourcingBomOfferOut,
@@ -39,7 +50,10 @@ from app.domain.sourcing.schemas import (
     SourcingSearchOut,
     SourcingSearchRaw,
     SourcingSearchResult,
+    StockAboveThreshold,
+    StockBelowThreshold,
 )
+from app.domain.workspaces.models import WorkspaceMember
 
 TTL_SECONDS = 30 * 60
 BOM_TTL_SECONDS = 10 * 60
@@ -49,6 +63,19 @@ TRUSTEDPARTS_LINKS = SourcingAttributionLinks(
     primary="https://www.trustedparts.com/",
     attribution="https://www.trustedparts.com/en/about",
 )
+_SOURCING_FILTER_ALERT_TYPES = {
+    "back_in_stock",
+    "out_of_authorized_stock",
+    "price_changed",
+}
+_THRESHOLD_SCHEMAS: dict[SourcingAlertType, type[BaseModel]] = {
+    "stock_below": StockBelowThreshold,
+    "stock_above": StockAboveThreshold,
+    "back_in_stock": BackInStockThreshold,
+    "out_of_authorized_stock": OutOfAuthorizedStockThreshold,
+    "price_changed": PriceChangedThreshold,
+    "bom_buyable": BomBuyableThreshold,
+}
 
 
 @dataclass(frozen=True)
@@ -82,6 +109,265 @@ class PurchasePlanCurrencyError(Exception):
 
 class PurchasePlanOverrideError(Exception):
     """Purchase plan conversion override is not valid for cached line offers."""
+
+
+def create_alert(
+    db: Session,
+    *,
+    workspace: Any,
+    user_id: UUID | None,
+    payload: SourcingAlertIn,
+) -> SourcingAlert:
+    values = _validated_alert_values(
+        db,
+        workspace=workspace,
+        alert_type=payload.alert_type,
+        part_id=payload.part_id,
+        project_id=payload.project_id,
+        threshold=payload.threshold,
+        country_code=payload.country_code,
+        currency_code=payload.currency_code,
+        distributor_filter=payload.distributor_filter,
+        notify_user_ids=payload.notify_user_ids,
+        cooldown_seconds=payload.cooldown_seconds,
+        enabled=payload.enabled,
+    )
+    alert = SourcingAlert(
+        workspace_id=workspace.id,
+        created_by=user_id,
+        **values,
+    )
+    db.add(alert)
+    db.flush()
+    return alert
+
+
+def list_alerts(
+    db: Session,
+    *,
+    workspace: Any,
+    enabled: bool | None = None,
+    alert_type: str | None = None,
+    part_id: UUID | None = None,
+    project_id: UUID | None = None,
+    include_archived: bool = False,
+) -> list[SourcingAlert]:
+    if part_id is not None:
+        assert_in_workspace(db, Part, part_id, workspace.id, label="part")
+    if project_id is not None:
+        assert_in_workspace(db, Project, project_id, workspace.id, label="project")
+
+    stmt = select(SourcingAlert).where(SourcingAlert.workspace_id == workspace.id)
+    if not include_archived:
+        stmt = stmt.where(SourcingAlert.archived_at.is_(None))
+    if enabled is not None:
+        stmt = stmt.where(SourcingAlert.enabled.is_(enabled))
+    if alert_type is not None:
+        stmt = stmt.where(SourcingAlert.alert_type == alert_type)
+    if part_id is not None:
+        stmt = stmt.where(SourcingAlert.part_id == part_id)
+    if project_id is not None:
+        stmt = stmt.where(SourcingAlert.project_id == project_id)
+    stmt = stmt.order_by(SourcingAlert.created_at.desc(), SourcingAlert.id)
+    return list(db.execute(stmt).scalars())
+
+
+def get_alert(
+    db: Session,
+    *,
+    workspace: Any,
+    alert_id: UUID,
+) -> SourcingAlert:
+    alert = db.execute(
+        select(SourcingAlert).where(
+            SourcingAlert.id == alert_id,
+            SourcingAlert.workspace_id == workspace.id,
+        )
+    ).scalar_one_or_none()
+    if alert is None:
+        raise_http(
+            404,
+            ErrorCodes.RESOURCE_NOT_FOUND,
+            "sourcing alert not found",
+            resource="sourcing_alert",
+        )
+    return alert
+
+
+def update_alert(
+    db: Session,
+    *,
+    workspace: Any,
+    alert_id: UUID,
+    payload: SourcingAlertPatch,
+) -> SourcingAlert:
+    if "alert_type" in payload.model_fields_set:
+        raise_http(
+            422,
+            "sourcing_alert.alert_type_immutable",
+            "alert_type is immutable",
+        )
+
+    alert = get_alert(db, workspace=workspace, alert_id=alert_id)
+    data = payload.model_dump(exclude_unset=True)
+    values = _validated_alert_values(
+        db,
+        workspace=workspace,
+        alert_type=alert.alert_type,
+        part_id=data.get("part_id", alert.part_id),
+        project_id=data.get("project_id", alert.project_id),
+        threshold=data.get("threshold", alert.threshold),
+        country_code=data.get("country_code", alert.country_code),
+        currency_code=data.get("currency_code", alert.currency_code),
+        distributor_filter=data.get("distributor_filter", alert.distributor_filter),
+        notify_user_ids=data.get("notify_user_ids", alert.notify_user_ids),
+        cooldown_seconds=data.get("cooldown_seconds", alert.cooldown_seconds),
+        enabled=data.get("enabled", alert.enabled),
+    )
+    for key, value in values.items():
+        setattr(alert, key, value)
+    db.flush()
+    return alert
+
+
+def archive_alert(
+    db: Session,
+    *,
+    workspace: Any,
+    alert_id: UUID,
+) -> SourcingAlert:
+    alert = get_alert(db, workspace=workspace, alert_id=alert_id)
+    if alert.archived_at is None:
+        alert.archived_at = utcnow()
+        db.flush()
+    return alert
+
+
+def _validated_alert_values(
+    db: Session,
+    *,
+    workspace: Any,
+    alert_type: SourcingAlertType | str,
+    part_id: UUID | None,
+    project_id: UUID | None,
+    threshold: dict[str, Any],
+    country_code: str | None,
+    currency_code: str | None,
+    distributor_filter: list[str] | None,
+    notify_user_ids: list[UUID] | list[str] | None,
+    cooldown_seconds: int,
+    enabled: bool,
+) -> dict[str, Any]:
+    if threshold is None:
+        raise_http(422, "sourcing_alert.invalid_threshold", "threshold is required")
+    if cooldown_seconds is None:
+        raise_http(422, "sourcing_alert.invalid_cooldown", "cooldown_seconds is required")
+    if enabled is None:
+        raise_http(422, "sourcing_alert.invalid_enabled", "enabled is required")
+    if alert_type not in _THRESHOLD_SCHEMAS:
+        raise_http(422, "sourcing_alert.invalid_type", "invalid alert_type")
+    if (part_id is None) == (project_id is None):
+        raise_http(
+            422,
+            "sourcing_alert.invalid_target",
+            "exactly one of part_id or project_id is required",
+        )
+    if alert_type == "bom_buyable":
+        if project_id is None or part_id is not None:
+            raise_http(
+                422,
+                "sourcing_alert.invalid_target",
+                "bom_buyable alerts require project_id",
+            )
+        if country_code is not None or currency_code is not None or distributor_filter:
+            raise_http(
+                422,
+                "sourcing_alert.invalid_scope_filter",
+                "bom_buyable alerts cannot use sourcing filters",
+            )
+    elif part_id is None or project_id is not None:
+        raise_http(
+            422,
+            "sourcing_alert.invalid_target",
+            "this alert type requires part_id",
+        )
+
+    if part_id is not None:
+        assert_in_workspace(db, Part, part_id, workspace.id, label="part")
+    if project_id is not None:
+        assert_in_workspace(db, Project, project_id, workspace.id, label="project")
+
+    validated_threshold = _validated_threshold(alert_type, threshold)
+    validated_notify_user_ids = _validated_notify_user_ids(
+        db,
+        workspace_id=workspace.id,
+        notify_user_ids=notify_user_ids,
+    )
+    if alert_type not in _SOURCING_FILTER_ALERT_TYPES:
+        country_code = None
+        currency_code = None
+        distributor_filter = None
+
+    return {
+        "alert_type": alert_type,
+        "part_id": part_id,
+        "project_id": project_id,
+        "threshold": validated_threshold,
+        "country_code": country_code,
+        "currency_code": currency_code,
+        "distributor_filter": distributor_filter,
+        "notify_user_ids": validated_notify_user_ids,
+        "cooldown_seconds": cooldown_seconds,
+        "enabled": enabled,
+    }
+
+
+def _validated_threshold(
+    alert_type: SourcingAlertType | str,
+    threshold: dict[str, Any],
+) -> dict[str, Any]:
+    schema = _THRESHOLD_SCHEMAS[alert_type]
+    try:
+        parsed = schema.model_validate(threshold)
+    except ValidationError as exc:
+        raise_http(
+            422,
+            "sourcing_alert.invalid_threshold",
+            "invalid threshold for alert_type",
+            errors=json.loads(exc.json()),
+        )
+    return parsed.model_dump(mode="json")
+
+
+def _validated_notify_user_ids(
+    db: Session,
+    *,
+    workspace_id: UUID,
+    notify_user_ids: list[UUID] | list[str] | None,
+) -> list[str] | None:
+    if notify_user_ids is None:
+        return None
+    requested = [UUID(str(user_id)) for user_id in notify_user_ids]
+    if not requested:
+        return []
+    active_members = set(
+        db.execute(
+            select(WorkspaceMember.user_id).where(
+                WorkspaceMember.workspace_id == workspace_id,
+                WorkspaceMember.status == "active",
+                WorkspaceMember.user_id.in_(requested),
+            )
+        ).scalars()
+    )
+    missing = [user_id for user_id in requested if user_id not in active_members]
+    if missing:
+        raise_http(
+            404,
+            ErrorCodes.WORKSPACE_MEMBER_NOT_FOUND,
+            "workspace member not found",
+            resource="workspace_member",
+        )
+    return [str(user_id) for user_id in requested]
 
 
 def build_purchase_plan(

--- a/backend/tests/test_sourcing_alerts_route.py
+++ b/backend/tests/test_sourcing_alerts_route.py
@@ -1,0 +1,320 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+
+import app.core.ratelimit as _ratelimit_mod
+from app.domain.sourcing.models import SourcingAlert
+from app.main import app
+from tests._factories import create_part, create_project_with_bom, signup_user
+
+
+def _signup(client: TestClient | None = None) -> TestClient:
+    client = client or TestClient(app)
+    signup_user(client, email=f"alerts-{uuid.uuid4().hex[:8]}@example.com")
+    return client
+
+
+@pytest.fixture(autouse=False)
+def limiter_enabled():
+    original = _ratelimit_mod.limiter.enabled
+    _ratelimit_mod.limiter.enabled = True
+    try:
+        _ratelimit_mod.limiter.reset()
+    except Exception:
+        pass
+    yield
+    _ratelimit_mod.limiter.enabled = original
+    try:
+        _ratelimit_mod.limiter.reset()
+    except Exception:
+        pass
+
+
+def _stock_alert_payload(part_id: str, **extra):
+    payload = {
+        "alert_type": "stock_below",
+        "part_id": part_id,
+        "threshold": {"qty": 5},
+    }
+    payload.update(extra)
+    return payload
+
+
+def _create_stock_alert(client: TestClient, part_id: str, **extra) -> dict:
+    r = client.post("/api/sourcing/alerts", json=_stock_alert_payload(part_id, **extra))
+    assert r.status_code == 200, r.text
+    return r.json()["data"]
+
+
+def _create_project_alert(
+    client: TestClient,
+    project_id: str,
+    *,
+    build_quantity: int = 1,
+    **extra,
+) -> dict:
+    payload = {
+        "alert_type": "bom_buyable",
+        "project_id": project_id,
+        "threshold": {"build_quantity": build_quantity},
+    }
+    payload.update(extra)
+    r = client.post("/api/sourcing/alerts", json=payload)
+    assert r.status_code == 200, r.text
+    return r.json()["data"]
+
+
+def _single_line_project(client: TestClient, *, name: str = "Alerts BOM") -> tuple[str, str]:
+    part_id = create_part(client, name=f"{name} part", mpn=f"ALERT-{uuid.uuid4().hex[:6]}")
+    project_id = create_project_with_bom(
+        client,
+        f"{name} {uuid.uuid4().hex[:6]}",
+        [{"part_id": part_id, "quantity": 1}],
+    )
+    return project_id, part_id
+
+
+def test_create_stock_below_alert(authed_client):
+    part_id = create_part(authed_client, name="Alert resistor")
+
+    data = _create_stock_alert(
+        authed_client,
+        part_id,
+        threshold={"qty": 12},
+        country_code="us",
+        currency_code="usd",
+        distributor_filter=["DigiKey"],
+    )
+
+    assert data["alert_type"] == "stock_below"
+    assert data["part_id"] == part_id
+    assert data["project_id"] is None
+    assert data["threshold"] == {"qty": 12}
+    assert data["country_code"] is None
+    assert data["currency_code"] is None
+    assert data["distributor_filter"] is None
+    assert data["enabled"] is True
+    assert data["archived_at"] is None
+
+
+@pytest.mark.parametrize(
+    ("alert_type", "threshold"),
+    [
+        ("stock_below", {"qty": -5}),
+        ("stock_above", {"qty": -5}),
+        ("back_in_stock", {"qty": 1}),
+        ("out_of_authorized_stock", {"qty": 1}),
+        ("price_changed", {"delta_pct": 150}),
+        ("bom_buyable", {"build_quantity": 0}),
+    ],
+)
+def test_create_with_invalid_threshold_returns_422(
+    authed_client,
+    alert_type: str,
+    threshold: dict,
+):
+    project_id, part_id = _single_line_project(authed_client)
+    payload = {
+        "alert_type": alert_type,
+        "threshold": threshold,
+    }
+    if alert_type == "bom_buyable":
+        payload["project_id"] = project_id
+    else:
+        payload["part_id"] = part_id
+
+    r = authed_client.post("/api/sourcing/alerts", json=payload)
+
+    assert r.status_code == 422, r.text
+    assert r.json()["status"]["category"] == "validation_error"
+
+
+def test_xor_part_project_validation(authed_client):
+    project_id, part_id = _single_line_project(authed_client)
+
+    both = authed_client.post(
+        "/api/sourcing/alerts",
+        json={
+            "alert_type": "stock_below",
+            "part_id": part_id,
+            "project_id": project_id,
+            "threshold": {"qty": 5},
+        },
+    )
+    neither = authed_client.post(
+        "/api/sourcing/alerts",
+        json={"alert_type": "stock_below", "threshold": {"qty": 5}},
+    )
+
+    assert both.status_code == 422, both.text
+    assert neither.status_code == 422, neither.text
+
+
+def test_bom_buyable_requires_project_id_not_part_id(authed_client):
+    part_id = create_part(authed_client, name="Not a project")
+
+    r = authed_client.post(
+        "/api/sourcing/alerts",
+        json={
+            "alert_type": "bom_buyable",
+            "part_id": part_id,
+            "threshold": {"build_quantity": 1},
+        },
+    )
+
+    assert r.status_code == 422, r.text
+    assert r.json()["status"]["category"] == "validation_error"
+
+
+def test_notify_user_ids_validated_against_workspace_members(authed_client):
+    part_id = create_part(authed_client, name="Notify target")
+
+    r = authed_client.post(
+        "/api/sourcing/alerts",
+        json=_stock_alert_payload(
+            part_id,
+            notify_user_ids=[str(uuid.uuid4())],
+        ),
+    )
+
+    assert r.status_code == 404, r.text
+    assert r.json()["status"]["category"] == "not_found"
+
+
+def test_foreign_part_id_returns_404():
+    client_a = _signup()
+    client_b = _signup()
+    part_a = create_part(client_a, name="Foreign target")
+
+    r = client_b.post("/api/sourcing/alerts", json=_stock_alert_payload(part_a))
+
+    assert r.status_code == 404, r.text
+    assert r.json()["status"]["category"] == "not_found"
+
+
+def test_list_filters(authed_client):
+    part_a = create_part(authed_client, name="Filter A")
+    part_b = create_part(authed_client, name="Filter B")
+    project_a, _ = _single_line_project(authed_client, name="Filter project A")
+    project_b, _ = _single_line_project(authed_client, name="Filter project B")
+
+    enabled_alert = _create_stock_alert(
+        authed_client,
+        part_a,
+        alert_type="stock_below",
+        threshold={"qty": 5},
+        enabled=True,
+    )
+    disabled_alert = _create_stock_alert(
+        authed_client,
+        part_a,
+        alert_type="stock_above",
+        threshold={"qty": 50},
+        enabled=False,
+    )
+    part_b_alert = _create_stock_alert(
+        authed_client,
+        part_b,
+        threshold={"qty": 7},
+    )
+    project_a_alert = _create_project_alert(authed_client, project_a, build_quantity=2)
+    project_b_alert = _create_project_alert(authed_client, project_b, build_quantity=3)
+    archived_alert = _create_stock_alert(
+        authed_client,
+        part_a,
+        threshold={"qty": 9},
+    )
+    authed_client.delete(f"/api/sourcing/alerts/{archived_alert['id']}")
+
+    disabled = authed_client.get("/api/sourcing/alerts?enabled=false").json()["data"]
+    assert {alert["id"] for alert in disabled} == {disabled_alert["id"]}
+
+    stock_above = authed_client.get("/api/sourcing/alerts?alert_type=stock_above").json()["data"]
+    assert {alert["id"] for alert in stock_above} == {disabled_alert["id"]}
+
+    part_filtered = authed_client.get(f"/api/sourcing/alerts?part_id={part_b}").json()["data"]
+    assert {alert["id"] for alert in part_filtered} == {part_b_alert["id"]}
+
+    project_filtered = authed_client.get(
+        f"/api/sourcing/alerts?project_id={project_a}"
+    ).json()["data"]
+    assert {alert["id"] for alert in project_filtered} == {project_a_alert["id"]}
+
+    include_archived = authed_client.get(
+        "/api/sourcing/alerts?include_archived=true"
+    ).json()["data"]
+    assert archived_alert["id"] in {alert["id"] for alert in include_archived}
+    assert enabled_alert["id"] in {alert["id"] for alert in include_archived}
+    assert project_b_alert["id"] in {alert["id"] for alert in include_archived}
+
+
+def test_patch_cannot_change_alert_type(authed_client):
+    part_id = create_part(authed_client, name="Patch target")
+    alert = _create_stock_alert(authed_client, part_id)
+
+    r = authed_client.patch(
+        f"/api/sourcing/alerts/{alert['id']}",
+        json={"alert_type": "stock_above"},
+    )
+
+    assert r.status_code == 422, r.text
+    assert r.json()["status"]["category"] == "validation_error"
+
+
+def test_delete_archives_not_hard_deletes(authed_client, db):
+    part_id = create_part(authed_client, name="Archive target")
+    alert = _create_stock_alert(authed_client, part_id)
+
+    r = authed_client.delete(f"/api/sourcing/alerts/{alert['id']}")
+
+    assert r.status_code == 200, r.text
+    row = db.execute(
+        select(SourcingAlert).where(SourcingAlert.id == uuid.UUID(alert["id"]))
+    ).scalar_one()
+    assert row.archived_at is not None
+
+
+def test_archived_excluded_from_default_list(authed_client):
+    part_id = create_part(authed_client, name="Default archive target")
+    alert = _create_stock_alert(authed_client, part_id)
+    authed_client.delete(f"/api/sourcing/alerts/{alert['id']}")
+
+    data = authed_client.get("/api/sourcing/alerts").json()["data"]
+
+    assert alert["id"] not in {item["id"] for item in data}
+
+
+def test_rate_limit_30_per_minute(authed_client, limiter_enabled):
+    part_id = create_part(authed_client, name="Rate limited alert target")
+    for qty in range(30):
+        r = authed_client.post(
+            "/api/sourcing/alerts",
+            json=_stock_alert_payload(part_id, threshold={"qty": qty}),
+        )
+        assert r.status_code == 200, r.text
+
+    r = authed_client.post(
+        "/api/sourcing/alerts",
+        json=_stock_alert_payload(part_id, threshold={"qty": 1000}),
+    )
+
+    assert r.status_code == 429, r.text
+    assert r.json()["status"]["category"] == "rate_limited"
+
+
+def test_workspace_isolation_two_workspaces_same_part_alerts():
+    client_a = _signup()
+    client_b = _signup()
+    part_a = create_part(client_a, name="Shared alert", mpn="ALERT-SHARED")
+    part_b = create_part(client_b, name="Shared alert", mpn="ALERT-SHARED")
+    alert_a = _create_stock_alert(client_a, part_a, threshold={"qty": 3})
+    alert_b = _create_stock_alert(client_b, part_b, threshold={"qty": 3})
+
+    data_b = client_b.get("/api/sourcing/alerts").json()["data"]
+
+    assert alert_b["id"] in {alert["id"] for alert in data_b}
+    assert alert_a["id"] not in {alert["id"] for alert in data_b}

--- a/backend/tests/test_sourcing_alerts_route.py
+++ b/backend/tests/test_sourcing_alerts_route.py
@@ -288,6 +288,58 @@ def test_archived_excluded_from_default_list(authed_client):
     assert alert["id"] not in {item["id"] for item in data}
 
 
+def test_get_archived_returns_404(authed_client):
+    part_id = create_part(authed_client, name="Get archived target")
+    alert = _create_stock_alert(authed_client, part_id)
+    authed_client.delete(f"/api/sourcing/alerts/{alert['id']}")
+
+    r = authed_client.get(f"/api/sourcing/alerts/{alert['id']}")
+
+    assert r.status_code == 404, r.text
+    assert r.json()["status"]["category"] == "not_found"
+
+
+def test_patch_archived_returns_404(authed_client):
+    part_id = create_part(authed_client, name="Patch archived target")
+    alert = _create_stock_alert(authed_client, part_id)
+    authed_client.delete(f"/api/sourcing/alerts/{alert['id']}")
+
+    r = authed_client.patch(
+        f"/api/sourcing/alerts/{alert['id']}",
+        json={"enabled": False},
+    )
+
+    assert r.status_code == 404, r.text
+    assert r.json()["status"]["category"] == "not_found"
+
+
+def test_delete_archived_returns_404(authed_client):
+    part_id = create_part(authed_client, name="Delete archived target")
+    alert = _create_stock_alert(authed_client, part_id)
+    authed_client.delete(f"/api/sourcing/alerts/{alert['id']}")
+
+    r = authed_client.delete(f"/api/sourcing/alerts/{alert['id']}")
+
+    assert r.status_code == 404, r.text
+    assert r.json()["status"]["category"] == "not_found"
+
+
+def test_list_alerts_paginates(authed_client):
+    part_id = create_part(authed_client, name="Paged alert target")
+    alerts = [
+        _create_stock_alert(authed_client, part_id, threshold={"qty": qty})
+        for qty in range(3)
+    ]
+
+    first = authed_client.get("/api/sourcing/alerts?limit=1").json()["data"]
+    second = authed_client.get("/api/sourcing/alerts?limit=1&offset=1").json()["data"]
+
+    assert len(first) == 1
+    assert len(second) == 1
+    assert first[0]["id"] != second[0]["id"]
+    assert {first[0]["id"], second[0]["id"]}.issubset({alert["id"] for alert in alerts})
+
+
 def test_rate_limit_30_per_minute(authed_client, limiter_enabled):
     part_id = create_part(authed_client, name="Rate limited alert target")
     for qty in range(30):

--- a/backend/tests/test_workspace_isolation.py
+++ b/backend/tests/test_workspace_isolation.py
@@ -531,6 +531,33 @@ def test_purchase_plan_isolated_by_workspace(monkeypatch):
     assert r.json()["status"]["category"] == "not_found"
 
 
+def test_sourcing_alerts_isolated_by_workspace():
+    a, b = _two_workspaces()
+    part_a = _create_part(a, "A-alert-part")
+    part_b = _create_part(b, "B-alert-part")
+    alert_a = a.post(
+        "/api/sourcing/alerts",
+        json={
+            "alert_type": "stock_below",
+            "part_id": part_a,
+            "threshold": {"qty": 1},
+        },
+    ).json()["data"]
+    alert_b = b.post(
+        "/api/sourcing/alerts",
+        json={
+            "alert_type": "stock_below",
+            "part_id": part_b,
+            "threshold": {"qty": 1},
+        },
+    ).json()["data"]
+
+    listed_b = b.get("/api/sourcing/alerts").json()["data"]
+
+    assert alert_b["id"] in {alert["id"] for alert in listed_b}
+    assert alert_a["id"] not in {alert["id"] for alert in listed_b}
+
+
 # ---------------------------------------------------------------------------
 # parts.default_storage_location_id on create / patch / bulk-import-from-scan
 # ---------------------------------------------------------------------------

--- a/docs/api/sourcing.md
+++ b/docs/api/sourcing.md
@@ -10,6 +10,156 @@ See [API conventions](./README.md) for envelope, errors, pagination. Connection 
 
 ## Routes
 
+### `GET /api/sourcing/alerts`
+
+List current workspace sourcing alerts.
+
+**Request**
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `enabled` | `boolean` | No | Filters enabled or disabled alerts. |
+| `alert_type` | `string` | No | One of the six MVP alert types in the threshold table below. |
+| `part_id` | `uuid` | No | Filters part-scoped alerts. |
+| `project_id` | `uuid` | No | Filters project-scoped alerts. |
+| `include_archived` | `boolean` | No | Defaults to `false`; archived rows are soft-deleted alerts. |
+
+**Response** — `200 OK` (envelope: `{ data, status }`)
+
+```json
+{
+  "data": [
+    {
+      "id": "9b7f7d43-6b5c-4f7d-bc0e-44c6d73f0992",
+      "alert_type": "stock_below",
+      "part_id": "012f2f63-3b2c-45c4-a841-682ec681f508",
+      "project_id": null,
+      "threshold": { "qty": 10 },
+      "enabled": true,
+      "archived_at": null
+    }
+  ],
+  "status": { "category": "ok", "message": "OK" }
+}
+```
+
+**Notes**
+
+- The service filters every query by `workspace_id`; archived rows are excluded unless requested.
+- Source: `backend/app/api/routes/sourcing.py:156-178`.
+- Service: `backend/app/domain/sourcing/service.py:145-172`.
+
+### `POST /api/sourcing/alerts`
+
+Create a workspace-scoped alert definition.
+
+**Request**
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `alert_type` | `string` | Yes | See threshold table below. Immutable after create. |
+| `part_id` | `uuid` | Conditional | Required for all non-`bom_buyable` alerts. Mutually exclusive with `project_id`. |
+| `project_id` | `uuid` | Conditional | Required for `bom_buyable`. Mutually exclusive with `part_id`. |
+| `threshold` | `object` | Yes | Validated per `alert_type` in the service layer. |
+| `country_code` | `string` | No | Two-letter sourcing filter for `back_in_stock`, `out_of_authorized_stock`, and `price_changed`. Ignored for stock threshold alerts. |
+| `currency_code` | `string` | No | Three-letter sourcing filter for `price_changed`. Ignored for stock threshold alerts. |
+| `distributor_filter` | `string[]` | No | Sourcing filter for authorized-stock and price alerts. Ignored for stock threshold alerts. |
+| `notify_user_ids` | `uuid[]` | No | `null` means default recipients. Non-null values must be active members of the workspace. |
+| `cooldown_seconds` | `integer` | No | Defaults to `86400`; minimum `60`. |
+| `enabled` | `boolean` | No | Defaults to `true`. |
+
+**Thresholds**
+
+| `alert_type` | Scope | `threshold` |
+|---|---|---|
+| `stock_below` | part | `{ "qty": 10 }`, integer `qty >= 0`. |
+| `stock_above` | part | `{ "qty": 50 }`, integer `qty >= 0`. |
+| `back_in_stock` | part | `{}`. |
+| `out_of_authorized_stock` | part | `{}`. |
+| `price_changed` | part | `{ "delta_pct": 5 }`, decimal `0 < delta_pct <= 100`. |
+| `bom_buyable` | project | `{ "build_quantity": 10 }`, integer `build_quantity >= 1`. |
+
+**Response** — `200 OK` (envelope: `{ data, status }`)
+
+Shape matches one item from `GET /api/sourcing/alerts`.
+
+**Errors**
+
+- `404 Not Found` — target part/project is missing or foreign, or a `notify_user_ids` entry is not an active workspace member.
+- `422 Unprocessable Entity` — invalid threshold, invalid target scope, both/neither `part_id` and `project_id`, immutable fields, or malformed body.
+- `429 Too Many Requests` — workspace rate limit: 30 creates/minute.
+
+**Notes**
+
+- `bom_buyable` rejects sourcing filters; stock threshold alerts silently drop sourcing filters.
+- Empty threshold objects are intentionally valid for transition alerts, so validation is mapped per type instead of using a nested discriminator.
+- Source: `backend/app/api/routes/sourcing.py:181-199`.
+- Service: `backend/app/domain/sourcing/service.py:114-142`.
+
+### `GET /api/sourcing/alerts/{alert_id}`
+
+Return one alert from the current workspace.
+
+**Request**
+
+Path: `alert_id` is a sourcing alert UUID in the current workspace.
+
+**Response** — `200 OK` (envelope: `{ data, status }`)
+
+Shape matches one item from `GET /api/sourcing/alerts`.
+
+**Errors**
+
+- `404 Not Found` — `alert_id` is missing or belongs to another workspace.
+
+**Notes**
+
+- Source: `backend/app/api/routes/sourcing.py:202-212`.
+- Service: `backend/app/domain/sourcing/service.py:175-194`.
+
+### `PATCH /api/sourcing/alerts/{alert_id}`
+
+Patch mutable alert fields.
+
+**Request**
+
+Path: `alert_id` is a sourcing alert UUID in the current workspace. Body accepts the same fields as create except `alert_type`; sending `alert_type` returns `422`.
+
+**Response** — `200 OK` (envelope: `{ data, status }`)
+
+Shape matches one item from `GET /api/sourcing/alerts`.
+
+**Errors**
+
+- `404 Not Found` — `alert_id`, target part/project, or a notify user is missing or foreign to the workspace.
+- `422 Unprocessable Entity` — invalid threshold, invalid target scope, `alert_type` in the patch body, or malformed body.
+
+**Notes**
+
+- Source: `backend/app/api/routes/sourcing.py:215-231`.
+- Service: `backend/app/domain/sourcing/service.py:197-230`.
+
+### `DELETE /api/sourcing/alerts/{alert_id}`
+
+Soft-delete an alert by setting `archived_at`.
+
+**Request**
+
+Path: `alert_id` is a sourcing alert UUID in the current workspace.
+
+**Response** — `200 OK` (envelope: `{ data, status }`)
+
+Returns the archived alert row.
+
+**Errors**
+
+- `404 Not Found` — `alert_id` is missing or belongs to another workspace.
+
+**Notes**
+
+- Source: `backend/app/api/routes/sourcing.py:234-244`.
+- Service: `backend/app/domain/sourcing/service.py:233-243`.
+
 ### `POST /api/projects/{project_id}/sourcing`
 
 Join a project's BOM shortage analysis to TrustedParts authorized-distributor offers.

--- a/docs/api/sourcing.md
+++ b/docs/api/sourcing.md
@@ -23,6 +23,8 @@ List current workspace sourcing alerts.
 | `part_id` | `uuid` | No | Filters part-scoped alerts. |
 | `project_id` | `uuid` | No | Filters project-scoped alerts. |
 | `include_archived` | `boolean` | No | Defaults to `false`; archived rows are soft-deleted alerts. |
+| `limit` | `integer` | No | Defaults to `100`; min `1`, max `500`. |
+| `offset` | `integer` | No | Defaults to `0`; deterministic order is newest first. |
 
 **Response** — `200 OK` (envelope: `{ data, status }`)
 
@@ -46,6 +48,7 @@ List current workspace sourcing alerts.
 **Notes**
 
 - The service filters every query by `workspace_id`; archived rows are excluded unless requested.
+- `include_archived=true` is list-only. GET-by-id, PATCH, and DELETE treat archived rows as not found.
 - Source: `backend/app/api/routes/sourcing.py:156-178`.
 - Service: `backend/app/domain/sourcing/service.py:145-172`.
 
@@ -76,7 +79,7 @@ Create a workspace-scoped alert definition.
 | `stock_above` | part | `{ "qty": 50 }`, integer `qty >= 0`. |
 | `back_in_stock` | part | `{}`. |
 | `out_of_authorized_stock` | part | `{}`. |
-| `price_changed` | part | `{ "delta_pct": 5 }`, decimal `0 < delta_pct <= 100`. |
+| `price_changed` | part | `{ "delta_pct": 5 }`, decimal `0 < delta_pct <= 100`. V1 is relative-change only; absolute target-price thresholds are out of scope for TP-502. |
 | `bom_buyable` | project | `{ "build_quantity": 10 }`, integer `build_quantity >= 1`. |
 
 **Response** — `200 OK` (envelope: `{ data, status }`)
@@ -91,7 +94,7 @@ Shape matches one item from `GET /api/sourcing/alerts`.
 
 **Notes**
 
-- `bom_buyable` rejects sourcing filters; stock threshold alerts silently drop sourcing filters.
+- `bom_buyable` rejects sourcing filters; stock threshold alerts silently drop sourcing filters because they evaluate internal stock only.
 - Empty threshold objects are intentionally valid for transition alerts, so validation is mapped per type instead of using a nested discriminator.
 - Source: `backend/app/api/routes/sourcing.py:181-199`.
 - Service: `backend/app/domain/sourcing/service.py:114-142`.
@@ -110,7 +113,7 @@ Shape matches one item from `GET /api/sourcing/alerts`.
 
 **Errors**
 
-- `404 Not Found` — `alert_id` is missing or belongs to another workspace.
+- `404 Not Found` — `alert_id` is missing, archived, or belongs to another workspace.
 
 **Notes**
 
@@ -131,7 +134,7 @@ Shape matches one item from `GET /api/sourcing/alerts`.
 
 **Errors**
 
-- `404 Not Found` — `alert_id`, target part/project, or a notify user is missing or foreign to the workspace.
+- `404 Not Found` — `alert_id` is missing, archived, or foreign to the workspace; target part/project or notify user is missing or foreign.
 - `422 Unprocessable Entity` — invalid threshold, invalid target scope, `alert_type` in the patch body, or malformed body.
 
 **Notes**
@@ -153,7 +156,7 @@ Returns the archived alert row.
 
 **Errors**
 
-- `404 Not Found` — `alert_id` is missing or belongs to another workspace.
+- `404 Not Found` — `alert_id` is missing, archived, or belongs to another workspace.
 
 **Notes**
 


### PR DESCRIPTION
## Summary

- Adds `GET/POST/GET by id/PATCH/DELETE /api/sourcing/alerts` with `{ data, status }` envelopes.
- Adds service-layer per-alert-type threshold validation, part/project XOR validation, immutable `alert_type`, soft-delete archive behavior, and workspace-member validation for `notify_user_ids`.
- Documents alert CRUD and threshold shapes in `docs/api/sourcing.md`.

Closes #418
Refs #416

## Merge Order

#431 is already merged. This PR is rebased onto `origin/main` and targets `main` directly.

## Validation

- `docker compose -f docker-compose.dev.yml exec backend pytest -k "sourcing_alerts_route or workspace_isolation"` — not run: `docker` is not installed in this environment.
- `docker compose -f docker-compose.dev.yml exec backend ruff check` — not run: `docker` is not installed in this environment.
- `cd backend && uv run python -m pytest tests/test_sourcing_alerts_route.py tests/test_workspace_isolation.py::test_sourcing_alerts_isolated_by_workspace -q` — passed: `18 passed, 1 warning`.
- `cd backend && uv run ruff check app/domain/sourcing/schemas.py app/domain/sourcing/service.py app/api/routes/sourcing.py tests/test_sourcing_alerts_route.py` — passed.
- `cd backend && WORK_DIR=. LINT_CMD="uv run ruff check app --output-format=concise" BASELINE_FILE="../.ruff-baseline.txt" bash ../scripts/lint-delta.sh` — passed: no new violations.
- `git diff --check origin/main...HEAD` — passed.

## Residual Risks

- Draft because exact Docker validation was unavailable here.
- A broad local `uv run python -m pytest -k "sourcing_alerts_route or workspace_isolation"` run hit an existing local fixture-order issue (`relation "users" does not exist`) after unrelated selected tests; the new alert route test file and the new workspace-isolation pin pass directly.
- `workspace-isolation-checker` was not available as a callable tool in this environment; manual review confirmed every alert query is scoped by workspace and request-supplied part/project/user IDs are validated against workspace membership.
