### PR TITLE
TPS-2: Validate TP responses via generated types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ the canonical record.
 
 ## 2026-05 — feedback brief fixes
 
+- **TPS-2 / #449** TrustedParts responses are now validated through the
+  generated Inventory API v2 models before app DTO mapping; auth moved to the
+  `X-Api-Key` header, deprecated `CompanyId` is no longer sent, and TP
+  `ErrorMessage` bodies now surface as upstream errors instead of empty results.
 - **FB-007 / #437** Active sourcing lists now backfill saved workspace
   sourcing defaults: `active_distributors` is unioned with preferred
   distributors, and saved country/currency values are appended when missing.

--- a/backend/app/api/routes/sourcing.py
+++ b/backend/app/api/routes/sourcing.py
@@ -142,6 +142,8 @@ def search_sourcing(
             "server_error",
             "TrustedParts request timed out",
         )
+    except ValueError as exc:
+        return _error_response(request, 422, "validation_error", str(exc))
     except SourcingClientError:
         return _error_response(
             request,
@@ -300,6 +302,8 @@ def source_project_bom(
             "server_error",
             "TrustedParts request timed out",
         )
+    except ValueError as exc:
+        return _error_response(request, 422, "validation_error", str(exc))
     except SourcingClientError:
         return _error_response(
             request,
@@ -365,6 +369,8 @@ def create_project_purchase_plan(
             "server_error",
             "TrustedParts request timed out",
         )
+    except ValueError as exc:
+        return _error_response(request, 422, "validation_error", str(exc))
     except SourcingClientError:
         return _error_response(
             request,
@@ -424,6 +430,8 @@ def refresh_purchase_plan(
             "server_error",
             "TrustedParts request timed out",
         )
+    except ValueError as exc:
+        return _error_response(request, 422, "validation_error", str(exc))
     except SourcingClientError:
         return _error_response(
             request,
@@ -531,6 +539,8 @@ def get_part_sourcing(
             "server_error",
             "TrustedParts request timed out",
         )
+    except ValueError as exc:
+        return _error_response(request, 422, "validation_error", str(exc))
     except SourcingClientError:
         return _error_response(
             request,
@@ -594,6 +604,8 @@ def refresh_part_sourcing(
             "server_error",
             "TrustedParts request timed out",
         )
+    except ValueError as exc:
+        return _error_response(request, 422, "validation_error", str(exc))
     except SourcingClientError:
         return _error_response(
             request,

--- a/backend/app/domain/sourcing/client.py
+++ b/backend/app/domain/sourcing/client.py
@@ -1,11 +1,24 @@
 """TrustedParts API v2 client for live sourcing lookups."""
+
 from __future__ import annotations
 
+import hashlib
+import json
+import logging
 from typing import Any
 
 import httpx
 from pydantic import ValidationError as PydanticValidationError
 
+from app.domain.sourcing._generated.trustedparts_v2 import (
+    InventoryApiResponse,
+    InventoryDistributorResult,
+    InventoryPartResult,
+    Price,
+    ProductPackageType,
+    ProductPricing,
+    SearchApiLink,
+)
 from app.domain.sourcing.schemas import (
     SourcingDistributor,
     SourcingLinks,
@@ -18,6 +31,10 @@ from app.domain.sourcing.schemas import (
 TP_V2_URL = "https://api.trustedparts.com/v2/search"
 TP_TIMEOUT_SECONDS = 8.0
 MAX_TP_QUERIES = 50
+MIN_SEARCH_TOKEN_LENGTH = 2
+MAX_SEARCH_TOKEN_LENGTH = 100
+
+logger = logging.getLogger(__name__)
 
 
 class SourcingClientError(Exception):
@@ -44,16 +61,17 @@ class SourcingValidationError(SourcingClientError):
     """TrustedParts returned a response this client cannot parse."""
 
 
-def _post_tp(url: str, json: dict[str, Any]) -> tuple[int, dict[str, Any]]:
+def _post_tp(
+    url: str,
+    json_body: dict[str, Any],
+    headers: dict[str, str],
+) -> tuple[int, dict[str, Any]]:
     """Network seam — monkeypatched in tests. Returns (status_code, body_dict)."""
     with httpx.Client(timeout=TP_TIMEOUT_SECONDS) as client:
         response = client.post(
             url,
-            json=json,
-            headers={
-                "Accept": "application/json",
-                "Content-Type": "application/json",
-            },
+            json=json_body,
+            headers=headers,
         )
     try:
         body = response.json()
@@ -99,6 +117,7 @@ class TrustedPartsClient:
             raise ValueError("TrustedParts search requires at least one query")
         if len(queries) > MAX_TP_QUERIES:
             raise ValueError("TrustedParts search accepts at most 50 queries")
+        _validate_search_tokens(queries)
 
         payload = self._payload(
             queries,
@@ -108,8 +127,9 @@ class TrustedPartsClient:
             use_cached_data=use_cached_data,
             is_crawler=is_crawler,
         )
+        request_hash = _request_hash(payload)
         try:
-            status, body = _post_tp(TP_V2_URL, payload)
+            status, body = _post_tp(TP_V2_URL, payload, _headers(self.api_key))
         except (httpx.TimeoutException, httpx.ConnectError) as exc:
             raise SourcingTimeoutError("TrustedParts request timed out") from exc
 
@@ -122,7 +142,13 @@ class TrustedPartsClient:
         if not 200 <= status <= 299:
             raise SourcingClientError(f"TrustedParts returned HTTP {status}")
 
-        return _parse_search_response(body)
+        validated = _validate_inventory_response(body, request_hash)
+        _handle_tp_messages(validated, request_hash)
+        error_message = _str_or_none(validated.ErrorMessage)
+        if error_message:
+            raise SourcingUpstreamError(f"TP error: {error_message}")
+
+        return _parse_search_response(validated)
 
     def _payload(
         self,
@@ -135,8 +161,6 @@ class TrustedPartsClient:
         is_crawler: bool,
     ) -> dict[str, Any]:
         payload: dict[str, Any] = {
-            "CompanyId": self.company_id,
-            "ApiKey": self.api_key,
             "CountryCode": self.country_code,
             "CurrencyCode": self.currency_code,
             "UserAgent": self.user_agent,
@@ -158,41 +182,97 @@ def _query_payload(query: SourcingQuery) -> dict[str, Any]:
     return item
 
 
-def _parse_search_response(body: dict[str, Any]) -> SourcingSearchRaw:
-    part_results = body.get("PartResults")
-    if not isinstance(part_results, list):
+def _headers(api_key: str) -> dict[str, str]:
+    return {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "X-Api-Key": api_key,
+    }
+
+
+def _validate_search_tokens(queries: list[SourcingQuery]) -> None:
+    for query in queries:
+        token_length = len(query.search_token)
+        if token_length < MIN_SEARCH_TOKEN_LENGTH or token_length > MAX_SEARCH_TOKEN_LENGTH:
+            raise ValueError("TrustedParts SearchToken length must be between 2 and 100")
+
+
+def _request_hash(payload: dict[str, Any]) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _validate_inventory_response(
+    body: dict[str, Any],
+    request_hash: str,
+) -> InventoryApiResponse:
+    try:
+        return InventoryApiResponse.model_validate(body)
+    except PydanticValidationError as exc:
+        logger.warning(
+            "TrustedParts response validation failed request_hash=%s errors=%s",
+            request_hash,
+            _validation_error_summary(exc),
+            extra={
+                "request_hash": request_hash,
+                "validation_errors": _validation_error_summary(exc),
+            },
+        )
+        raise SourcingValidationError(
+            "TrustedParts response did not match generated schema"
+        ) from exc
+
+
+def _validation_error_summary(exc: PydanticValidationError) -> list[dict[str, str]]:
+    return [
+        {
+            "type": str(error["type"]),
+            "path": ".".join(str(part) for part in error["loc"]),
+        }
+        for error in exc.errors(
+            include_url=False,
+            include_context=False,
+            include_input=False,
+        )
+    ]
+
+
+def _handle_tp_messages(response: InventoryApiResponse, request_hash: str) -> None:
+    for message in response.Messages or []:
+        logger.info(
+            "TrustedParts tp_message: %s",
+            message,
+            extra={"request_hash": request_hash, "tp_message": message},
+        )
+
+
+def _parse_search_response(response: InventoryApiResponse) -> SourcingSearchRaw:
+    part_results = response.PartResults
+    if part_results is None:
         raise SourcingValidationError("TrustedParts response PartResults is not a list")
 
     offers: list[SourcingOffer] = []
     for part in part_results:
-        if not isinstance(part, dict):
-            raise SourcingValidationError("TrustedParts response contains an invalid part")
         offers.append(_offer_from_part(part))
 
-    request_id = body.get("RequestId") or body.get("RequestID") or body.get("request_id")
-    if request_id is not None and not isinstance(request_id, str):
-        request_id = str(request_id)
-
     try:
-        return SourcingSearchRaw.model_validate(
-            {"offers": offers, "request_id": request_id}
-        )
+        return SourcingSearchRaw.model_validate({"offers": offers, "request_id": None})
     except PydanticValidationError as exc:
         raise SourcingValidationError("TrustedParts response did not match sourcing DTOs") from exc
 
 
-def _offer_from_part(part: dict[str, Any]) -> SourcingOffer:
+def _offer_from_part(part: InventoryPartResult) -> SourcingOffer:
     distributors: list[SourcingDistributor] = []
     description: str | None = None
     datasheet_url: str | None = None
     manufacturer_url: str | None = None
 
-    for distributor in _list_of_dicts(part.get("Distributors"), "Distributors"):
-        name = _str_or_none(distributor.get("Name")) or ""
-        for result in _list_of_dicts(distributor.get("DistributorResults"), "DistributorResults"):
+    for distributor in part.Distributors or []:
+        name = _str_or_none(distributor.Name) or ""
+        for result in distributor.DistributorResults or []:
             if description is None:
-                description = _str_or_none(result.get("Description"))
-            links = _links_by_type(result.get("Links"))
+                description = _str_or_none(result.Description)
+            links = _links_by_type(result.Links)
             if datasheet_url is None:
                 datasheet_url = _first_matching_link(links, "datasheet")
             if manufacturer_url is None:
@@ -202,12 +282,12 @@ def _offer_from_part(part: dict[str, Any]) -> SourcingOffer:
     try:
         return SourcingOffer.model_validate(
             {
-                "mpn": _str_or_none(part.get("PartNumber")) or "",
-                "manufacturer": _str_or_none(part.get("Manufacturer")),
+                "mpn": _str_or_none(part.PartNumber) or "",
+                "manufacturer": _str_or_none(part.Manufacturer),
                 "description": description,
                 "distributors": distributors,
                 "links": SourcingLinks(
-                    primary=_str_or_none(part.get("ProductUrl")),
+                    primary=_str_or_none(part.ProductUrl),
                     manufacturer=manufacturer_url,
                     datasheet=datasheet_url,
                 ),
@@ -219,23 +299,13 @@ def _offer_from_part(part: dict[str, Any]) -> SourcingOffer:
 
 def _distributor_from_result(
     distributor_name: str,
-    result: dict[str, Any],
+    result: InventoryDistributorResult,
     links: dict[str, str],
 ) -> SourcingDistributor:
-    pricing = result.get("Pricing")
-    if pricing is None:
-        pricing = {}
-    if not isinstance(pricing, dict):
-        raise SourcingValidationError("TrustedParts Pricing is not an object")
-
-    stock = result.get("Stock")
-    if stock is None:
-        stock = {}
-    if not isinstance(stock, dict):
-        raise SourcingValidationError("TrustedParts Stock is not an object")
-
-    packages = _list_of_dicts(result.get("Packaging"), "Packaging")
-    price_breaks = _price_breaks(pricing.get("Prices"))
+    pricing = result.Pricing
+    stock = result.Stock
+    packages = result.Packaging or []
+    price_breaks = _price_breaks(pricing.Prices if pricing is not None else None)
     product_url = (
         _first_matching_link(links, "distributor")
         or _first_matching_link(links, "product")
@@ -246,49 +316,42 @@ def _distributor_from_result(
         return SourcingDistributor.model_validate(
             {
                 "name": distributor_name,
-                "sku": _str_or_none(result.get("DistributorPartNumber")),
+                "sku": _str_or_none(result.DistributorPartNumber),
                 "packaging": _first_package_type(packages),
                 "moq": _moq(packages, pricing),
                 "lead_time_days": None,
-                "stock": _int_or_none(stock.get("QuantityOnHand")),
+                "stock": _int_or_none(stock.QuantityOnHand if stock is not None else None),
                 "unit_price": price_breaks[0].unit_price if price_breaks else None,
-                "currency": _str_or_none(pricing.get("CurrencyCode")),
+                "currency": _str_or_none(pricing.CurrencyCode if pricing is not None else None),
                 "price_breaks": price_breaks,
                 "product_url": product_url,
             }
         )
     except PydanticValidationError as exc:
-        raise SourcingValidationError(
-            "TrustedParts distributor result did not match DTOs"
-        ) from exc
+        raise SourcingValidationError("TrustedParts distributor result did not match DTOs") from exc
 
 
-def _price_breaks(raw_prices: Any) -> list[SourcingPriceBreak]:
-    price_rows = _list_of_dicts(raw_prices, "Prices")
+def _price_breaks(price_rows: list[Price] | None) -> list[SourcingPriceBreak]:
     breaks: list[SourcingPriceBreak] = []
-    for row in price_rows:
-        quantity = _int_or_none(row.get("Quantity"))
-        amount = _float_or_none(row.get("Amount"))
+    for row in price_rows or []:
+        quantity = _int_or_none(row.Quantity)
+        amount = _float_or_none(row.Amount)
         if quantity is None or amount is None:
             continue
         try:
             breaks.append(
-                SourcingPriceBreak.model_validate(
-                    {"quantity": quantity, "unit_price": amount}
-                )
+                SourcingPriceBreak.model_validate({"quantity": quantity, "unit_price": amount})
             )
         except PydanticValidationError as exc:
-            raise SourcingValidationError(
-                "TrustedParts price break did not match DTOs"
-            ) from exc
+            raise SourcingValidationError("TrustedParts price break did not match DTOs") from exc
     return breaks
 
 
-def _links_by_type(raw_links: Any) -> dict[str, str]:
+def _links_by_type(raw_links: list[SearchApiLink] | None) -> dict[str, str]:
     links: dict[str, str] = {}
-    for link in _list_of_dicts(raw_links, "Links"):
-        link_type = _str_or_none(link.get("Type"))
-        url = _str_or_none(link.get("Url"))
+    for link in raw_links or []:
+        link_type = _str_or_none(link.Type)
+        url = _str_or_none(link.Url)
         if link_type and url:
             links[link_type.lower()] = url
     return links
@@ -308,36 +371,26 @@ def _first_non_matching_link(links: dict[str, str], needles: set[str]) -> str | 
     return None
 
 
-def _list_of_dicts(raw_items: Any, field_name: str) -> list[dict[str, Any]]:
-    if raw_items is None:
-        return []
-    if not isinstance(raw_items, list):
-        raise SourcingValidationError(f"TrustedParts {field_name} is not a list")
-    items: list[dict[str, Any]] = []
-    for item in raw_items:
-        if not isinstance(item, dict):
-            raise SourcingValidationError(f"TrustedParts {field_name} contains a non-object")
-        items.append(item)
-    return items
-
-
-def _first_package_type(packages: list[dict[str, Any]]) -> str | None:
+def _first_package_type(packages: list[ProductPackageType]) -> str | None:
     for package in packages:
-        value = _str_or_none(package.get("PackageType"))
+        value = _str_or_none(package.PackageType)
         if value:
             return value
     return None
 
 
-def _moq(packages: list[dict[str, Any]], pricing: dict[str, Any]) -> int | None:
+def _moq(
+    packages: list[ProductPackageType],
+    pricing: ProductPricing | None,
+) -> int | None:
     values = [
         value
         for package in packages
-        if (value := _int_or_none(package.get("MinimumOrderQuantity"))) is not None
+        if (value := _int_or_none(package.MinimumOrderQuantity)) is not None
     ]
     if values:
         return min(values)
-    return _int_or_none(pricing.get("MinimumQuantity"))
+    return _int_or_none(pricing.MinimumQuantity if pricing is not None else None)
 
 
 def _str_or_none(value: Any) -> str | None:

--- a/backend/app/domain/sourcing/client.py
+++ b/backend/app/domain/sourcing/client.py
@@ -142,13 +142,17 @@ class TrustedPartsClient:
         if not 200 <= status <= 299:
             raise SourcingClientError(f"TrustedParts returned HTTP {status}")
 
-        validated = _validate_inventory_response(body, request_hash)
+        request_id = _legacy_request_id(body)
+        validated = _validate_inventory_response(
+            _body_without_legacy_request_id(body),
+            request_hash,
+        )
         _handle_tp_messages(validated, request_hash)
         error_message = _str_or_none(validated.ErrorMessage)
         if error_message:
             raise SourcingUpstreamError(f"TP error: {error_message}")
 
-        return _parse_search_response(validated)
+        return _parse_search_response(validated, request_id=request_id)
 
     def _payload(
         self,
@@ -223,6 +227,22 @@ def _validate_inventory_response(
         ) from exc
 
 
+def _legacy_request_id(body: dict[str, Any]) -> str | None:
+    for key in ("RequestId", "RequestID", "request_id"):
+        if key not in body:
+            continue
+        value = body[key]
+        return value if isinstance(value, str) else str(value)
+    return None
+
+
+def _body_without_legacy_request_id(body: dict[str, Any]) -> dict[str, Any]:
+    cleaned = dict(body)
+    for key in ("RequestId", "RequestID", "request_id"):
+        cleaned.pop(key, None)
+    return cleaned
+
+
 def _validation_error_summary(exc: PydanticValidationError) -> list[dict[str, str]]:
     return [
         {
@@ -246,7 +266,11 @@ def _handle_tp_messages(response: InventoryApiResponse, request_hash: str) -> No
         )
 
 
-def _parse_search_response(response: InventoryApiResponse) -> SourcingSearchRaw:
+def _parse_search_response(
+    response: InventoryApiResponse,
+    *,
+    request_id: str | None,
+) -> SourcingSearchRaw:
     part_results = response.PartResults
     if part_results is None:
         raise SourcingValidationError("TrustedParts response PartResults is not a list")
@@ -256,7 +280,9 @@ def _parse_search_response(response: InventoryApiResponse) -> SourcingSearchRaw:
         offers.append(_offer_from_part(part))
 
     try:
-        return SourcingSearchRaw.model_validate({"offers": offers, "request_id": None})
+        return SourcingSearchRaw.model_validate(
+            {"offers": offers, "request_id": request_id}
+        )
     except PydanticValidationError as exc:
         raise SourcingValidationError("TrustedParts response did not match sourcing DTOs") from exc
 

--- a/backend/app/domain/sourcing/factory.py
+++ b/backend/app/domain/sourcing/factory.py
@@ -14,15 +14,12 @@ def make_sourcing_provider(workspace: Any) -> TrustedPartsClient | None:
     if workspace.sourcing_provider != "trustedparts" or not workspace.sourcing_api_key_enc:
         return None
 
-    company_id = (
-        decrypt(workspace.sourcing_company_id_enc) if workspace.sourcing_company_id_enc else None
-    )
     api_key = decrypt(workspace.sourcing_api_key_enc)
     if not api_key:
         return None
 
     return TrustedPartsClient(
-        company_id=company_id or "",
+        company_id="",
         api_key=api_key,
         country_code=workspace.sourcing_country_code,
         currency_code=workspace.sourcing_currency_code,

--- a/backend/app/domain/sourcing/factory.py
+++ b/backend/app/domain/sourcing/factory.py
@@ -11,20 +11,18 @@ from app.domain.sourcing.client import TrustedPartsClient
 
 def make_sourcing_provider(workspace: Any) -> TrustedPartsClient | None:
     """Return a TrustedParts client for a configured workspace."""
-    if (
-        workspace.sourcing_provider != "trustedparts"
-        or not workspace.sourcing_company_id_enc
-        or not workspace.sourcing_api_key_enc
-    ):
+    if workspace.sourcing_provider != "trustedparts" or not workspace.sourcing_api_key_enc:
         return None
 
-    company_id = decrypt(workspace.sourcing_company_id_enc)
+    company_id = (
+        decrypt(workspace.sourcing_company_id_enc) if workspace.sourcing_company_id_enc else None
+    )
     api_key = decrypt(workspace.sourcing_api_key_enc)
-    if not company_id or not api_key:
+    if not api_key:
         return None
 
     return TrustedPartsClient(
-        company_id=company_id,
+        company_id=company_id or "",
         api_key=api_key,
         country_code=workspace.sourcing_country_code,
         currency_code=workspace.sourcing_currency_code,

--- a/backend/app/domain/sourcing/service.py
+++ b/backend/app/domain/sourcing/service.py
@@ -899,6 +899,8 @@ def search(
     clean_mpns = [mpn.strip() for mpn in mpns]
     if not 1 <= len(clean_mpns) <= 50 or any(not mpn for mpn in clean_mpns):
         raise ValueError("sourcing search requires 1 to 50 non-empty MPNs")
+    if any(len(mpn) < 2 or len(mpn) > 100 for mpn in clean_mpns):
+        raise ValueError("TrustedParts SearchToken length must be between 2 and 100")
 
     provider = make_sourcing_provider(workspace)
     if provider is None:

--- a/backend/tests/test_sourcing_bom_integration.py
+++ b/backend/tests/test_sourcing_bom_integration.py
@@ -27,13 +27,19 @@ class _TrustedPartsPost:
         cls.distributor_by_workspace = {}
 
     @classmethod
-    def post(cls, url: str, json: dict[str, Any]) -> tuple[int, dict[str, Any]]:
+    def post(
+        cls,
+        url: str,
+        json: dict[str, Any],
+        headers: dict[str, str],
+    ) -> tuple[int, dict[str, Any]]:
         queries = json["Queries"]
+        credential_id = headers["X-Api-Key"].removeprefix("api-key-")
         cls.calls.append(
             {
                 "url": url,
                 "queries": [query["SearchToken"] for query in queries],
-                "company_id": json["CompanyId"],
+                "company_id": credential_id,
                 "use_cached_data": json["UseCachedData"],
                 "distributors": json.get("Distributors"),
             }
@@ -41,9 +47,8 @@ class _TrustedPartsPost:
         return (
             200,
             {
-                "RequestId": f"tp-{len(cls.calls)}",
                 "PartResults": [
-                    _tp_part_result(query["SearchToken"], json["CompanyId"])
+                    _tp_part_result(query["SearchToken"], credential_id)
                     for query in queries
                     if query["SearchToken"] not in cls.missing_mpns
                 ],

--- a/backend/tests/test_sourcing_client.py
+++ b/backend/tests/test_sourcing_client.py
@@ -32,7 +32,6 @@ def _query(token: str = "STM32F103C8T6") -> SourcingQuery:
 
 def _trustedparts_response() -> dict:
     return {
-        "RequestId": "req-1",
         "PartResults": [
             {
                 "PartNumber": "STM32F103C8T6",
@@ -83,13 +82,13 @@ def test_happy_path_returns_offers(monkeypatch):
     monkeypatch.setattr(
         sourcing_client,
         "_post_tp",
-        lambda url, json: (200, _trustedparts_response()),
+        lambda url, json_body, headers: (200, _trustedparts_response()),
     )
 
     result = _client().search([_query()])
 
     assert isinstance(result, SourcingSearchRaw)
-    assert result.request_id == "req-1"
+    assert result.request_id is None
     assert result.offers[0].mpn == "STM32F103C8T6"
     assert result.offers[0].manufacturer == "STMicroelectronics"
     assert result.offers[0].description == "MCU 32-bit ARM Cortex-M3"
@@ -110,8 +109,9 @@ def test_happy_path_returns_offers(monkeypatch):
 def test_request_payload_shape(monkeypatch):
     captured: dict[str, dict] = {}
 
-    def fake_post(url, json):
-        captured["json"] = json
+    def fake_post(url, json_body, headers):
+        captured["json"] = json_body
+        captured["headers"] = headers
         return 200, {"PartResults": []}
 
     monkeypatch.setattr(sourcing_client, "_post_tp", fake_post)
@@ -130,8 +130,6 @@ def test_request_payload_shape(monkeypatch):
     )
 
     payload = captured["json"]
-    assert payload["CompanyId"] == "company-1"
-    assert payload["ApiKey"] == "api-key-1"
     assert payload["CountryCode"] == "CZ"
     assert payload["CurrencyCode"] == "EUR"
     assert payload["UserAgent"] == "stockManager/test workspace=ws-1"
@@ -145,12 +143,70 @@ def test_request_payload_shape(monkeypatch):
         {"SearchToken": "BAV99"},
     ]
     assert "SourceIp" not in payload
+    assert "ApiKey" not in payload
+    assert "CompanyId" not in payload
+    assert captured["headers"]["X-Api-Key"] == "api-key-1"
+
+
+def test_api_key_sent_in_x_api_key_header_not_body(monkeypatch):
+    captured: dict[str, dict] = {}
+
+    def fake_post(url, json_body, headers):
+        captured["body"] = json_body
+        captured["headers"] = headers
+        return 200, {"PartResults": []}
+
+    monkeypatch.setattr(sourcing_client, "_post_tp", fake_post)
+
+    _client().search([_query()])
+
+    assert captured["headers"]["X-Api-Key"] == "api-key-1"
+    assert captured["body"].get("ApiKey") is None
+
+
+def test_company_id_not_sent_in_request_body(monkeypatch):
+    captured: dict[str, dict] = {}
+
+    def fake_post(url, json_body, headers):
+        captured["body"] = json_body
+        return 200, {"PartResults": []}
+
+    monkeypatch.setattr(sourcing_client, "_post_tp", fake_post)
+
+    _client().search([_query()])
+
+    assert captured["body"].get("CompanyId") is None
+
+
+def test_api_key_never_logged(monkeypatch, caplog):
+    api_key = "super-secret-api-key"
+    client = TrustedPartsClient(
+        company_id="company-1",
+        api_key=api_key,
+        country_code="CZ",
+        currency_code="EUR",
+        user_agent="stockManager/test workspace=ws-1",
+    )
+
+    monkeypatch.setattr(
+        sourcing_client,
+        "_post_tp",
+        lambda url, json_body, headers: (
+            200,
+            {"Messages": ["using cached data"], "PartResults": []},
+        ),
+    )
+
+    with caplog.at_level("INFO", logger=sourcing_client.__name__):
+        client.search([_query()])
+
+    assert api_key not in caplog.text
 
 
 def test_too_many_queries_raises_before_network(monkeypatch):
     calls = 0
 
-    def fake_post(url, json):
+    def fake_post(url, json_body, headers):
         nonlocal calls
         calls += 1
         return 200, {"PartResults": []}
@@ -168,29 +224,61 @@ def test_empty_queries_raises():
         _client().search([])
 
 
+def test_search_token_too_short_raises_value_error(monkeypatch):
+    calls = 0
+
+    def fake_post(url, json_body, headers):
+        nonlocal calls
+        calls += 1
+        return 200, {"PartResults": []}
+
+    monkeypatch.setattr(sourcing_client, "_post_tp", fake_post)
+
+    with pytest.raises(ValueError, match="SearchToken"):
+        _client().search([_query("x")])
+
+    assert calls == 0
+
+
+def test_search_token_too_long_raises_value_error(monkeypatch):
+    calls = 0
+
+    def fake_post(url, json_body, headers):
+        nonlocal calls
+        calls += 1
+        return 200, {"PartResults": []}
+
+    monkeypatch.setattr(sourcing_client, "_post_tp", fake_post)
+
+    with pytest.raises(ValueError, match="SearchToken"):
+        _client().search([_query("x" * 101)])
+
+    assert calls == 0
+
+
 def test_401_maps_to_auth_error(monkeypatch):
-    monkeypatch.setattr(sourcing_client, "_post_tp", lambda url, json: (401, {}))
+    monkeypatch.setattr(sourcing_client, "_post_tp", lambda url, json_body, headers: (401, {}))
 
     with pytest.raises(SourcingAuthError):
         _client().search([_query()])
 
 
 def test_429_maps_to_rate_limit_error(monkeypatch):
-    monkeypatch.setattr(sourcing_client, "_post_tp", lambda url, json: (429, {}))
+    monkeypatch.setattr(sourcing_client, "_post_tp", lambda url, json_body, headers: (429, {}))
 
     with pytest.raises(SourcingRateLimitError):
         _client().search([_query()])
 
 
 def test_500_maps_to_upstream_error(monkeypatch):
-    monkeypatch.setattr(sourcing_client, "_post_tp", lambda url, json: (500, {}))
+    monkeypatch.setattr(sourcing_client, "_post_tp", lambda url, json_body, headers: (500, {}))
 
     with pytest.raises(SourcingUpstreamError):
         _client().search([_query()])
 
 
 def test_timeout_maps_to_timeout_error(monkeypatch):
-    def timeout(url, json):
+    def timeout(url, json_body, headers):
         raise httpx.TimeoutException("simulated timeout")
 
     monkeypatch.setattr(sourcing_client, "_post_tp", timeout)
@@ -203,18 +291,84 @@ def test_unparseable_body_maps_to_validation_error(monkeypatch):
     monkeypatch.setattr(
         sourcing_client,
         "_post_tp",
-        lambda url, json: (200, {"PartResults": {"bad": "shape"}}),
+        lambda url, json_body, headers: (200, {"PartResults": {"bad": "shape"}}),
     )
 
     with pytest.raises(SourcingValidationError):
         _client().search([_query()])
 
 
+def test_malformed_response_raises_sourcing_validation_error(monkeypatch):
+    monkeypatch.setattr(
+        sourcing_client,
+        "_post_tp",
+        lambda url, json_body, headers: (200, {"bogus": True}),
+    )
+
+    with pytest.raises(SourcingValidationError):
+        _client().search([_query()])
+
+
+def test_validation_error_does_not_leak_response_body_to_logs(monkeypatch, caplog):
+    secret_body_value = "body-secret-should-not-log"
+    monkeypatch.setattr(
+        sourcing_client,
+        "_post_tp",
+        lambda url, json_body, headers: (200, {"bogus": secret_body_value}),
+    )
+
+    with caplog.at_level("WARNING", logger=sourcing_client.__name__):
+        with pytest.raises(SourcingValidationError):
+            _client().search([_query()])
+
+    assert secret_body_value not in caplog.text
+    assert "request_hash=" in caplog.text
+    assert "extra_forbidden" in caplog.text
+
+
+def test_error_message_on_200_raises_sourcing_upstream_error(monkeypatch):
+    monkeypatch.setattr(
+        sourcing_client,
+        "_post_tp",
+        lambda url, json_body, headers: (
+            200,
+            {"ErrorMessage": "rate limit exceeded"},
+        ),
+    )
+
+    with pytest.raises(SourcingUpstreamError, match="rate limit exceeded"):
+        _client().search([_query()])
+
+
+def test_messages_on_200_logged_not_raised(monkeypatch, caplog):
+    monkeypatch.setattr(
+        sourcing_client,
+        "_post_tp",
+        lambda url, json_body, headers: (
+            200,
+            {"Messages": ["using cached data"], "PartResults": []},
+        ),
+    )
+
+    with caplog.at_level("INFO", logger=sourcing_client.__name__):
+        result = _client().search([_query()])
+
+    assert result.offers == []
+    records = [
+        record
+        for record in caplog.records
+        if getattr(record, "tp_message", None) == "using cached data"
+    ]
+    assert records
+    assert "tp_message" in records[0].getMessage()
+    assert "using cached data" in records[0].getMessage()
+
+
 def test_dtos_round_trip_cleanly(monkeypatch):
     monkeypatch.setattr(
         sourcing_client,
         "_post_tp",
-        lambda url, json: (200, _trustedparts_response()),
+        lambda url, json_body, headers: (200, _trustedparts_response()),
     )
 
     result = _client().search([_query()])

--- a/backend/tests/test_sourcing_client.py
+++ b/backend/tests/test_sourcing_client.py
@@ -32,6 +32,7 @@ def _query(token: str = "STM32F103C8T6") -> SourcingQuery:
 
 def _trustedparts_response() -> dict:
     return {
+        "RequestId": "req-1",
         "PartResults": [
             {
                 "PartNumber": "STM32F103C8T6",
@@ -88,7 +89,7 @@ def test_happy_path_returns_offers(monkeypatch):
     result = _client().search([_query()])
 
     assert isinstance(result, SourcingSearchRaw)
-    assert result.request_id is None
+    assert result.request_id == "req-1"
     assert result.offers[0].mpn == "STM32F103C8T6"
     assert result.offers[0].manufacturer == "STMicroelectronics"
     assert result.offers[0].description == "MCU 32-bit ARM Cortex-M3"

--- a/backend/tests/test_sourcing_search_route.py
+++ b/backend/tests/test_sourcing_search_route.py
@@ -156,6 +156,17 @@ def test_too_few_or_too_many_mpns_422(authed_client):
     assert r.json()["status"]["category"] == "validation_error"
 
 
+def test_short_search_token_returns_422_without_provider_call(authed_client):
+    _configure_sourcing(authed_client)
+
+    r = authed_client.post("/api/sourcing/search", json={"mpns": ["x"]})
+
+    assert r.status_code == 422, r.text
+    assert r.json()["status"]["category"] == "validation_error"
+    assert "SearchToken" in r.json()["status"]["message"]
+    assert _FakeTrustedPartsClient.calls == []
+
+
 def test_unconfigured_returns_409(authed_client, monkeypatch):
     monkeypatch.setattr(
         "app.domain.sourcing.service.make_sourcing_provider",

--- a/backend/tests/test_sourcing_test_route.py
+++ b/backend/tests/test_sourcing_test_route.py
@@ -151,7 +151,7 @@ def test_good_creds_returns_ok_and_latency(authed_client, monkeypatch):
     assert body["data"]["latency_ms"] > 0
     assert _SuccessfulTrustedPartsClient.calls == [
         {
-            "company_id": "company-123",
+            "company_id": "",
             "api_key": "api-key-456",
             "country_code": "CZ",
             "currency_code": "EUR",
@@ -215,8 +215,8 @@ def test_workspace_isolation_uses_own_creds(db, monkeypatch):
     ws_b = db.get(Workspace, ws_b_id)
     assert ws_a is not None
     assert ws_b is not None
-    a_tokens = {ws_a.sourcing_company_id_enc, ws_a.sourcing_api_key_enc}
-    b_tokens = {ws_b.sourcing_company_id_enc, ws_b.sourcing_api_key_enc}
+    a_tokens = {ws_a.sourcing_api_key_enc}
+    b_tokens = {ws_b.sourcing_api_key_enc}
     seen_tokens: list[str | None] = []
 
     def decrypt_spy(token: str | None) -> str | None:
@@ -236,7 +236,7 @@ def test_workspace_isolation_uses_own_creds(db, monkeypatch):
     assert r.json()["data"]["ok"] is True
     assert set(seen_tokens) == b_tokens
     assert not set(seen_tokens) & a_tokens
-    assert _SuccessfulTrustedPartsClient.calls[-1]["company_id"] == "company-b"
+    assert _SuccessfulTrustedPartsClient.calls[-1]["company_id"] == ""
     assert _SuccessfulTrustedPartsClient.calls[-1]["api_key"] == "api-key-b"
 
 

--- a/backend/tests/test_workspace_isolation.py
+++ b/backend/tests/test_workspace_isolation.py
@@ -1041,14 +1041,16 @@ def test_sourcing_bom_isolated_by_workspace(db, monkeypatch):
     BUDGET._events.clear()
     calls: list[dict] = []
 
-    def fake_post(_url, json):
+    def fake_post(_url, json, headers):
         mpn = json["Queries"][0]["SearchToken"]
-        distributor = "SourceA" if json["CompanyId"] == "company-a" else "SourceB"
-        calls.append({"company_id": json["CompanyId"], "mpn": mpn})
+        company_id = headers["X-Api-Key"].removeprefix("key-")
+        distributor = "SourceA" if company_id == "company-a" else "SourceB"
+        calls.append({"company_id": company_id, "mpn": mpn})
+        assert "CompanyId" not in json
+        assert "ApiKey" not in json
         return (
             200,
             {
-                "RequestId": f"req-{len(calls)}",
                 "PartResults": [
                     {
                         "PartNumber": mpn,

--- a/backend/tests/test_workspace_isolation.py
+++ b/backend/tests/test_workspace_isolation.py
@@ -469,8 +469,8 @@ def test_sourcing_search_uses_caller_workspace_secrets(monkeypatch):
         ws_b = session.get(Workspace, ws_b_id)
         assert ws_a is not None
         assert ws_b is not None
-        a_tokens = {ws_a.sourcing_company_id_enc, ws_a.sourcing_api_key_enc}
-        b_tokens = {ws_b.sourcing_company_id_enc, ws_b.sourcing_api_key_enc}
+        a_tokens = {ws_a.sourcing_api_key_enc}
+        b_tokens = {ws_b.sourcing_api_key_enc}
 
     seen_tokens: list[str | None] = []
 
@@ -497,11 +497,7 @@ def test_sourcing_search_uses_caller_workspace_secrets(monkeypatch):
     assert r.json()["data"]["cache_hit"] is False
     assert set(seen_tokens) == b_tokens
     assert not set(seen_tokens) & a_tokens
-    assert [call["company_id"] for call in RecordingTrustedPartsClient.calls] == [
-        "company-a",
-        "company-b",
-    ]
-    assert RecordingTrustedPartsClient.calls[-1]["company_id"] == "company-b"
+    assert [call["company_id"] for call in RecordingTrustedPartsClient.calls] == ["", ""]
     assert RecordingTrustedPartsClient.calls[-1]["api_key"] == "api-key-b"
 
 

--- a/docs/api/sourcing.md
+++ b/docs/api/sourcing.md
@@ -621,7 +621,7 @@ When TrustedParts is not configured or rejects the probe, the HTTP status remain
 
 **Notes**
 
-- The route decrypts only the current workspace's `sourcing_company_id_enc` and `sourcing_api_key_enc`, then passes plaintext directly to `TrustedPartsClient`; the plaintext credentials are not serialized or logged.
+- The route decrypts the current workspace's `sourcing_api_key_enc` and optional deprecated `sourcing_company_id_enc`, then passes plaintext directly to `TrustedPartsClient`; the plaintext credentials are not serialized or logged. TrustedParts requests authenticate with the `X-Api-Key` header and do not send `CompanyId` in the body.
 - Probe token: `TEST_PROBE_DO_NOT_BUY`; called with `use_cached_data=false`.
 - Friendly failure messages: `not configured`, `invalid credentials`, `rate limited by TrustedParts`, `timeout reaching TrustedParts`, `TrustedParts upstream error`.
 - Source: `backend/app/api/routes/sourcing.py:33-78`.

--- a/docs/api/sourcing.md
+++ b/docs/api/sourcing.md
@@ -621,7 +621,7 @@ When TrustedParts is not configured or rejects the probe, the HTTP status remain
 
 **Notes**
 
-- The route decrypts the current workspace's `sourcing_api_key_enc` and optional deprecated `sourcing_company_id_enc`, then passes plaintext directly to `TrustedPartsClient`; the plaintext credentials are not serialized or logged. TrustedParts requests authenticate with the `X-Api-Key` header and do not send `CompanyId` in the body.
+- The route decrypts the current workspace's `sourcing_api_key_enc`, then passes plaintext directly to `TrustedPartsClient`; the plaintext credential is not serialized or logged. Deprecated `sourcing_company_id_enc` is no longer decrypted for TrustedParts Inventory API v2 calls. TrustedParts requests authenticate with the `X-Api-Key` header and do not send `CompanyId` in the body.
 - Probe token: `TEST_PROBE_DO_NOT_BUY`; called with `use_cached_data=false`.
 - Friendly failure messages: `not configured`, `invalid credentials`, `rate limited by TrustedParts`, `timeout reaching TrustedParts`, `TrustedParts upstream error`.
 - Source: `backend/app/api/routes/sourcing.py:33-78`.

--- a/docs/domain/providers.md
+++ b/docs/domain/providers.md
@@ -25,7 +25,7 @@ TrustedParts sourcing state also lives on the `Workspace` row (`backend/app/doma
 | Column | Notes |
 |---|---|
 | `sourcing_provider` | `none` until a sourcing provider integration is configured. DB default `none`. |
-| `sourcing_company_id_enc` | Encrypted sourcing account/company identifier. Exposed only as `has_sourcing_company_id` on `GET /api/workspaces/current`. |
+| `sourcing_company_id_enc` | Deprecated encrypted sourcing account/company identifier. Exposed only as `has_sourcing_company_id` on `GET /api/workspaces/current`; not sent to TrustedParts Inventory API v2 requests. |
 | `sourcing_api_key_enc` | Encrypted sourcing API key. Exposed only as `has_sourcing_api_key` on `GET /api/workspaces/current`. |
 | `sourcing_country_code` | Optional ISO 3166-1 alpha-2 country code for provider locale. |
 | `sourcing_currency_code` | Optional ISO 4217 currency code for sourcing responses. |

--- a/docs/domain/sourcing.md
+++ b/docs/domain/sourcing.md
@@ -22,8 +22,8 @@ type/path, never the response body.
 
 TrustedParts authentication is sent via the `X-Api-Key` request header. The
 request body no longer includes `ApiKey` or deprecated `CompanyId`; the encrypted
-workspace CompanyId column remains for compatibility but is not required for new
-requests. HTTP 200 responses with `ErrorMessage` become upstream errors, while
+workspace CompanyId column remains for compatibility but is not decrypted or
+required for new requests. HTTP 200 responses with `ErrorMessage` become upstream errors, while
 `Messages[]` entries are logged at INFO with a `tp_message` tag and do not fail
 the search.
 

--- a/docs/domain/sourcing.md
+++ b/docs/domain/sourcing.md
@@ -4,6 +4,29 @@ Audience: engineer
 
 TrustedParts sourcing stores short-lived provider responses and keeps cache reads workspace-scoped.
 
+## Schema Validation
+
+Live TrustedParts responses are validated against the generated Inventory API v2
+Pydantic models before the app maps them into public sourcing DTOs. The generated
+`InventoryApiResponse` owns the wire-format contract; `SourcingOffer`,
+`SourcingDistributor`, and `SourcingSearchRaw` remain the stable app-facing
+contract. Malformed HTTP 200 responses raise `SourcingValidationError`, which API
+routes surface as 502 envelopes instead of silently returning partial offers.
+
+The generated models keep the TrustedParts swagger's `additionalProperties: false`
+as `extra="forbid"`. This is strict everywhere: if TrustedParts adds an
+unannounced field, production calls can return 502 until operators refresh
+`docs/schemas/trustedparts-v2.json`, run `make regen-tp-models`, and deploy the
+regenerated models. Validation logs include only the request hash and error
+type/path, never the response body.
+
+TrustedParts authentication is sent via the `X-Api-Key` request header. The
+request body no longer includes `ApiKey` or deprecated `CompanyId`; the encrypted
+workspace CompanyId column remains for compatibility but is not required for new
+requests. HTTP 200 responses with `ErrorMessage` become upstream errors, while
+`Messages[]` entries are logged at INFO with a `tp_message` tag and do not fail
+the search.
+
 ## Cache Table
 
 `sourcing_cache` stores one response per `(workspace_id, query_hash)`.

--- a/docs/frontend/projects.md
+++ b/docs/frontend/projects.md
@@ -6,7 +6,7 @@ Project-detail UI flows that span the project tabs, builds, and sourcing routes.
 
 ## Source BOM
 
-Project detail and build detail both render the shared `SourceBomButton`. It reads `GET /api/workspaces/current` through `api.get()` and the workspace-scoped `["ws", wsId, "ws", "current"]` query key; when `has_sourcing_company_id` is false, the button is disabled with the `Sourcing not configured` cue instead of linking to the sourcing route. Sources: `web/src/routes/projects/sourcing/SourceBomButton.tsx:18-48`, `web/src/routes/projects/detail/ProjectLayout.tsx:24-29`, `web/src/routes/builds/BuildDetail.tsx:179-186`.
+Project detail and build detail both render the shared `SourceBomButton`. It reads `GET /api/workspaces/current` through `api.get()` and the workspace-scoped `["ws", wsId, "ws", "current"]` query key; when `has_sourcing_api_key` is false, the button is disabled with the `Sourcing not configured` cue instead of linking to the sourcing route. Sources: `web/src/routes/projects/sourcing/SourceBomButton.tsx:18-48`, `web/src/routes/projects/detail/ProjectLayout.tsx:24-29`, `web/src/routes/builds/BuildDetail.tsx:179-186`.
 
 `/projects/:projectId/sourcing` is a lazy child of the project detail route. The page initializes build quantity plus country, currency, and distributor filters from workspace sourcing settings, then posts to `POST /api/projects/{project_id}/sourcing` through `api.post()` with a workspace-scoped TanStack key. Sources: `web/src/App.tsx:98-106`, `web/src/App.tsx:278-285`, `web/src/routes/projects/sourcing/ProjectSourcingPage.tsx:390-424`.
 

--- a/docs/frontend/workspace-settings.md
+++ b/docs/frontend/workspace-settings.md
@@ -9,15 +9,16 @@ Frontend notes for `/settings/workspace` cards that edit workspace-scoped config
 The Workspace page mounts `SourcingCard` below the parts data provider card.
 Source: `web/src/routes/settings/Workspace.tsx:655`.
 
-The card edits TrustedParts sourcing preferences with provider, masked CompanyId
-and API key inputs, country, currency, preferred distributors, and dashboard
-cache preference. Save calls `api.patch("/workspaces/current", body)` and
-invalidates the workspace-current query; test connection calls
+The card edits TrustedParts sourcing preferences with provider, API key, deprecated
+CompanyId, country, currency, preferred distributors, and dashboard cache
+preference. Save calls `api.patch("/workspaces/current", body)` and invalidates
+the workspace-current query; test connection calls
 `api.post("/workspaces/current/sourcing/test", {})`.
 Source: `web/src/routes/settings/SourcingCard.tsx:85-134`.
 
 Credential values are never read back from the API. The UI clears typed
 credential fields after save and displays only the `Configured ✓` pill when
-`has_sourcing_company_id && has_sourcing_api_key` is true.
+`has_sourcing_api_key` is true. CompanyId is marked deprecated because
+TrustedParts no longer requires it for Inventory API v2 requests.
 Source: `web/src/routes/settings/SourcingCard.tsx:70-82`,
 `web/src/routes/settings/SourcingCard.tsx:137-147`.

--- a/docs/runbooks/provider-outage.md
+++ b/docs/runbooks/provider-outage.md
@@ -162,7 +162,7 @@ TrustedParts sourcing is separate from the Mouser/DigiKey catalog providers. It 
 Integration entry points:
 
 - `backend/app/domain/sourcing/client.py` — TrustedParts API v2 client.
-- `backend/app/domain/sourcing/factory.py:12` — decrypts the current workspace's sourcing credentials and builds the client.
+- `backend/app/domain/sourcing/factory.py:12` — decrypts the current workspace's sourcing API key and builds the client.
 - `backend/app/domain/sourcing/service.py:39` — cache, budget, and response attribution facade.
 - `backend/app/api/routes/sourcing.py:87` — member search route and error mapping.
 

--- a/docs/runbooks/provider-outage.md
+++ b/docs/runbooks/provider-outage.md
@@ -170,8 +170,8 @@ Integration entry points:
 
 | Symptom | Likely cause | Action |
 |---|---|---|
-| `409 sourcing not configured` | Workspace has no TrustedParts company ID/API key | Workspace admin configures sourcing credentials in workspace settings. |
-| `502 TrustedParts rejected sourcing credentials` | Company ID or API key is invalid/revoked | Workspace admin re-issues credentials in TrustedParts and saves them again. |
+| `409 sourcing not configured` | Workspace has no TrustedParts API key | Workspace admin configures sourcing credentials in workspace settings. |
+| `502 TrustedParts rejected sourcing credentials` | TrustedParts API key is invalid/revoked | Workspace admin re-issues credentials in TrustedParts and saves them again. |
 | `502 TrustedParts rate limit reached` | TrustedParts throttled the key | Ask the workspace to pause high-volume sourcing; retry after the provider window clears. |
 | `502 TrustedParts request timed out` or upstream failure | TrustedParts or network outage | Use manual entry/fallback below; retry when provider status recovers. |
 | `503 sourcing budget exhausted` | Local hard parts-count budget blocked live calls | Wait for the rolling window to expire; cached hits still avoid additional budget consumption. |
@@ -186,7 +186,7 @@ Integration entry points:
 ### Credential issues
 
 1. Confirm only one workspace is affected.
-2. Ask a workspace admin to update TrustedParts company ID and API key in workspace settings.
+2. Ask a workspace admin to update the TrustedParts API key in workspace settings.
 3. Use `POST /api/workspaces/current/sourcing/test` to confirm the credentials probe returns `{ "ok": true }`.
 4. If the test route succeeds but search still fails, inspect `backend/app/domain/sourcing/service.py:39` and `backend/app/api/routes/sourcing.py:87` for regression in defaults, cache, or error mapping.
 

--- a/web/src/routes/projects/detail/__tests__/ProjectBOM.test.tsx
+++ b/web/src/routes/projects/detail/__tests__/ProjectBOM.test.tsx
@@ -136,6 +136,7 @@ function mockApi(
         sourcing_currency_code: "USD",
         sourcing_preferred_distributors: [],
         has_sourcing_company_id: true,
+        has_sourcing_api_key: true,
       } as never;
     }
     throw new Error(`unexpected GET ${path}`);

--- a/web/src/routes/projects/sourcing/SourceBomButton.tsx
+++ b/web/src/routes/projects/sourcing/SourceBomButton.tsx
@@ -10,7 +10,7 @@ export type SourcingWorkspaceSettings = {
   active_countries: string[];
   active_currencies: string[];
   active_distributors: string[];
-  has_sourcing_company_id: boolean;
+  has_sourcing_api_key: boolean;
 };
 
 type Props = {
@@ -23,7 +23,7 @@ export function SourceBomButton({ projectId, className }: Props) {
     queryKey: useWsKey("ws", "current"),
     queryFn: () => api.get<SourcingWorkspaceSettings>("/workspaces/current"),
   });
-  const disabled = workspace?.has_sourcing_company_id === false;
+  const disabled = workspace?.has_sourcing_api_key === false;
   const classes = className ?? "btn-primary";
 
   if (!projectId || disabled) {

--- a/web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.test.tsx
+++ b/web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.test.tsx
@@ -31,6 +31,7 @@ function workspace(overrides: Record<string, unknown> = {}) {
     active_currencies: ["USD", "EUR", "JPY"],
     active_distributors: ["DigiKey", "Mouser", "Arrow"],
     has_sourcing_company_id: true,
+    has_sourcing_api_key: true,
     ...overrides,
   };
 }
@@ -552,7 +553,7 @@ describe("ProjectSourcingPage", () => {
   });
 
   it("Source BOM button is disabled when workspace lacks sourcing creds", async () => {
-    mockReads({ has_sourcing_company_id: false });
+    mockReads({ has_sourcing_api_key: false });
     const client = new QueryClient({
       defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
     });

--- a/web/src/routes/settings/SourcingCard.tsx
+++ b/web/src/routes/settings/SourcingCard.tsx
@@ -134,7 +134,7 @@ export function SourcingCard({
     saveMutation.mutate(body);
   }
 
-  const configured = hasCompanyId && hasApiKey;
+  const configured = hasApiKey;
 
   return (
     <form className="card p-4 mb-4 space-y-3 text-sm" onSubmit={submit}>
@@ -161,7 +161,13 @@ export function SourcingCard({
           </select>
         </div>
         <div>
-          <label className="label" htmlFor="sourcing-company-id">CompanyId</label>
+          <label
+            className="label"
+            htmlFor="sourcing-company-id"
+            title="TrustedParts no longer requires this; you may safely leave it blank"
+          >
+            CompanyId (deprecated)
+          </label>
           <input
             id="sourcing-company-id"
             className="input font-mono text-xs"
@@ -172,7 +178,8 @@ export function SourcingCard({
               setCompanyIdTouched(true);
               setCompanyId(e.target.value);
             }}
-            placeholder={hasCompanyId ? "•••••••• (CompanyId set)" : "CompanyId"}
+            placeholder={hasCompanyId ? "•••••••• (deprecated CompanyId set)" : "Optional"}
+            title="TrustedParts no longer requires this; you may safely leave it blank"
           />
         </div>
         <div>

--- a/web/src/routes/settings/__dom__/SourcingCard.dom.test.tsx
+++ b/web/src/routes/settings/__dom__/SourcingCard.dom.test.tsx
@@ -49,7 +49,7 @@ describe("SourcingCard", () => {
 
     expect(screen.getByRole("heading", { name: "Sourcing provider" })).toBeDefined();
     expect(screen.getByLabelText("Provider")).toBeDefined();
-    expect(screen.getByLabelText("CompanyId")).toBeDefined();
+    expect(screen.getByLabelText("CompanyId (deprecated)")).toBeDefined();
     expect(screen.getByLabelText("API Key")).toBeDefined();
     expect(screen.getByLabelText("Country")).toBeDefined();
     expect(screen.getByLabelText("Currency")).toBeDefined();
@@ -73,7 +73,7 @@ describe("SourcingCard", () => {
     const { invalidateSpy } = renderCard();
 
     await user.selectOptions(screen.getByLabelText("Provider"), "trustedparts");
-    await user.type(screen.getByLabelText("CompanyId"), "company-123");
+    await user.type(screen.getByLabelText("CompanyId (deprecated)"), "company-123");
     await user.type(screen.getByLabelText("API Key"), "api-456");
     await user.type(screen.getByLabelText("Country"), "cz");
     await user.type(screen.getByLabelText("Currency"), "eur");
@@ -138,7 +138,7 @@ describe("SourcingCard", () => {
     });
     renderCard();
 
-    await user.type(screen.getByLabelText("CompanyId"), "secret-company-id");
+    await user.type(screen.getByLabelText("CompanyId (deprecated)"), "secret-company-id");
     await user.type(screen.getByLabelText("API Key"), "secret-api-key");
     await user.click(screen.getByRole("button", { name: "Save" }));
 


### PR DESCRIPTION
## Summary

- Validates every successful TrustedParts response with the generated `InventoryApiResponse` before mapping to the existing `SourcingOffer`, `SourcingDistributor`, and `SourcingSearchRaw` DTOs.
- Refactors the adapter to consume generated Pydantic objects through typed attributes instead of raw response dict walks; public DTO fields are unchanged.
- Moves TrustedParts auth to the `X-Api-Key` header, removes `ApiKey` and deprecated `CompanyId` from the request body, and treats API key alone as sufficient sourcing configuration.
- Handles HTTP 200 `ErrorMessage` as `SourcingUpstreamError`; logs `Messages[]` at INFO with a `tp_message` tag without raising.
- Marks CompanyId deprecated in workspace settings and updates the Source BOM gating to use `has_sourcing_api_key`.
- Follow-up review fixes: API SearchToken validation now returns 422 envelopes at sourcing route boundaries, deprecated CompanyId is no longer decrypted in the factory, and legacy request-id fields are preserved for the app DTO while generated TP validation remains strict for the v2 body.

## Behavior Change

Malformed TrustedParts HTTP 200 responses now raise `SourcingValidationError` after generated-schema validation instead of silently producing half-empty offers. TrustedParts HTTP 200 bodies with `ErrorMessage` now raise `SourcingUpstreamError`. The existing route-layer error mapping surfaces both as 502 envelopes instead of empty result sets. Search tokens outside TrustedParts' 2..100 character range are rejected before the network call and API routes return a 422 envelope.

## Extra-Mode Strategy

This PR keeps the generated TrustedParts models strict everywhere (`extra="forbid"`) and does not hand-edit generated code. If TrustedParts adds an unannounced response field, calls can fail with 502 until operators refresh `docs/schemas/trustedparts-v2.json`, run `make regen-tp-models`, and deploy the regenerated models. Validation logs include only request hash plus validation error type/path, never the response body.

Known legacy request-id fields (`RequestId`, `RequestID`, `request_id`) are carried forward into `SourcingSearchRaw.request_id` before strict generated validation so the existing app DTO behavior is preserved. They are not part of the TrustedParts v2 generated model.

## Validation

Docker validation was unavailable in this environment because `docker` is not installed (`docker: command not found`), so I used the repo-local fallback path.

- `cd backend && uv run python -m pytest -q tests/test_sourcing_client.py tests/test_sourcing_search_route.py::test_short_search_token_returns_422_without_provider_call tests/test_workspace_isolation.py::test_sourcing_search_uses_caller_workspace_secrets`
  - `22 passed, 1 warning in 2.20s`
- `cd backend && uv run python -m pytest -q -k "sourcing or workspace_isolation"`
  - `282 passed, 833 deselected, 6 warnings in 54.87s`
- `cd backend && LINT_CMD="uv run ruff check app --output-format=concise" BASELINE_FILE="../.ruff-baseline.txt" WORK_DIR="." bash ../scripts/lint-delta.sh`
  - `lint-delta: no new violations (baseline: 159, current: 145, fixed since baseline: 14)`
- `cd backend && uv run ruff check app/domain/sourcing/client.py app/domain/sourcing/factory.py app/domain/sourcing/service.py app/api/routes/sourcing.py tests/test_sourcing_client.py tests/test_sourcing_search_route.py tests/test_workspace_isolation.py tests/test_sourcing_test_route.py`
  - `All checks passed!`
- `cd backend && bash -c "! grep -nE '\\.get\\(' app/domain/sourcing/client.py | grep -v _post_tp"`
  - no output, exit 0
- `git diff --check`
  - no output, exit 0
- `cd web && npm test -- SourcingCard.dom.test.tsx ProjectSourcingPage.test.tsx ProjectBOM.test.tsx`
  - `Test Files 3 passed (3); Tests 35 passed (35)`

Note: a plain `uv run ruff check` still reports the repository's pre-existing nonzero baseline outside this PR. The baseline-aware CI-style gate and direct ruff on the touched Python files are clean.

## Merge Order

1. #458 (TPS-1 foundation) already merged.
2. This PR (#449) before #451 and #457.
3. Hold #456 or rebase it if it edits sourcing docs/tests in parallel.

Refs #449
