### PR TITLE
FB-008: Sourcing empty-state diagnostics

### DIFF
--- a/backend/app/domain/sourcing/schemas.py
+++ b/backend/app/domain/sourcing/schemas.py
@@ -518,6 +518,9 @@ class SourcingBomLineOut(BaseModel):
     best_offer: SourcingBomOfferOut | None = None
     est_extended_cost: Decimal | None = None
     lead_time_days: int | None = None
+    cache_hit: bool | None = None
+    reason: Literal["ok", "no_mpn", "no_offers"] = "ok"
+    fx_status: Literal["unavailable"] | None = None
     risk_flags: list[
         Literal[
             "single_source",

--- a/backend/app/domain/sourcing/service.py
+++ b/backend/app/domain/sourcing/service.py
@@ -1151,6 +1151,8 @@ def _source_bom_line(
     offers = _joined_offers(candidate_mpns, search_results, qty=max(short_by, 1))
     best_offer = _best_offer_at_qty(offers, short_by)
     authorized_stock = sum(offer.stock for offer in offers)
+    cache_hit = _bom_line_cache_hit(candidate_mpns, search_results)
+    reason = _bom_line_reason(candidate_mpns, offers)
 
     return SourcingBomLineOut(
         project_entry_id=UUID(str(row["project_entry_id"])),
@@ -1171,6 +1173,8 @@ def _source_bom_line(
             else None
         ),
         lead_time_days=best_offer.lead_time_days if best_offer is not None else None,
+        cache_hit=cache_hit,
+        reason=reason,
         risk_flags=_risk_flags(
             offers,
             best_offer=best_offer,
@@ -1178,6 +1182,33 @@ def _source_bom_line(
             preferred_distributors=preferred_distributors,
         ),
     )
+
+
+def _bom_line_cache_hit(
+    mpns: list[str],
+    search_results: dict[str, SourcingSearchResult],
+) -> bool | None:
+    if not mpns:
+        return None
+    results = [
+        result
+        for mpn in mpns
+        if (result := search_results.get(mpn.casefold())) is not None
+    ]
+    if not results:
+        return None
+    return all(result.cache_hit for result in results)
+
+
+def _bom_line_reason(
+    mpns: list[str],
+    offers: list[SourcingBomOfferOut],
+) -> str:
+    if not mpns:
+        return "no_mpn"
+    if not offers:
+        return "no_offers"
+    return "ok"
 
 
 def _joined_offers(

--- a/backend/tests/test_sourcing_bom_route.py
+++ b/backend/tests/test_sourcing_bom_route.py
@@ -193,6 +193,48 @@ def test_basic_bom_returns_enriched_lines(authed_client):
     assert row["best_offer"]["distributor"] == "Mouser"
     assert isinstance(row["best_offer"]["unit_price"], str)
     assert isinstance(row["est_extended_cost"], str)
+    assert row["reason"] == "ok"
+    assert row["cache_hit"] is False
+    assert row["fx_status"] is None
+
+
+def test_bom_row_reports_no_mpn_without_provider_call(authed_client):
+    _configure_sourcing(authed_client)
+    part_id = create_part(authed_client, name="Unnumbered", mpn=None)
+    project_id = create_project_with_bom(
+        authed_client,
+        "Missing MPN BOM",
+        [{"part_id": part_id, "quantity": 3}],
+    )
+
+    r = _post_sourcing(authed_client, project_id)
+
+    assert r.status_code == 200, r.text
+    row = r.json()["data"]["rows"][0]
+    assert row["mpn"] is None
+    assert row["offers"] == []
+    assert row["reason"] == "no_mpn"
+    assert row["cache_hit"] is None
+    assert _FakeTrustedPartsClient.calls == []
+
+
+def test_bom_row_reports_no_offers_and_cache_hit(authed_client):
+    _configure_sourcing(authed_client)
+    project_id = _single_line_project(authed_client, mpn="NO-OFFERS")
+    _FakeTrustedPartsClient.offers_by_mpn = {"NO-OFFERS": []}
+
+    first = _post_sourcing(authed_client, project_id)
+    second = _post_sourcing(authed_client, project_id)
+
+    assert first.status_code == 200, first.text
+    assert second.status_code == 200, second.text
+    first_row = first.json()["data"]["rows"][0]
+    second_row = second.json()["data"]["rows"][0]
+    assert first_row["reason"] == "no_offers"
+    assert first_row["cache_hit"] is False
+    assert second_row["reason"] == "no_offers"
+    assert second_row["cache_hit"] is True
+    assert len(_FakeTrustedPartsClient.calls) == 1
 
 
 def test_bom_with_substitutes_dedupes_mpns(authed_client, monkeypatch):

--- a/docs/api/sourcing.md
+++ b/docs/api/sourcing.md
@@ -193,6 +193,9 @@ Path: `project_id` is a project UUID in the current workspace.
         "available": 0,
         "short_by": 20,
         "authorized_stock": 60,
+        "cache_hit": false,
+        "reason": "ok",
+        "fx_status": null,
         "best_offer": {
           "distributor": "Mouser",
           "unit_price": "0.10",
@@ -226,8 +229,9 @@ Path: `project_id` is a project UUID in the current workspace.
 - The route validates `project_id` with `assert_in_workspace()` before calling the sourcing service.
 - The service reuses `shortage_analysis()`, `dedupe_mpns()`, `chunk_mpns()`, and per-MPN `search()` cache rows; BOM chunks use `ttl_seconds=600`.
 - Decimal prices and extended costs serialize as strings.
-- Source: `backend/app/api/routes/sourcing.py:134-194`.
-- Service: `backend/app/domain/sourcing/service.py:71-135`.
+- Each row exposes sourcing diagnostics: `reason` is `ok`, `no_mpn`, or `no_offers`; `cache_hit` is `true`/`false` for searched rows and `null` when no MPN was searched; `fx_status` is reserved for row-level conversion failures and is `null` unless represented.
+- Source: `backend/app/api/routes/sourcing.py:251-309`.
+- Service: `backend/app/domain/sourcing/service.py:820-881`, `backend/app/domain/sourcing/service.py:1143-1212`.
 - Pricing: `backend/app/domain/sourcing/pricing.py:9-40`.
 
 ### `POST /api/projects/{project_id}/purchase-plan`

--- a/web/src/routes/projects/sourcing/ProjectSourcingPage.tsx
+++ b/web/src/routes/projects/sourcing/ProjectSourcingPage.tsx
@@ -186,10 +186,12 @@ function EmptyBomState({ projectId }: { projectId: string }) {
 
 function SourcingDiagnosticsPanel({
   data,
+  projectId,
   status,
   onRefresh,
 }: {
   data?: SourcingBomResponse;
+  projectId: string;
   status: number | null;
   onRefresh: () => void;
 }) {
@@ -243,6 +245,11 @@ function SourcingDiagnosticsPanel({
           <RefreshCw size={14} aria-hidden="true" />
           Refresh prices
         </button>
+      )}
+      {allNoMpn && (
+        <Link className="btn" to={`/projects/${projectId}/import`}>
+          Edit BOM
+        </Link>
       )}
     </div>
   );
@@ -720,6 +727,7 @@ export default function ProjectSourcingPage() {
       {query.data && !hasRows && <EmptyBomState projectId={projectId} />}
       <SourcingDiagnosticsPanel
         data={query.data}
+        projectId={projectId}
         status={status}
         onRefresh={() => query.refetch()}
       />

--- a/web/src/routes/projects/sourcing/ProjectSourcingPage.tsx
+++ b/web/src/routes/projects/sourcing/ProjectSourcingPage.tsx
@@ -50,6 +50,9 @@ type SourcingBomLine = {
   best_offer?: SourcingBomOffer | null;
   est_extended_cost?: string | number | null;
   lead_time_days?: number | null;
+  cache_hit?: boolean | null;
+  reason?: "ok" | "no_mpn" | "no_offers" | null;
+  fx_status?: "unavailable" | null;
   risk_flags: RiskFlag[];
 };
 
@@ -181,16 +184,66 @@ function EmptyBomState({ projectId }: { projectId: string }) {
   );
 }
 
-function NotConfiguredState() {
-  return (
-    <div className="card p-4 space-y-3" role="status">
-      <div className="font-medium">Sourcing not configured.</div>
-      <div className="text-sm text-muted">
-        Ask a workspace admin to configure TrustedParts in Settings → Sourcing.
+function SourcingDiagnosticsPanel({
+  data,
+  status,
+  onRefresh,
+}: {
+  data?: SourcingBomResponse;
+  status: number | null;
+  onRefresh: () => void;
+}) {
+  if (status === 409) {
+    return (
+      <div className="card p-4 space-y-3" role="status" aria-label="Sourcing diagnostics">
+        <div>
+          <div className="font-medium">Sourcing not configured.</div>
+          <div className="text-sm text-muted">
+            Sourcing cannot run until TrustedParts credentials and workspace defaults are configured.
+          </div>
+        </div>
+        <Link className="btn" to="/settings/workspace">
+          Open Settings → Sourcing
+        </Link>
       </div>
-      <Link className="btn" to="/settings/workspace">
-        Open Settings → Sourcing
-      </Link>
+    );
+  }
+
+  const rows = data?.rows ?? [];
+  if (rows.length === 0 || rows.some(row => row.best_offer)) {
+    return null;
+  }
+
+  const allNoMpn = rows.every(row => row.reason === "no_mpn" || !row.mpn);
+  const allCacheHit = rows.every(row => row.cache_hit === true);
+  const fxUnavailable = rows.some(row => row.fx_status === "unavailable");
+
+  let title = "No matching offers found.";
+  let description = "TrustedParts returned no authorized offers for the selected country, currency, and distributors.";
+
+  if (allNoMpn) {
+    title = "BOM lines need manufacturer part numbers.";
+    description = "Add MPNs to these parts, then source the BOM again.";
+  } else if (fxUnavailable) {
+    title = "Prices were found, but currency conversion is unavailable.";
+    description = "Retry later or choose the offer currency while exchange rates are unavailable.";
+  } else if (allCacheHit) {
+    title = "Only cached no-offer results were available.";
+    description = "Refresh prices to check TrustedParts again for the current sourcing filters.";
+  }
+
+  return (
+    <div className="card p-4 space-y-3" role="status" aria-label="Sourcing diagnostics">
+      <div>
+        <div className="font-medium">{title}</div>
+        <div className="text-sm text-muted">{description}</div>
+      </div>
+      {allCacheHit && (
+        <button type="button" className="btn" onClick={onRefresh}>
+          <RefreshCw size={14} aria-hidden="true" />
+          Refresh prices
+        </button>
+      )}
     </div>
   );
 }
@@ -652,7 +705,6 @@ export default function ProjectSourcingPage() {
       </div>
 
       {query.isLoading && <SourcingSkeleton />}
-      {status === 409 && <NotConfiguredState />}
       {status === 503 && <BudgetState disabledUntil={budgetDisabledUntil} onRetry={() => query.refetch()} />}
       {status === 502 && (
         <div className="card p-4" role="status">
@@ -666,6 +718,11 @@ export default function ProjectSourcingPage() {
       )}
 
       {query.data && !hasRows && <EmptyBomState projectId={projectId} />}
+      <SourcingDiagnosticsPanel
+        data={query.data}
+        status={status}
+        onRefresh={() => query.refetch()}
+      />
 
       {query.data && hasRows && (
         <>

--- a/web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.test.tsx
+++ b/web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.test.tsx
@@ -372,8 +372,107 @@ describe("ProjectSourcingPage", () => {
     renderPage();
 
     expect(await screen.findByText("Sourcing not configured.")).toBeDefined();
+    expect(screen.getByRole("status", { name: "Sourcing diagnostics" })).toBeDefined();
+    expect(screen.getByText("Sourcing cannot run until TrustedParts credentials and workspace defaults are configured.")).toBeDefined();
     const link = screen.getByRole("link", { name: "Open Settings → Sourcing" });
     expect(link.getAttribute("href")).toBe("/settings/workspace");
+  });
+
+  it("renders diagnostic guidance when every BOM row is missing an MPN", async () => {
+    mockReads();
+    const base = sourcingResponse();
+    vi.spyOn(api, "post").mockResolvedValue(sourcingResponse({
+      rows: base.rows.map(row => ({
+        ...row,
+        mpn: null,
+        authorized_stock: 0,
+        offers: [],
+        best_offer: null,
+        est_extended_cost: null,
+        lead_time_days: null,
+        reason: "no_mpn",
+        cache_hit: null,
+        risk_flags: [],
+      })),
+    }));
+
+    renderPage();
+
+    expect(await screen.findByRole("status", { name: "Sourcing diagnostics" })).toBeDefined();
+    expect(screen.getByText("BOM lines need manufacturer part numbers.")).toBeDefined();
+    expect(screen.getByText("Add MPNs to these parts, then source the BOM again.")).toBeDefined();
+  });
+
+  it("renders cached empty-result guidance with a Refresh prices action", async () => {
+    const user = userEvent.setup();
+    mockReads();
+    const base = sourcingResponse();
+    const post = vi.spyOn(api, "post").mockResolvedValue(sourcingResponse({
+      rows: base.rows.map(row => ({
+        ...row,
+        authorized_stock: 0,
+        offers: [],
+        best_offer: null,
+        est_extended_cost: null,
+        lead_time_days: null,
+        reason: "no_offers",
+        cache_hit: true,
+        risk_flags: [],
+      })),
+    }));
+
+    renderPage();
+
+    expect(await screen.findByText("Only cached no-offer results were available.")).toBeDefined();
+    await user.click(screen.getByRole("button", { name: "Refresh prices" }));
+
+    await waitFor(() => expect(post).toHaveBeenCalledTimes(2));
+  });
+
+  it("renders FX guidance when unavailable is represented in unmatched rows", async () => {
+    mockReads();
+    const base = sourcingResponse();
+    vi.spyOn(api, "post").mockResolvedValue(sourcingResponse({
+      rows: base.rows.map(row => ({
+        ...row,
+        offers: [{ ...row.offers[0], unit_price: null }],
+        best_offer: null,
+        est_extended_cost: null,
+        lead_time_days: null,
+        reason: "no_offers",
+        cache_hit: false,
+        fx_status: "unavailable",
+        risk_flags: [],
+      })),
+    }));
+
+    renderPage();
+
+    expect(await screen.findByText("Prices were found, but currency conversion is unavailable.")).toBeDefined();
+    expect(screen.getByText("Retry later or choose the offer currency while exchange rates are unavailable.")).toBeDefined();
+  });
+
+  it("renders generic no-offers diagnostics when all rows are unmatched", async () => {
+    mockReads();
+    const base = sourcingResponse();
+    vi.spyOn(api, "post").mockResolvedValue(sourcingResponse({
+      rows: base.rows.map(row => ({
+        ...row,
+        authorized_stock: 0,
+        offers: [],
+        best_offer: null,
+        est_extended_cost: null,
+        lead_time_days: null,
+        reason: "no_offers",
+        cache_hit: false,
+        risk_flags: [],
+      })),
+    }));
+
+    renderPage();
+
+    expect(await screen.findByText("No matching offers found.")).toBeDefined();
+    expect(screen.getByText("TrustedParts returned no authorized offers for the selected country, currency, and distributors.")).toBeDefined();
   });
 
   it("503 path renders budget banner", async () => {

--- a/web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.test.tsx
+++ b/web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.test.tsx
@@ -401,6 +401,7 @@ describe("ProjectSourcingPage", () => {
     expect(await screen.findByRole("status", { name: "Sourcing diagnostics" })).toBeDefined();
     expect(screen.getByText("BOM lines need manufacturer part numbers.")).toBeDefined();
     expect(screen.getByText("Add MPNs to these parts, then source the BOM again.")).toBeDefined();
+    expect(screen.getByRole("link", { name: "Edit BOM" }).getAttribute("href")).toBe("/projects/project-123/import");
   });
 
   it("renders cached empty-result guidance with a Refresh prices action", async () => {


### PR DESCRIPTION
## Summary
- Add a sourcing empty-state diagnostics panel on the Project Sourcing page when every BOM row is unmatched.
- Expose minimal per-BOM-row diagnostics: `reason`, `cache_hit`, and reserved `fx_status` without changing the existing API envelope.
- Cover no-MPN, cached no-offer, FX-unavailable, generic no-offer, and not-configured guidance paths with focused tests.
- Add the requested Edit BOM action for all-no-MPN rows and Refresh prices for all-cache-hit empty rows.

## Hypothesis walk
- H1: Likely root cause is the distributor-default/filter intersection bug. That was handled by #437 / PR #440, which is now merged; this PR was rebased onto `main` after #440.
- H2: TrustedParts credential/config problems need user workspace data. This PR only surfaces the existing not-configured status as actionable diagnostics.
- H3: Country/currency/filter data mismatches need user request/response data. This PR does not patch speculative geography behavior.
- H5: Cache-related stale no-offer results need user cache state. This PR surfaces all-cache-hit empty rows and gives users a Refresh prices action.
- No backend sourcing bug was proven beyond the diagnostic contract gap; the backend change is limited to row-level diagnostic fields.

## Tests run
- `cd backend && TEST_DATABASE_URL=postgresql+psycopg://stockmgr:stockmgr@127.0.0.1:5432/stockmgr_test uv run --extra dev python -m pytest -q tests/test_sourcing_bom_route.py` (16 passed)
- `cd web && npm test -- ProjectSourcingPage --run` (21 passed after rebase)
- `cd web && npm run typecheck` (passed after rebase)
- `cd backend && uv run --extra dev ruff check app/domain/sourcing/schemas.py app/domain/sourcing/service.py tests/test_sourcing_bom_route.py`
- `cd web && LINT_CMD="npm run lint -- --format=unix" BASELINE_FILE="../.eslint-baseline.txt" WORK_DIR="." bash ../scripts/lint-delta.sh`
- `git diff --check` and `git diff --cached --check`

## Merge order
Satisfied: #440 (#437) merged before this PR, and this branch is rebased onto `main`.

Refs #438
