### PR TITLE
TPS-1: Bake TrustedParts swagger + code-gen + ADR-0022

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,35 @@ jobs:
             exit 1
           fi
 
+  tp-schema-drift:
+    # TPS-1 / issue #448: the bundled TrustedParts OpenAPI document and
+    # generated Pydantic v2 models are committed artifacts. Refresh both and
+    # fail if the checked-in copies are stale.
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        run: pip install --no-cache-dir uv==0.11.8
+
+      - name: Install backend generation deps
+        working-directory: backend
+        run: uv sync --frozen --extra dev --dev
+
+      - name: Refresh TrustedParts schema and generated models
+        run: |
+          make refresh-tp-spec
+          make regen-tp-models
+
+      - name: Assert TrustedParts schema artifacts are current
+        run: git diff --exit-code -- docs/schemas/trustedparts-v2.json backend/app/domain/sourcing/_generated
+
   backend-tests:
     # Make the dependency on lockfile-drift explicit at the job level so the
     # ordering matches the comment on the lockfile-drift job (it runs *before*
@@ -635,6 +664,7 @@ jobs:
   #   - pip-audit         (SEC2-016)   — HIGH/CRITICAL CVEs in the pinned set
   #   - npm-audit         (issue #305) — CVEs in the npm production dep set
   #   - line-count-budget (CQ-002/003) — per-file line-count caps
+  #   - tp-schema-drift   (#448)       — TrustedParts schema/model drift
   #   - backend-tests                  — pytest + alembic
   #   - web-build                      — tsc -b + vite build (+ sourcemap upload)
   #   - prod-validate                  — docker compose config sanity check
@@ -647,7 +677,7 @@ jobs:
     # Only redeploy on green main pushes. PRs and feature branches just run
     # the test/validate/security jobs above.
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: [ci-policy, lockfile-drift, pip-audit, npm-audit, line-count-budget, backend-tests, web-build, prod-validate, playwright-e2e]
+    needs: [ci-policy, lockfile-drift, pip-audit, npm-audit, line-count-budget, tp-schema-drift, backend-tests, web-build, prod-validate, playwright-e2e]
     runs-on: ubuntu-latest
     # Environment association. Today this just scopes any environment-level
     # secrets we add later; if a "Required reviewers" protection rule is

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,8 +152,10 @@ jobs:
 
   tp-schema-drift:
     # TPS-1 / issue #448: the bundled TrustedParts OpenAPI document and
-    # generated Pydantic v2 models are committed artifacts. Refresh both and
-    # fail if the checked-in copies are stale.
+    # generated Pydantic v2 models are committed artifacts. Regenerate from
+    # the bundled schema and fail if the checked-in generated models are stale.
+    # Do not fetch the live TrustedParts schema in CI; ADR-0022 keeps refresh
+    # as an explicit operator action via `make refresh-tp-spec`.
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -171,13 +173,11 @@ jobs:
         working-directory: backend
         run: uv sync --frozen --extra dev --dev
 
-      - name: Refresh TrustedParts schema and generated models
-        run: |
-          make refresh-tp-spec
-          make regen-tp-models
+      - name: Regenerate TrustedParts models
+        run: make regen-tp-models
 
       - name: Assert TrustedParts schema artifacts are current
-        run: git diff --exit-code -- docs/schemas/trustedparts-v2.json backend/app/domain/sourcing/_generated
+        run: git diff --exit-code -- backend/app/domain/sourcing/_generated
 
   backend-tests:
     # Make the dependency on lockfile-drift explicit at the job level so the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,6 +245,11 @@ them, that's the bug.
   the hourly cache sweep and `backend-cron-alerts` handles the 15-minute alert
   evaluator. They share the same `run_job` registry per ADR-0021; adding a
   third cadence means a third sidecar, not a parallel scheduler.
+- **TrustedParts generated models are schema-pinned.** Refresh
+  `docs/schemas/trustedparts-v2.json` with `make refresh-tp-spec`, regenerate
+  `backend/app/domain/sourcing/_generated/` with `make regen-tp-models`, and
+  keep the AUTO-GENERATED header intact. ADR-0022 owns the pinning and CI drift
+  gate; client integration belongs to the follow-up PR, not the foundation PR.
 - **Maintenance mode is toggled by the deploy script via
   `a2enconf parts-maintenance`.** Do not bypass the deploy path without
   also disabling it with `a2disconf parts-maintenance`.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
-.PHONY: dev-up dev-down dev-logs dev-rebuild prod-up prod-logs prod-rebuild
+.PHONY: dev-up dev-down dev-logs dev-rebuild prod-up prod-logs prod-rebuild refresh-tp-spec regen-tp-models
+
+TP_SPEC_URL := https://api.trustedparts.com/swagger/inventory-api-v2/swagger.json
+TP_SPEC := docs/schemas/trustedparts-v2.json
+TP_GENERATED := backend/app/domain/sourcing/_generated/trustedparts_v2.py
 
 dev-up:
 	docker compose -f docker-compose.dev.yml up --build
@@ -20,3 +24,25 @@ prod-logs:
 
 prod-rebuild:
 	docker compose -f docker-compose.prod.yml --env-file .env.prod up -d --build --force-recreate
+
+refresh-tp-spec:
+	mkdir -p "$(dir $(TP_SPEC))"
+	curl -fsSL "$(TP_SPEC_URL)" | jq --sort-keys . > "$(TP_SPEC)"
+
+regen-tp-models:
+	mkdir -p "$(dir $(TP_GENERATED))"
+	cd backend && uv run datamodel-codegen \
+		--input ../$(TP_SPEC) \
+		--input-file-type openapi \
+		--output ../$(TP_GENERATED) \
+		--output-model-type pydantic_v2.BaseModel \
+		--target-python-version 3.12 \
+		--target-pydantic-version 2.11 \
+		--use-standard-collections \
+		--use-union-operator \
+		--use-annotated \
+		--field-constraints \
+		--use-double-quotes \
+		--formatters black isort \
+		--disable-timestamp \
+		--custom-file-header '# AUTO-GENERATED FILE - DO NOT EDIT. Run `make regen-tp-models` from the repository root.'

--- a/backend/app/domain/sourcing/_generated/__init__.py
+++ b/backend/app/domain/sourcing/_generated/__init__.py
@@ -1,0 +1,1 @@
+"""Generated TrustedParts schema models."""

