### PR TITLE
TPS-4: Parse 13 TrustedParts gap fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ the canonical record.
 
 ## 2026-05 — feedback brief fixes
 
+- **TPS-4 / #451** TrustedParts gap-field parsing now surfaces lifecycle
+  risk, supply-chain risk, tariff status, manufacturer id, specifications,
+  distributor id, RoHS compliance, availability text, quantity multiple,
+  formatted price amount, price text, TP current date, and TP response time
+  in sourcing DTOs and route responses.
 - **TPS-2 / #449** TrustedParts responses are now validated through the
   generated Inventory API v2 models before app DTO mapping; auth moved to the
   `X-Api-Key` header, deprecated `CompanyId` is no longer sent, and TP

--- a/backend/app/api/routes/sourcing.py
+++ b/backend/app/api/routes/sourcing.py
@@ -633,6 +633,10 @@ def _part_sourcing_payload(
         "mpn": result.mpn,
         "offers": [offer.model_dump(mode="json") for offer in result.offers],
         "request_id": result.request_id,
+        "tp_current_date": (
+            out.tp_current_date.isoformat() if out.tp_current_date is not None else None
+        ),
+        "tp_response_time": out.tp_response_time,
         "powered_by": out.powered_by,
         "fetched_at": result.fetched_at.isoformat(),
         "cache_hit": result.cache_hit,

--- a/backend/app/domain/sourcing/client.py
+++ b/backend/app/domain/sourcing/client.py
@@ -25,7 +25,9 @@ from app.domain.sourcing.schemas import (
     SourcingOffer,
     SourcingPriceBreak,
     SourcingQuery,
+    SourcingRohsCompliance,
     SourcingSearchRaw,
+    SourcingSpecification,
 )
 
 TP_V2_URL = "https://api.trustedparts.com/v2/search"
@@ -281,7 +283,12 @@ def _parse_search_response(
 
     try:
         return SourcingSearchRaw.model_validate(
-            {"offers": offers, "request_id": request_id}
+            {
+                "offers": offers,
+                "request_id": request_id,
+                "tp_current_date": response.CurrentDate,
+                "tp_response_time": _str_or_none(response.ResponseTime),
+            }
         )
     except PydanticValidationError as exc:
         raise SourcingValidationError("TrustedParts response did not match sourcing DTOs") from exc
@@ -303,7 +310,14 @@ def _offer_from_part(part: InventoryPartResult) -> SourcingOffer:
                 datasheet_url = _first_matching_link(links, "datasheet")
             if manufacturer_url is None:
                 manufacturer_url = _first_matching_link(links, "manufacturer")
-            distributors.append(_distributor_from_result(name, result, links))
+            distributors.append(
+                _distributor_from_result(
+                    name,
+                    distributor.Id,
+                    result,
+                    links,
+                )
+            )
 
     try:
         return SourcingOffer.model_validate(
@@ -317,6 +331,11 @@ def _offer_from_part(part: InventoryPartResult) -> SourcingOffer:
                     manufacturer=manufacturer_url,
                     datasheet=datasheet_url,
                 ),
+                "lifecycle_risk": _str_or_none(part.LifecycleRisk),
+                "supply_chain_risk": _str_or_none(part.SupplyChainRisk),
+                "is_affected_by_tariff": part.IsAffectedByTariff,
+                "manufacturer_id": part.ManufacturerId,
+                "specifications": _specifications(part.Specifications),
             }
         )
     except PydanticValidationError as exc:
@@ -325,6 +344,7 @@ def _offer_from_part(part: InventoryPartResult) -> SourcingOffer:
 
 def _distributor_from_result(
     distributor_name: str,
+    distributor_id: int | None,
     result: InventoryDistributorResult,
     links: dict[str, str],
 ) -> SourcingDistributor:
