### PR TITLE
TP-503: Wire sourcing-alerts-evaluate into run_job + backend-cron-alerts sidecar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,6 +238,10 @@ them, that's the bug.
 - **Periodic jobs run through one scheduler path.** ADR-0021 chooses a
   `backend-cron` sidecar + CLI entry point; don't add parallel APScheduler,
   FastAPI lifespan, host cron, or systemd-timer jobs for app maintenance.
+- **Two backend-cron sidecars run separate cadences.** `backend-cron` handles
+  the hourly cache sweep and `backend-cron-alerts` handles the 15-minute alert
+  evaluator. They share the same `run_job` registry per ADR-0021; adding a
+  third cadence means a third sidecar, not a parallel scheduler.
 - **Maintenance mode is toggled by the deploy script via
   `a2enconf parts-maintenance`.** Do not bypass the deploy path without
   also disabling it with `a2disconf parts-maintenance`.

--- a/backend/app/cli/run_job.py
+++ b/backend/app/cli/run_job.py
@@ -43,6 +43,12 @@ def _run_sourcing_cache_sweep(db: Session) -> int:
     return sweep_expired_all_workspaces(db)
 
 
+def _run_sourcing_alerts_evaluate(db: Session) -> int:
+    from app.domain.sourcing.alerts_evaluator import evaluate_all_alerts
+
+    return evaluate_all_alerts(db)
+
+
 JOBS: dict[str, JobSpec] = {
     "sourcing-cache-sweep": JobSpec(
         name="sourcing-cache-sweep",
@@ -50,7 +56,19 @@ JOBS: dict[str, JobSpec] = {
         cadence="hourly",
         idempotency="Deletes only rows whose expires_at is already in the past.",
         run=_run_sourcing_cache_sweep,
-    )
+    ),
+    "sourcing-alerts-evaluate": JobSpec(
+        name="sourcing-alerts-evaluate",
+        owner="backend/sourcing",
+        cadence="every 15 minutes",
+        idempotency=(
+            "Reads enabled, non-archived sourcing_alerts; for each, compares "
+            "current state to threshold; sends one notification per transition "
+            "with cooldown enforced via last_notified_at. Re-running within "
+            "cooldown is a no-op."
+        ),
+        run=_run_sourcing_alerts_evaluate,
+    ),
 }
 
 

--- a/backend/tests/test_ci_workflow.py
+++ b/backend/tests/test_ci_workflow.py
@@ -155,6 +155,24 @@ def test_compose_prod_backend_cron_command_shape():
     assert "uvicorn" not in joined
 
 