--- a/backend/app/domain/sourcing/_generated/trustedparts_v2.py
+++ b/backend/app/domain/sourcing/_generated/trustedparts_v2.py
@@ -1,0 +1,348 @@
+# AUTO-GENERATED FILE - DO NOT EDIT. Run `make regen-tp-models` from the repository root.
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from pydantic import AwareDatetime, BaseModel, ConfigDict, Field
+
+
+class PartSpecification(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    Key: Annotated[str | None, Field(description="The specification name")] = None
+    Value: Annotated[str | None, Field(description="The specification value")] = None
+
+
+class Price(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    Amount: Annotated[float | None, Field(description="Price amount")] = None
+    FormattedAmount: Annotated[
+        str | None, Field(description="Formatted price amount")
+    ] = None
+    Quantity: Annotated[float | None, Field(description="Quantity for price")] = None
+    Text: Annotated[str | None, Field(description="Text representation of price")] = (
+        None
+    )
+
+
+class ProductPackageType(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    MinimumOrderQuantity: Annotated[
+        int | None, Field(description="Minimum order quantity")
+    ] = None
+    PackageType: Annotated[str | None, Field(description="Package type")] = None
+
+
+class ProductPricing(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    CurrencyCode: Annotated[
+        str | None,
+        Field(description='Currency code for the pricing amounts (e.g., "USD").'),
+    ] = None
+    MinimumQuantity: Annotated[
+        float | None, Field(description="Minimum order quantity for the price.")
+    ] = None
+    Prices: Annotated[
+        list[Price] | None, Field(description="List of prices for specific quantities.")
+    ] = None
+    QuantityMultiple: Annotated[
+        float | None, Field(description="Quanitity multiple")
+    ] = None
+
+
+class RohsCompliance(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    Description: Annotated[
+        str | None, Field(description="Description of RoHS compliance")
+    ] = None
+    IsCompliant: Annotated[
+        bool | None, Field(description="Is the product RoHS compliant?")
+    ] = None
+    Region: Annotated[
+        str | None, Field(description="Region for the RoHS compliance information")
+    ] = None
+
+
+class SearchApiLink(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    Type: Annotated[
+        str | None, Field(description='Type of link (e.g., "datasheet", "distributor")')
+    ] = None
+    Url: Annotated[str | None, Field(description="URL of the link.")] = None
+
+
+class SearchQuery(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    Manufacturers: Annotated[
+        list[str] | None,
+        Field(
+            description='The manufacturers that will be searched.\nAdd this section to limit the search results to one more more manufacturers.\nOmit this section to search all authorized manufacturers.\nOur supported manufacturers can be found <a href="https://www.trustedparts.com/docs/api/manufacturers-list/">here</a>.',
+            examples=[
+                [
+                    "enter a manufacturer name or remove the optional Manufacturers parameter"
+                ]
+            ],
+        ),
+    ] = None
+    SearchToken: Annotated[
+        str,
+        Field(
+            description="Enter the search term. The search term must be at least two characters and no more than 100 characters.",
+            examples=["bav99"],
+            max_length=100,
+            min_length=2,
+        ),
+    ]
+
+
+class StockInfo(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    Availability: Annotated[
+        str | None,
+        Field(
+            description='Contains a message about stock availability. For instance, "In Stock".'
+        ),
+    ] = None
+    QuantityOnHand: Annotated[
+        float | None,
+        Field(
+            description="Indicates number of parts currently on hand. Will be null if we are not going to disclose the exact number."
+        ),
+    ] = None
+
+
+class InventoryApiRequest(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    ApiKey: Annotated[
+        str | None,
+        Field(
+            description="Enter your assigned API key.\nThe assigned API key can be found on the API Credentials page.\n            \nAlternatively, you may provide the API key in the X-Api-Key header and omit this parameter\nfrom the request.",
+            examples=["enter my api key"],
+        ),
+    ] = None
+    CompanyId: Annotated[
+        str | None,
+        Field(
+            description="Company identifier assigned to your account.\nThe assigned company identifier can be found on the API Credentials page.\n            \nThis property is deprecated, no longer required and may be omitted.",
+            examples=["enter my company id (deprecated)"],
+        ),
+    ] = None
+    CountryCode: Annotated[
+        str | None,
+        Field(
+            description="Enter a two-character ISO code or leave blank for geolocation.\n\nLeave this field blank if you would like us to geolocate the SourceIp parameter\nand use the country that the IP address is from. If you use the TrustedParts.com API\nto provide results on a website, this allows you to provide regional results to each\nuser without any effort on your part.",
+            examples=["US"],
+        ),
+    ] = None
+    CurrencyCode: Annotated[
+        str | None,
+        Field(description="Enter a three-character ISO currency code. (Optional)"),
+    ] = "USD"
+    Distributors: Annotated[
+        list[str] | None,
+        Field(
+            description='The distributors that will be included in this search.\nAdd this section to limit the search results to one or more distributors.\nOmit this section to search all authorized distributors.\nOur supported distributors can be found <a href="https://www.trustedparts.com/docs/api/distributors-list/">here</a>.',
+            examples=[
+                [
+                    "enter a distributor name or remove the optional Distributors parameter"
+                ]
+            ],
+        ),
+    ] = None
+    ExactMatch: Annotated[
+        bool | None,
+        Field(
+            description="Set to true to view parts that match the search term exactly.\nSet to false to include partial match results.\nNote: Partial match results are only available for single part number requests.\nMost punctuation and spacing are ignored when determining what is an exact match.\nFor instance, BAT-54C is an exact match for BAT54C.",
+            examples=[False],
+        ),
+    ] = False
+    InStockOnly: Annotated[
+        bool | None,
+        Field(
+            description="Set to true to view in-stock results only. (Optional)",
+            examples=[False],
+        ),
+    ] = False
+    IsCrawler: Annotated[
+        bool | None,
+        Field(
+            description="Set to true if the end user is a crawler or bot (e.g. Google, Bing, Baidu).\nSet to false if the end user is not a crawler or if undetermined.",
+            examples=[False],
+        ),
+    ] = None
+    LanguageCode: Annotated[
+        str | None,
+        Field(
+            description="Enter the ISO language code for part specification translations or leave blank for English.\n\nSupported values: \n\nde, en, es, fr, it, pt, ja, zh-hans, zh-hant",
+            examples=["en"],
+        ),
+    ] = "en"
+    Queries: Annotated[
+        list[SearchQuery],
+        Field(
+            description="The part number(s) and manufacturer(s) you want to search for.\n\nAdd a separate query for each part number search.\n\nNote: If you enter multiple part numbers, an exact match search will be performed\nfor each part number. Partial match results are only available for single part number requests."
+        ),
+    ]
+    SourceIp: Annotated[
+        str | None,
+        Field(
+            description="Provide the IP (Internet Protocol) address of the end user who will view the results.\nPlease ensure the accuracy of this value so that TrustedParts.com can verify\nthe identity of users who receive results. \n<b>Geolocation:</b> When the CountryCode parameter is omitted or left blank, the\nSourceIp parameter will be used to geolocate the request and provide regional results.",
+            examples=["enter my IP address"],
+        ),
+    ] = None
+    UseCachedData: Annotated[
+        bool | None,
+        Field(
+            description="If this parameter is not supplied or set to false, the TrustedParts.com API\nwill provide results based on real-time stock and pricing services provided\nby participating distributors. This is the preferred setting since it yields\nthe most accurate results. However, if you need extremely fast responses or\nneed to submit a high volume of requests in a short period of time, you may\nset this parameter to true. This will direct the TrustedParts.com API to use\nan optimized search process that retrieves results from locally-cached data\ninstead of real-time data.",
+            examples=[False],
+        ),
+    ] = False
+    UserAgent: Annotated[
+        str | None,
+        Field(
+            description="Provide the user agent of the requesting application or end user's browser.\nPlease ensure the accuracy of this value so that TrustedParts.com can verify\nthe identity of users who receive results.",
+            examples=["enter my application user agent"],
+        ),
+    ] = None
+
+
+class ProductCompliance(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    RoHS: Annotated[
+        list[RohsCompliance] | None,
+        Field(
+            description="Contains regional RoHS compliance information for products."
+        ),
+    ] = None
+
+
+class InventoryDistributorResult(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    Compliance: ProductCompliance | None = None
+    Description: Annotated[str | None, Field(description="The part's description.")] = (
+        None
+    )
+    DistributorPartNumber: Annotated[
+        str | None, Field(description="The distributor part number.")
+    ] = None
+    Links: Annotated[
+        list[SearchApiLink] | None,
+        Field(
+            description="Links. For example, datasheet URL or distributor product URL."
+        ),
+    ] = None
+    Packaging: Annotated[
+        list[ProductPackageType] | None, Field(description="Packaging information.")
+    ] = None
+    Pricing: ProductPricing | None = None
+    Stock: StockInfo | None = None
+
+
+class PartDistributor(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    DistributorResults: Annotated[
+        list[InventoryDistributorResult] | None,
+        Field(description="The list of matched manufacturer parts."),
+    ] = None
+    Id: Annotated[int | None, Field(description="Distributor Id")] = None
+    Name: Annotated[str | None, Field(description="Distributor name.")] = None
+
+
+class InventoryPartResult(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    Distributors: Annotated[
+        list[PartDistributor] | None,
+        Field(description="The distributors with matches."),
+    ] = None
+    IsAffectedByTariff: Annotated[
+        bool | None,
+        Field(
+            description="Have TrustedParts.com distributors indicated that the part is affected by tariffs in the United States?"
+        ),
+    ] = None
+    LifecycleRisk: Annotated[
+        str | None,
+        Field(
+            description="Lifecycle risk of a matching part.\n            \nPlease email user-requests@trustedparts.com to see if our policies allow this information\nto be provided to you."
+        ),
+    ] = None
+    Manufacturer: Annotated[
+        str | None, Field(description="The manufacturer name for the result.")
+    ] = None
+    ManufacturerId: Annotated[
+        int | None,
+        Field(description="The TrustedParts manufacturer ID for the result."),
+    ] = None
+    PartNumber: Annotated[
+        str | None, Field(description="The manufacturer part number for the result.")
+    ] = None
+    ProductUrl: Annotated[
+        str | None,
+        Field(description="The TrustedParts.com product page for the result."),
+    ] = None
+    Specifications: Annotated[
+        list[PartSpecification] | None,
+        Field(
+            description="Specifications of a matching part.\n            \nPlease email user-requests@trustedparts.com to see if our policies allow this information\nto be provided to you."
+        ),
+    ] = None
+    SupplyChainRisk: Annotated[
+        str | None,
+        Field(
+            description="Supply Chain risk of a matching part.\n            \nPlease email user-requests@trustedparts.com to see if our policies allow this information\nto be provided to you."
+        ),
+    ] = None
+
+
+class InventoryApiResponse(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    CurrentDate: Annotated[
+        AwareDatetime | None,
+        Field(description="Date and time that results were returned."),
+    ] = None
+    ErrorMessage: Annotated[
+        str | None,
+        Field(description="A message regarding an error generated by the search."),
+    ] = None
+    Messages: Annotated[
+        list[str] | None, Field(description="Messages regarding the search results.")
+    ] = None
+    OriginalRequest: InventoryApiRequest | None = None
+    PartResults: Annotated[
+        list[InventoryPartResult] | None,
+        Field(description="The search results grouped by part number searched for."),
+    ] = None
+    ResponseTime: Annotated[
+        str | None,
+        Field(
+            description="The amount of time it took for the API to respond with results."
+        ),
+    ] = None

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -96,7 +96,12 @@ line-length = 100
 target-version = "py312"
 # Alembic revision files have boilerplate `# revision identifiers, used
 # by Alembic.` blocks that confuse the import-order rule.
-extend-exclude = ["alembic/versions"]
+extend-exclude = ["alembic/versions", "app/domain/sourcing/_generated"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I"]
+
+[dependency-groups]
+dev = [
+    "datamodel-code-generator>=0.57.0",
+]

--- a/backend/tests/test_tp_schema_bundled.py
+++ b/backend/tests/test_tp_schema_bundled.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SPEC_PATH = ROOT / "docs" / "schemas" / "trustedparts-v2.json"
+GENERATED_PATH = (
+    ROOT / "backend" / "app" / "domain" / "sourcing" / "_generated" / "trustedparts_v2.py"
+)
+GENERATED_HEADER = (
+    "# AUTO-GENERATED FILE - DO NOT EDIT. "
+    "Run `make regen-tp-models` from the repository root."
+)
+
+
+def test_bundled_trustedparts_schema_loads() -> None:
+    schema = json.loads(SPEC_PATH.read_text())
+
+    assert schema["openapi"] == "3.0.4"
+    assert schema["info"]["title"] == "TrustedParts.com Inventory API"
+    assert schema["info"]["version"] == "2.0"
+    assert schema["paths"]["/v2/search"]["post"]["requestBody"]["content"][
+        "application/json"
+    ]["schema"]["$ref"] == "#/components/schemas/InventoryApiRequest"
+
+
+def test_generated_trustedparts_module_imports_and_has_header() -> None:
+    first_line = GENERATED_PATH.read_text().splitlines()[0]
+    assert first_line == GENERATED_HEADER
+
+    module = importlib.import_module("app.domain.sourcing._generated.trustedparts_v2")
+
+    assert module.InventoryApiRequest.model_fields["Queries"].is_required()
+    assert "PartResults" in module.InventoryApiResponse.model_fields

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -52,6 +52,15 @@ wheels = [
 ]
 
 [[package]]
+name = "argcomplete"
+version = "3.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/61/0b9ae6399dd4a58d8c1b1dc5a27d6f2808023d0b5dd3104bb99f45a33ff6/argcomplete-3.6.3.tar.gz", hash = "sha256:62e8ed4fd6a45864acc8235409461b72c9a28ee785a2011cc5eb78318786c89c", size = 73754, upload-time = "2025-10-20T03:33:34.741Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/f5/9373290775639cb67a2fce7f629a1c240dce9f12fe927bc32b2736e16dfc/argcomplete-3.6.3-py3-none-any.whl", hash = "sha256:f5007b3a600ccac5d25bbce33089211dfd49eab4a7718da3f10e3082525a92ce", size = 43846, upload-time = "2025-10-20T03:33:33.021Z" },
+]
+
+[[package]]
 name = "argon2-cffi"
 version = "25.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -92,6 +101,38 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/74/cd/15777dfde1c29d96de7f18edf4cc94c385646852e7c7b0320aa91ccca583/argon2_cffi_bindings-25.1.0-cp39-abi3-win32.whl", hash = "sha256:473bcb5f82924b1becbb637b63303ec8d10e84c8d241119419897a26116515d2", size = 27180, upload-time = "2025-07-30T10:01:57.759Z" },
     { url = "https://files.pythonhosted.org/packages/e2/c6/a759ece8f1829d1f162261226fbfd2c6832b3ff7657384045286d2afa384/argon2_cffi_bindings-25.1.0-cp39-abi3-win_amd64.whl", hash = "sha256:a98cd7d17e9f7ce244c0803cad3c23a7d379c301ba618a5fa76a67d116618b98", size = 31715, upload-time = "2025-07-30T10:01:58.56Z" },
     { url = "https://files.pythonhosted.org/packages/42/b9/f8d6fa329ab25128b7e98fd83a3cb34d9db5b059a9847eddb840a0af45dd/argon2_cffi_bindings-25.1.0-cp39-abi3-win_arm64.whl", hash = "sha256:b0fdbcf513833809c882823f98dc2f931cf659d9a1429616ac3adebb49f5db94", size = 27149, upload-time = "2025-07-30T10:01:59.329Z" },
+]
+
+[[package]]
+name = "black"
+version = "26.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "mypy-extensions" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "platformdirs" },
+    { name = "pytokens" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e1/c5/61175d618685d42b005847464b8fb4743a67b1b8fdb75e50e5a96c31a27a/black-26.3.1.tar.gz", hash = "sha256:2c50f5063a9641c7eed7795014ba37b0f5fa227f3d408b968936e24bc0566b07", size = 666155, upload-time = "2026-03-12T03:36:03.593Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/f8/da5eae4fc75e78e6dceb60624e1b9662ab00d6b452996046dfa9b8a6025b/black-26.3.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b5e6f89631eb88a7302d416594a32faeee9fb8fb848290da9d0a5f2903519fc1", size = 1895920, upload-time = "2026-03-12T03:40:13.921Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/9f/04e6f26534da2e1629b2b48255c264cabf5eedc5141d04516d9d68a24111/black-26.3.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:41cd2012d35b47d589cb8a16faf8a32ef7a336f56356babd9fcf70939ad1897f", size = 1718499, upload-time = "2026-03-12T03:40:15.239Z" },
+    { url = "https://files.pythonhosted.org/packages/04/91/a5935b2a63e31b331060c4a9fdb5a6c725840858c599032a6f3aac94055f/black-26.3.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f76ff19ec5297dd8e66eb64deda23631e642c9393ab592826fd4bdc97a4bce7", size = 1794994, upload-time = "2026-03-12T03:40:17.124Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/0a/86e462cdd311a3c2a8ece708d22aba17d0b2a0d5348ca34b40cdcbea512e/black-26.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:ddb113db38838eb9f043623ba274cfaf7d51d5b0c22ecb30afe58b1bb8322983", size = 1420867, upload-time = "2026-03-12T03:40:18.83Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/e5/22515a19cb7eaee3440325a6b0d95d2c0e88dd180cb011b12ae488e031d1/black-26.3.1-cp312-cp312-win_arm64.whl", hash = "sha256:dfdd51fc3e64ea4f35873d1b3fb25326773d55d2329ff8449139ebaad7357efb", size = 1230124, upload-time = "2026-03-12T03:40:20.425Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/77/5728052a3c0450c53d9bb3945c4c46b91baa62b2cafab6801411b6271e45/black-26.3.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:855822d90f884905362f602880ed8b5df1b7e3ee7d0db2502d4388a954cc8c54", size = 1895034, upload-time = "2026-03-12T03:40:21.813Z" },
+    { url = "https://files.pythonhosted.org/packages/52/73/7cae55fdfdfbe9d19e9a8d25d145018965fe2079fa908101c3733b0c55a0/black-26.3.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8a33d657f3276328ce00e4d37fe70361e1ec7614da5d7b6e78de5426cb56332f", size = 1718503, upload-time = "2026-03-12T03:40:23.666Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/87/af89ad449e8254fdbc74654e6467e3c9381b61472cc532ee350d28cfdafb/black-26.3.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f1cd08e99d2f9317292a311dfe578fd2a24b15dbce97792f9c4d752275c1fa56", size = 1793557, upload-time = "2026-03-12T03:40:25.497Z" },
+    { url = "https://files.pythonhosted.org/packages/43/10/d6c06a791d8124b843bf325ab4ac7d2f5b98731dff84d6064eafd687ded1/black-26.3.1-cp313-cp313-win_amd64.whl", hash = "sha256:c7e72339f841b5a237ff14f7d3880ddd0fc7f98a1199e8c4327f9a4f478c1839", size = 1422766, upload-time = "2026-03-12T03:40:27.14Z" },
+    { url = "https://files.pythonhosted.org/packages/59/4f/40a582c015f2d841ac24fed6390bd68f0fc896069ff3a886317959c9daf8/black-26.3.1-cp313-cp313-win_arm64.whl", hash = "sha256:afc622538b430aa4c8c853f7f63bc582b3b8030fd8c80b70fb5fa5b834e575c2", size = 1232140, upload-time = "2026-03-12T03:40:28.882Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/da/e36e27c9cebc1311b7579210df6f1c86e50f2d7143ae4fcf8a5017dc8809/black-26.3.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2d6bfaf7fd0993b420bed691f20f9492d53ce9a2bcccea4b797d34e947318a78", size = 1889234, upload-time = "2026-03-12T03:40:30.964Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/7b/9871acf393f64a5fa33668c19350ca87177b181f44bb3d0c33b2d534f22c/black-26.3.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:f89f2ab047c76a9c03f78d0d66ca519e389519902fa27e7a91117ef7611c0568", size = 1720522, upload-time = "2026-03-12T03:40:32.346Z" },
+    { url = "https://files.pythonhosted.org/packages/03/87/e766c7f2e90c07fb7586cc787c9ae6462b1eedab390191f2b7fc7f6170a9/black-26.3.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b07fc0dab849d24a80a29cfab8d8a19187d1c4685d8a5e6385a5ce323c1f015f", size = 1787824, upload-time = "2026-03-12T03:40:33.636Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/94/2424338fb2d1875e9e83eed4c8e9c67f6905ec25afd826a911aea2b02535/black-26.3.1-cp314-cp314-win_amd64.whl", hash = "sha256:0126ae5b7c09957da2bdbd91a9ba1207453feada9e9fe51992848658c6c8e01c", size = 1445855, upload-time = "2026-03-12T03:40:35.442Z" },
+    { url = "https://files.pythonhosted.org/packages/86/43/0c3338bd928afb8ee7471f1a4eec3bdbe2245ccb4a646092a222e8669840/black-26.3.1-cp314-cp314-win_arm64.whl", hash = "sha256:92c0ec1f2cc149551a2b7b47efc32c866406b6891b0ee4625e95967c8f4acfb1", size = 1258109, upload-time = "2026-03-12T03:40:36.832Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/0d/52d98722666d6fc6c3dd4c76df339501d6efd40e0ff95e6186a7b7f0befd/black-26.3.1-py3-none-any.whl", hash = "sha256:2bd5aa94fc267d38bb21a70d7410a89f1a1d318841855f698746f8e7f51acd1b", size = 207542, upload-time = "2026-03-12T03:36:01.668Z" },
 ]
 
 [[package]]
@@ -350,6 +391,25 @@ wheels = [
 ]
 
 [[package]]
+name = "datamodel-code-generator"
+version = "0.57.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "argcomplete" },
+    { name = "black" },
+    { name = "genson" },
+    { name = "inflect" },
+    { name = "isort" },
+    { name = "jinja2" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/44/87d5980f813a1e323c5d726b3ac5fec8c915ce8a77fcdceaf9c00457dbae/datamodel_code_generator-0.57.0.tar.gz", hash = "sha256:0eda778ea06eaa476e542a5f1fe1d14cc3bbf686edb33a0ad6151c7d19089906", size = 932941, upload-time = "2026-05-07T16:21:55.819Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/c1/4fb9a44bb4a305b860c5a5b1866dcccfac3b76f5f170a9e68fc7733e16d2/datamodel_code_generator-0.57.0-py3-none-any.whl", hash = "sha256:d26bf5defe5154493d0aa5a822b7725332b9e9dd2abccc2f8856052286aa83b5", size = 259343, upload-time = "2026-05-07T16:21:53.823Z" },
+]
+
+[[package]]
 name = "deprecated"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -397,6 +457,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5d/45/c130091c2dfa061bbfe3150f2a5091ef1adf149f2a8d2ae769ecaf6e99a2/fastapi-0.136.1.tar.gz", hash = "sha256:7af665ad7acfa0a3baf8983d393b6b471b9da10ede59c60045f49fbc89a0fa7f", size = 397448, upload-time = "2026-04-23T16:49:44.046Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/ff/2e4eca3ade2c22fe1dea7043b8ee9dabe47753349eb1b56a202de8af6349/fastapi-0.136.1-py3-none-any.whl", hash = "sha256:a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f", size = 117683, upload-time = "2026-04-23T16:49:42.437Z" },
+]
+
+[[package]]
+name = "genson"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/cf/2303c8ad276dcf5ee2ad6cf69c4338fd86ef0f471a5207b069adf7a393cf/genson-1.3.0.tar.gz", hash = "sha256:e02db9ac2e3fd29e65b5286f7135762e2cd8a986537c075b06fc5f1517308e37", size = 34919, upload-time = "2024-05-15T22:08:49.123Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/5c/e226de133afd8bb267ec27eead9ae3d784b95b39a287ed404caab39a5f50/genson-1.3.0-py3-none-any.whl", hash = "sha256:468feccd00274cc7e4c09e84b08704270ba8d95232aa280f65b986139cec67f7", size = 21470, upload-time = "2024-05-15T22:08:47.056Z" },
 ]
 
 [[package]]
@@ -514,6 +583,19 @@ wheels = [
 ]
 
 [[package]]
+name = "inflect"
+version = "7.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+    { name = "typeguard" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/c6/943357d44a21fd995723d07ccaddd78023eace03c1846049a2645d4324a3/inflect-7.5.0.tar.gz", hash = "sha256:faf19801c3742ed5a05a8ce388e0d8fe1a07f8d095c82201eb904f5d27ad571f", size = 73751, upload-time = "2024-12-28T17:11:18.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/eb/427ed2b20a38a4ee29f24dbe4ae2dafab198674fe9a85e3d6adf9e5f5f41/inflect-7.5.0-py3-none-any.whl", hash = "sha256:2aea70e5e70c35d8350b8097396ec155ffd68def678c7ff97f51aa69c1d92344", size = 35197, upload-time = "2024-12-28T17:11:15.931Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -523,12 +605,33 @@ wheels = [
 ]
 
 [[package]]
+name = "isort"
+version = "8.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/7c/ec4ab396d31b3b395e2e999c8f46dec78c5e29209fac49d1f4dace04041d/isort-8.0.1.tar.gz", hash = "sha256:171ac4ff559cdc060bcfff550bc8404a486fee0caab245679c2abe7cb253c78d", size = 769592, upload-time = "2026-02-28T10:08:20.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/95/c7c34aa53c16353c56d0b802fba48d5f5caa2cdee7958acbcb795c830416/isort-8.0.1-py3-none-any.whl", hash = "sha256:28b89bc70f751b559aeca209e6120393d43fbe2490de0559662be7a9787e3d75", size = 89733, upload-time = "2026-02-28T10:08:19.466Z" },
+]
+
+[[package]]
 name = "itsdangerous"
 version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173", size = 54410, upload-time = "2024-04-16T21:28:15.614Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef", size = 16234, upload-time = "2024-04-16T21:28:14.499Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
 ]
 
 [[package]]
@@ -621,12 +724,48 @@ wheels = [
 ]
 
 [[package]]
+name = "more-itertools"
+version = "11.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/f7/139d22fef48ac78127d18e01d80cf1be40236ae489769d17f35c3d425293/more_itertools-11.0.2.tar.gz", hash = "sha256:392a9e1e362cbc106a2457d37cabf9b36e5e12efd4ebff1654630e76597df804", size = 144659, upload-time = "2026-04-09T15:01:33.297Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/98/6af411189d9413534c3eb691182bff1f5c6d44ed2f93f2edfe52a1bbceb8/more_itertools-11.0.2-py3-none-any.whl", hash = "sha256:6e35b35f818b01f691643c6c611bc0902f2e92b46c18fffa77ae1e7c46e912e4", size = 71939, upload-time = "2026-04-09T15:01:32.21Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.9.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
 ]
 
 [[package]]
@@ -880,6 +1019,35 @@ wheels = [
 ]
 
 [[package]]
+name = "pytokens"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/34/b4e015b99031667a7b960f888889c5bd34ef585c85e1cb56a594b92836ac/pytokens-0.4.1.tar.gz", hash = "sha256:292052fe80923aae2260c073f822ceba21f3872ced9a68bb7953b348e561179a", size = 23015, upload-time = "2026-01-30T01:03:45.924Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/5d/e44573011401fb82e9d51e97f1290ceb377800fb4eed650b96f4753b499c/pytokens-0.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:140709331e846b728475786df8aeb27d24f48cbcf7bcd449f8de75cae7a45083", size = 160663, upload-time = "2026-01-30T01:03:06.473Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/e6/5bbc3019f8e6f21d09c41f8b8654536117e5e211a85d89212d59cbdab381/pytokens-0.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d6c4268598f762bc8e91f5dbf2ab2f61f7b95bdc07953b602db879b3c8c18e1", size = 255626, upload-time = "2026-01-30T01:03:08.177Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/3c/2d5297d82286f6f3d92770289fd439956b201c0a4fc7e72efb9b2293758e/pytokens-0.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:24afde1f53d95348b5a0eb19488661147285ca4dd7ed752bbc3e1c6242a304d1", size = 269779, upload-time = "2026-01-30T01:03:09.756Z" },
+    { url = "https://files.pythonhosted.org/packages/20/01/7436e9ad693cebda0551203e0bf28f7669976c60ad07d6402098208476de/pytokens-0.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5ad948d085ed6c16413eb5fec6b3e02fa00dc29a2534f088d3302c47eb59adf9", size = 268076, upload-time = "2026-01-30T01:03:10.957Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/df/533c82a3c752ba13ae7ef238b7f8cdd272cf1475f03c63ac6cf3fcfb00b6/pytokens-0.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:3f901fe783e06e48e8cbdc82d631fca8f118333798193e026a50ce1b3757ea68", size = 103552, upload-time = "2026-01-30T01:03:12.066Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/dc/08b1a080372afda3cceb4f3c0a7ba2bde9d6a5241f1edb02a22a019ee147/pytokens-0.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8bdb9d0ce90cbf99c525e75a2fa415144fd570a1ba987380190e8b786bc6ef9b", size = 160720, upload-time = "2026-01-30T01:03:13.843Z" },
+    { url = "https://files.pythonhosted.org/packages/64/0c/41ea22205da480837a700e395507e6a24425151dfb7ead73343d6e2d7ffe/pytokens-0.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5502408cab1cb18e128570f8d598981c68a50d0cbd7c61312a90507cd3a1276f", size = 254204, upload-time = "2026-01-30T01:03:14.886Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/d2/afe5c7f8607018beb99971489dbb846508f1b8f351fcefc225fcf4b2adc0/pytokens-0.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29d1d8fb1030af4d231789959f21821ab6325e463f0503a61d204343c9b355d1", size = 268423, upload-time = "2026-01-30T01:03:15.936Z" },
+    { url = "https://files.pythonhosted.org/packages/68/d4/00ffdbd370410c04e9591da9220a68dc1693ef7499173eb3e30d06e05ed1/pytokens-0.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:970b08dd6b86058b6dc07efe9e98414f5102974716232d10f32ff39701e841c4", size = 266859, upload-time = "2026-01-30T01:03:17.458Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/c9/c3161313b4ca0c601eeefabd3d3b576edaa9afdefd32da97210700e47652/pytokens-0.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:9bd7d7f544d362576be74f9d5901a22f317efc20046efe2034dced238cbbfe78", size = 103520, upload-time = "2026-01-30T01:03:18.652Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/a7/b470f672e6fc5fee0a01d9e75005a0e617e162381974213a945fcd274843/pytokens-0.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4a14d5f5fc78ce85e426aa159489e2d5961acf0e47575e08f35584009178e321", size = 160821, upload-time = "2026-01-30T01:03:19.684Z" },
+    { url = "https://files.pythonhosted.org/packages/80/98/e83a36fe8d170c911f864bfded690d2542bfcfacb9c649d11a9e6eb9dc41/pytokens-0.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97f50fd18543be72da51dd505e2ed20d2228c74e0464e4262e4899797803d7fa", size = 254263, upload-time = "2026-01-30T01:03:20.834Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/95/70d7041273890f9f97a24234c00b746e8da86df462620194cef1d411ddeb/pytokens-0.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc74c035f9bfca0255c1af77ddd2d6ae8419012805453e4b0e7513e17904545d", size = 268071, upload-time = "2026-01-30T01:03:21.888Z" },
+    { url = "https://files.pythonhosted.org/packages/da/79/76e6d09ae19c99404656d7db9c35dfd20f2086f3eb6ecb496b5b31163bad/pytokens-0.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f66a6bbe741bd431f6d741e617e0f39ec7257ca1f89089593479347cc4d13324", size = 271716, upload-time = "2026-01-30T01:03:23.633Z" },
+    { url = "https://files.pythonhosted.org/packages/79/37/482e55fa1602e0a7ff012661d8c946bafdc05e480ea5a32f4f7e336d4aa9/pytokens-0.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:b35d7e5ad269804f6697727702da3c517bb8a5228afa450ab0fa787732055fc9", size = 104539, upload-time = "2026-01-30T01:03:24.788Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e8/20e7db907c23f3d63b0be3b8a4fd1927f6da2395f5bcc7f72242bb963dfe/pytokens-0.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8fcb9ba3709ff77e77f1c7022ff11d13553f3c30299a9fe246a166903e9091eb", size = 168474, upload-time = "2026-01-30T01:03:26.428Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/81/88a95ee9fafdd8f5f3452107748fd04c24930d500b9aba9738f3ade642cc/pytokens-0.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79fc6b8699564e1f9b521582c35435f1bd32dd06822322ec44afdeba666d8cb3", size = 290473, upload-time = "2026-01-30T01:03:27.415Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/35/3aa899645e29b6375b4aed9f8d21df219e7c958c4c186b465e42ee0a06bf/pytokens-0.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d31b97b3de0f61571a124a00ffe9a81fb9939146c122c11060725bd5aea79975", size = 303485, upload-time = "2026-01-30T01:03:28.558Z" },
+    { url = "https://files.pythonhosted.org/packages/52/a0/07907b6ff512674d9b201859f7d212298c44933633c946703a20c25e9d81/pytokens-0.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:967cf6e3fd4adf7de8fc73cd3043754ae79c36475c1c11d514fc72cf5490094a", size = 306698, upload-time = "2026-01-30T01:03:29.653Z" },
+    { url = "https://files.pythonhosted.org/packages/39/2a/cbbf9250020a4a8dd53ba83a46c097b69e5eb49dd14e708f496f548c6612/pytokens-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:584c80c24b078eec1e227079d56dc22ff755e0ba8654d8383b2c549107528918", size = 116287, upload-time = "2026-01-30T01:03:30.912Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/78/397db326746f0a342855b81216ae1f0a32965deccfd7c830a2dbc66d2483/pytokens-0.4.1-py3-none-any.whl", hash = "sha256:26cef14744a8385f35d0e095dc8b3a7583f6c953c2e3d269c7f82484bf5ad2de", size = 13729, upload-time = "2026-01-30T01:03:45.029Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1071,6 +1239,11 @@ dev = [
     { name = "ruff" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "datamodel-code-generator" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "alembic", specifier = ">=1.13" },
@@ -1096,6 +1269,21 @@ requires-dist = [
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32" },
 ]
 provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "datamodel-code-generator", specifier = ">=0.57.0" }]
+
+[[package]]
+name = "typeguard"
+version = "4.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2b/e8/66e25efcc18542d58706ce4e50415710593721aae26e794ab1dec34fb66f/typeguard-4.5.1.tar.gz", hash = "sha256:f6f8ecbbc819c9bc749983cc67c02391e16a9b43b8b27f15dc70ed7c4a007274", size = 80121, upload-time = "2026-02-19T16:09:03.392Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/88/b55b3117287a8540b76dbdd87733808d4d01c8067a3b339408c250bb3600/typeguard-4.5.1-py3-none-any.whl", hash = "sha256:44d2bf329d49a244110a090b55f5f91aa82d9a9834ebfd30bcc73651e4a8cc40", size = 36745, upload-time = "2026-02-19T16:09:01.6Z" },
+]
 
 [[package]]
 name = "typing-extensions"

--- a/docs/adr/0020-trustedparts-sourcing-provider-split.md
+++ b/docs/adr/0020-trustedparts-sourcing-provider-split.md
@@ -30,6 +30,11 @@ Phase 5b sourcing alerts use the same domain boundary; see
 
 TrustedParts results must stay visibly distinct from catalog-provider data. Public or UI surfaces that combine distributor data from multiple origins need an explicit future decision before launch.
 
+The official TrustedParts Inventory API v2 OpenAPI document is bundled and used
+to generate Pydantic v2 models per [ADR-0022](0022-trustedparts-schema-version-pinning.md).
+The schema foundation is intentionally separate from wiring those generated
+models into the client.
+
 ## Reports policy: no persistent price history
 
 Reports may use TrustedParts prices only as a transient request-time input. The replenishment-cost report recomputes replacement cost from existing on-hand lot costs and the short-lived sourcing cache on each request (`backend/app/domain/reports/service.py:39`); it must not add a report-specific table, column, or long-lived price snapshot because that would turn cached TrustedParts offers into persistent price history.
@@ -68,5 +73,6 @@ This does not permit persistent TrustedParts price history or historical FX char
 - Source: `backend/app/api/routes/sourcing.py:87`
 - Related ADR: [ADR-0007](0007-provider-catalog-vs-spec-split.md)
 - Related ADR: [ADR-0021](0021-periodic-jobs-scheduler.md)
+- Related ADR: [ADR-0022](0022-trustedparts-schema-version-pinning.md)
 - Issue: `https://github.com/matescb/stockManager/issues/329`
 - Plan: `/home/matyas/.claude/plans/read-all-the-documentation-robust-giraffe.md`

--- a/docs/adr/0022-trustedparts-schema-version-pinning.md
+++ b/docs/adr/0022-trustedparts-schema-version-pinning.md
@@ -27,17 +27,20 @@ Bundle the official TrustedParts Inventory API v2 OpenAPI document at
 `backend/app/domain/sourcing/_generated/trustedparts_v2.py` with
 `datamodel-code-generator` and a fixed AUTO-GENERATED header.
 
-CI runs a `tp-schema-drift` job that refreshes the bundled schema, regenerates
-the models, and fails if the checked-in files change.
+CI runs a deterministic `tp-schema-drift` job that regenerates the models from
+the bundled schema and fails if the checked-in generated files change. CI does
+not fetch the live TrustedParts schema; operators refresh the bundle explicitly
+with `make refresh-tp-spec`.
 
 ## Consequences
 
 - **Good**: Schema changes are explicit in PR diffs, generated code is
   reproducible, and issue #449 can integrate typed TrustedParts DTOs without
   also establishing the schema supply chain.
-- **Trade-offs**: CI now depends on TrustedParts' Swagger endpoint for this
-  drift gate. If the endpoint is unavailable, the gate fails until the upstream
-  outage clears or the job is intentionally adjusted.
+- **Trade-offs**: Refreshing requires an explicit operator action, so upstream
+  schema changes are discovered when someone runs `make refresh-tp-spec` rather
+  than by a live CI fetch. The generated file is intentionally verbose and
+  reviewable as a committed artifact.
 - **What it forbids**: Hand-editing generated TrustedParts models, regenerating
   from an unofficial schema URL, or wiring the generated models into
   `client.py` before the client-integration PR.
@@ -47,6 +50,9 @@ the models, and fails if the checked-in files change.
 - **Generate directly from the remote URL in every developer workflow** —
   rejected because local model regeneration would not show which upstream schema
   was reviewed and committed.
+- **Fetch the live schema in CI** — rejected because CI would depend on
+  TrustedParts availability and stable network access instead of the bundled
+  source-of-truth artifact.
 - **Check in only the schema, not generated models** — rejected because import
   and header drift would not be caught before the integration PR.
 - **Vendor a manually edited schema subset** — rejected because it loses the

--- a/docs/adr/0022-trustedparts-schema-version-pinning.md
+++ b/docs/adr/0022-trustedparts-schema-version-pinning.md
@@ -1,0 +1,62 @@
+# ADR-0022: TrustedParts schema version pinning
+
+Audience: engineer
+
+- **Status**: Accepted
+- **Date**: 2026-05-10
+- **Supersedes**: —
+- **Superseded by**: —
+
+## Context
+
+TrustedParts Inventory API v2 is an external contract. The current client still
+uses hand-written DTOs, while follow-up work will use generated Pydantic models
+to reduce drift from the official OpenAPI schema. Without a bundled schema and a
+CI drift gate, generated code can silently lag behind the upstream Swagger UI.
+
+TrustedParts publishes the v2 Swagger UI from the official API host, and the UI
+loads `inventory-api-v2/swagger.json` (`Makefile:3`). The generated models live
+under the sourcing domain because ADR-0020 keeps procurement sourcing separate
+from catalog enrichment.
+
+## Decision
+
+Bundle the official TrustedParts Inventory API v2 OpenAPI document at
+`docs/schemas/trustedparts-v2.json`, formatted deterministically with `jq
+--sort-keys`. Generate Pydantic v2 models into
+`backend/app/domain/sourcing/_generated/trustedparts_v2.py` with
+`datamodel-code-generator` and a fixed AUTO-GENERATED header.
+
+CI runs a `tp-schema-drift` job that refreshes the bundled schema, regenerates
+the models, and fails if the checked-in files change.
+
+## Consequences
+
+- **Good**: Schema changes are explicit in PR diffs, generated code is
+  reproducible, and issue #449 can integrate typed TrustedParts DTOs without
+  also establishing the schema supply chain.
+- **Trade-offs**: CI now depends on TrustedParts' Swagger endpoint for this
+  drift gate. If the endpoint is unavailable, the gate fails until the upstream
+  outage clears or the job is intentionally adjusted.
+- **What it forbids**: Hand-editing generated TrustedParts models, regenerating
+  from an unofficial schema URL, or wiring the generated models into
+  `client.py` before the client-integration PR.
+
+## Alternatives considered
+
+- **Generate directly from the remote URL in every developer workflow** —
+  rejected because local model regeneration would not show which upstream schema
+  was reviewed and committed.
+- **Check in only the schema, not generated models** — rejected because import
+  and header drift would not be caught before the integration PR.
+- **Vendor a manually edited schema subset** — rejected because it loses the
+  official OpenAPI contract and makes upstream drift harder to audit.
+
+## References
+
+- Source: `Makefile:3`
+- Source: `docs/schemas/trustedparts-v2.json`
+- Source: `backend/app/domain/sourcing/_generated/trustedparts_v2.py`
+- Source: `.github/workflows/ci.yml`
+- Related ADR: [ADR-0020](0020-trustedparts-sourcing-provider-split.md)
+- Issue: `https://github.com/matescb/stockManager/issues/448`

--- a/docs/schemas/README.md
+++ b/docs/schemas/README.md
@@ -1,0 +1,29 @@
+# Bundled External Schemas
+
+Audience: engineer
+
+Pinned third-party API schemas used for drift checks and generated code.
+
+## TrustedParts Inventory API v2
+
+`trustedparts-v2.json` is the pretty-printed OpenAPI document served by
+TrustedParts' official Swagger UI:
+`https://api.trustedparts.com/swagger/inventory-api-v2/swagger.json`.
+
+Refresh and regenerate the checked-in Pydantic models from the repository root:
+
+```bash
+make refresh-tp-spec
+make regen-tp-models
+```
+
+`make refresh-tp-spec` sorts JSON keys with `jq` so the bundled schema is stable.
+`make regen-tp-models` writes
+`backend/app/domain/sourcing/_generated/trustedparts_v2.py` with a fixed
+AUTO-GENERATED header. The CI `tp-schema-drift` job runs both targets and fails
+if either the bundled schema or generated models differ from the committed
+copies.
+
+Do not wire these generated models into
+`backend/app/domain/sourcing/client.py` in the schema-foundation PR; issue #449
+owns that integration.

--- a/docs/schemas/README.md
+++ b/docs/schemas/README.md
@@ -18,11 +18,11 @@ make regen-tp-models
 ```
 
 `make refresh-tp-spec` sorts JSON keys with `jq` so the bundled schema is stable.
-`make regen-tp-models` writes
+Run it only when intentionally refreshing from TrustedParts. `make regen-tp-models` writes
 `backend/app/domain/sourcing/_generated/trustedparts_v2.py` with a fixed
-AUTO-GENERATED header. The CI `tp-schema-drift` job runs both targets and fails
-if either the bundled schema or generated models differ from the committed
-copies.
+AUTO-GENERATED header. The CI `tp-schema-drift` job regenerates models from the
+bundled schema and fails if generated models differ from the committed copies.
+CI does not fetch the live TrustedParts schema.
 
 Do not wire these generated models into
 `backend/app/domain/sourcing/client.py` in the schema-foundation PR; issue #449

--- a/docs/schemas/trustedparts-v2.json
+++ b/docs/schemas/trustedparts-v2.json
@@ -1,0 +1,534 @@
+{
+  "components": {
+    "schemas": {
+      "InventoryApiRequest": {
+        "additionalProperties": false,
+        "description": "Defines the information needed to submit a search query.",
+        "properties": {
+          "ApiKey": {
+            "description": "Enter your assigned API key.\nThe assigned API key can be found on the API Credentials page.\n            \nAlternatively, you may provide the API key in the X-Api-Key header and omit this parameter\nfrom the request.",
+            "example": "enter my api key",
+            "nullable": true,
+            "type": "string"
+          },
+          "CompanyId": {
+            "description": "Company identifier assigned to your account.\nThe assigned company identifier can be found on the API Credentials page.\n            \nThis property is deprecated, no longer required and may be omitted.",
+            "example": "enter my company id (deprecated)",
+            "nullable": true,
+            "type": "string"
+          },
+          "CountryCode": {
+            "description": "Enter a two-character ISO code or leave blank for geolocation.\n\nLeave this field blank if you would like us to geolocate the SourceIp parameter\nand use the country that the IP address is from. If you use the TrustedParts.com API\nto provide results on a website, this allows you to provide regional results to each\nuser without any effort on your part.",
+            "example": "US",
+            "nullable": true,
+            "type": "string"
+          },
+          "CurrencyCode": {
+            "default": "USD",
+            "description": "Enter a three-character ISO currency code. (Optional)",
+            "nullable": true,
+            "type": "string"
+          },
+          "Distributors": {
+            "description": "The distributors that will be included in this search.\nAdd this section to limit the search results to one or more distributors.\nOmit this section to search all authorized distributors.\nOur supported distributors can be found <a href=\"https://www.trustedparts.com/docs/api/distributors-list/\">here</a>.",
+            "example": [
+              "enter a distributor name or remove the optional Distributors parameter"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "ExactMatch": {
+            "default": false,
+            "description": "Set to true to view parts that match the search term exactly.\nSet to false to include partial match results.\nNote: Partial match results are only available for single part number requests.\nMost punctuation and spacing are ignored when determining what is an exact match.\nFor instance, BAT-54C is an exact match for BAT54C.",
+            "example": false,
+            "type": "boolean"
+          },
+          "InStockOnly": {
+            "default": false,
+            "description": "Set to true to view in-stock results only. (Optional)",
+            "example": false,
+            "type": "boolean"
+          },
+          "IsCrawler": {
+            "description": "Set to true if the end user is a crawler or bot (e.g. Google, Bing, Baidu).\nSet to false if the end user is not a crawler or if undetermined.",
+            "example": false,
+            "type": "boolean"
+          },
+          "LanguageCode": {
+            "default": "en",
+            "description": "Enter the ISO language code for part specification translations or leave blank for English.\n\nSupported values: \n\nde, en, es, fr, it, pt, ja, zh-hans, zh-hant",
+            "example": "en",
+            "nullable": true,
+            "type": "string"
+          },
+          "Queries": {
+            "description": "The part number(s) and manufacturer(s) you want to search for.\n\nAdd a separate query for each part number search.\n\nNote: If you enter multiple part numbers, an exact match search will be performed\nfor each part number. Partial match results are only available for single part number requests.",
+            "items": {
+              "$ref": "#/components/schemas/SearchQuery"
+            },
+            "type": "array"
+          },
+          "SourceIp": {
+            "description": "Provide the IP (Internet Protocol) address of the end user who will view the results.\nPlease ensure the accuracy of this value so that TrustedParts.com can verify\nthe identity of users who receive results. \n<b>Geolocation:</b> When the CountryCode parameter is omitted or left blank, the\nSourceIp parameter will be used to geolocate the request and provide regional results.",
+            "example": "enter my IP address",
+            "nullable": true,
+            "type": "string"
+          },
+          "UseCachedData": {
+            "default": false,
+            "description": "If this parameter is not supplied or set to false, the TrustedParts.com API\nwill provide results based on real-time stock and pricing services provided\nby participating distributors. This is the preferred setting since it yields\nthe most accurate results. However, if you need extremely fast responses or\nneed to submit a high volume of requests in a short period of time, you may\nset this parameter to true. This will direct the TrustedParts.com API to use\nan optimized search process that retrieves results from locally-cached data\ninstead of real-time data.",
+            "example": false,
+            "type": "boolean"
+          },
+          "UserAgent": {
+            "description": "Provide the user agent of the requesting application or end user's browser.\nPlease ensure the accuracy of this value so that TrustedParts.com can verify\nthe identity of users who receive results.",
+            "example": "enter my application user agent",
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "Queries"
+        ],
+        "type": "object"
+      },
+      "InventoryApiResponse": {
+        "additionalProperties": false,
+        "description": "Search results for a search query.",
+        "properties": {
+          "CurrentDate": {
+            "description": "Date and time that results were returned.",
+            "format": "date-time",
+            "type": "string"
+          },
+          "ErrorMessage": {
+            "description": "A message regarding an error generated by the search.",
+            "nullable": true,
+            "type": "string"
+          },
+          "Messages": {
+            "description": "Messages regarding the search results.",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "OriginalRequest": {
+            "$ref": "#/components/schemas/InventoryApiRequest"
+          },
+          "PartResults": {
+            "description": "The search results grouped by part number searched for.",
+            "items": {
+              "$ref": "#/components/schemas/InventoryPartResult"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "ResponseTime": {
+            "description": "The amount of time it took for the API to respond with results.",
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "InventoryDistributorResult": {
+        "additionalProperties": false,
+        "description": "Contains the information for a part that matched a search.",
+        "properties": {
+          "Compliance": {
+            "$ref": "#/components/schemas/ProductCompliance"
+          },
+          "Description": {
+            "description": "The part's description.",
+            "nullable": true,
+            "type": "string"
+          },
+          "DistributorPartNumber": {
+            "description": "The distributor part number.",
+            "nullable": true,
+            "type": "string"
+          },
+          "Links": {
+            "description": "Links. For example, datasheet URL or distributor product URL.",
+            "items": {
+              "$ref": "#/components/schemas/SearchApiLink"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "Packaging": {
+            "description": "Packaging information.",
+            "items": {
+              "$ref": "#/components/schemas/ProductPackageType"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "Pricing": {
+            "$ref": "#/components/schemas/ProductPricing"
+          },
+          "Stock": {
+            "$ref": "#/components/schemas/StockInfo"
+          }
+        },
+        "type": "object"
+      },
+      "InventoryPartResult": {
+        "additionalProperties": false,
+        "description": "Contains search result information for a part number.",
+        "properties": {
+          "Distributors": {
+            "description": "The distributors with matches.",
+            "items": {
+              "$ref": "#/components/schemas/PartDistributor"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "IsAffectedByTariff": {
+            "description": "Have TrustedParts.com distributors indicated that the part is affected by tariffs in the United States?",
+            "type": "boolean"
+          },
+          "LifecycleRisk": {
+            "description": "Lifecycle risk of a matching part.\n            \nPlease email user-requests@trustedparts.com to see if our policies allow this information\nto be provided to you.",
+            "nullable": true,
+            "type": "string"
+          },
+          "Manufacturer": {
+            "description": "The manufacturer name for the result.",
+            "nullable": true,
+            "type": "string"
+          },
+          "ManufacturerId": {
+            "description": "The TrustedParts manufacturer ID for the result.",
+            "format": "int32",
+            "type": "integer"
+          },
+          "PartNumber": {
+            "description": "The manufacturer part number for the result.",
+            "nullable": true,
+            "type": "string"
+          },
+          "ProductUrl": {
+            "description": "The TrustedParts.com product page for the result.",
+            "nullable": true,
+            "type": "string"
+          },
+          "Specifications": {
+            "description": "Specifications of a matching part.\n            \nPlease email user-requests@trustedparts.com to see if our policies allow this information\nto be provided to you.",
+            "items": {
+              "$ref": "#/components/schemas/PartSpecification"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "SupplyChainRisk": {
+            "description": "Supply Chain risk of a matching part.\n            \nPlease email user-requests@trustedparts.com to see if our policies allow this information\nto be provided to you.",
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "PartDistributor": {
+        "additionalProperties": false,
+        "description": "Contains the information for a distributor that has search results.",
+        "properties": {
+          "DistributorResults": {
+            "description": "The list of matched manufacturer parts.",
+            "items": {
+              "$ref": "#/components/schemas/InventoryDistributorResult"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "Id": {
+            "description": "Distributor Id",
+            "format": "int32",
+            "type": "integer"
+          },
+          "Name": {
+            "description": "Distributor name.",
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "PartSpecification": {
+        "additionalProperties": false,
+        "description": "Contains part specifications for the part result.",
+        "properties": {
+          "Key": {
+            "description": "The specification name",
+            "nullable": true,
+            "type": "string"
+          },
+          "Value": {
+            "description": "The specification value",
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "Price": {
+        "additionalProperties": false,
+        "description": "Contains price information for a specific quantity.",
+        "properties": {
+          "Amount": {
+            "description": "Price amount",
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "FormattedAmount": {
+            "description": "Formatted price amount",
+            "nullable": true,
+            "type": "string"
+          },
+          "Quantity": {
+            "description": "Quantity for price",
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "Text": {
+            "description": "Text representation of price",
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ProductCompliance": {
+        "additionalProperties": false,
+        "description": "Contains regulatory compliance information for products.",
+        "properties": {
+          "RoHS": {
+            "description": "Contains regional RoHS compliance information for products.",
+            "items": {
+              "$ref": "#/components/schemas/RohsCompliance"
+            },
+            "nullable": true,
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "ProductPackageType": {
+        "additionalProperties": false,
+        "description": "Contains product package type information.",
+        "properties": {
+          "MinimumOrderQuantity": {
+            "description": "Minimum order quantity",
+            "format": "int32",
+            "nullable": true,
+            "type": "integer"
+          },
+          "PackageType": {
+            "description": "Package type",
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ProductPricing": {
+        "additionalProperties": false,
+        "description": "Contains pricing information for products.",
+        "properties": {
+          "CurrencyCode": {
+            "description": "Currency code for the pricing amounts (e.g., \"USD\").",
+            "nullable": true,
+            "type": "string"
+          },
+          "MinimumQuantity": {
+            "description": "Minimum order quantity for the price.",
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "Prices": {
+            "description": "List of prices for specific quantities.",
+            "items": {
+              "$ref": "#/components/schemas/Price"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "QuantityMultiple": {
+            "description": "Quanitity multiple",
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          }
+        },
+        "type": "object"
+      },
+      "RohsCompliance": {
+        "additionalProperties": false,
+        "description": "Contains RoHS compliance information for products.",
+        "properties": {
+          "Description": {
+            "description": "Description of RoHS compliance",
+            "nullable": true,
+            "type": "string"
+          },
+          "IsCompliant": {
+            "description": "Is the product RoHS compliant?",
+            "nullable": true,
+            "type": "boolean"
+          },
+          "Region": {
+            "description": "Region for the RoHS compliance information",
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "SearchApiLink": {
+        "additionalProperties": false,
+        "description": "Contains a link (URL) with a type.",
+        "properties": {
+          "Type": {
+            "description": "Type of link (e.g., \"datasheet\", \"distributor\")",
+            "nullable": true,
+            "type": "string"
+          },
+          "Url": {
+            "description": "URL of the link.",
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "SearchQuery": {
+        "additionalProperties": false,
+        "description": "Represents a single search query.",
+        "properties": {
+          "Manufacturers": {
+            "description": "The manufacturers that will be searched.\nAdd this section to limit the search results to one more more manufacturers.\nOmit this section to search all authorized manufacturers.\nOur supported manufacturers can be found <a href=\"https://www.trustedparts.com/docs/api/manufacturers-list/\">here</a>.",
+            "example": [
+              "enter a manufacturer name or remove the optional Manufacturers parameter"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "SearchToken": {
+            "description": "Enter the search term. The search term must be at least two characters and no more than 100 characters.",
+            "example": "bav99",
+            "maxLength": 100,
+            "minLength": 2,
+            "type": "string"
+          }
+        },
+        "required": [
+          "SearchToken"
+        ],
+        "type": "object"
+      },
+      "StockInfo": {
+        "additionalProperties": false,
+        "description": "Contains stock information for an api search result.",
+        "properties": {
+          "Availability": {
+            "description": "Contains a message about stock availability. For instance, \"In Stock\".",
+            "nullable": true,
+            "type": "string"
+          },
+          "QuantityOnHand": {
+            "description": "Indicates number of parts currently on hand. Will be null if we are not going to disclose the exact number.",
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          }
+        },
+        "type": "object"
+      }
+    },
+    "securitySchemes": {
+      "ApiKey": {
+        "description": "API Key. Use 'X-Api-Key: {apiKey}' header.",
+        "in": "header",
+        "name": "X-Api-Key",
+        "type": "apiKey"
+      }
+    }
+  },
+  "info": {
+    "description": "Pricing and Stock information for available parts.",
+    "title": "TrustedParts.com Inventory API",
+    "version": "2.0"
+  },
+  "openapi": "3.0.4",
+  "paths": {
+    "/v2/search": {
+      "post": {
+        "description": "Submits a search request to the TrustedParts.com API and returns matching inventory results.",
+        "operationId": "InventorySearchV2",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InventoryApiRequest"
+              }
+            },
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/InventoryApiRequest"
+              }
+            }
+          },
+          "description": "Your search request."
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InventoryApiResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/InventoryApiResponse"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Get TrustedParts.com Inventory API search results",
+        "tags": [
+          "InventoryApiV2"
+        ]
+      }
+    }
+  },
+  "security": [
+    {
+      "ApiKey": []
+    }
+  ],
+  "servers": [
+    {
+      "url": "https://api.trustedparts.com"
+    }
+  ],
+  "tags": [
+    {
+      "name": "InventoryApiV2"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Bundles the official TrustedParts Inventory API v2 OpenAPI document from `https://api.trustedparts.com/swagger/inventory-api-v2/swagger.json` as `docs/schemas/trustedparts-v2.json` with deterministic `jq --sort-keys` formatting.
- Adds deterministic `make refresh-tp-spec` and `make regen-tp-models` targets, plus generated Pydantic v2 models under `backend/app/domain/sourcing/_generated/` with an AUTO-GENERATED header.
- Adds ADR-0022, cross-links ADR-0020, documents the schema workflow, and adds a deterministic `tp-schema-drift` CI gate wired directly into deploy needs.
- Adds focused tests for bundled schema loadability and generated module import/header.

## Tests
- `make refresh-tp-spec`
- `make regen-tp-models && git diff --exit-code -- backend/app/domain/sourcing/_generated/`
- `uv run python -m pytest -q -k tp_schema_bundled` (2 passed)
- `uv run ruff check tests/test_tp_schema_bundled.py --output-format=concise`
- `LINT_CMD="ruff check app --output-format=concise" BASELINE_FILE="../.ruff-baseline.txt" WORK_DIR="." bash ../scripts/lint-delta.sh`
- `uv lock --check`
- `git diff --check` / `git diff --cached --check`

## Notes
- `backend/app/domain/sourcing/client.py` was intentionally untouched; #449 owns wiring generated TrustedParts types into the client.
- The new `tp-schema-drift` job does not fetch the live TrustedParts schema in CI. It regenerates models from the bundled schema and fails on generated-model drift; live refresh is an explicit operator action through `make refresh-tp-spec`.
- Merge order: #448 before #449/#451/#452/#453/#454/#455/#456/#457.

Refs #448
