### PR TITLE
FB-007: Backfill active_distributors with preferred + intersection-default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ the canonical record.
 
 ## 2026-05 — feedback brief fixes
 
+- **FB-007 / #437** Active sourcing lists now backfill saved workspace
+  sourcing defaults: `active_distributors` is unioned with preferred
+  distributors, and saved country/currency values are appended when missing.
+  Project Sourcing also defaults distributor filters to the saved/active
+  intersection before falling back to the first active distributor.
 - **FB-003c / #412** Sourcing capacity now prices the requested build
   quantity when after-purchase capacity floors to zero, fixing missing
   `est_purchase_cost` values at low build quantities.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,6 +238,9 @@ them, that's the bug.
 - **Periodic jobs run through one scheduler path.** ADR-0021 chooses a
   `backend-cron` sidecar + CLI entry point; don't add parallel APScheduler,
   FastAPI lifespan, host cron, or systemd-timer jobs for app maintenance.
+- **Active-list migrations must preserve saved workspace defaults.** When a
+  new active list is introduced, backfill it from any existing per-workspace
+  value; FB-003a missed this for sourcing distributors and FB-007 fixed it.
 - **Two backend-cron sidecars run separate cadences.** `backend-cron` handles
   the hourly cache sweep and `backend-cron-alerts` handles the 15-minute alert
   evaluator. They share the same `run_job` registry per ADR-0021; adding a