@@ -341,6 +361,7 @@ def _distributor_from_result(
     try:
         return SourcingDistributor.model_validate(
             {
+                "distributor_id": distributor_id,
                 "name": distributor_name,
                 "sku": _str_or_none(result.DistributorPartNumber),
                 "packaging": _first_package_type(packages),
@@ -351,6 +372,13 @@ def _distributor_from_result(
                 "currency": _str_or_none(pricing.CurrencyCode if pricing is not None else None),
                 "price_breaks": price_breaks,
                 "product_url": product_url,
+                "rohs_compliance": _rohs_compliance(result),
+                "availability_text": _str_or_none(
+                    stock.Availability if stock is not None else None
+                ),
+                "quantity_multiple": _int_count_or_none(
+                    pricing.QuantityMultiple if pricing is not None else None
+                ),
             }
         )
     except PydanticValidationError as exc:
@@ -366,11 +394,47 @@ def _price_breaks(price_rows: list[Price] | None) -> list[SourcingPriceBreak]:
             continue
         try:
             breaks.append(
-                SourcingPriceBreak.model_validate({"quantity": quantity, "unit_price": amount})
+                SourcingPriceBreak.model_validate(
+                    {
+                        "quantity": quantity,
+                        "unit_price": amount,
+                        "formatted_amount": _str_or_none(row.FormattedAmount),
+                        "text": _str_or_none(row.Text),
+                    }
+                )
             )
         except PydanticValidationError as exc:
             raise SourcingValidationError("TrustedParts price break did not match DTOs") from exc
     return breaks
+
+
+def _specifications(raw_specs: Any) -> list[SourcingSpecification]:
+    specs: list[SourcingSpecification] = []
+    for item in raw_specs or []:
+        key = _str_or_none(item.Key)
+        value = _str_or_none(item.Value)
+        if key is None or value is None:
+            continue
+        specs.append(SourcingSpecification(key=key, value=value))
+    return specs
+
+
+def _rohs_compliance(result: InventoryDistributorResult) -> list[SourcingRohsCompliance]:
+    compliance = result.Compliance
+    rows = compliance.RoHS if compliance is not None else None
+    out: list[SourcingRohsCompliance] = []
+    for row in rows or []:
+        region = _str_or_none(row.Region)
+        if region is None or row.IsCompliant is None:
+            continue
+        out.append(
+            SourcingRohsCompliance(
+                region=region,
+                is_compliant=row.IsCompliant,
+                description=_str_or_none(row.Description),
+            )
+        )
+    return out
 
 
 def _links_by_type(raw_links: list[SearchApiLink] | None) -> dict[str, str]:
@@ -433,6 +497,15 @@ def _int_or_none(value: Any) -> int | None:
         return None
     try:
         return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _int_count_or_none(value: Any) -> int | None:
+    if value is None or value == "":
+        return None
+    try:
+        return int(round(float(value)))
     except (TypeError, ValueError):
         return None
 

--- a/backend/app/domain/sourcing/schemas.py
+++ b/backend/app/domain/sourcing/schemas.py
@@ -21,6 +21,8 @@ class SourcingPriceBreak(BaseModel):
 
     quantity: int
     unit_price: float
+    formatted_amount: str | None = None
+    text: str | None = None
 
 
 class SourcingConvertedPriceBreak(BaseModel):
@@ -40,6 +42,7 @@ class SourcingBomPriceBreakOut(BaseModel):
 class SourcingDistributor(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
+    distributor_id: int | None = None
     name: str
     sku: str | None = None
     packaging: str | None = None
@@ -55,6 +58,24 @@ class SourcingDistributor(BaseModel):
     price_breaks: list[SourcingPriceBreak] = Field(default_factory=list)
     price_breaks_converted: list[SourcingConvertedPriceBreak] | None = None
     product_url: str | None = None
+    rohs_compliance: list["SourcingRohsCompliance"] = Field(default_factory=list)
+    availability_text: str | None = None
+    quantity_multiple: int | None = None
+
+
+class SourcingSpecification(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    key: str
+    value: str
+
+
+class SourcingRohsCompliance(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    region: str
+    is_compliant: bool
+    description: str | None = None
 
 
 class SourcingLinks(BaseModel):
@@ -73,6 +94,11 @@ class SourcingOffer(BaseModel):
     description: str | None = None
     distributors: list[SourcingDistributor] = Field(default_factory=list)
     links: SourcingLinks = Field(default_factory=SourcingLinks)
+    lifecycle_risk: str | None = None
+    supply_chain_risk: str | None = None
+    is_affected_by_tariff: bool | None = None
+    manufacturer_id: int | None = None
+    specifications: list[SourcingSpecification] = Field(default_factory=list)
 
 
 class SourcingSearchRaw(BaseModel):
@@ -80,6 +106,8 @@ class SourcingSearchRaw(BaseModel):
 
     offers: list[SourcingOffer]
     request_id: str | None = None
+    tp_current_date: datetime | None = None
+    tp_response_time: str | None = None
 
 
 class SourcingSearchIn(BaseModel):
@@ -129,6 +157,8 @@ class SourcingSearchResult(BaseModel):
     mpn: str
     offers: list[SourcingOffer] = Field(default_factory=list)
     request_id: str | None = None
+    tp_current_date: datetime | None = None
+    tp_response_time: str | None = None
     fetched_at: datetime
     cache_hit: bool
 
@@ -138,6 +168,8 @@ class SourcingSearchOut(BaseModel):
 
     results: list[SourcingSearchResult]
     request_id: str | None = None
+    tp_current_date: datetime | None = None
+    tp_response_time: str | None = None
     powered_by: Literal["TrustedParts"] = "TrustedParts"
     fetched_at: datetime
     cache_hit: bool
@@ -299,6 +331,11 @@ class SourcingBomOfferOut(BaseModel):
     lead_time_days: int | None = None
     price_breaks: list[SourcingBomPriceBreakOut] = Field(default_factory=list)
     url: str | None = None
+    lifecycle_risk: str | None = None
+    supply_chain_risk: str | None = None
+    is_affected_by_tariff: bool | None = None
+    manufacturer_id: int | None = None
+    specifications: list[SourcingSpecification] = Field(default_factory=list)
 
 
 class DistributorCoverageRowOut(BaseModel):

--- a/backend/app/domain/sourcing/service.py
+++ b/backend/app/domain/sourcing/service.py
@@ -951,6 +951,12 @@ def search(
             return {
                 "offers": [offer.model_dump(mode="json") for offer in raw.offers],
                 "request_id": raw.request_id,
+                "tp_current_date": (
+                    raw.tp_current_date.isoformat()
+                    if raw.tp_current_date is not None
+                    else None
+                ),
+                "tp_response_time": raw.tp_response_time,
                 "fetched_at": fetched_at.isoformat(),
             }
 
@@ -973,6 +979,8 @@ def search(
                 mpn=mpn,
                 offers=raw.offers,
                 request_id=raw.request_id,
+                tp_current_date=raw.tp_current_date,
+                tp_response_time=raw.tp_response_time,
                 fetched_at=fetched_at,
                 cache_hit=cache_hit,
             )
@@ -980,9 +988,19 @@ def search(
 
     response_fetched_at = max((result.fetched_at for result in results), default=utcnow())
     request_id = next((result.request_id for result in results if result.request_id), None)
+    tp_current_date = max(
+        (result.tp_current_date for result in results if result.tp_current_date is not None),
+        default=None,
+    )
+    tp_response_time = next(
+        (result.tp_response_time for result in results if result.tp_response_time),
+        None,
+    )
     return SourcingSearchOut(
         results=results,
         request_id=request_id,
+        tp_current_date=tp_current_date,
+        tp_response_time=tp_response_time,
         fetched_at=response_fetched_at,
         cache_hit=all(result.cache_hit for result in results),
         links=TRUSTEDPARTS_LINKS,
@@ -1098,6 +1116,8 @@ def _raw_from_cache_response(response: dict[str, Any]) -> SourcingSearchRaw:
         {
             "offers": response.get("offers", []),
             "request_id": response.get("request_id"),
+            "tp_current_date": response.get("tp_current_date"),
+            "tp_response_time": response.get("tp_response_time"),
         }
     )
 
@@ -1240,6 +1260,11 @@ def _joined_offers(
                         lead_time_days=distributor.lead_time_days,
                         price_breaks=_price_breaks_for_distributor(distributor),
                         url=distributor.product_url or offer.links.primary,
+                        lifecycle_risk=offer.lifecycle_risk,
+                        supply_chain_risk=offer.supply_chain_risk,
+                        is_affected_by_tariff=offer.is_affected_by_tariff,
+                        manufacturer_id=offer.manufacturer_id,
+                        specifications=offer.specifications,
                     )
                 )
     return out

--- a/backend/tests/test_sourcing_bom_route.py
+++ b/backend/tests/test_sourcing_bom_route.py
@@ -17,6 +17,7 @@ from app.domain.sourcing.schemas import (
     SourcingPriceBreak,
     SourcingQuery,
     SourcingSearchRaw,
+    SourcingSpecification,
 )
 from app.main import app
 from tests._factories import add_stock, create_part, create_project_with_bom, signup_user
@@ -57,11 +58,19 @@ def _offer(
     moq: int | None = 1,
     lead_time_days: int | None = 3,
     currency: str = "EUR",
+    lifecycle_risk: str | None = None,
+    supply_chain_risk: str | None = None,
+    is_affected_by_tariff: bool | None = None,
 ) -> SourcingOffer:
     return SourcingOffer(
         mpn=mpn,
         manufacturer="TestCo",
         description=f"Offer for {mpn}",
+        lifecycle_risk=lifecycle_risk,
+        supply_chain_risk=supply_chain_risk,
+        is_affected_by_tariff=is_affected_by_tariff,
+        manufacturer_id=12345,
+        specifications=[SourcingSpecification(key="Package", value="SOT-23")],
         distributors=[
             SourcingDistributor(
                 name=distributor,
@@ -196,6 +205,36 @@ def test_basic_bom_returns_enriched_lines(authed_client):
     assert row["reason"] == "ok"
     assert row["cache_hit"] is False
     assert row["fx_status"] is None
+
+
+def test_bom_response_includes_lifecycle_risk_per_offer(authed_client):
+    _configure_sourcing(authed_client)
+    project_id = _single_line_project(authed_client, mpn="RISK-MPN")
+    _FakeTrustedPartsClient.offers_by_mpn = {
+        "RISK-MPN": [_offer("RISK-MPN", lifecycle_risk="Medium")]
+    }
+
+    r = _post_sourcing(authed_client, project_id)
+
+    assert r.status_code == 200, r.text
+    row = r.json()["data"]["rows"][0]
+    assert row["offers"][0]["lifecycle_risk"] == "Medium"
+    assert row["best_offer"]["lifecycle_risk"] == "Medium"
+
+
+def test_bom_response_includes_is_affected_by_tariff_per_offer(authed_client):
+    _configure_sourcing(authed_client)
+    project_id = _single_line_project(authed_client, mpn="TARIFF-MPN")
+    _FakeTrustedPartsClient.offers_by_mpn = {
+        "TARIFF-MPN": [_offer("TARIFF-MPN", is_affected_by_tariff=True)]
+    }
+
+    r = _post_sourcing(authed_client, project_id)
+
+    assert r.status_code == 200, r.text
+    row = r.json()["data"]["rows"][0]
+    assert row["offers"][0]["is_affected_by_tariff"] is True
+    assert row["best_offer"]["is_affected_by_tariff"] is True
 
 
 def test_bom_row_reports_no_mpn_without_provider_call(authed_client):

--- a/backend/tests/test_sourcing_client.py
+++ b/backend/tests/test_sourcing_client.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from copy import deepcopy
+from datetime import datetime, timezone
+
 import httpx
 import pytest
 
@@ -33,19 +36,47 @@ def _query(token: str = "STM32F103C8T6") -> SourcingQuery:
 def _trustedparts_response() -> dict:
     return {
         "RequestId": "req-1",
+        "CurrentDate": "2026-05-10T12:00:00Z",
+        "ResponseTime": "00:00:01.234",
         "PartResults": [
             {
                 "PartNumber": "STM32F103C8T6",
                 "Manufacturer": "STMicroelectronics",
+                "LifecycleRisk": "Low",
+                "SupplyChainRisk": "Elevated",
+                "IsAffectedByTariff": True,
+                "ManufacturerId": 12345,
+                "Specifications": [
+                    {"Key": "Package", "Value": "LQFP-48"},
+                    {"Key": "Core", "Value": "ARM Cortex-M3"},
+                ],
                 "ProductUrl": "https://www.trustedparts.com/en/part/...",
                 "Distributors": [
                     {
+                        "Id": 9876,
                         "Name": "DigiKey",
                         "DistributorResults": [
                             {
                                 "Description": "MCU 32-bit ARM Cortex-M3",
                                 "DistributorPartNumber": "497-1234-1-ND",
-                                "Stock": {"QuantityOnHand": 1200},
+                                "Stock": {
+                                    "Availability": "In Stock",
+                                    "QuantityOnHand": 1200,
+                                },
+                                "Compliance": {
+                                    "RoHS": [
+                                        {
+                                            "Region": "EU",
+                                            "IsCompliant": True,
+                                            "Description": "RoHS compliant",
+                                        },
+                                        {
+                                            "Region": "CN",
+                                            "IsCompliant": False,
+                                            "Description": None,
+                                        },
+                                    ]
+                                },
                                 "Links": [
                                     {
                                         "Type": "datasheet",
@@ -59,9 +90,20 @@ def _trustedparts_response() -> dict:
                                 "Pricing": {
                                     "CurrencyCode": "EUR",
                                     "MinimumQuantity": 1,
+                                    "QuantityMultiple": 5.0,
                                     "Prices": [
-                                        {"Quantity": 1, "Amount": 2.5},
-                                        {"Quantity": 10, "Amount": 2.1},
+                                        {
+                                            "Quantity": 1,
+                                            "Amount": 2.5,
+                                            "FormattedAmount": "€2.50",
+                                            "Text": "1+ €2.50",
+                                        },
+                                        {
+                                            "Quantity": 10,
+                                            "Amount": 2.1,
+                                            "FormattedAmount": "€2.10",
+                                            "Text": "10+ €2.10",
+                                        },
                                     ],
                                 },
                                 "Packaging": [
@@ -79,14 +121,17 @@ def _trustedparts_response() -> dict:
     }
 
 
-def test_happy_path_returns_offers(monkeypatch):
+def _search_response(monkeypatch, response: dict):
     monkeypatch.setattr(
         sourcing_client,
         "_post_tp",
-        lambda url, json_body, headers: (200, _trustedparts_response()),
+        lambda url, json_body, headers: (200, response),
     )
+    return _client().search([_query()])
 
-    result = _client().search([_query()])
+
+def test_happy_path_returns_offers(monkeypatch):
+    result = _search_response(monkeypatch, _trustedparts_response())
 
     assert isinstance(result, SourcingSearchRaw)
     assert result.request_id == "req-1"
@@ -105,6 +150,171 @@ def test_happy_path_returns_offers(monkeypatch):
     assert distributor.price_breaks[1].quantity == 10
     assert distributor.price_breaks[1].unit_price == 2.1
     assert distributor.product_url == "https://example.com/product"
+
+
+def test_lifecycle_risk_parsed_when_present(monkeypatch):
+    result = _search_response(monkeypatch, _trustedparts_response())
+
+    assert result.offers[0].lifecycle_risk == "Low"
+
+
+def test_lifecycle_risk_is_none_when_absent(monkeypatch):
+    response = deepcopy(_trustedparts_response())
+    response["PartResults"][0].pop("LifecycleRisk")
+
+    result = _search_response(monkeypatch, response)
+
+    assert result.offers[0].lifecycle_risk is None
+
+
+def test_supply_chain_risk_parsed_when_present(monkeypatch):
+    result = _search_response(monkeypatch, _trustedparts_response())
+
+    assert result.offers[0].supply_chain_risk == "Elevated"
+
+
+def test_supply_chain_risk_is_none_when_absent(monkeypatch):
+    response = deepcopy(_trustedparts_response())
+    response["PartResults"][0].pop("SupplyChainRisk")
+
+    result = _search_response(monkeypatch, response)
+
+    assert result.offers[0].supply_chain_risk is None
+
+
+def test_is_affected_by_tariff_parsed_when_present(monkeypatch):
+    result = _search_response(monkeypatch, _trustedparts_response())
+
+    assert result.offers[0].is_affected_by_tariff is True
+
+
+def test_manufacturer_id_parsed_when_present(monkeypatch):
+    result = _search_response(monkeypatch, _trustedparts_response())
+
+    assert result.offers[0].manufacturer_id == 12345
+
+
+def test_specifications_parsed_as_list_of_key_value(monkeypatch):
+    result = _search_response(monkeypatch, _trustedparts_response())
+
+    assert [item.model_dump() for item in result.offers[0].specifications] == [
+        {"key": "Package", "value": "LQFP-48"},
+        {"key": "Core", "value": "ARM Cortex-M3"},
+    ]
+
+
+def test_specifications_empty_list_when_absent(monkeypatch):
+    response = deepcopy(_trustedparts_response())
+    response["PartResults"][0].pop("Specifications")
+
+    result = _search_response(monkeypatch, response)
+
+    assert result.offers[0].specifications == []
+
+
+def test_tou_gated_null_fields_surface_none_and_empty_lists(monkeypatch):
+    response = deepcopy(_trustedparts_response())
+    part = response["PartResults"][0]
+    part["LifecycleRisk"] = None
+    part["SupplyChainRisk"] = None
+    part["Specifications"] = None
+
+    result = _search_response(monkeypatch, response)
+    offer = result.offers[0]
+
+    assert offer.lifecycle_risk is None
+    assert offer.supply_chain_risk is None
+    assert offer.specifications == []
+
+
+def test_rohs_compliance_parsed_per_distributor_per_region(monkeypatch):
+    result = _search_response(monkeypatch, _trustedparts_response())
+    rohs = result.offers[0].distributors[0].rohs_compliance
+
+    assert [item.model_dump() for item in rohs] == [
+        {
+            "region": "EU",
+            "is_compliant": True,
+            "description": "RoHS compliant",
+        },
+        {"region": "CN", "is_compliant": False, "description": None},
+    ]
+
+
+def test_rohs_compliance_empty_list_when_absent(monkeypatch):
+    response = deepcopy(_trustedparts_response())
+    response["PartResults"][0]["Distributors"][0]["DistributorResults"][0].pop(
+        "Compliance"
+    )
+
+    result = _search_response(monkeypatch, response)
+
+    assert result.offers[0].distributors[0].rohs_compliance == []
+
+
+def test_availability_text_parsed_when_present(monkeypatch):
+    result = _search_response(monkeypatch, _trustedparts_response())
+
+    assert result.offers[0].distributors[0].availability_text == "In Stock"
+
+
+def test_quantity_multiple_rounded_to_int(monkeypatch):
+    result = _search_response(monkeypatch, _trustedparts_response())
+
+    assert result.offers[0].distributors[0].quantity_multiple == 5
+
+
+def test_quantity_multiple_none_when_absent(monkeypatch):
+    response = deepcopy(_trustedparts_response())
+    response["PartResults"][0]["Distributors"][0]["DistributorResults"][0]["Pricing"].pop(
+        "QuantityMultiple"
+    )
+
+    result = _search_response(monkeypatch, response)
+
+    assert result.offers[0].distributors[0].quantity_multiple is None
+
+
+def test_distributor_id_parsed(monkeypatch):
+    result = _search_response(monkeypatch, _trustedparts_response())
+
+    assert result.offers[0].distributors[0].distributor_id == 9876
+
+
+def test_distributor_id_none_when_absent(monkeypatch):
+    response = deepcopy(_trustedparts_response())
+    response["PartResults"][0]["Distributors"][0].pop("Id")
+
+    result = _search_response(monkeypatch, response)
+
+    assert result.offers[0].distributors[0].distributor_id is None
+
+
+def test_price_break_includes_formatted_amount_and_text(monkeypatch):
+    response = deepcopy(_trustedparts_response())
+    price = response["PartResults"][0]["Distributors"][0]["DistributorResults"][0]["Pricing"][
+        "Prices"
+    ][0]
+    price["FormattedAmount"] = "$0.12"
+    price["Text"] = "1+ $0.12"
+
+    result = _search_response(monkeypatch, response)
+    price_break = result.offers[0].distributors[0].price_breaks[0]
+
+    assert price_break.formatted_amount == "$0.12"
+    assert price_break.text == "1+ $0.12"
+
+
+def test_response_envelope_includes_tp_current_date(monkeypatch):
+    result = _search_response(monkeypatch, _trustedparts_response())
+
+    assert result.tp_current_date == datetime(2026, 5, 10, 12, tzinfo=timezone.utc)
+
+
+def test_response_envelope_includes_tp_response_time(monkeypatch):
+    result = _search_response(monkeypatch, _trustedparts_response())
+
+    assert result.tp_response_time == "00:00:01.234"
 
 
 def test_request_payload_shape(monkeypatch):

--- a/backend/tests/test_sourcing_part_route.py
+++ b/backend/tests/test_sourcing_part_route.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import uuid
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from decimal import Decimal
 
 import pytest
@@ -15,7 +15,9 @@ from app.domain.sourcing.schemas import (
     SourcingOffer,
     SourcingPriceBreak,
     SourcingQuery,
+    SourcingRohsCompliance,
     SourcingSearchRaw,
+    SourcingSpecification,
 )
 from app.main import app
 from tests._factories import create_part, signup_user
@@ -53,6 +55,17 @@ class _FakeTrustedPartsClient:
     returned_currency: str | None = None
     unit_price: float = 1.23
     price_breaks: list[SourcingPriceBreak] = []
+    lifecycle_risk: str | None = None
+    supply_chain_risk: str | None = None
+    is_affected_by_tariff: bool | None = None
+    manufacturer_id: int | None = None
+    specifications: list[SourcingSpecification] = []
+    distributor_id: int | None = None
+    rohs_compliance: list[SourcingRohsCompliance] = []
+    availability_text: str | None = None
+    quantity_multiple: int | None = None
+    tp_current_date: datetime | None = None
+    tp_response_time: str | None = None
 
     def __init__(self) -> None:
         self.country_code = "CZ"
@@ -85,8 +98,14 @@ class _FakeTrustedPartsClient:
                     mpn=query.search_token,
                     manufacturer="ST",
                     description="Test offer",
+                    lifecycle_risk=self.lifecycle_risk,
+                    supply_chain_risk=self.supply_chain_risk,
+                    is_affected_by_tariff=self.is_affected_by_tariff,
+                    manufacturer_id=self.manufacturer_id,
+                    specifications=self.specifications,
                     distributors=[
                         SourcingDistributor(
+                            distributor_id=self.distributor_id,
                             name="DigiKey",
                             sku=f"{query.search_token}-DK",
                             stock=42,
@@ -94,6 +113,9 @@ class _FakeTrustedPartsClient:
                             currency=returned_currency,
                             price_breaks=self.price_breaks,
                             product_url="https://www.trustedparts.com/product",
+                            rohs_compliance=self.rohs_compliance,
+                            availability_text=self.availability_text,
+                            quantity_multiple=self.quantity_multiple,
                         )
                     ],
                     links=SourcingLinks(
@@ -102,6 +124,8 @@ class _FakeTrustedPartsClient:
                 )
             ],
             request_id=f"req-{len(self.calls)}",
+            tp_current_date=self.tp_current_date,
+            tp_response_time=self.tp_response_time,
         )
 
 
@@ -113,6 +137,17 @@ def reset_sourcing_state(monkeypatch):
     _FakeTrustedPartsClient.returned_currency = None
     _FakeTrustedPartsClient.unit_price = 1.23
     _FakeTrustedPartsClient.price_breaks = []
+    _FakeTrustedPartsClient.lifecycle_risk = None
+    _FakeTrustedPartsClient.supply_chain_risk = None
+    _FakeTrustedPartsClient.is_affected_by_tariff = None
+    _FakeTrustedPartsClient.manufacturer_id = None
+    _FakeTrustedPartsClient.specifications = []
+    _FakeTrustedPartsClient.distributor_id = None
+    _FakeTrustedPartsClient.rohs_compliance = []
+    _FakeTrustedPartsClient.availability_text = None
+    _FakeTrustedPartsClient.quantity_multiple = None
+    _FakeTrustedPartsClient.tp_current_date = None
+    _FakeTrustedPartsClient.tp_response_time = None
     BUDGET._events.clear()
     try:
         _ratelimit_mod.limiter.reset()
@@ -178,6 +213,76 @@ def test_part_with_mpn_returns_offers(authed_client, monkeypatch):
             "use_cached_data": False,
         }
     ]
+
+
+def test_per_part_response_includes_all_8_new_fields(authed_client):
+    _configure_sourcing(authed_client)
+    _FakeTrustedPartsClient.lifecycle_risk = "Low"
+    _FakeTrustedPartsClient.supply_chain_risk = "Elevated"
+    _FakeTrustedPartsClient.is_affected_by_tariff = True
+    _FakeTrustedPartsClient.manufacturer_id = 12345
+    _FakeTrustedPartsClient.specifications = [
+        SourcingSpecification(key="Package", value="LQFP-48")
+    ]
+    _FakeTrustedPartsClient.distributor_id = 9876
+    _FakeTrustedPartsClient.rohs_compliance = [
+        SourcingRohsCompliance(
+            region="EU",
+            is_compliant=True,
+            description="RoHS compliant",
+        )
+    ]
+    _FakeTrustedPartsClient.availability_text = "In Stock"
+    _FakeTrustedPartsClient.quantity_multiple = 5
+    _FakeTrustedPartsClient.price_breaks = [
+        SourcingPriceBreak(
+            quantity=1,
+            unit_price=1.23,
+            formatted_amount="$1.23",
+            text="1+ $1.23",
+        )
+    ]
+    _FakeTrustedPartsClient.tp_current_date = datetime(
+        2026,
+        5,
+        10,
+        12,
+        tzinfo=timezone.utc,
+    )
+    _FakeTrustedPartsClient.tp_response_time = "00:00:01.234"
+    part_id = create_part(authed_client, name="STM32", mpn="STM32F103C8T6")
+
+    r = authed_client.get(f"/api/parts/{part_id}/sourcing")
+
+    assert r.status_code == 200, r.text
+    data = r.json()["data"]
+    assert datetime.fromisoformat(data["tp_current_date"]) == datetime(
+        2026,
+        5,
+        10,
+        12,
+        tzinfo=timezone.utc,
+    )
+    assert data["tp_response_time"] == "00:00:01.234"
+    offer = data["offers"][0]
+    assert offer["lifecycle_risk"] == "Low"
+    assert offer["supply_chain_risk"] == "Elevated"
+    assert offer["is_affected_by_tariff"] is True
+    assert offer["manufacturer_id"] == 12345
+    assert offer["specifications"] == [{"key": "Package", "value": "LQFP-48"}]
+    distributor = offer["distributors"][0]
+    assert distributor["distributor_id"] == 9876
+    assert distributor["rohs_compliance"] == [
+        {
+            "region": "EU",
+            "is_compliant": True,
+            "description": "RoHS compliant",
+        }
+    ]
+    assert distributor["availability_text"] == "In Stock"
+    assert distributor["quantity_multiple"] == 5
+    assert distributor["price_breaks"][0]["formatted_amount"] == "$1.23"
+    assert distributor["price_breaks"][0]["text"] == "1+ $1.23"
 
 
 def test_part_without_mpn_returns_no_mpn_reason_and_skips_network(authed_client):

--- a/backend/tests/test_sourcing_search_route.py
+++ b/backend/tests/test_sourcing_search_route.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
 from fastapi.testclient import TestClient
@@ -97,6 +97,8 @@ class _FakeTrustedPartsClient:
                 )
             ],
             request_id=f"req-{len(self.calls)}",
+            tp_current_date=datetime(2026, 5, 10, 12, tzinfo=timezone.utc),
+            tp_response_time="00:00:01.234",
         )
 
 
@@ -136,8 +138,24 @@ def test_envelope_shape(authed_client):
     datetime.fromisoformat(data["fetched_at"])
     assert data["links"]["primary"]
     assert data["request_id"] == "req-1"
+    assert datetime.fromisoformat(data["tp_current_date"]) == datetime(
+        2026,
+        5,
+        10,
+        12,
+        tzinfo=timezone.utc,
+    )
+    assert data["tp_response_time"] == "00:00:01.234"
     assert data["cache_hit"] is False
     assert data["results"][0]["mpn"] == "STM32F103C8T6"
+    assert datetime.fromisoformat(data["results"][0]["tp_current_date"]) == datetime(
+        2026,
+        5,
+        10,
+        12,
+        tzinfo=timezone.utc,
+    )
+    assert data["results"][0]["tp_response_time"] == "00:00:01.234"
     assert data["results"][0]["cache_hit"] is False
 
 

--- a/docs/api/sourcing.md
+++ b/docs/api/sourcing.md
@@ -201,7 +201,12 @@ Path: `project_id` is a project UUID in the current workspace.
           "unit_price": "0.10",
           "currency": "EUR",
           "moq": 1,
-          "lead_time_days": 3
+          "lead_time_days": 3,
+          "lifecycle_risk": "Low",
+          "supply_chain_risk": null,
+          "is_affected_by_tariff": false,
+          "manufacturer_id": 12345,
+          "specifications": []
         },
         "est_extended_cost": "2.00",
         "risk_flags": []
@@ -230,8 +235,9 @@ Path: `project_id` is a project UUID in the current workspace.
 - The service reuses `shortage_analysis()`, `dedupe_mpns()`, `chunk_mpns()`, and per-MPN `search()` cache rows; BOM chunks use `ttl_seconds=600`.
 - Decimal prices and extended costs serialize as strings.
 - Each row exposes sourcing diagnostics: `reason` is `ok`, `no_mpn`, or `no_offers`; `cache_hit` is `true`/`false` for searched rows and `null` when no MPN was searched; `fx_status` is reserved for row-level conversion failures and is `null` unless represented.
-- Source: `backend/app/api/routes/sourcing.py:251-309`.
-- Service: `backend/app/domain/sourcing/service.py:820-881`, `backend/app/domain/sourcing/service.py:1143-1212`.
+- BOM offer projections carry offer-level TrustedParts gap fields for downstream risk/report consumers; distributor-level gap fields remain on part/search offer DTOs.
+- Source: `backend/app/api/routes/sourcing.py:253-315`.
+- Service: `backend/app/domain/sourcing/service.py:820-882`, `backend/app/domain/sourcing/service.py:1236-1270`.
 - Pricing: `backend/app/domain/sourcing/pricing.py:9-40`.
 
 ### `POST /api/projects/{project_id}/purchase-plan`
@@ -418,12 +424,37 @@ Path: `part_id` is a part UUID in the current workspace.
     "offers": [
       {
         "mpn": "STM32F103C8T6",
+        "lifecycle_risk": "Low",
+        "supply_chain_risk": "Elevated",
+        "is_affected_by_tariff": true,
+        "manufacturer_id": 12345,
+        "specifications": [
+          { "key": "Package", "value": "LQFP-48" }
+        ],
         "distributors": [
           {
+            "distributor_id": 9876,
             "name": "DigiKey",
             "stock": 42,
+            "availability_text": "In Stock",
+            "quantity_multiple": 5,
             "unit_price": 1.23,
             "currency": "USD",
+            "rohs_compliance": [
+              {
+                "region": "EU",
+                "is_compliant": true,
+                "description": "RoHS compliant"
+              }
+            ],
+            "price_breaks": [
+              {
+                "quantity": 1,
+                "unit_price": 1.23,
+                "formatted_amount": "$1.23",
+                "text": "1+ $1.23"
+              }
+            ],
             "unit_price_converted": "1.1070",
             "currency_displayed": "EUR",
             "fx_converted": true,
@@ -436,6 +467,8 @@ Path: `part_id` is a part UUID in the current workspace.
       }
     ],
     "request_id": "trustedparts-request-id",
+    "tp_current_date": "2026-05-10T12:00:00+00:00",
+    "tp_response_time": "00:00:01.234",
     "powered_by": "TrustedParts",
     "fetched_at": "2026-05-08T12:00:00+00:00",
     "cache_hit": false,
@@ -473,10 +506,11 @@ Parts without an MPN return a successful no-network response.
 - The route validates `part_id` with `assert_in_workspace()` before reading the part MPN.
 - The local cache is scoped by `workspace_id`; the part-detail route calls sourcing search with `ttl_seconds=1800`.
 - When a `currency` query param is supplied, distributor prices that still arrive in another currency are display-converted through the global ECB daily snapshot. Native `unit_price` / `currency` stay unchanged; converted display values are exposed as `unit_price_converted`, `currency_displayed`, `fx_converted`, `fx_rate_date`, and `price_breaks_converted`.
+- TrustedParts gap fields surface on each offer (`lifecycle_risk`, `supply_chain_risk`, `is_affected_by_tariff`, `manufacturer_id`, `specifications`), each distributor (`distributor_id`, `rohs_compliance`, `availability_text`, `quantity_multiple`), each price break (`formatted_amount`, `text`), and on the response (`tp_current_date`, `tp_response_time`). ToU-gated fields may be `null` or `[]`.
 - `fx_status` is `unavailable` when at least one requested conversion could not be produced; affected rows keep native prices.
 - The route uses member-or-higher role gating and maps the same sourcing exceptions as `POST /api/sourcing/search`.
-- Source: `backend/app/api/routes/sourcing.py:376`.
-- Service: `backend/app/domain/sourcing/service.py:595`.
+- Source: `backend/app/api/routes/sourcing.py:484-552`.
+- Service: `backend/app/domain/sourcing/service.py:930-1007`.
 - FX: `backend/app/domain/fx/rates.py:46`.
 
 ### `POST /api/parts/{part_id}/sourcing/refresh`
@@ -519,8 +553,8 @@ Shape matches `GET /api/parts/{part_id}/sourcing`. `cache_hit` is `false` when t
 - The route validates `part_id` with `assert_in_workspace()` before reading the part MPN.
 - Refresh calls sourcing search with `use_cached_data=false`, `ttl_seconds=1800`, and `force_refresh=true`; the cache helper still upserts on `(workspace_id, query_hash)`.
 - Forced refreshes consume the in-process parts-count budget because they always call TrustedParts unless the hard budget check blocks first.
-- Source: `backend/app/api/routes/sourcing.py:214-274`.
-- Service: `backend/app/domain/sourcing/service.py:62-142`.
+- Source: `backend/app/api/routes/sourcing.py:555-617`.
+- Service: `backend/app/domain/sourcing/service.py:930-1007`.
 - Cache: `backend/app/domain/sourcing/cache.py:28-72`.
 
 ### `POST /api/sourcing/search`
@@ -550,16 +584,42 @@ Search TrustedParts for 1-50 exact MPNs using the current workspace's encrypted 
           {
             "mpn": "STM32F103C8T6",
             "distributors": [
-              { "name": "DigiKey", "stock": 42, "unit_price": 1.23, "currency": "EUR" }
-            ]
+              {
+                "distributor_id": 9876,
+                "name": "DigiKey",
+                "stock": 42,
+                "availability_text": "In Stock",
+                "quantity_multiple": 5,
+                "unit_price": 1.23,
+                "currency": "EUR",
+                "rohs_compliance": [],
+                "price_breaks": [
+                  {
+                    "quantity": 1,
+                    "unit_price": 1.23,
+                    "formatted_amount": "€1.23",
+                    "text": "1+ €1.23"
+                  }
+                ]
+              }
+            ],
+            "lifecycle_risk": null,
+            "supply_chain_risk": null,
+            "is_affected_by_tariff": false,
+            "manufacturer_id": 12345,
+            "specifications": []
           }
         ],
         "request_id": "trustedparts-request-id",
+        "tp_current_date": "2026-05-10T12:00:00+00:00",
+        "tp_response_time": "00:00:01.234",
         "fetched_at": "2026-05-08T12:00:00+00:00",
         "cache_hit": false
       }
     ],
     "request_id": "trustedparts-request-id",
+    "tp_current_date": "2026-05-10T12:00:00+00:00",
+    "tp_response_time": "00:00:01.234",
     "powered_by": "TrustedParts",
     "fetched_at": "2026-05-08T12:00:00+00:00",
     "cache_hit": false,
@@ -584,8 +644,9 @@ Search TrustedParts for 1-50 exact MPNs using the current workspace's encrypted 
 
 - The route uses member-or-higher role gating and never decrypts credentials in the handler; decryption happens in `make_sourcing_provider()`.
 - Local cache rows are scoped by `workspace_id`, and cache hits do not consume the in-process parts-count budget.
-- Source: `backend/app/api/routes/sourcing.py:87`.
-- Service: `backend/app/domain/sourcing/service.py:39`.
+- `tp_current_date` is the TrustedParts response timestamp serialized as ISO-8601 when present; `tp_response_time` preserves the upstream diagnostic string.
+- Source: `backend/app/api/routes/sourcing.py:96-155`.
+- Service: `backend/app/domain/sourcing/service.py:930-1007`.
 - Factory: `backend/app/domain/sourcing/factory.py:12`.
 
 ### `POST /api/workspaces/current/sourcing/test`

--- a/docs/domain/sourcing.md
+++ b/docs/domain/sourcing.md
@@ -27,6 +27,27 @@ required for new requests. HTTP 200 responses with `ErrorMessage` become upstrea
 `Messages[]` entries are logged at INFO with a `tp_message` tag and do not fail
 the search.
 
+## TrustedParts Gap Fields (TPS-4)
+
+The adapter maps the Inventory API v2 fields that were previously dropped into public
+DTOs after generated-model validation. Offer DTOs carry `lifecycle_risk`,
+`supply_chain_risk`, `is_affected_by_tariff`, `manufacturer_id`, and `specifications`.
+Distributor DTOs carry `distributor_id`, `rohs_compliance`, `availability_text`, and
+`quantity_multiple`. Price breaks carry `formatted_amount` and `text`. Search outputs
+carry `tp_current_date` and `tp_response_time`; the cache stores those response-level
+fields alongside the offer JSON so part-detail and search reads keep the same metadata
+on cache hits.
+
+TrustedParts marks some fields as ToU-gated. Workspaces without access can receive
+`null` for `lifecycle_risk` and `supply_chain_risk`; `specifications` and
+`rohs_compliance` default to `[]` so callers can iterate without null checks. No enum
+constraints are applied to lifecycle risk, supply chain risk, or availability text.
+Quantity multiple is exposed as an integer count.
+
+Sources: `backend/app/domain/sourcing/client.py:285-418`,
+`backend/app/domain/sourcing/service.py:951-1007`,
+`backend/app/domain/sourcing/schemas.py:19-110`
+
 ## Cache Table
 
 `sourcing_cache` stores one response per `(workspace_id, query_hash)`.


### PR DESCRIPTION
## Summary

Parses all 13 TrustedParts Inventory API v2 gap fields from the generated validated models into app DTOs and route responses:

- Offer fields: `lifecycle_risk`, `supply_chain_risk`, `is_affected_by_tariff`, `manufacturer_id`, `specifications`.
- Distributor fields: `distributor_id`, `rohs_compliance`, `availability_text`, `quantity_multiple`.
- Price-break fields: `formatted_amount`, `text`.
- Response metadata: `tp_current_date`, `tp_response_time`.

The adapter keeps typed generated-object access from TPS-2, defaults ToU-gated arrays to `[]`, keeps lifecycle/supply/availability as free strings, carries response metadata through cache reads, and mirrors offer-level fields into BOM offer projections.

## Validation

Docker validation was unavailable in this environment because `docker` is not installed, so I used the repo-local fallback path.

- `cd backend && uv run python -m pytest -q tests/test_sourcing_client.py tests/test_sourcing_search_route.py tests/test_sourcing_part_route.py tests/test_sourcing_bom_route.py`
  - `78 passed, 4 warnings in 16.76s`
- `cd backend && uv run python -m pytest -q -k "sourcing"`
  - `252 passed, 885 deselected, 5 warnings in 37.51s`
- `cd backend && uv run ruff check app/domain/sourcing/client.py app/domain/sourcing/schemas.py app/domain/sourcing/service.py app/api/routes/sourcing.py tests/test_sourcing_client.py tests/test_sourcing_search_route.py tests/test_sourcing_part_route.py tests/test_sourcing_bom_route.py`
  - `All checks passed!`
- `cd backend && LINT_CMD="uv run ruff check app --output-format=concise" BASELINE_FILE="../.ruff-baseline.txt" WORK_DIR="." bash ../scripts/lint-delta.sh`
  - `lint-delta: no new violations (baseline: 159, current: 145, fixed since baseline: 14)`
- `git diff --check`
  - no output, exit 0
- `cd backend && bash -c "! grep -nE '\\.get\\(' app/domain/sourcing/client.py | grep -v _post_tp"`
  - no output, exit 0

## Manual Smoke

Real TrustedParts credentials are not available in this environment, so I could not run the live `curl /api/sourcing/search` smoke. The added route/client tests assert the new fields on `/api/sourcing/search`, `/api/parts/{id}/sourcing`, and `/api/projects/{id}/sourcing` using the existing provider seams.

## Merge Order

1. #459 / #449 is already merged.
2. This PR (#451) before #452 and #454.
3. Hold or rebase #456 and #457 if they overlap sourcing adapter/docs/tests.

Refs #451
