### PR TITLE
TP-509: Alerts management page + per-part / per-project shortcuts

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -54,6 +54,7 @@ The single most load-bearing file is `ARCHITECTURE.md`. Don't restate things fro
 | Projects and BOM | [`user/projects-and-bom.md`](user/projects-and-bom.md) |
 | Builds — consume stock against a BOM | [`user/builds.md`](user/builds.md) |
 | Reports | [`user/reports.md`](user/reports.md) |
+| Alerts | [`user/alerts.md`](user/alerts.md) |
 | Workspace members and roles | [`user/workspace-management.md`](user/workspace-management.md) |
 | Account, password, theme | [`user/account.md`](user/account.md) |
 

--- a/docs/frontend/components.md
+++ b/docs/frontend/components.md
@@ -218,6 +218,16 @@ TrustedParts source pill with `aria-label="Source: TrustedParts"`
 (`:20-23`) so TrustedParts-derived distributor data stays visually and
 accessibly labelled.
 
+## Alerts Modal
+
+`web/src/routes/sourcing/alerts/AlertFormModal.tsx` is the shared create/edit
+surface for `/sourcing/alerts`, the part Authorized supply shortcut, and the
+project Source BOM shortcut. The modal builds the discriminated threshold
+payload before calling `web/src/lib/sourcingAlerts.ts`, keeps empty recipients
+as `null` so the backend can target workspace admins, and only renders
+TrustedParts country/currency/distributor filters for alert types accepted by
+the backend sourcing-alert validator.
+
 `web/src/routes/parts/detail/AuthorizedSupplyTab.tsx` mounts the part
 detail **Authorized supply** tab. It reads
 `GET /api/parts/{part_id}/sourcing`, displays TrustedParts attribution

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -28,6 +28,7 @@ Each **workspace** is isolated. Members of one workspace cannot see another work
 - [Projects and bill of materials](projects-and-bom.md)
 - [Builds — consume stock against a BOM](builds.md)
 - [Reports](reports.md)
+- [Alerts](alerts.md)
 
 ### Settings
 

--- a/docs/user/alerts.md
+++ b/docs/user/alerts.md
@@ -1,0 +1,54 @@
+# Alerts
+
+Audience: end user
+
+How to create and manage sourcing alerts for parts and project BOMs.
+
+Alerts live under **Alerts** in the sidebar. Use them when you want Stock Manager to email the right people after stock or authorized-supply conditions change.
+
+## Create an alert
+
+1. Open **Alerts**.
+2. Click **Create alert**.
+3. Choose the alert type.
+4. Choose the part or project.
+5. Fill in the threshold if the alert type needs one.
+6. Choose recipients, or leave recipients empty to notify workspace admins.
+7. Click **Create alert**.
+
+Part alerts can watch internal stock, authorized stock availability, or price movement. Project alerts can watch when a BOM becomes buyable for a build quantity.
+
+> _Screenshot: the Alerts page with the create modal open._
+
+## Create an alert from a part
+
+1. Open a part.
+2. Click **Authorized supply**.
+3. Click **Set alert**.
+4. Choose the alert type and finish the form.
+
+The part is already selected in the form.
+
+## Create an alert from Source BOM
+
+1. Open a project.
+2. Click **Sourcing**.
+3. Set the build quantity you care about.
+4. Click **Set BOM-buyable alert**.
+5. Save the alert.
+
+The project and build quantity are already selected in the form.
+
+## Manage existing alerts
+
+Use the filters at the top of **Alerts** to narrow by alert type, enabled state, or archived alerts.
+
+- Click **Edit** to change the threshold, recipients, cooldown, or enabled state.
+- Click **Archive** to stop an alert from evaluating.
+- Turn **Include archived** on to review archived alerts.
+
+## What to do if it doesn't work
+
+- **You do not see a distributor, country, or currency** — ask a workspace admin to add it under **Settings** → **Workspace**.
+- **No email arrives** — check that the alert is enabled and that the cooldown has passed. Workspace admins receive alerts when no recipients are selected.
+- **A part alert cannot be saved** — choose a part and check that the threshold value is inside the allowed range.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -97,6 +97,7 @@ const ExpiringLotsReport = lazy(() =>
 );
 const SourcingRiskReport = lazy(() => import("@/routes/reports/SourcingRiskReport"));
 const ReplenishmentCostReport = lazy(() => import("@/routes/reports/ReplenishmentCostReport"));
+const AlertsPage = lazy(() => import("@/routes/sourcing/alerts/AlertsPage"));
 
 const ProjectsList = lazy(() => import("@/routes/projects/ProjectsList"));
 const ProjectCreate = lazy(() => import("@/routes/projects/ProjectCreate"));