+def test_compose_prod_backend_cron_alerts_command_shape():
+    """backend-cron-alerts must use the shared CLI scheduler path."""
+    assert _COMPOSE_PROD_PATH.exists(), (
+        f"missing compose file at {_COMPOSE_PROD_PATH}"
+    )
+    data = yaml.safe_load(_COMPOSE_PROD_PATH.read_text())
+    cron = data["services"]["backend-cron-alerts"]
+    cmd = cron.get("command")
+
+    assert isinstance(cmd, list), (
+        "backend-cron-alerts.command must be a YAML list (JSON-array form)"
+    )
+    joined = " ".join(str(part) for part in cmd)
+    assert "python -m app.cli.run_job sourcing-alerts-evaluate" in joined
+    assert "sleep 900" in joined
+    assert "uvicorn" not in joined
+
+
 def test_dockerfile_prod_no_sentry_token_arg():
     """web/Dockerfile.prod must NOT declare ARG SENTRY_AUTH_TOKEN.
 

--- a/backend/tests/test_run_job.py
+++ b/backend/tests/test_run_job.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from sqlalchemy.orm import Session
 
-from app.cli.run_job import JobSpec, UnknownJobError, main, run_job
+from app.cli.run_job import JOBS, JobSpec, UnknownJobError, main, run_job
 
 
 class _FakeSession:
@@ -64,3 +64,38 @@ def test_run_job_main_returns_nonzero_for_unknown_job(capsys) -> None:
 
     assert exit_code == 2
     assert "unknown job 'missing'" in capsys.readouterr().err
+
+
+def test_sourcing_alerts_evaluate_registered() -> None:
+    spec = JOBS["sourcing-alerts-evaluate"]
+
+    assert spec.name == "sourcing-alerts-evaluate"
+    assert spec.owner == "backend/sourcing"
+    assert spec.cadence == "every 15 minutes"
+    assert "enabled, non-archived sourcing_alerts" in spec.idempotency
+    assert "cooldown" in spec.idempotency
+
+
+def test_sourcing_alerts_evaluate_dispatches_to_module(monkeypatch) -> None:
+    session = _FakeSession()
+    calls: list[Session] = []
+
+    def _evaluate_all_alerts(db: Session) -> int:
+        calls.append(db)
+        return 7
+
+    monkeypatch.setattr(
+        "app.domain.sourcing.alerts_evaluator.evaluate_all_alerts",
+        _evaluate_all_alerts,
+    )
+
+    affected = run_job(
+        "sourcing-alerts-evaluate",
+        session_factory=lambda: session,  # type: ignore[return-value]
+    )
+
+    assert affected == 7
+    assert calls == [session]
+    assert session.committed is True
+    assert session.rolled_back is False
+    assert session.closed is True

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -208,6 +208,51 @@ services:
     security_opt: ["no-new-privileges:true"]
     cap_drop: ["ALL"]
 
+  backend-cron-alerts:
+    build: ./backend
+    restart: unless-stopped
+    mem_limit: 512m
+    cpus: "0.5"
+    pids_limit: 256
+    oom_kill_disable: false
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"
+    environment:
+      # Same runtime config shape as backend. Keep POSTGRES_* discrete so
+      # DATABASE_URL is assembled inside Settings without leaking the password
+      # through docker inspect interpolation.
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_HOST: db
+      POSTGRES_PORT: "5432"
+      SESSION_SECRET: ${SESSION_SECRET}
+      UPLOAD_DIR: /data/uploads
+      APP_ENV: prod
+      CORS_ORIGINS: ${CORS_ORIGINS}
+      WORKSPACE_SECRETS_KEY: ${WORKSPACE_SECRETS_KEY}
+      SENTRY_DSN: ${SENTRY_DSN:-}
+      SENTRY_TRACES_SAMPLE_RATE: ${SENTRY_TRACES_SAMPLE_RATE:-0.0}
+      SENTRY_RELEASE: ${SENTRY_RELEASE:-}
+      VITE_SENTRY_DSN: ${VITE_SENTRY_DSN:-}
+      SMTP_HOST: ${SMTP_HOST}
+      SMTP_PORT: ${SMTP_PORT:-587}
+      SMTP_USER: ${SMTP_USER}
+      SMTP_PASSWORD: ${SMTP_PASSWORD}
+      MAIL_FROM: ${MAIL_FROM}
+      APP_BASE_URL: ${APP_BASE_URL}
+    depends_on:
+      backend:
+        condition: service_healthy
+    # Runs the 15-minute sourcing alert evaluator through the shared backend
+    # CLI. Alert-level cooldowns enforce per-alert notification frequency.
+    command: ["sh", "-c", "while true; do python -m app.cli.run_job sourcing-alerts-evaluate; sleep 900; done"]
+    security_opt: ["no-new-privileges:true"]
+    cap_drop: ["ALL"]
+
   web:
     build:
       # Context is the repo root so the Dockerfile can COPY both `web/` (sources)

--- a/docs/adr/0021-periodic-jobs-scheduler.md
+++ b/docs/adr/0021-periodic-jobs-scheduler.md
@@ -26,6 +26,11 @@ Periodic jobs run through a dedicated `backend-cron` sidecar container that invo
 
 Each job must be registered in the CLI allow-list with a clear owner, cadence, and idempotency expectations. The sidecar owns scheduling; the FastAPI request process does not grow a second scheduler.
 
+Jobs using this scheduler:
+
+- `sourcing-cache-sweep` — hourly TrustedParts cache retention sweep in `backend-cron`.
+- `sourcing-alerts-evaluate` — 15-minute sourcing alert evaluator in `backend-cron-alerts`.
+
 ## Consequences
 
 - **Good**:

--- a/docs/runbooks/on-call-quickstart.md
+++ b/docs/runbooks/on-call-quickstart.md
@@ -118,8 +118,8 @@ sudo -u deploy docker compose -f docker-compose.prod.yml --env-file .env.prod \
   "SELECT id, alert_type, enabled, archived_at, last_checked_at, last_notified_at, last_evaluation_state FROM sourcing_alerts WHERE workspace_id = '<WORKSPACE_ID>' ORDER BY created_at DESC LIMIT 20;"
 ```
 
-- `last_checked_at` is null or stale: the alert evaluator job did not run; check the
-  backend-cron-alerts container once TP-503 lands.
+- `last_checked_at` is null or stale: the alert evaluator job did not run; check
+  `backend-cron-alerts`, which runs `sourcing-alerts-evaluate` every 15 minutes.
 - `last_evaluation_state` is null: first evaluation records state and does not notify.
 - `last_notified_at` is recent: cooldown may be suppressing another email; compare with
   `cooldown_seconds`.


### PR DESCRIPTION
## Summary

- Registers `sourcing-alerts-evaluate` in the shared `app.cli.run_job` registry, dispatching to `app.domain.sourcing.alerts_evaluator.evaluate_all_alerts(db)` from #432.
- Adds the `backend-cron-alerts` production sidecar with the existing backend-cron config shape and 15-minute `sleep 900` cadence.
- Adds focused registry/dispatch and compose-shape tests, plus the required CLAUDE.md, ADR-0021, and on-call runbook notes.

Closes #419
Refs #416

## Dependency

#432 merged before this PR (#419), so this branch is rebased onto `origin/main` at `01f6d6a`.

## Validation

- `cd backend && uv run --extra dev pytest -q tests/test_run_job.py tests/test_ci_workflow.py -k "run_job or ci_workflow"` -> `17 passed, 1 warning in 2.01s`.
- `cd backend && uv run --extra dev ruff check app/cli/run_job.py tests/test_run_job.py tests/test_ci_workflow.py` -> `All checks passed!`.
- `git diff --check` -> passed.
- `cd backend && uv run --extra dev python -m app.cli.run_job sourcing-alerts-evaluate` -> attempted, but this non-Docker environment has no compose network DB; SQLAlchemy failed resolving host `db`.
- Docker validation commands from #419 were not runnable because `docker` is not installed here (`docker --version` -> command not found), including `docker compose ... exec`, `docker compose ... config`, and local prod sidecar startup.

## Scope Notes

- No evaluator internals changed; this only wires the #432 evaluator into the registry and production sidecar.
- No frontend work included.