--- a/backend/alembic/versions/0045_backfill_active_distributors.py
+++ b/backend/alembic/versions/0045_backfill_active_distributors.py
@@ -1,0 +1,88 @@
+"""Backfill active sourcing lists from saved workspace defaults.
+
+Revision ID: 0045
+Revises: 0044
+Create Date: 2026-05-10
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy.engine import Connection
+
+from alembic import op
+
+revision = "0045"
+down_revision = "0044"
+branch_labels = None
+depends_on = None
+
+
+def backfill_active_lists(conn: Connection) -> None:
+    conn.execute(
+        sa.text(
+            """
+            UPDATE workspaces AS ws
+            SET active_distributors = (
+                SELECT COALESCE(
+                    jsonb_agg(to_jsonb(value) ORDER BY first_seen),
+                    '[]'::jsonb
+                ) AS values
+                FROM (
+                    SELECT value, min(ord) AS first_seen
+                    FROM (
+                        SELECT value, ord
+                        FROM jsonb_array_elements_text(
+                            COALESCE(ws.active_distributors, '[]'::jsonb)
+                        ) WITH ORDINALITY AS active(value, ord)
+                        UNION ALL
+                        SELECT value, ord + 1000000
+                        FROM jsonb_array_elements_text(
+                            COALESCE(ws.sourcing_preferred_distributors, '[]'::jsonb)
+                        ) WITH ORDINALITY AS preferred(value, ord)
+                    ) combined
+                    GROUP BY value
+                ) deduped
+            )
+            WHERE ws.sourcing_preferred_distributors IS NOT NULL
+            """
+        )
+    )
+    conn.execute(
+        sa.text(
+            """
+            UPDATE workspaces
+            SET active_countries =
+                CASE
+                    WHEN COALESCE(active_countries, '[]'::jsonb) ? sourcing_country_code
+                    THEN active_countries
+                    ELSE COALESCE(active_countries, '[]'::jsonb) || to_jsonb(sourcing_country_code)
+                END
+            WHERE sourcing_country_code IS NOT NULL
+            """
+        )
+    )
+    conn.execute(
+        sa.text(
+            """
+            UPDATE workspaces
+            SET active_currencies =
+                CASE
+                    WHEN COALESCE(active_currencies, '[]'::jsonb) ? sourcing_currency_code
+                    THEN active_currencies
+                    ELSE COALESCE(active_currencies, '[]'::jsonb)
+                        || to_jsonb(sourcing_currency_code)
+                END
+            WHERE sourcing_currency_code IS NOT NULL
+            """
+        )
+    )
+
+
+def upgrade() -> None:
+    backfill_active_lists(op.get_bind())
+
+
+def downgrade() -> None:
+    # No-op: unmerging these active-list values would remove user data.
+    pass

--- a/backend/tests/test_workspace_active_lists.py
+++ b/backend/tests/test_workspace_active_lists.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import importlib.util
+from pathlib import Path
 from uuid import UUID
 
 from fastapi.testclient import TestClient
@@ -14,6 +16,21 @@ from app.domain.workspaces.master_lists import (
 from app.domain.workspaces.models import Workspace
 from app.main import app
 from tests._factories import signup_user
+
+
+def _load_backfill_migration():
+    path = (
+        Path(__file__).resolve().parent.parent
+        / "alembic"
+        / "versions"
+        / "0045_backfill_active_distributors.py"
+    )
+    spec = importlib.util.spec_from_file_location("migration_0045", path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def _current_workspace(client: TestClient) -> dict:
@@ -126,3 +143,28 @@ def test_workspace_isolation_active_lists(db):
     db_ws_b = db.get(Workspace, UUID(ws_b["id"]))
     assert db_ws_b is not None
     assert db_ws_b.active_currencies == DEFAULT_ACTIVE_CURRENCIES
+
+
+def test_migration_backfills_active_lists_with_saved_sourcing_defaults(authed_client, db):
+    body = _current_workspace(authed_client)
+    ws = db.get(Workspace, UUID(body["id"]))
+    assert ws is not None
+    ws.active_distributors = ["DigiKey", "Mouser"]
+    ws.sourcing_preferred_distributors = ["Arrow", "Newark"]
+    ws.active_countries = ["CZ", "DE"]
+    ws.sourcing_country_code = "US"
+    ws.active_currencies = ["EUR", "CZK"]
+    ws.sourcing_currency_code = "USD"
+    db.flush()
+
+    migration = _load_backfill_migration()
+    migration.backfill_active_lists(db.connection())
+    migration.backfill_active_lists(db.connection())
+    db.expire(ws)
+
+    assert set(ws.active_distributors) == {"DigiKey", "Mouser", "Arrow", "Newark"}
+    assert len(ws.active_distributors) == 4
+    assert set(ws.active_countries) == {"CZ", "DE", "US"}
+    assert len(ws.active_countries) == 3
+    assert set(ws.active_currencies) == {"EUR", "CZK", "USD"}
+    assert len(ws.active_currencies) == 3

--- a/web/src/routes/projects/sourcing/ProjectSourcingPage.tsx
+++ b/web/src/routes/projects/sourcing/ProjectSourcingPage.tsx
@@ -144,8 +144,8 @@ function defaultFromActiveList(saved: string | null | undefined, active: string[
 
 function distributorsFromActiveList(saved: string[] | null | undefined, active: string[]): string[] {
   if (!saved || saved.length === 0) return [];
-  const savedAllActive = saved.every(item => active.includes(item));
-  if (savedAllActive) return saved;
+  const intersection = saved.filter(item => active.includes(item));
+  if (intersection.length > 0) return intersection;
   return active[0] ? [active[0]] : [];
 }
 
@@ -450,7 +450,7 @@ export default function ProjectSourcingPage() {
       preferred.length > 0 &&
       preferred.some(item => !workspace.active_distributors.includes(item))
     ) {
-      warnings.push(`Workspace preferred distributors are not all active; using ${workspace.active_distributors[0]}.`);
+      warnings.push("Workspace preferred distributors are not all active; using active distributors only.");
     }
     return warnings;
   }, [workspace, defaultsApplied]);

--- a/web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.test.tsx
+++ b/web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.test.tsx
@@ -248,6 +248,35 @@ describe("ProjectSourcingPage", () => {
     expect((screen.getByRole("checkbox", { name: "DigiKey" }) as HTMLInputElement).checked).toBe(false);
   });
 
+  it("partial-overlap distributors default to saved active intersection", async () => {
+    mockReads({
+      sourcing_preferred_distributors: ["A", "B", "C"],
+      active_distributors: ["A", "B", "X"],
+    });
+    vi.spyOn(api, "post").mockResolvedValue(sourcingResponse());
+
+    renderPage();
+
+    expect((await screen.findByRole("checkbox", { name: "A" }) as HTMLInputElement).checked).toBe(true);
+    expect((screen.getByRole("checkbox", { name: "B" }) as HTMLInputElement).checked).toBe(true);
+    expect((screen.getByRole("checkbox", { name: "X" }) as HTMLInputElement).checked).toBe(false);
+    expect(await screen.findByText("Workspace preferred distributors are not all active; using active distributors only.")).toBeDefined();
+  });
+
+  it("no-overlap distributors fall back to first active distributor", async () => {
+    mockReads({
+      sourcing_preferred_distributors: ["X", "Y"],
+      active_distributors: ["A", "B"],
+    });
+    vi.spyOn(api, "post").mockResolvedValue(sourcingResponse());
+
+    renderPage();
+
+    expect((await screen.findByRole("checkbox", { name: "A" }) as HTMLInputElement).checked).toBe(true);
+    expect((screen.getByRole("checkbox", { name: "B" }) as HTMLInputElement).checked).toBe(false);
+    expect(await screen.findByText("Workspace preferred distributors are not all active; using active distributors only.")).toBeDefined();
+  });
+
   it("if default not in active list, falls back to first item with warning visible", async () => {
     mockReads({
       sourcing_currency_code: "GBP",


### PR DESCRIPTION
## Summary
- Add migration 0045 to backfill active sourcing lists from saved workspace sourcing defaults.
- Union `active_distributors` with `sourcing_preferred_distributors` idempotently, and append saved country/currency values when missing.
- Update Project Sourcing distributor defaults to use saved ∩ active before falling back to the first active distributor.
- Add backend/frontend regression tests plus CLAUDE.md and CHANGELOG notes.

## Tests run
- `DATABASE_URL=postgresql+psycopg://stockmgr:stockmgr@127.0.0.1:5432/stockmgr_test uv run alembic upgrade head && ... downgrade -1 && ... upgrade head`
- `TEST_DATABASE_URL=postgresql+psycopg://stockmgr:stockmgr@127.0.0.1:5432/stockmgr_test uv run python -m pytest -q -k workspace_active_lists` (8 passed, 1092 deselected)
- `TEST_DATABASE_URL=postgresql+psycopg://stockmgr:stockmgr@127.0.0.1:5432/stockmgr_test uv run python -m pytest -q tests/test_workspace_active_lists.py` (7 passed)
- `npm test -- ProjectSourcingPage --run` (17 passed)
- `npm run typecheck`
- `uv run ruff check tests/test_workspace_active_lists.py alembic/versions/0045_backfill_active_distributors.py`
- `npm run lint -- --format=unix` reports the existing 8 baseline violations only; `LINT_CMD="npm run lint -- --format=unix" BASELINE_FILE="../.eslint-baseline.txt" WORK_DIR="." bash ../scripts/lint-delta.sh` passed with no new violations.
- `git diff --check` and `git diff --cached --check`

## Migration notes
- New revision: `0045_backfill_active_distributors.py`, after current head `0044`.
- Upgrade is idempotent and preserves existing active-list ordering before appending saved values.
- Downgrade is intentionally a no-op because unmerging would remove user data.
- Docker validation commands could not run because Docker is not installed in this environment; local Postgres validation was used instead.

## Merge order
#437 before #438

Refs #437