@@ -278,6 +279,7 @@ export default function App() {
               <Route path="expiring" element={<LazyRoute><ExpiringLotsReport /></LazyRoute>} />
               <Route path="sourcing-risk" element={<LazyRoute><SourcingRiskReport /></LazyRoute>} />
             </Route>
+            <Route path="/sourcing/alerts" element={<LazyRoute><AlertsPage /></LazyRoute>} />
 
             <Route path="/projects" element={<LazyRoute><ProjectsList /></LazyRoute>} />
             <Route path="/projects/archived" element={<LazyRoute><ProjectsList archived /></LazyRoute>} />

--- a/web/src/components/CommandPalette.tsx
+++ b/web/src/components/CommandPalette.tsx
@@ -4,6 +4,7 @@ import { Command } from "cmdk";
 import { useQuery } from "@tanstack/react-query";
 import {
   BarChart3,
+  Bell,
   Boxes,
   FolderKanban,
   Hammer,
@@ -95,6 +96,9 @@ export default function CommandPalette() {
           </Command.Item>
           <Command.Item value="nav reports" onSelect={() => go("/reports")}>
             <BarChart3 size={14} /> Reports
+          </Command.Item>
+          <Command.Item value="nav sourcing alerts notifications" onSelect={() => go("/sourcing/alerts")}>
+            <Bell size={14} /> Alerts
           </Command.Item>
           <Command.Item
             value="nav settings workspace members"

--- a/web/src/components/layout/AppShell.tsx
+++ b/web/src/components/layout/AppShell.tsx
@@ -2,6 +2,7 @@ import { ReactNode, useEffect, useRef, useState } from "react";
 import { Link, NavLink, useLocation } from "react-router-dom";
 import {
   BarChart3,
+  Bell,
   Boxes,
   Check,
   ChevronDown,
@@ -33,6 +34,7 @@ const NAV: NavItem[] = [
   { to: "/orders",   label: "Orders",   icon: ShoppingCart },
   { to: "/builds",   label: "Builds",   icon: Hammer },
   { to: "/reports",  label: "Reports",  icon: BarChart3 },
+  { to: "/sourcing/alerts", label: "Alerts", icon: Bell },
 ];
 
 function pageTitleFor(pathname: string): string {

--- a/web/src/lib/sourcingAlerts.ts
+++ b/web/src/lib/sourcingAlerts.ts
@@ -1,0 +1,128 @@
+import { api, type ApiOptions } from "@/lib/api";
+
+export const ALERT_TYPES = [
+  "stock_below",
+  "stock_above",
+  "back_in_stock",
+  "out_of_authorized_stock",
+  "price_changed",
+  "bom_buyable",
+] as const;
+
+export type SourcingAlertType = typeof ALERT_TYPES[number];
+
+export type SourcingAlertThreshold =
+  | { qty: number }
+  | { delta_pct: number }
+  | { build_quantity: number }
+  | Record<string, never>;
+
+export type SourcingAlert = {
+  id: string;
+  workspace_id: string;
+  alert_type: SourcingAlertType;
+  part_id: string | null;
+  project_id: string | null;
+  threshold: SourcingAlertThreshold;
+  country_code: string | null;
+  currency_code: string | null;
+  distributor_filter: string[] | null;
+  notify_user_ids: string[] | null;
+  cooldown_seconds: number;
+  enabled: boolean;
+  last_checked_at: string | null;
+  last_notified_at: string | null;
+  archived_at: string | null;
+  created_by: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type SourcingAlertInput = {
+  alert_type: SourcingAlertType;
+  part_id?: string | null;
+  project_id?: string | null;
+  threshold: SourcingAlertThreshold;
+  country_code?: string | null;
+  currency_code?: string | null;
+  distributor_filter?: string[] | null;
+  notify_user_ids?: string[] | null;
+  cooldown_seconds: number;
+  enabled: boolean;
+};
+
+export type SourcingAlertFilters = {
+  alert_type?: SourcingAlertType | "";
+  enabled?: boolean | null;
+  include_archived?: boolean;
+  part_id?: string | null;
+  project_id?: string | null;
+};
+
+export type WorkspaceSourcingSettings = {
+  sourcing_country_code?: string | null;
+  sourcing_currency_code?: string | null;
+  sourcing_preferred_distributors?: string[] | null;
+  active_countries?: string[];
+  active_currencies?: string[];
+  active_distributors?: string[];
+};
+
+export type WorkspaceMemberOption = {
+  id: string;
+  user_id: string;
+  email: string;
+  name: string;
+  role: "owner" | "admin" | "member" | "viewer";
+  status: "active" | "invited" | "disabled";
+};
+
+export function alertTypeLabel(type: SourcingAlertType): string {
+  switch (type) {
+    case "stock_below":
+      return "Stock below";
+    case "stock_above":
+      return "Stock above";
+    case "back_in_stock":
+      return "Back in stock";
+    case "out_of_authorized_stock":
+      return "Out of authorized stock";
+    case "price_changed":
+      return "Price changed";
+    case "bom_buyable":
+      return "BOM buyable";
+  }
+}
+
+export function isProjectAlert(type: SourcingAlertType): boolean {
+  return type === "bom_buyable";
+}
+
+export function isSourcingFilteredAlert(type: SourcingAlertType): boolean {
+  return type === "back_in_stock" || type === "out_of_authorized_stock" || type === "price_changed";
+}
+
+export function listSourcingAlerts(filters: SourcingAlertFilters = {}, opts?: ApiOptions) {
+  const params = new URLSearchParams();
+  if (filters.alert_type) params.set("alert_type", filters.alert_type);
+  if (filters.enabled !== undefined && filters.enabled !== null) {
+    params.set("enabled", String(filters.enabled));
+  }
+  if (filters.include_archived) params.set("include_archived", "true");
+  if (filters.part_id) params.set("part_id", filters.part_id);
+  if (filters.project_id) params.set("project_id", filters.project_id);
+  const suffix = params.toString();
+  return api.get<SourcingAlert[]>(`/sourcing/alerts${suffix ? `?${suffix}` : ""}`, opts);
+}
+
+export function createSourcingAlert(payload: SourcingAlertInput) {
+  return api.post<SourcingAlert, SourcingAlertInput>("/sourcing/alerts", payload);
+}
+
+export function updateSourcingAlert(id: string, payload: SourcingAlertInput) {
+  return api.patch<SourcingAlert, SourcingAlertInput>(`/sourcing/alerts/${id}`, payload);
+}
+
+export function archiveSourcingAlert(id: string) {
+  return api.delete<SourcingAlert>(`/sourcing/alerts/${id}`);
+}

--- a/web/src/routes/parts/detail/AuthorizedSupplyTab.tsx
+++ b/web/src/routes/parts/detail/AuthorizedSupplyTab.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { ExternalLink, Plus, RefreshCw } from "lucide-react";
+import { BellPlus, ExternalLink, Plus, RefreshCw } from "lucide-react";
 import { toast } from "sonner";
 import { InlineQueryError } from "@/components/QueryStateBoundary";
 import { ApiError, api } from "@/lib/api";
@@ -13,6 +13,8 @@ import type { Column } from "@/components/DataTable";
 import { DataTable } from "@/components/DataTable";
 import { PoweredByTrustedParts } from "@/components/PoweredByTrustedParts";
 import { SourcingSourceLabel } from "@/components/SourcingSourceLabel";
+import type { SourcingAlertType } from "@/lib/sourcingAlerts";
+import AlertFormModal from "@/routes/sourcing/alerts/AlertFormModal";
 import {
   CreateOrderLineModal,
   type CreateOrderLineSource,
@@ -249,6 +251,7 @@ export function AuthorizedSupplyTab({ partId }: { partId: string }) {
   const [quantity, setQuantity] = useState(1);
   const [customQuantity, setCustomQuantity] = useState("1");
   const [orderLineSource, setOrderLineSource] = useState<CreateOrderLineSource | null>(null);
+  const [alertModalOpen, setAlertModalOpen] = useState(false);
 
   const query = useQuery({
     queryKey,
@@ -471,18 +474,28 @@ export function AuthorizedSupplyTab({ partId }: { partId: string }) {
             </span>
           )}
         </div>
-        <button
-          type="button"
-          className="btn-primary inline-flex items-center gap-1.5"
-          disabled={refreshMutation.isPending}
-          onClick={() => {
-            refreshMutation.reset();
-            refreshMutation.mutate();
-          }}
-        >
-          <RefreshCw size={14} className={refreshMutation.isPending ? "animate-spin" : ""} />
-          {refreshMutation.isPending ? "Refreshing…" : "Refresh live"}
-        </button>
+        <div className="flex flex-wrap justify-end gap-2">
+          <button
+            type="button"
+            className="btn inline-flex items-center gap-1.5"
+            onClick={() => setAlertModalOpen(true)}
+          >
+            <BellPlus size={14} aria-hidden="true" />
+            Set alert
+          </button>
+          <button
+            type="button"
+            className="btn-primary inline-flex items-center gap-1.5"
+            disabled={refreshMutation.isPending}
+            onClick={() => {
+              refreshMutation.reset();
+              refreshMutation.mutate();
+            }}
+          >
+            <RefreshCw size={14} className={refreshMutation.isPending ? "animate-spin" : ""} />
+            {refreshMutation.isPending ? "Refreshing…" : "Refresh live"}
+          </button>
+        </div>
       </div>
 
       {status === 503 && (
@@ -600,6 +613,17 @@ export function AuthorizedSupplyTab({ partId }: { partId: string }) {
         open={orderLineSource !== null}
         source={orderLineSource}
         onClose={() => setOrderLineSource(null)}
+      />
+      <AlertFormModal
+        open={alertModalOpen}
+        title="Set alert on this part"
+        initialValues={{ part_id: partId, alert_type: "back_in_stock" }}
+        allowedTypes={["back_in_stock", "out_of_authorized_stock", "price_changed", "stock_below", "stock_above"] satisfies SourcingAlertType[]}
+        onClose={() => setAlertModalOpen(false)}
+        onSaved={() => {
+          queryClient.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "sourcing-alerts") });
+          toast.success("Alert created.");
+        }}
       />
     </div>
   );

--- a/web/src/routes/parts/detail/__tests__/AuthorizedSupplyTab.test.tsx
+++ b/web/src/routes/parts/detail/__tests__/AuthorizedSupplyTab.test.tsx
@@ -103,6 +103,48 @@ function mockApiGet(response: unknown, workspaceCurrency: string | null = "EUR")
   });
 }
 
+function mockApiGetWithAlertPicker(response: unknown, workspaceCurrency: string | null = "EUR") {
+  return vi.spyOn(api, "get").mockImplementation((path: string) => {
+    if (path === "/workspaces/current") {
+      return Promise.resolve(workspaceResponse(workspaceCurrency));
+    }
+    if (path === "/workspaces/members") {
+      return Promise.resolve([]);
+    }
+    if (path.startsWith("/parts?")) {
+      return Promise.resolve([
+        {
+          id: partId,
+          part_type: "linked",
+          name: "STM32",
+          manufacturer: "STMicroelectronics",
+          mpn: "STM32F103C8T6",
+          internal_part_number: null,
+          description: null,
+          footprint: null,
+          notes_markdown: null,
+          low_stock_report_quantity: null,
+          attrition_percentage: 0,
+          attrition_min_quantity: 0,
+          default_storage_location_id: null,
+          default_storage_mandatory: false,
+          serialized: false,
+          linked_provider: null,
+          linked_external_id: null,
+          last_refresh_at: null,
+          description_locally_edited: false,
+          archived_at: null,
+          on_hand: 0,
+          reserved: 0,
+          available: 0,
+          image_url: null,
+        },
+      ]);
+    }
+    return Promise.resolve(response);
+  });
+}
+
 function mockApiGetError(error: ApiError, workspaceCurrency: string | null = "EUR") {
   return vi.spyOn(api, "get").mockImplementation((path: string) => {
     if (path === "/workspaces/current") {
@@ -195,6 +237,20 @@ describe("AuthorizedSupplyTab", () => {
       expect(api.post).toHaveBeenCalledWith(`/parts/${partId}/sourcing/refresh`, {});
     });
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: sourcingQueryKey });
+  });
+
+  it("Set-alert button opens modal with part_id pre-filled", async () => {
+    const user = userEvent.setup();
+    mockApiGetWithAlertPicker(sourcingResponse());
+    vi.spyOn(api, "post").mockResolvedValue({ id: "alert-1" });
+
+    renderTab();
+
+    await screen.findByText("Powered by TrustedParts");
+    await user.click(screen.getByRole("button", { name: "Set alert" }));
+
+    expect(await screen.findByRole("dialog", { name: "Set alert on this part" })).toBeDefined();
+    expect((screen.getByRole("radio", { name: /STM32/ }) as HTMLInputElement).checked).toBe(true);
   });
 
   it("distributor filter narrows visible rows", async () => {

--- a/web/src/routes/projects/sourcing/ProjectSourcingPage.tsx
+++ b/web/src/routes/projects/sourcing/ProjectSourcingPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
-import { FolderKanban, RefreshCw } from "lucide-react";
+import { BellPlus, FolderKanban, RefreshCw } from "lucide-react";
 import { toast } from "sonner";
 import EmptyState from "@/components/EmptyState";
 import { DataTable, type Column } from "@/components/DataTable";
@@ -9,6 +9,7 @@ import { PoweredByTrustedParts } from "@/components/PoweredByTrustedParts";
 import { SourcingSourceLabel } from "@/components/SourcingSourceLabel";
 import { ApiError, api } from "@/lib/api";
 import { useWsKey } from "@/lib/queryKeys";
+import AlertFormModal from "@/routes/sourcing/alerts/AlertFormModal";
 import type { Project } from "@/types";
 import PurchasePlanOptionsModal from "./PurchasePlanOptionsModal";
 import type { PurchasePlan, PurchasePlanRequest } from "./purchasePlanTypes";
@@ -402,6 +403,7 @@ export default function ProjectSourcingPage() {
   const [defaultsApplied, setDefaultsApplied] = useState(false);
   const [budgetDisabledUntil, setBudgetDisabledUntil] = useState<number | null>(null);
   const [planModalOpen, setPlanModalOpen] = useState(false);
+  const [alertModalOpen, setAlertModalOpen] = useState(false);
   const [planPending, setPlanPending] = useState(false);
 
   const { data: workspace } = useQuery({
@@ -619,10 +621,19 @@ export default function ProjectSourcingPage() {
             {filterWarnings.join(" ")}
           </div>
         )}
-        <div className="mt-3 flex justify-end">
+        <div className="mt-3 flex flex-wrap justify-end gap-2">
           <button
             type="button"
-            className="btn mr-2"
+            className="btn"
+            disabled={!projectId}
+            onClick={() => setAlertModalOpen(true)}
+          >
+            <BellPlus size={14} aria-hidden="true" />
+            Set BOM-buyable alert
+          </button>
+          <button
+            type="button"
+            className="btn"
             disabled={sourceDisabled || !hasRows}
             onClick={() => setPlanModalOpen(true)}
           >
@@ -673,6 +684,14 @@ export default function ProjectSourcingPage() {
         pending={planPending}
         onClose={() => setPlanModalOpen(false)}
         onSubmit={generatePurchasePlan}
+      />
+      <AlertFormModal
+        open={alertModalOpen}
+        title="Set BOM-buyable alert"
+        initialValues={{ alert_type: "bom_buyable", project_id: projectId, build_quantity: Math.max(1, Math.floor(buildQuantity || 1)) }}
+        allowedTypes={["bom_buyable"]}
+        onClose={() => setAlertModalOpen(false)}
+        onSaved={() => toast.success("Alert created.")}
       />
     </div>
   );

--- a/web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.test.tsx
+++ b/web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.test.tsx
@@ -181,6 +181,8 @@ function apiError(status: number, message: string) {
 function mockReads(workspaceOverrides: Record<string, unknown> = {}) {
   vi.spyOn(api, "get").mockImplementation(async path => {
     if (path === "/workspaces/current") return workspace(workspaceOverrides) as never;
+    if (path === "/workspaces/members") return [] as never;
+    if (String(path).startsWith("/projects?")) return [project()] as never;
     if (path === `/projects/${projectId}`) return project() as never;
     throw new Error(`unexpected GET ${path}`);
   });
@@ -401,6 +403,23 @@ describe("ProjectSourcingPage", () => {
         }),
       );
     });
+  });
+
+  it("Set BOM-buyable alert opens modal with project and build quantity pre-filled", async () => {
+    const user = userEvent.setup();
+    mockReads();
+    vi.spyOn(api, "post").mockResolvedValue(sourcingResponse());
+
+    renderPage();
+
+    await screen.findByText("BOM rows");
+    await user.clear(screen.getByLabelText("Build quantity"));
+    await user.type(screen.getByLabelText("Build quantity"), "12");
+    await user.click(screen.getByRole("button", { name: "Set BOM-buyable alert" }));
+
+    const dialog = await screen.findByRole("dialog", { name: "Set BOM-buyable alert" });
+    expect((within(dialog).getByLabelText("Project") as HTMLSelectElement).value).toBe(projectId);
+    expect((within(dialog).getByLabelText("Build quantity") as HTMLInputElement).value).toBe("12");
   });
 
   it("Source BOM button is disabled when workspace lacks sourcing creds", async () => {

--- a/web/src/routes/sourcing/alerts/AlertFormModal.tsx
+++ b/web/src/routes/sourcing/alerts/AlertFormModal.tsx
@@ -1,0 +1,525 @@
+import { FormEvent, useEffect, useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Bell, Loader2, X } from "lucide-react";
+import { ApiError, api } from "@/lib/api";
+import { useAuth } from "@/lib/auth";
+import { useApiMutation } from "@/lib/mutations";
+import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
+import {
+  ALERT_TYPES,
+  alertTypeLabel,
+  createSourcingAlert,
+  isProjectAlert,
+  isSourcingFilteredAlert,
+  type SourcingAlert,
+  type SourcingAlertInput,
+  type SourcingAlertType,
+  type WorkspaceMemberOption,
+  type WorkspaceSourcingSettings,
+  updateSourcingAlert,
+} from "@/lib/sourcingAlerts";
+import type { Part, Project } from "@/types";
+
+export type AlertFormInitialValues = {
+  alert_type?: SourcingAlertType;
+  part_id?: string | null;
+  project_id?: string | null;
+  build_quantity?: number;
+};
+
+type Props = {
+  open: boolean;
+  mode?: "create" | "edit";
+  alert?: SourcingAlert | null;
+  initialValues?: AlertFormInitialValues;
+  allowedTypes?: SourcingAlertType[];
+  title?: string;
+  onClose: () => void;
+  onSaved?: (alert: SourcingAlert) => void;
+};
+
+const DEFAULT_COOLDOWN_SECONDS = 86400;
+const EMPTY_THRESHOLD_TYPES = new Set<SourcingAlertType>([
+  "back_in_stock",
+  "out_of_authorized_stock",
+]);
+
+function positiveInt(value: string, fallback: number): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.max(fallback, Math.floor(parsed));
+}
+
+function thresholdFromAlert(alert: SourcingAlert | null | undefined, key: string, fallback: string): string {
+  const value = alert?.threshold?.[key as keyof typeof alert.threshold];
+  return value == null ? fallback : String(value);
+}
+
+function defaultFromActiveList(saved: string | null | undefined, active: string[]): string {
+  if (saved && active.includes(saved)) return saved;
+  return active[0] ?? "";
+}
+
+function memberLabel(member: WorkspaceMemberOption): string {
+  return member.name ? `${member.name} (${member.email})` : member.email;
+}
+
+function partSubtitle(part: Part): string {
+  return [part.mpn, part.manufacturer].filter(Boolean).join(" - ");
+}
+
+export default function AlertFormModal({
+  open,
+  mode = "create",
+  alert = null,
+  initialValues,
+  allowedTypes = [...ALERT_TYPES],
+  title,
+  onClose,
+  onSaved,
+}: Props) {
+  const { workspaceId } = useAuth();
+  const isEdit = mode === "edit" && alert !== null;
+  const initialType = initialValues?.alert_type ?? alert?.alert_type ?? allowedTypes[0] ?? "stock_below";
+  const [alertType, setAlertType] = useState<SourcingAlertType>(initialType);
+  const [enabled, setEnabled] = useState(alert?.enabled ?? true);
+  const [cooldownSeconds, setCooldownSeconds] = useState(String(alert?.cooldown_seconds ?? DEFAULT_COOLDOWN_SECONDS));
+  const [notifyUserIds, setNotifyUserIds] = useState<string[]>(alert?.notify_user_ids ?? []);
+  const [partId, setPartId] = useState(alert?.part_id ?? initialValues?.part_id ?? "");
+  const [projectId, setProjectId] = useState(alert?.project_id ?? initialValues?.project_id ?? "");
+  const [qty, setQty] = useState(thresholdFromAlert(alert, "qty", "0"));
+  const [deltaPct, setDeltaPct] = useState(thresholdFromAlert(alert, "delta_pct", "5"));
+  const [buildQuantity, setBuildQuantity] = useState(
+    String(initialValues?.build_quantity ?? thresholdFromAlert(alert, "build_quantity", "1")),
+  );
+  const [countryCode, setCountryCode] = useState(alert?.country_code ?? "");
+  const [currencyCode, setCurrencyCode] = useState(alert?.currency_code ?? "");
+  const [distributorFilter, setDistributorFilter] = useState<string[]>(alert?.distributor_filter ?? []);
+  const [partSearch, setPartSearch] = useState("");
+  const [debouncedPartSearch, setDebouncedPartSearch] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const nextType = initialValues?.alert_type ?? alert?.alert_type ?? allowedTypes[0] ?? "stock_below";
+    setAlertType(nextType);
+    setEnabled(alert?.enabled ?? true);
+    setCooldownSeconds(String(alert?.cooldown_seconds ?? DEFAULT_COOLDOWN_SECONDS));
+    setNotifyUserIds(alert?.notify_user_ids ?? []);
+    setPartId(alert?.part_id ?? initialValues?.part_id ?? "");
+    setProjectId(alert?.project_id ?? initialValues?.project_id ?? "");
+    setQty(thresholdFromAlert(alert, "qty", "0"));
+    setDeltaPct(thresholdFromAlert(alert, "delta_pct", "5"));
+    setBuildQuantity(String(initialValues?.build_quantity ?? thresholdFromAlert(alert, "build_quantity", "1")));
+    setCountryCode(alert?.country_code ?? "");
+    setCurrencyCode(alert?.currency_code ?? "");
+    setDistributorFilter(alert?.distributor_filter ?? []);
+    setPartSearch("");
+    setError(null);
+  }, [open, alert, initialValues, allowedTypes]);
+
+  useEffect(() => {
+    const handle = window.setTimeout(() => setDebouncedPartSearch(partSearch.trim()), 250);
+    return () => window.clearTimeout(handle);
+  }, [partSearch]);
+
+  const workspaceQuery = useQuery({
+    queryKey: useWsKey("ws", "current"),
+    queryFn: () => api.get<WorkspaceSourcingSettings>("/workspaces/current"),
+    enabled: open,
+  });
+  const membersQuery = useQuery({
+    queryKey: useWsKey("ws", "members"),
+    queryFn: () => api.get<WorkspaceMemberOption[]>("/workspaces/members"),
+    enabled: open,
+  });
+  const partsQuery = useQuery({
+    queryKey: useWsKey("parts", "alert-picker", debouncedPartSearch),
+    queryFn: () => {
+      const params = new URLSearchParams({ limit: "20" });
+      if (debouncedPartSearch) {
+        params.set("q", debouncedPartSearch);
+        params.set("search", debouncedPartSearch);
+      }
+      return api.get<Part[]>(`/parts?${params.toString()}`);
+    },
+    enabled: open && !isProjectAlert(alertType),
+  });
+  const projectsQuery = useQuery({
+    queryKey: useWsKey("projects", "alert-picker"),
+    queryFn: () => api.get<Project[]>("/projects?limit=200"),
+    enabled: open && isProjectAlert(alertType),
+  });
+
+  const activeMembers = useMemo(
+    () => (membersQuery.data ?? []).filter(member => member.status === "active"),
+    [membersQuery.data],
+  );
+  const parts = partsQuery.data ?? [];
+  const projects = projectsQuery.data ?? [];
+  const workspace = workspaceQuery.data;
+  const availableTypes = allowedTypes.length > 0 ? allowedTypes : [...ALERT_TYPES];
+  const showSourcingFilters = isSourcingFilteredAlert(alertType);
+
+  useEffect(() => {
+    if (!open || !workspace || isEdit || !showSourcingFilters) return;
+    const activeCountries = workspace.active_countries ?? [];
+    const activeCurrencies = workspace.active_currencies ?? [];
+    const activeDistributors = workspace.active_distributors ?? [];
+    setCountryCode(current => current || defaultFromActiveList(workspace.sourcing_country_code, activeCountries));
+    setCurrencyCode(current => current || defaultFromActiveList(workspace.sourcing_currency_code, activeCurrencies));
+    setDistributorFilter(current => current.length > 0 ? current : (workspace.sourcing_preferred_distributors ?? []).filter(
+      distributor => activeDistributors.includes(distributor),
+    ));
+  }, [open, workspace, isEdit, showSourcingFilters]);
+
+  const mutation = useApiMutation<SourcingAlert, SourcingAlertInput>({
+    mutationKey: wsKeyOf(workspaceId, "sourcing-alerts", isEdit ? alert?.id : "create"),
+    mutationFn: payload => isEdit && alert
+      ? updateSourcingAlert(alert.id, payload)
+      : createSourcingAlert(payload),
+    onSuccess: saved => {
+      onSaved?.(saved);
+      onClose();
+    },
+    onError: err => {
+      setError(err instanceof ApiError ? err.userMessage : "Failed to save alert.");
+    },
+  });
+
+  if (!open) return null;
+
+  function buildPayload(): SourcingAlertInput | null {
+    const cooldown = Number(cooldownSeconds);
+    if (!Number.isFinite(cooldown) || cooldown < 60) {
+      setError("Cooldown must be at least 60 seconds.");
+      return null;
+    }
+    if (!isProjectAlert(alertType) && !partId) {
+      setError("Choose a part for this alert.");
+      return null;
+    }
+    if (isProjectAlert(alertType) && !projectId) {
+      setError("Choose a project for this alert.");
+      return null;
+    }
+
+    let threshold: SourcingAlertInput["threshold"] = {};
+    if (alertType === "stock_below" || alertType === "stock_above") {
+      const parsedQty = Number(qty);
+      if (!Number.isInteger(parsedQty) || parsedQty < 0) {
+        setError("Quantity must be an integer of 0 or more.");
+        return null;
+      }
+      threshold = { qty: parsedQty };
+    } else if (alertType === "price_changed") {
+      const parsedDelta = Number(deltaPct);
+      if (!Number.isFinite(parsedDelta) || parsedDelta < 0.1 || parsedDelta > 100) {
+        setError("Price-change percentage must be between 0.1 and 100.");
+        return null;
+      }
+      threshold = { delta_pct: parsedDelta };
+    } else if (alertType === "bom_buyable") {
+      const parsedBuild = Number(buildQuantity);
+      if (!Number.isInteger(parsedBuild) || parsedBuild < 1) {
+        setError("Build quantity must be an integer of 1 or more.");
+        return null;
+      }
+      threshold = { build_quantity: parsedBuild };
+    }
+
+    const payload: SourcingAlertInput = {
+      alert_type: alertType,
+      part_id: isProjectAlert(alertType) ? null : partId,
+      project_id: isProjectAlert(alertType) ? projectId : null,
+      threshold,
+      cooldown_seconds: Math.floor(cooldown),
+      enabled,
+      notify_user_ids: notifyUserIds.length > 0 ? notifyUserIds : null,
+      country_code: null,
+      currency_code: null,
+      distributor_filter: null,
+    };
+
+    if (showSourcingFilters) {
+      payload.country_code = countryCode || null;
+      payload.currency_code = currencyCode || null;
+      payload.distributor_filter = distributorFilter.length > 0 ? distributorFilter : null;
+    }
+    return payload;
+  }
+
+  function submit(event: FormEvent) {
+    event.preventDefault();
+    setError(null);
+    const payload = buildPayload();
+    if (!payload) return;
+    mutation.mutate(payload);
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="alert-form-title"
+      onMouseDown={event => {
+        if (event.target === event.currentTarget && !mutation.isPending) onClose();
+      }}
+    >
+      <form className="card max-h-[92vh] w-full max-w-3xl overflow-auto p-4 shadow-lg" noValidate onSubmit={submit}>
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <div className="flex items-center gap-2">
+              <Bell size={18} aria-hidden="true" />
+              <h2 id="alert-form-title" className="text-base font-semibold text-text">
+                {title ?? (isEdit ? "Edit alert" : "Create alert")}
+              </h2>
+            </div>
+            <p className="mt-1 text-sm text-muted">
+              {isEdit ? "Update the threshold, recipients, and active state." : "Choose when this workspace should be notified."}
+            </p>
+          </div>
+          <button type="button" className="btn-ghost btn-sm" onClick={onClose} disabled={mutation.isPending} aria-label="Close alert form">
+            <X size={16} aria-hidden="true" />
+          </button>
+        </div>
+
+        {error && <div className="mt-3 card p-3 text-sm text-danger" role="alert">{error}</div>}
+
+        <div className="mt-4 grid grid-cols-1 gap-3 md:grid-cols-3">
+          <label className="label">
+            Alert type
+            <select
+              className="input"
+              value={alertType}
+              disabled={mutation.isPending || isEdit}
+              onChange={event => {
+                const next = event.currentTarget.value as SourcingAlertType;
+                setAlertType(next);
+                if (isProjectAlert(next)) setPartId("");
+                else setProjectId("");
+              }}
+            >
+              {availableTypes.map(type => (
+                <option key={type} value={type}>{alertTypeLabel(type)}</option>
+              ))}
+            </select>
+          </label>
+          <label className="label">
+            Cooldown seconds
+            <input
+              className="input"
+              type="number"
+              min={60}
+              step={60}
+              inputMode="numeric"
+              value={cooldownSeconds}
+              onChange={event => setCooldownSeconds(event.currentTarget.value)}
+              disabled={mutation.isPending}
+            />
+          </label>
+          <label className="label flex-row items-center gap-2 pt-6">
+            <input
+              type="checkbox"
+              checked={enabled}
+              onChange={event => setEnabled(event.currentTarget.checked)}
+              disabled={mutation.isPending}
+            />
+            Enabled
+          </label>
+        </div>
+
+        <div className="mt-4 grid grid-cols-1 gap-4 lg:grid-cols-2">
+          {!isProjectAlert(alertType) ? (
+            <section className="space-y-2">
+              <label className="label">
+                Part
+                <input
+                  className="input"
+                  placeholder="Search MPN or name..."
+                  value={partSearch}
+                  onChange={event => setPartSearch(event.currentTarget.value)}
+                  disabled={mutation.isPending}
+                />
+              </label>
+              <div className="max-h-56 overflow-auto rounded border border-border">
+                {partsQuery.isLoading ? (
+                  <div className="flex items-center gap-2 p-3 text-sm text-muted">
+                    <Loader2 size={14} className="animate-spin" /> Loading parts...
+                  </div>
+                ) : parts.length === 0 ? (
+                  <div className="p-3 text-sm text-muted">No parts found.</div>
+                ) : (
+                  <div className="divide-y divide-border">
+                    {parts.map(part => (
+                      <label key={part.id} className="flex cursor-pointer items-center gap-3 p-3 hover:bg-panel2/40">
+                        <input
+                          type="radio"
+                          name="alert-part"
+                          checked={partId === part.id}
+                          onChange={() => setPartId(part.id)}
+                          disabled={mutation.isPending}
+                        />
+                        <span className="min-w-0">
+                          <span className="block truncate text-sm font-medium">{part.name}</span>
+                          <span className="block truncate text-xs text-muted">{partSubtitle(part) || "No MPN"}</span>
+                        </span>
+                      </label>
+                    ))}
+                  </div>
+                )}
+              </div>
+              {partId && !parts.some(part => part.id === partId) && (
+                <div className="text-xs text-muted">Selected part: {partId}</div>
+              )}
+            </section>
+          ) : (
+            <section className="space-y-2">
+              <label className="label">
+                Project
+                <select
+                  className="input"
+                  value={projectId}
+                  onChange={event => setProjectId(event.currentTarget.value)}
+                  disabled={mutation.isPending || projectsQuery.isLoading}
+                >
+                  <option value="">Choose project...</option>
+                  {projects.map(project => (
+                    <option key={project.id} value={project.id}>{project.name}</option>
+                  ))}
+                </select>
+              </label>
+              {projectId && !projects.some(project => project.id === projectId) && (
+                <div className="text-xs text-muted">Selected project: {projectId}</div>
+              )}
+            </section>
+          )}
+
+          <section className="space-y-3">
+            {(alertType === "stock_below" || alertType === "stock_above") && (
+              <label className="label">
+                Quantity
+                <input
+                  className="input"
+                  type="number"
+                  min={0}
+                  step={1}
+                  inputMode="numeric"
+                  value={qty}
+                  onChange={event => setQty(event.currentTarget.value)}
+                  disabled={mutation.isPending}
+                />
+              </label>
+            )}
+            {alertType === "price_changed" && (
+              <label className="label">
+                Delta percent
+                <input
+                  className="input"
+                  type="number"
+                  min={0.1}
+                  max={100}
+                  step={0.1}
+                  inputMode="decimal"
+                  value={deltaPct}
+                  onChange={event => setDeltaPct(event.currentTarget.value)}
+                  disabled={mutation.isPending}
+                />
+              </label>
+            )}
+            {alertType === "bom_buyable" && (
+              <label className="label">
+                Build quantity
+                <input
+                  className="input"
+                  type="number"
+                  min={1}
+                  step={1}
+                  inputMode="numeric"
+                  value={buildQuantity}
+                  onChange={event => setBuildQuantity(event.currentTarget.value)}
+                  onBlur={() => setBuildQuantity(String(positiveInt(buildQuantity, 1)))}
+                  disabled={mutation.isPending}
+                />
+              </label>
+            )}
+            {EMPTY_THRESHOLD_TYPES.has(alertType) && (
+              <div className="rounded border border-border p-3 text-sm text-muted">
+                This alert triggers on an availability transition; no numeric threshold is needed.
+              </div>
+            )}
+            <label className="label">
+              Recipients
+              <select
+                multiple
+                className="input min-h-32"
+                value={notifyUserIds}
+                onChange={event => {
+                  setNotifyUserIds(Array.from(event.currentTarget.selectedOptions).map(option => option.value));
+                }}
+                disabled={mutation.isPending || membersQuery.isLoading}
+              >
+                {activeMembers.map(member => (
+                  <option key={member.user_id} value={member.user_id}>{memberLabel(member)}</option>
+                ))}
+              </select>
+            </label>
+            <div className="text-xs text-muted">Leave recipients empty to notify workspace admins.</div>
+          </section>
+        </div>
+
+        {showSourcingFilters && (
+          <fieldset className="mt-4 border-t border-border pt-4">
+            <legend className="section-title">Sourcing filters</legend>
+            <div className="mt-2 grid grid-cols-1 gap-3 md:grid-cols-3">
+              <label className="label">
+                Country
+                <select
+                  className="input uppercase"
+                  value={countryCode}
+                  onChange={event => setCountryCode(event.currentTarget.value)}
+                  disabled={mutation.isPending || workspaceQuery.isLoading}
+                >
+                  <option value="">Workspace default</option>
+                  {(workspace?.active_countries ?? []).map(item => <option key={item} value={item}>{item}</option>)}
+                </select>
+              </label>
+              <label className="label">
+                Currency
+                <select
+                  className="input uppercase"
+                  value={currencyCode}
+                  onChange={event => setCurrencyCode(event.currentTarget.value)}
+                  disabled={mutation.isPending || workspaceQuery.isLoading}
+                >
+                  <option value="">Workspace default</option>
+                  {(workspace?.active_currencies ?? []).map(item => <option key={item} value={item}>{item}</option>)}
+                </select>
+              </label>
+              <label className="label">
+                Distributor filter
+                <select
+                  multiple
+                  className="input min-h-32"
+                  value={distributorFilter}
+                  onChange={event => setDistributorFilter(Array.from(event.currentTarget.selectedOptions).map(option => option.value))}
+                  disabled={mutation.isPending || workspaceQuery.isLoading}
+                >
+                  {(workspace?.active_distributors ?? []).map(item => <option key={item} value={item}>{item}</option>)}
+                </select>
+              </label>
+            </div>
+          </fieldset>
+        )}
+
+        <div className="mt-4 flex justify-end gap-2">
+          <button type="button" className="btn" onClick={onClose} disabled={mutation.isPending}>Cancel</button>
+          <button type="submit" className="btn-primary" disabled={mutation.isPending}>
+            {mutation.isPending ? "Saving..." : isEdit ? "Save alert" : "Create alert"}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/web/src/routes/sourcing/alerts/AlertsPage.tsx
+++ b/web/src/routes/sourcing/alerts/AlertsPage.tsx
@@ -1,0 +1,243 @@
+import { useCallback, useMemo, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { Archive, BellPlus, Pencil } from "lucide-react";
+import { toast } from "sonner";
+import { useConfirm } from "@/components/ConfirmDialog";
+import { DataTable, type Column } from "@/components/DataTable";
+import { PoweredByTrustedParts } from "@/components/PoweredByTrustedParts";
+import { InlineQueryError } from "@/components/QueryStateBoundary";
+import { ApiError, api } from "@/lib/api";
+import { useAuth } from "@/lib/auth";
+import { formatDateTime } from "@/lib/format";
+import { useApiMutation } from "@/lib/mutations";
+import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
+import {
+  alertTypeLabel,
+  archiveSourcingAlert,
+  isProjectAlert,
+  listSourcingAlerts,
+  type SourcingAlert,
+  type SourcingAlertType,
+} from "@/lib/sourcingAlerts";
+import type { Part, Project } from "@/types";
+import AlertFormModal from "./AlertFormModal";
+
+type EnabledFilter = "all" | "enabled" | "disabled";
+
+function formatThreshold(alert: SourcingAlert): string {
+  switch (alert.alert_type) {
+    case "stock_below":
+      return `Below ${(alert.threshold as { qty?: number }).qty ?? 0}`;
+    case "stock_above":
+      return `Above ${(alert.threshold as { qty?: number }).qty ?? 0}`;
+    case "price_changed":
+      return `${(alert.threshold as { delta_pct?: number }).delta_pct ?? 0}% change`;
+    case "bom_buyable":
+      return `Build ${(alert.threshold as { build_quantity?: number }).build_quantity ?? 1}`;
+    case "back_in_stock":
+      return "Authorized stock returns";
+    case "out_of_authorized_stock":
+      return "Authorized stock reaches zero";
+  }
+}
+
+function mapById<T extends { id: string }>(rows: T[] | undefined): Map<string, T> {
+  return new Map((rows ?? []).map(row => [row.id, row]));
+}
+
+export default function AlertsPage() {
+  const { workspaceId } = useAuth();
+  const qc = useQueryClient();
+  const confirm = useConfirm();
+  const [typeFilter, setTypeFilter] = useState<SourcingAlertType | "">("");
+  const [enabledFilter, setEnabledFilter] = useState<EnabledFilter>("all");
+  const [includeArchived, setIncludeArchived] = useState(false);
+  const [formAlert, setFormAlert] = useState<SourcingAlert | null>(null);
+  const [formOpen, setFormOpen] = useState(false);
+
+  const enabled = enabledFilter === "all" ? null : enabledFilter === "enabled";
+  const query = useQuery({
+    queryKey: useWsKey("sourcing-alerts", typeFilter, enabledFilter, includeArchived),
+    queryFn: ({ signal }) => listSourcingAlerts({
+      alert_type: typeFilter,
+      enabled,
+      include_archived: includeArchived,
+    }, { signal }),
+  });
+  const partsQuery = useQuery({
+    queryKey: useWsKey("parts", "alert-scope-map"),
+    queryFn: () => api.get<Part[]>("/parts?limit=200"),
+  });
+  const projectsQuery = useQuery({
+    queryKey: useWsKey("projects", "alert-scope-map"),
+    queryFn: () => api.get<Project[]>("/projects?limit=200"),
+  });
+  const partMap = useMemo(() => mapById(partsQuery.data), [partsQuery.data]);
+  const projectMap = useMemo(() => mapById(projectsQuery.data), [projectsQuery.data]);
+  const rows = query.data ?? [];
+
+  const archiveMutation = useApiMutation<SourcingAlert, SourcingAlert>({
+    mutationKey: wsKeyOf(workspaceId, "sourcing-alerts", "archive"),
+    mutationFn: alert => archiveSourcingAlert(alert.id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "sourcing-alerts") });
+      toast.success("Alert archived.");
+    },
+    onError: error => {
+      toast.error(error instanceof ApiError ? error.userMessage : "Failed to archive alert.");
+    },
+  });
+
+  function invalidateAlerts() {
+    qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "sourcing-alerts") });
+  }
+
+  const scopeLabel = useCallback((alert: SourcingAlert): string => {
+    if (isProjectAlert(alert.alert_type)) {
+      return projectMap.get(alert.project_id ?? "")?.name ?? alert.project_id ?? "Project";
+    }
+    return partMap.get(alert.part_id ?? "")?.name ?? alert.part_id ?? "Part";
+  }, [partMap, projectMap]);
+
+  const columns = useMemo<Column<SourcingAlert>[]>(() => [
+    {
+      key: "type",
+      header: "Type",
+      accessor: row => alertTypeLabel(row.alert_type),
+      render: row => <span className="pill">{alertTypeLabel(row.alert_type)}</span>,
+    },
+    { key: "scope", header: "Scope", accessor: scopeLabel },
+    { key: "threshold", header: "Threshold", accessor: formatThreshold },
+    {
+      key: "enabled",
+      header: "Enabled",
+      accessor: row => row.enabled,
+      render: row => row.enabled ? <span className="pill bg-success/10 text-success">Enabled</span> : <span className="pill">Disabled</span>,
+    },
+    {
+      key: "last_checked",
+      header: "Last checked",
+      accessor: row => row.last_checked_at ?? "",
+      render: row => row.last_checked_at ? formatDateTime(row.last_checked_at) : "—",
+    },
+    {
+      key: "last_notified",
+      header: "Last notified",
+      accessor: row => row.last_notified_at ?? "",
+      render: row => row.last_notified_at ? formatDateTime(row.last_notified_at) : "—",
+    },
+    {
+      key: "actions",
+      header: "",
+      render: row => (
+        <div className="flex flex-wrap justify-end gap-2">
+          <button
+            type="button"
+            className="btn btn-sm"
+            onClick={() => {
+              setFormAlert(row);
+              setFormOpen(true);
+            }}
+          >
+            <Pencil size={14} aria-hidden="true" />
+            Edit
+          </button>
+          <button
+            type="button"
+            className="btn-danger btn-sm"
+            disabled={archiveMutation.isPending || row.archived_at !== null}
+            onClick={async () => {
+              const ok = await confirm({
+                title: "Archive alert?",
+                message: "Archived alerts stop evaluating but remain visible when archived rows are included.",
+                confirmLabel: "Archive",
+                severity: "danger",
+              });
+              if (ok) archiveMutation.mutate(row);
+            }}
+          >
+            <Archive size={14} aria-hidden="true" />
+            Archive
+          </button>
+        </div>
+      ),
+    },
+  ], [archiveMutation, confirm, scopeLabel]);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <div className="text-sm text-muted">Sourcing</div>
+          <div className="mt-1 flex flex-wrap items-center gap-2">
+            <h1 className="text-xl font-semibold">Alerts</h1>
+            <PoweredByTrustedParts />
+          </div>
+        </div>
+        <button
+          type="button"
+          className="btn-primary"
+          onClick={() => {
+            setFormAlert(null);
+            setFormOpen(true);
+          }}
+        >
+          <BellPlus size={16} aria-hidden="true" />
+          Create alert
+        </button>
+      </div>
+
+      <div className="card p-3">
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+          <label className="label">
+            Alert type
+            <select className="input" value={typeFilter} onChange={event => setTypeFilter(event.currentTarget.value as SourcingAlertType | "")}>
+              <option value="">All types</option>
+              <option value="stock_below">Stock below</option>
+              <option value="stock_above">Stock above</option>
+              <option value="back_in_stock">Back in stock</option>
+              <option value="out_of_authorized_stock">Out of authorized stock</option>
+              <option value="price_changed">Price changed</option>
+              <option value="bom_buyable">BOM buyable</option>
+            </select>
+          </label>
+          <label className="label">
+            Enabled
+            <select className="input" value={enabledFilter} onChange={event => setEnabledFilter(event.currentTarget.value as EnabledFilter)}>
+              <option value="all">All</option>
+              <option value="enabled">Enabled only</option>
+              <option value="disabled">Disabled only</option>
+            </select>
+          </label>
+          <label className="label flex-row items-center gap-2 pt-6">
+            <input
+              type="checkbox"
+              checked={includeArchived}
+              onChange={event => setIncludeArchived(event.currentTarget.checked)}
+            />
+            Include archived
+          </label>
+        </div>
+      </div>
+
+      {query.isError && <InlineQueryError query={query} label="sourcing alerts" />}
+      <DataTable
+        tableId="sourcing-alerts"
+        rows={rows}
+        rowKey={row => row.id}
+        columns={columns}
+        searchPlaceholder="Search alerts..."
+        exportFilename="sourcing-alerts"
+        empty={query.isLoading ? "Loading alerts..." : "No sourcing alerts."}
+      />
+
+      <AlertFormModal
+        open={formOpen}
+        mode={formAlert ? "edit" : "create"}
+        alert={formAlert}
+        onClose={() => setFormOpen(false)}
+        onSaved={invalidateAlerts}
+      />
+    </div>
+  );
+}

--- a/web/src/routes/sourcing/alerts/__tests__/AlertFormModal.test.tsx
+++ b/web/src/routes/sourcing/alerts/__tests__/AlertFormModal.test.tsx
@@ -1,0 +1,209 @@
+// @vitest-environment jsdom
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ComponentProps } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { api } from "@/lib/api";
+import AlertFormModal from "../AlertFormModal";
+
+vi.mock("@/lib/auth", () => ({
+  useAuth: () => ({ workspaceId: "ws-1" }),
+}));
+
+const part = {
+  id: "11111111-1111-4111-8111-111111111111",
+  part_type: "linked",
+  name: "STM32",
+  manufacturer: "ST",
+  mpn: "STM32F103C8T6",
+  internal_part_number: null,
+  description: null,
+  footprint: null,
+  notes_markdown: null,
+  low_stock_report_quantity: null,
+  attrition_percentage: 0,
+  attrition_min_quantity: 0,
+  default_storage_location_id: null,
+  default_storage_mandatory: false,
+  serialized: false,
+  linked_provider: null,
+  linked_external_id: null,
+  last_refresh_at: null,
+  description_locally_edited: false,
+  archived_at: null,
+  on_hand: 0,
+  reserved: 0,
+  available: 0,
+  image_url: null,
+};
+
+const project = {
+  id: "22222222-2222-4222-8222-222222222222",
+  name: "Amplifier",
+  description: null,
+  notes_markdown: null,
+  associated_subassembly_part_id: null,
+  archived_at: null,
+  created_at: "2026-05-10T12:00:00+00:00",
+  updated_at: "2026-05-10T12:00:00+00:00",
+};
+
+function workspace() {
+  return {
+    sourcing_country_code: "US",
+    sourcing_currency_code: "USD",
+    sourcing_preferred_distributors: ["DigiKey"],
+    active_countries: ["US", "CZ"],
+    active_currencies: ["USD", "EUR"],
+    active_distributors: ["DigiKey", "Mouser"],
+  };
+}
+
+function members() {
+  return [
+    {
+      id: "member-1",
+      user_id: "33333333-3333-4333-8333-333333333333",
+      email: "admin@example.com",
+      name: "Admin User",
+      role: "admin",
+      status: "active",
+    },
+    {
+      id: "member-2",
+      user_id: "44444444-4444-4444-8444-444444444444",
+      email: "disabled@example.com",
+      name: "Disabled User",
+      role: "member",
+      status: "disabled",
+    },
+  ];
+}
+
+function mockApiReads() {
+  vi.spyOn(api, "get").mockImplementation(async path => {
+    if (path === "/workspaces/current") return workspace() as never;
+    if (path === "/workspaces/members") return members() as never;
+    if (String(path).startsWith("/parts?")) return [part] as never;
+    if (String(path).startsWith("/projects?")) return [project] as never;
+    throw new Error(`unexpected GET ${path}`);
+  });
+}
+
+function renderModal(
+  props: Partial<ComponentProps<typeof AlertFormModal>> = {},
+) {
+  const client = new QueryClient({
+    defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+  });
+  render(
+    <QueryClientProvider client={client}>
+      <AlertFormModal open onClose={vi.fn()} {...props} />
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  cleanup();
+  localStorage.clear();
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+});
+
+describe("AlertFormModal", () => {
+  it("bom_buyable shows project picker and build_quantity field", async () => {
+    mockApiReads();
+
+    renderModal({
+      initialValues: { alert_type: "bom_buyable", project_id: project.id, build_quantity: 7 },
+      allowedTypes: ["bom_buyable"],
+    });
+
+    expect(await screen.findByLabelText("Project")).toBeDefined();
+    expect(screen.getByLabelText("Build quantity")).toBeDefined();
+    expect((screen.getByLabelText("Build quantity") as HTMLInputElement).value).toBe("7");
+    expect(screen.queryByLabelText("Part")).toBeNull();
+  });
+
+  it("back_in_stock shows no threshold field", async () => {
+    mockApiReads();
+
+    renderModal({
+      initialValues: { alert_type: "back_in_stock", part_id: part.id },
+      allowedTypes: ["back_in_stock"],
+    });
+
+    expect(await screen.findByText("This alert triggers on an availability transition; no numeric threshold is needed.")).toBeDefined();
+    expect(screen.queryByLabelText("Quantity")).toBeNull();
+    expect(screen.queryByLabelText("Delta percent")).toBeNull();
+    expect(screen.queryByLabelText("Build quantity")).toBeNull();
+  });
+
+  it("cooldown < 60 surfaces validation error", async () => {
+    const user = userEvent.setup();
+    mockApiReads();
+    vi.spyOn(api, "post").mockResolvedValue({} as never);
+
+    renderModal({
+      initialValues: { alert_type: "bom_buyable", project_id: project.id, build_quantity: 1 },
+      allowedTypes: ["bom_buyable"],
+    });
+
+    await screen.findByLabelText("Project");
+    await user.clear(screen.getByLabelText("Cooldown seconds"));
+    await user.type(screen.getByLabelText("Cooldown seconds"), "59");
+    await user.click(screen.getByRole("button", { name: "Create alert" }));
+
+    expect((await screen.findByRole("alert")).textContent).toContain("Cooldown must be at least 60 seconds.");
+    expect(api.post).not.toHaveBeenCalled();
+  });
+
+  it("submit posts the correct payload shape per alert type", async () => {
+    const user = userEvent.setup();
+    mockApiReads();
+    const post = vi.spyOn(api, "post").mockResolvedValue({ id: "alert-1" } as never);
+
+    renderModal({
+      initialValues: { alert_type: "price_changed", part_id: part.id },
+      allowedTypes: ["price_changed"],
+    });
+
+    await screen.findByText("STM32");
+    await user.clear(screen.getByLabelText("Delta percent"));
+    await user.type(screen.getByLabelText("Delta percent"), "12.5");
+    await user.selectOptions(screen.getByLabelText("Country"), "CZ");
+    await user.selectOptions(screen.getByLabelText("Currency"), "EUR");
+    await user.selectOptions(screen.getByLabelText("Distributor filter"), ["Mouser"]);
+    await user.selectOptions(screen.getByLabelText("Recipients"), ["33333333-3333-4333-8333-333333333333"]);
+    await user.click(screen.getByRole("button", { name: "Create alert" }));
+
+    await waitFor(() => {
+      expect(post).toHaveBeenCalledWith("/sourcing/alerts", {
+        alert_type: "price_changed",
+        part_id: part.id,
+        project_id: null,
+        threshold: { delta_pct: 12.5 },
+        cooldown_seconds: 86400,
+        enabled: true,
+        notify_user_ids: ["33333333-3333-4333-8333-333333333333"],
+        country_code: "CZ",
+        currency_code: "EUR",
+        distributor_filter: ["DigiKey", "Mouser"],
+      });
+    });
+  });
+
+  it("notify_user_ids picker excludes non-members", async () => {
+    mockApiReads();
+
+    renderModal({
+      initialValues: { alert_type: "back_in_stock", part_id: part.id },
+      allowedTypes: ["back_in_stock"],
+    });
+
+    expect(await screen.findByRole("option", { name: "Admin User (admin@example.com)" })).toBeDefined();
+    const recipients = screen.getByLabelText("Recipients");
+    expect(within(recipients).queryByRole("option", { name: "Disabled User (disabled@example.com)" })).toBeNull();
+  });
+});

