### PR TITLE
FB-006: Auto-link BOM row to existing Part on canonical-MPN collision

### DIFF
--- a/backend/app/domain/projects/bom_import_provider.py
+++ b/backend/app/domain/projects/bom_import_provider.py
@@ -39,6 +39,7 @@ def import_unmatched_from_provider(
     )
 
     created = 0
+    linked_existing = 0
     pending: list[BomProviderPendingChoice] = []
     failures: list[BomProviderFailure] = []
 
@@ -48,7 +49,7 @@ def import_unmatched_from_provider(
             with db.begin_nested():
                 _link_existing(entry, existing.id, user_id)
                 db.flush()
-            created += 1
+            linked_existing += 1
             continue
 
         outcome = _lookup_entry(provider, entry)
@@ -61,7 +62,7 @@ def import_unmatched_from_provider(
 
         try:
             with db.begin_nested():
-                _create_and_link(
+                linked = _create_or_link(
                     db,
                     workspace_id=workspace.id,
                     user_id=user_id,
@@ -72,10 +73,14 @@ def import_unmatched_from_provider(
         except Exception as exc:
             failures.append(_failure(entry, _entry_mpn(entry), _safe_exception_reason(exc)))
             continue
-        created += 1
+        if linked:
+            linked_existing += 1
+        else:
+            created += 1
 
     return BomProviderImportOut(
         created=created,
+        linked_existing=linked_existing,
         pending_choices=pending,
         failures=failures,
         provider=provider.name,
@@ -101,6 +106,7 @@ def commit_provider_import_choices(
     by_id = {row.id: row for row in rows}
 
     created = 0
+    linked_existing = 0
     failures: list[BomProviderFailure] = []
     for entry_id, manufacturer in choices.items():
         entry = by_id.get(entry_id)
@@ -113,7 +119,7 @@ def commit_provider_import_choices(
             with db.begin_nested():
                 _link_existing(entry, existing.id, user_id)
                 db.flush()
-            created += 1
+            linked_existing += 1
             continue
 
         lookup = _lookup_raw(provider, mpn)
@@ -126,7 +132,7 @@ def commit_provider_import_choices(
 
         try:
             with db.begin_nested():
-                _create_and_link(
+                linked = _create_or_link(
                     db,
                     workspace_id=workspace.id,
                     user_id=user_id,
@@ -137,10 +143,14 @@ def commit_provider_import_choices(
         except Exception as exc:
             failures.append(_failure(entry, mpn, _safe_exception_reason(exc)))
             continue
-        created += 1
+        if linked:
+            linked_existing += 1
+        else:
+            created += 1
 
     return BomProviderImportOut(
         created=created,
+        linked_existing=linked_existing,
         pending_choices=[],
         failures=failures,
         provider=provider.name,
@@ -239,7 +249,7 @@ def _record_for_manufacturer(lookup: dict, manufacturer: str) -> dict | None:
     return None
 
 
-def _create_and_link(
+def _create_or_link(
     db,
     *,
     workspace_id: UUID,
@@ -247,7 +257,14 @@ def _create_and_link(
     provider_name: str,
     entry: ProjectEntry,
     lookup_result: dict,
-) -> None:
+) -> bool:
+    canonical_mpn = _lookup_result_mpn(lookup_result)
+    existing = _active_part_by_mpn(db, workspace_id=workspace_id, mpn=canonical_mpn)
+    if existing is not None:
+        _link_existing(entry, existing.id, user_id)
+        db.flush()
+        return True
+
     mpn = _entry_mpn(entry)
     part = create_from_provider_lookup(
         db,
@@ -261,6 +278,7 @@ def _create_and_link(
     entry.entry_type = "part"
     entry.updated_by = user_id
     db.flush()
+    return False
 
 
 def _active_part_by_mpn(db, *, workspace_id: UUID, mpn: str) -> Part | None:
@@ -301,6 +319,10 @@ def _capture_exception(exc: Exception) -> None:
 
 def _entry_mpn(entry: ProjectEntry) -> str:
     return (entry.name or "").strip()
+
+
+def _lookup_result_mpn(lookup_result: dict) -> str:
+    return str(lookup_result.get("mpn") or "").strip()
 
 
 def _manufacturer(record: dict) -> str | None:

--- a/backend/app/domain/projects/schemas.py
+++ b/backend/app/domain/projects/schemas.py
@@ -176,6 +176,7 @@ class BomProviderFailure(BaseModel):
 
 class BomProviderImportOut(BaseModel):
     created: int
+    linked_existing: int = 0
     pending_choices: list[BomProviderPendingChoice] = []
     failures: list[BomProviderFailure] = []
     provider: str

--- a/backend/tests/test_bom_import_provider.py
+++ b/backend/tests/test_bom_import_provider.py
@@ -115,6 +115,7 @@ def test_bulk_import_creates_real_parts_with_specs(authed, monkeypatch):
     assert r.status_code == 200, r.text
     body = r.json()["data"]
     assert body["created"] == 1
+    assert body["linked_existing"] == 0
     assert body["pending_choices"] == []
     assert body["failures"] == []
 
@@ -149,6 +150,7 @@ def test_bulk_import_skips_already_matched_rows(authed, monkeypatch):
     )
     assert r.status_code == 200, r.text
     assert r.json()["data"]["created"] == 0
+    assert r.json()["data"]["linked_existing"] == 0
     assert calls == []
 
 
@@ -168,9 +170,43 @@ def test_bulk_import_links_existing_workspace_part_without_provider_lookup(authe
     )
     assert r.status_code == 200, r.text
     body = r.json()["data"]
-    assert body["created"] == 1
+    assert body["created"] == 0
+    assert body["linked_existing"] == 1
     assert body["failures"] == []
     assert calls == []
+
+    entry = authed.get(f"/api/projects/{project_id}/entries").json()["data"][0]
+    assert entry["id"] == entry_id
+    assert entry["entry_type"] == "part"
+    assert entry["part_id"] == part_id
+    assert len(authed.get("/api/parts?limit=200").json()["data"]) == 1
+
+
+def test_bulk_import_links_existing_canonical_provider_mpn_after_lookup(authed, monkeypatch):
+    calls = []
+
+    def canonical_lookup(provider, mpn):
+        calls.append(mpn)
+        return _lookup_result("STM32F103C8T6", "ST")
+
+    monkeypatch.setattr(
+        "app.domain.projects.bom_import_provider.lookup_with_cache",
+        canonical_lookup,
+    )
+    project_id = _project(authed)
+    part_id = _part(authed, "STM32F103C8T6")
+    entry_id = _entry(authed, project_id, "stm32f103")
+
+    r = authed.post(
+        f"/api/projects/{project_id}/bom/import-from-provider",
+        json={"entry_ids": None},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()["data"]
+    assert body["created"] == 0
+    assert body["linked_existing"] == 1
+    assert body["failures"] == []
+    assert calls == ["stm32f103"]
 
     entry = authed.get(f"/api/projects/{project_id}/entries").json()["data"][0]
     assert entry["id"] == entry_id
@@ -196,6 +232,7 @@ def test_bulk_import_null_entry_ids_caps_rows_and_reports_truncated(authed, monk
     assert r.status_code == 200, r.text
     body = r.json()["data"]
     assert body["created"] == 200
+    assert body["linked_existing"] == 0
     assert body["truncated"] is True
     assert len(calls) == 200
     entries = authed.get(f"/api/projects/{project_id}/entries").json()["data"]
@@ -219,6 +256,7 @@ def test_ambiguous_mpn_returns_pending_choices_no_commit(authed, monkeypatch):
     assert r.status_code == 200, r.text
     body = r.json()["data"]
     assert body["created"] == 0
+    assert body["linked_existing"] == 0
     assert body["pending_choices"][0]["entry_id"] == entry_id
     manufacturers = {c["manufacturer"] for c in body["pending_choices"][0]["candidates"]}
     assert manufacturers == {"Alpha", "Beta"}
@@ -244,6 +282,7 @@ def test_commit_choices_creates_parts_from_chosen_manufacturer(authed, monkeypat
     )
     assert r.status_code == 200, r.text
     assert r.json()["data"]["created"] == 1
+    assert r.json()["data"]["linked_existing"] == 0
     entry = authed.get(f"/api/projects/{project_id}/entries").json()["data"][0]
     part = authed.get(f"/api/parts/{entry['part_id']}").json()["data"]
     assert part["manufacturer"] == "Beta"
@@ -264,6 +303,7 @@ def test_failed_lookup_appears_in_failures_not_as_stub(authed, monkeypatch):
     assert r.status_code == 200, r.text
     body = r.json()["data"]
     assert body["created"] == 0
+    assert body["linked_existing"] == 0
     assert body["failures"][0]["mpn"] == "NOPE"
     assert "no match" in body["failures"][0]["reason"]
     assert (
@@ -304,6 +344,7 @@ def test_per_row_savepoint_isolates_failures(authed, monkeypatch):
     assert r.status_code == 200, r.text
     body = r.json()["data"]
     assert body["created"] == 2
+    assert body["linked_existing"] == 0
     assert body["failures"][0]["mpn"] == "BAD"
     rows = authed.get(f"/api/projects/{project_id}/entries").json()["data"]
     assert [row["entry_type"] for row in rows] == ["part", "unmatched", "part"]
@@ -345,6 +386,7 @@ def test_workspace_isolation_two_workspaces_same_mpn(monkeypatch):
     )
     assert rb.status_code == 200, rb.text
     assert rb.json()["data"]["created"] == 1
+    assert rb.json()["data"]["linked_existing"] == 0
 
     assert (
         a.get(f"/api/projects/{project_a}/entries").json()["data"][0]["entry_type"]

--- a/docs/api/projects.md
+++ b/docs/api/projects.md
@@ -244,6 +244,7 @@ and rate-limited at 30 calls/minute per workspace.
 ```json
 {
   "created": 1,
+  "linked_existing": 0,
   "pending_choices": [],
   "failures": [{ "entry_id": "…", "mpn": "NOPE", "reason": "no match" }],
   "provider": "mouser",
@@ -258,10 +259,11 @@ when the workspace has no configured parts provider.
 
 - Uses per-row savepoints; one failed lookup or write does not roll back rows that already created parts.
 - `entry_ids: null` processes at most 200 unmatched rows per call and sets `truncated: true` when more remain.
-- If an unmatched row's MPN already exists as an active part in the workspace, the row is linked to that part without another provider lookup.
+- `created` counts new provider-backed parts. `linked_existing` counts rows linked to an active same-workspace part whose MPN matched either before lookup or after provider canonicalisation.
+- If an unmatched row's display name already contains an existing active MPN, the row is linked to that part without another provider lookup.
 - This is not the CSV `auto_create_missing_parts` path. It does not create stub parts; failures stay unmatched.
 - Source: `backend/app/api/routes/projects.py:276-294`.
-- Service: `backend/app/domain/projects/bom_import_provider.py:21-72`.
+- Service: `backend/app/domain/projects/bom_import_provider.py:25-88`, `backend/app/domain/projects/bom_import_provider.py:252-281`.
 
 ### `POST /api/projects/{project_id}/bom/import-from-provider/commit-choices`
 
@@ -281,7 +283,7 @@ Commit manufacturer choices returned by `pending_choices`.
 
 - Re-runs provider lookup for each selected entry and creates the part only when the selected manufacturer is present.
 - Source: `backend/app/api/routes/projects.py:297-315`.
-- Service: `backend/app/domain/projects/bom_import_provider.py:75-130`.
+- Service: `backend/app/domain/projects/bom_import_provider.py:91-155`, `backend/app/domain/projects/bom_import_provider.py:252-281`.
 
 ## BOM import presets (`/api/bom-presets`)
 

--- a/docs/user/projects-and-bom.md
+++ b/docs/user/projects-and-bom.md
@@ -96,9 +96,10 @@ When your workspace has a Mouser or DigiKey parts provider configured, the BOM t
 1. Click **Import all unmatched from provider** to import the next batch of unmatched rows, or click **Import from provider** on one row.
 2. The app looks up each row's MPN with the configured provider.
 3. Rows whose MPN already exists in your library are matched to that existing part.
-4. Rows with a single provider match create a linked library part with provider specs and media, then the BOM row becomes matched.
-5. Rows with more than one manufacturer choice open a picker. Select the right manufacturer and click **Import selected**.
-6. Rows the provider cannot resolve remain unmatched. The failure panel lists the MPN and reason.
+4. Rows whose provider match resolves to an MPN that already exists in your library are matched to that existing part.
+5. Rows with a single new provider match create a linked library part with provider specs and media, then the BOM row becomes matched.
+6. Rows with more than one manufacturer choice open a picker. Select the right manufacturer and click **Import selected**.
+7. Rows the provider cannot resolve remain unmatched. The failure panel lists the MPN and reason.
 
 This provider flow does not create stub parts. Failed lookups stay on the BOM so you can retry later or match them by hand.
 Bulk provider import processes up to 200 unmatched rows at a time; run it again if the page reports remaining rows.

--- a/web/src/routes/projects/detail/ProjectBOM.tsx
+++ b/web/src/routes/projects/detail/ProjectBOM.tsx
@@ -22,6 +22,7 @@ type WorkspaceProviderSettings = {
 
 type BomProviderImportOut = {
   created: number;
+  linked_existing: number;
   pending_choices: BomProviderPendingChoice[];
   failures: BomProviderFailure[];
   provider: WorkspaceProviderSettings["parts_provider"];
@@ -80,10 +81,20 @@ export default function ProjectBOM() {
   });
 
   function handleProviderResult(result: BomProviderImportOut) {
-    if (result.created > 0) {
+    if (result.created > 0 || result.linked_existing > 0) {
       qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "project", projectId, "entries") });
       qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "parts") });
-      toast.success(`Created ${result.created} part${result.created === 1 ? "" : "s"} from ${PROVIDER_LABEL[result.provider] ?? result.provider}.`);
+      const providerName = PROVIDER_LABEL[result.provider] ?? result.provider;
+      const messages: string[] = [];
+      if (result.created > 0) {
+        messages.push(`Created ${result.created} part${result.created === 1 ? "" : "s"}`);
+      }
+      if (result.linked_existing > 0) {
+        messages.push(
+          `${result.created > 0 ? "linked" : "Linked"} ${result.linked_existing} existing part${result.linked_existing === 1 ? "" : "s"}`,
+        );
+      }
+      toast.success(`${messages.join(" and ")} from ${providerName}.`);
     }
     if (result.pending_choices.length > 0) {
       setPendingChoices(result.pending_choices);

--- a/web/src/routes/projects/detail/__tests__/ProjectBOM.test.tsx
+++ b/web/src/routes/projects/detail/__tests__/ProjectBOM.test.tsx
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import { toast } from "sonner";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { api } from "@/lib/api";
 import type { Part, ProjectEntry } from "@/types";
@@ -83,6 +84,7 @@ const parts = [
 
 type ImportResponse = {
   created: number;
+  linked_existing: number;
   pending_choices: Array<{
     entry_id: string;
     mpn: string;
@@ -147,6 +149,7 @@ function mockApi(
     if (path === `/projects/${projectId}/bom/import-from-provider`) {
       return (options.importResponse ?? {
         created: 0,
+        linked_existing: 0,
         pending_choices: [],
         failures: [],
         provider: options.partsProvider ?? "none",
@@ -156,6 +159,7 @@ function mockApi(
     if (path === `/projects/${projectId}/bom/import-from-provider/commit-choices`) {
       return (options.commitResponse ?? {
         created: 0,
+        linked_existing: 0,
         pending_choices: [],
         failures: [],
         provider: options.partsProvider ?? "none",
@@ -286,6 +290,7 @@ describe("ProjectBOM", () => {
         partsProvider: "mouser",
         importResponse: {
           created: 0,
+          linked_existing: 0,
           pending_choices: [],
           failures: [{ entry_id: "entry-unmatched", mpn: "NOPE", reason: "no match for MPN" }],
           provider: "mouser",
@@ -303,6 +308,36 @@ describe("ProjectBOM", () => {
     expect(screen.getByText("no match for MPN")).toBeDefined();
   });
 
+  it("toasts existing provider links separately from created parts", async () => {
+    mockApi(
+      {
+        current: [
+          bomEntry({ id: "entry-unmatched", entry_type: "unmatched", part_id: null, name: "STM32" }),
+        ],
+      },
+      {
+        partsProvider: "mouser",
+        importResponse: {
+          created: 0,
+          linked_existing: 1,
+          pending_choices: [],
+          failures: [],
+          provider: "mouser",
+          truncated: false,
+        },
+      },
+    );
+    const user = userEvent.setup();
+
+    renderPage();
+
+    await user.click(await screen.findByRole("button", { name: "Import all unmatched from Mouser" }));
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith("Linked 1 existing part from Mouser.");
+    });
+  });
+
   it("ambiguity modal opens with candidates and posts commit-choices on confirm", async () => {
     mockApi(
       {
@@ -314,6 +349,7 @@ describe("ProjectBOM", () => {
         partsProvider: "mouser",
         importResponse: {
           created: 0,
+          linked_existing: 0,
           pending_choices: [{
             entry_id: "entry-unmatched",
             mpn: "AMB-1",
@@ -328,6 +364,7 @@ describe("ProjectBOM", () => {
         },
         commitResponse: {
           created: 1,
+          linked_existing: 0,
           pending_choices: [],
           failures: [],
           provider: "mouser",


### PR DESCRIPTION
## Summary
- Split provider BOM import accounting into newly created provider-backed parts and existing active same-workspace Part links via `linked_existing`.
- Link BOM rows to an existing Part when the provider returns a canonical MPN that already exists, instead of surfacing the unique-index conflict as a row failure.
- Preserve the pre-lookup best-effort link path so rows whose display name is the MPN still avoid provider calls.
- Surface existing links in the BOM UI success toast and document the API/user behavior.

## Tests run
- `uv run --project /mnt/data/WORK/stockManager-1/.codex/worktrees/fb-006-436/backend --with alembic --with pytest pytest /mnt/data/WORK/stockManager-1/.codex/worktrees/fb-006-436/backend/tests/test_bom_import_provider.py -q`
- `uv run --project /mnt/data/WORK/stockManager-1/.codex/worktrees/fb-006-436/backend ruff check /mnt/data/WORK/stockManager-1/.codex/worktrees/fb-006-436/backend/app/domain/projects/bom_import_provider.py /mnt/data/WORK/stockManager-1/.codex/worktrees/fb-006-436/backend/app/domain/projects/schemas.py /mnt/data/WORK/stockManager-1/.codex/worktrees/fb-006-436/backend/tests/test_bom_import_provider.py`
- `npm --prefix /mnt/data/WORK/stockManager-1/.codex/worktrees/fb-006-436/web test -- ProjectBOM.test.tsx`
- `npm --prefix /mnt/data/WORK/stockManager-1/.codex/worktrees/fb-006-436/web run typecheck`
- `git -C /mnt/data/WORK/stockManager-1/.codex/worktrees/fb-006-436 diff --check`

## No-stub-fallback confirmation
Provider import still does not create stub parts on failed lookups. The existing failure path remains intact and is covered by `test_failed_lookup_appears_in_failures_not_as_stub`.

## Toast wording
- Existing-only link: `Linked 1 existing part from Mouser.`
- Mixed create/link: `Created N parts and linked M existing parts from <provider>.`

Refs #436