--- a/web/src/routes/sourcing/alerts/__tests__/AlertsPage.test.tsx
+++ b/web/src/routes/sourcing/alerts/__tests__/AlertsPage.test.tsx
@@ -1,0 +1,185 @@
+// @vitest-environment jsdom
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ConfirmDialogProvider } from "@/components/ConfirmDialog";
+import { api } from "@/lib/api";
+import AlertsPage from "../AlertsPage";
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({
+  useAuth: () => ({ workspaceId: "ws-1" }),
+}));
+
+const partId = "11111111-1111-4111-8111-111111111111";
+const projectId = "22222222-2222-4222-8222-222222222222";
+
+function alert(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "alert-1",
+    workspace_id: "ws-1",
+    alert_type: "stock_below",
+    part_id: partId,
+    project_id: null,
+    threshold: { qty: 10 },
+    country_code: null,
+    currency_code: null,
+    distributor_filter: null,
+    notify_user_ids: null,
+    cooldown_seconds: 86400,
+    enabled: true,
+    last_checked_at: "2026-05-10T12:00:00+00:00",
+    last_notified_at: null,
+    archived_at: null,
+    created_by: null,
+    created_at: "2026-05-10T10:00:00+00:00",
+    updated_at: "2026-05-10T10:00:00+00:00",
+    ...overrides,
+  };
+}
+
+function parts() {
+  return [{
+    id: partId,
+    part_type: "linked",
+    name: "STM32",
+    manufacturer: "ST",
+    mpn: "STM32F103C8T6",
+    internal_part_number: null,
+    description: null,
+    footprint: null,
+    notes_markdown: null,
+    low_stock_report_quantity: null,
+    attrition_percentage: 0,
+    attrition_min_quantity: 0,
+    default_storage_location_id: null,
+    default_storage_mandatory: false,
+    serialized: false,
+    linked_provider: null,
+    linked_external_id: null,
+    last_refresh_at: null,
+    description_locally_edited: false,
+    archived_at: null,
+    on_hand: 0,
+    reserved: 0,
+    available: 0,
+    image_url: null,
+  }];
+}
+
+function projects() {
+  return [{
+    id: projectId,
+    name: "Amplifier",
+    description: null,
+    notes_markdown: null,
+    associated_subassembly_part_id: null,
+    archived_at: null,
+    created_at: "2026-05-10T12:00:00+00:00",
+    updated_at: "2026-05-10T12:00:00+00:00",
+  }];
+}
+
+function mockReads() {
+  vi.spyOn(api, "get").mockImplementation(async path => {
+    if (String(path).startsWith("/parts?")) return parts() as never;
+    if (String(path).startsWith("/projects?")) return projects() as never;
+    if (String(path).startsWith("/sourcing/alerts")) {
+      if (String(path).includes("alert_type=bom_buyable")) {
+        return [alert({
+          id: "alert-2",
+          alert_type: "bom_buyable",
+          part_id: null,
+          project_id: projectId,
+          threshold: { build_quantity: 5 },
+        })] as never;
+      }
+      return [
+        alert(),
+        alert({
+          id: "alert-2",
+          alert_type: "bom_buyable",
+          part_id: null,
+          project_id: projectId,
+          threshold: { build_quantity: 5 },
+        }),
+      ] as never;
+    }
+    throw new Error(`unexpected GET ${path}`);
+  });
+}
+
+function renderPage() {
+  const client = new QueryClient({
+    defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+  });
+  render(
+    <QueryClientProvider client={client}>
+      <ConfirmDialogProvider>
+        <AlertsPage />
+      </ConfirmDialogProvider>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  cleanup();
+  localStorage.clear();
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+});
+
+describe("AlertsPage", () => {
+  it("renders list of alerts from server", async () => {
+    mockReads();
+
+    renderPage();
+
+    expect(await screen.findByText("STM32")).toBeDefined();
+    expect(screen.getAllByText("Stock below").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("BOM buyable").length).toBeGreaterThan(0);
+    expect(screen.getByText("Amplifier")).toBeDefined();
+    expect(screen.getByText("Below 10")).toBeDefined();
+  });
+
+  it("filter by alert_type narrows visible rows", async () => {
+    const user = userEvent.setup();
+    mockReads();
+
+    renderPage();
+
+    await screen.findByText("STM32");
+    await user.selectOptions(screen.getByLabelText("Alert type"), "bom_buyable");
+
+    await waitFor(() => {
+      expect(api.get).toHaveBeenCalledWith("/sourcing/alerts?alert_type=bom_buyable", expect.any(Object));
+    });
+    const table = screen.getByRole("table");
+    expect(within(table).getByText("BOM buyable")).toBeDefined();
+    expect(within(table).queryByText("Stock below")).toBeNull();
+  });
+
+  it("archive prompts confirmation then DELETEs", async () => {
+    const user = userEvent.setup();
+    mockReads();
+    const del = vi.spyOn(api, "delete").mockResolvedValue(alert({ archived_at: "2026-05-10T13:00:00+00:00" }) as never);
+
+    renderPage();
+
+    await screen.findByText("STM32");
+    await user.click(screen.getAllByRole("button", { name: "Archive" })[0]);
+    const archiveButtons = await screen.findAllByRole("button", { name: "Archive" });
+    await user.click(archiveButtons[archiveButtons.length - 1]);
+
+    await waitFor(() => {
+      expect(del).toHaveBeenCalledWith("/sourcing/alerts/alert-1");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `/sourcing/alerts` management route with filters, DataTable listing, create/edit modal, and archive confirmation.
- Adds shared alert form modal and API helpers for the TP-502 CRUD envelope endpoints.
- Wires per-part Authorized supply and per-project Source BOM shortcuts into the same modal with prefilled targets.
- Adds user/frontend docs and focused Vitest coverage for the page, modal, and shortcuts.

Closes #421

## Dependency
PR #433 has merged to `main`; this PR was rebased onto `main` after that merge.

Merge order satisfied: #433 before this PR (#421).

## Validation
- `cd web && npm run typecheck` — passed after rebase.
- `cd web && npm test -- src/routes/sourcing/alerts/__tests__/AlertsPage.test.tsx src/routes/sourcing/alerts/__tests__/AlertFormModal.test.tsx src/routes/parts/detail/__tests__/AuthorizedSupplyTab.test.tsx src/routes/projects/sourcing/__tests__/ProjectSourcingPage.test.tsx` — passed after rebase, 42 tests.
- `git diff --check` — passed after rebase.
- Prior raw `cd web && npm run lint` reported existing baseline violations in unrelated files; lint-delta passed with no new violations before the rebase.

## Screenshots
- Local browser smoke was attempted against mocked API responses; screenshot capture was not attached because the Playwright route stub failed in this environment before rendering the authenticated route.
