### PR TITLE
TPS-10: LanguageCode workspace setting for TP spec translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ the canonical record.
 - **TPS-5 / #452** Project Sourcing BOM rows and the Sourcing Risk report now
   flag TrustedParts lifecycle-risk text, supply-chain-risk text, tariff
   exposure, and EU RoHS non-compliance from the TPS-4 gap fields.
+- **TPS-10 / #457** Workspace sourcing settings can now store an optional
+  TrustedParts `LanguageCode` for specification translations.
 - **TPS-4 / #451** TrustedParts gap-field parsing now surfaces lifecycle
   risk, supply-chain risk, tariff status, manufacturer id, specifications,
   distributor id, RoHS compliance, availability text, quantity multiple,

--- a/backend/alembic/versions/0046_workspace_sourcing_language.py
+++ b/backend/alembic/versions/0046_workspace_sourcing_language.py
@@ -1,0 +1,51 @@
+"""Add optional TrustedParts sourcing language code.
+
+Revision ID: 0046
+Revises: 0045
+Create Date: 2026-05-10
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "0046"
+down_revision = "0045"
+branch_labels = None
+depends_on = None
+
+_VALID_LANGUAGE_CODES = (
+    "de",
+    "en",
+    "es",
+    "fr",
+    "it",
+    "pt",
+    "ja",
+    "zh-hans",
+    "zh-hant",
+)
+
+
+def upgrade() -> None:
+    op.add_column(
+        "workspaces",
+        sa.Column("sourcing_language_code", sa.String(length=10), nullable=True),
+    )
+    op.create_check_constraint(
+        "ck_workspaces_sourcing_language_code",
+        "workspaces",
+        "sourcing_language_code IS NULL OR sourcing_language_code IN "
+        f"{_VALID_LANGUAGE_CODES!r}",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "ck_workspaces_sourcing_language_code",
+        "workspaces",
+        type_="check",
+    )
+    op.drop_column("workspaces", "sourcing_language_code")

--- a/backend/app/api/routes/workspaces.py
+++ b/backend/app/api/routes/workspaces.py
@@ -153,6 +153,7 @@ def _serialize_workspace(ws: Workspace, new_token: str | None = None) -> dict:
         "sourcing_provider": ws.sourcing_provider or "none",
         "sourcing_country_code": ws.sourcing_country_code,
         "sourcing_currency_code": ws.sourcing_currency_code,
+        "sourcing_language_code": ws.sourcing_language_code,
         "sourcing_preferred_distributors": ws.sourcing_preferred_distributors,
         "active_currencies": ws.active_currencies,
         "active_countries": ws.active_countries,

--- a/backend/app/domain/sourcing/client.py
+++ b/backend/app/domain/sourcing/client.py
@@ -98,11 +98,13 @@ class TrustedPartsClient:
         country_code: str | None,
         currency_code: str | None,
         user_agent: str,
+        language_code: str | None = None,
     ) -> None:
         self.company_id = company_id
         self.api_key = api_key
         self.country_code = country_code
         self.currency_code = currency_code
+        self.language_code = language_code
         self.user_agent = user_agent
 
     def search(
@@ -178,6 +180,8 @@ class TrustedPartsClient:
         }
         if distributors:
             payload["Distributors"] = distributors
+        if self.language_code:
+            payload["LanguageCode"] = self.language_code
         return payload
 
 

--- a/backend/app/domain/sourcing/factory.py
+++ b/backend/app/domain/sourcing/factory.py
@@ -23,5 +23,6 @@ def make_sourcing_provider(workspace: Any) -> TrustedPartsClient | None:
         api_key=api_key,
         country_code=workspace.sourcing_country_code,
         currency_code=workspace.sourcing_currency_code,
+        language_code=workspace.sourcing_language_code,
         user_agent=f"stockManager/{git_sha()} workspace={workspace.id}",
     )

--- a/backend/app/domain/workspaces/models.py
+++ b/backend/app/domain/workspaces/models.py
@@ -3,7 +3,17 @@ from __future__ import annotations
 import uuid
 
 import sqlalchemy as sa
-from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Index, String, UniqueConstraint, text
+from sqlalchemy import (
+    Boolean,
+    CheckConstraint,
+    Column,
+    DateTime,
+    ForeignKey,
+    Index,
+    String,
+    UniqueConstraint,
+    text,
+)
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 
 from app.core.time import utcnow
@@ -18,6 +28,11 @@ from app.infra.db import Base
 class Workspace(Base):
     __tablename__ = "workspaces"
     __table_args__ = (
+        CheckConstraint(
+            "sourcing_language_code IS NULL OR sourcing_language_code IN "
+            "('de','en','es','fr','it','pt','ja','zh-hans','zh-hant')",
+            name="ck_workspaces_sourcing_language_code",
+        ),
         # Partial unique index: only non-NULL hashes must be distinct.
         # Mirrors the index created by migration 0025.
         Index(
@@ -31,7 +46,11 @@ class Workspace(Base):
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     name = Column(String(200), nullable=False)
     kind = Column(String(20), nullable=False, default="organization")  # personal | organization
-    owner_user_id = Column(UUID(as_uuid=True), ForeignKey("users.id", ondelete="RESTRICT"), nullable=False)
+    owner_user_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
     currency_default = Column(String(3), nullable=False, default="USD")
     lot_control_enabled = Column(Boolean, nullable=False, default=True)
     serial_tracking_enabled = Column(Boolean, nullable=False, default=False)
@@ -60,6 +79,7 @@ class Workspace(Base):
     sourcing_api_key_enc = Column(String(1024), nullable=True)
     sourcing_country_code = Column(String(2), nullable=True)
     sourcing_currency_code = Column(String(3), nullable=True)
+    sourcing_language_code = Column(String(10), nullable=True)
     sourcing_preferred_distributors = Column(JSONB, nullable=True)
     active_currencies = Column(
         JSONB,
@@ -99,8 +119,18 @@ class WorkspaceMember(Base):
     )
 
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    workspace_id = Column(UUID(as_uuid=True), ForeignKey("workspaces.id", ondelete="CASCADE"), nullable=False, index=True)
-    user_id = Column(UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
+    workspace_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("workspaces.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    user_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
     role = Column(String(40), nullable=False, default="member")  # owner | admin | member | viewer
     status = Column(String(20), nullable=False, default="active")  # invited | active | disabled
     created_at = Column(DateTime(timezone=True), nullable=False, default=utcnow)
@@ -124,7 +154,12 @@ class WorkspaceInvitation(Base):
     )
 
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    workspace_id = Column(UUID(as_uuid=True), ForeignKey("workspaces.id", ondelete="CASCADE"), nullable=False, index=True)
+    workspace_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("workspaces.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
     email = Column(String(320), nullable=False, index=True)
     role = Column(String(40), nullable=False, default="member")
     # SHA-256 hex digest of the plaintext token. Kept for backward
@@ -138,10 +173,18 @@ class WorkspaceInvitation(Base):
     # are invalidated on deploy — see migration docstring).
     token_hmac = Column(String(64), nullable=True)
     status = Column(String(20), nullable=False, default="pending")  # pending | accepted | revoked
-    invited_by = Column(UUID(as_uuid=True), ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
+    invited_by = Column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+    )
     created_at = Column(DateTime(timezone=True), nullable=False, default=utcnow)
     accepted_at = Column(DateTime(timezone=True), nullable=True)
-    accepted_by = Column(UUID(as_uuid=True), ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
+    accepted_by = Column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+    )
 
 
 class WorkspaceCatalogToken(Base):

--- a/backend/app/domain/workspaces/schemas.py
+++ b/backend/app/domain/workspaces/schemas.py
@@ -25,6 +25,17 @@ __all__ = [
 
 CurrencyCode = Annotated[str, StringConstraints(pattern=r"^[A-Z]{3}$")]
 CountryCode = Annotated[str, StringConstraints(pattern=r"^[A-Z]{2}$")]
+SourcingLanguageCode = Literal[
+    "de",
+    "en",
+    "es",
+    "fr",
+    "it",
+    "pt",
+    "ja",
+    "zh-hans",
+    "zh-hant",
+]
 DistributorName = Annotated[
     str,
     StringConstraints(strip_whitespace=True, min_length=1, max_length=120),
@@ -64,6 +75,7 @@ class WorkspacePatch(BaseModel):
     sourcing_api_key: str | None = Field(default=None, max_length=256)
     sourcing_country_code: str | None = Field(default=None, min_length=2, max_length=2)
     sourcing_currency_code: str | None = Field(default=None, min_length=3, max_length=3)
+    sourcing_language_code: SourcingLanguageCode | None = None
     sourcing_preferred_distributors: list[str] | None = None
     active_currencies: list[CurrencyCode] | None = Field(default=None, min_length=1)
     active_countries: list[CountryCode] | None = Field(default=None, min_length=1)

--- a/backend/tests/test_sourcing_client.py
+++ b/backend/tests/test_sourcing_client.py
@@ -389,6 +389,42 @@ def test_company_id_not_sent_in_request_body(monkeypatch):
     assert captured["body"].get("CompanyId") is None
 
 
+def test_search_request_includes_language_code_when_workspace_has_it_set(monkeypatch):
+    captured: dict[str, dict] = {}
+    client = TrustedPartsClient(
+        company_id="company-1",
+        api_key="api-key-1",
+        country_code="CZ",
+        currency_code="EUR",
+        user_agent="stockManager/test workspace=ws-1",
+        language_code="de",
+    )
+
+    def fake_post(url, json_body, headers):
+        captured["body"] = json_body
+        return 200, {"PartResults": []}
+
+    monkeypatch.setattr(sourcing_client, "_post_tp", fake_post)
+
+    client.search([_query()])
+
+    assert captured["body"]["LanguageCode"] == "de"
+
+
+def test_search_request_omits_language_code_when_workspace_has_none(monkeypatch):
+    captured: dict[str, dict] = {}
+
+    def fake_post(url, json_body, headers):
+        captured["body"] = json_body
+        return 200, {"PartResults": []}
+
+    monkeypatch.setattr(sourcing_client, "_post_tp", fake_post)
+
+    _client().search([_query()])
+
+    assert "LanguageCode" not in captured["body"]
+
+
 def test_api_key_never_logged(monkeypatch, caplog):
     api_key = "super-secret-api-key"
     client = TrustedPartsClient(

--- a/backend/tests/test_sourcing_test_route.py
+++ b/backend/tests/test_sourcing_test_route.py
@@ -57,11 +57,13 @@ class _SuccessfulTrustedPartsClient:
         country_code: str | None,
         currency_code: str | None,
         user_agent: str,
+        language_code: str | None = None,
     ) -> None:
         self.company_id = company_id
         self.api_key = api_key
         self.country_code = country_code
         self.currency_code = currency_code
+        self.language_code = language_code
         self.user_agent = user_agent
 
     def search(

--- a/backend/tests/test_workspace_isolation.py
+++ b/backend/tests/test_workspace_isolation.py
@@ -426,11 +426,13 @@ def test_sourcing_search_uses_caller_workspace_secrets(monkeypatch):
             country_code: str | None,
             currency_code: str | None,
             user_agent: str,
+            language_code: str | None = None,
         ) -> None:
             self.company_id = company_id
             self.api_key = api_key
             self.country_code = country_code
             self.currency_code = currency_code
+            self.language_code = language_code
             self.user_agent = user_agent
 
         def search(self, queries: list[SourcingQuery], *, use_cached_data: bool, **_kwargs):

--- a/backend/tests/test_workspace_sourcing_settings.py
+++ b/backend/tests/test_workspace_sourcing_settings.py
@@ -2,11 +2,24 @@ from __future__ import annotations
 
 from uuid import UUID
 
+import pytest
 from sqlalchemy import select
 
 from app.core.secrets import decrypt
 from app.domain.audit.models import AuditLog
 from app.domain.workspaces.models import Workspace
+
+VALID_LANGUAGE_CODES = (
+    "de",
+    "en",
+    "es",
+    "fr",
+    "it",
+    "pt",
+    "ja",
+    "zh-hans",
+    "zh-hant",
+)
 
 
 def _current_workspace_id(authed_client) -> UUID:
@@ -46,6 +59,46 @@ def test_set_sourcing_credentials_persists_ciphertext(authed_client, db):
     assert ws.sourcing_api_key_enc is not None
     assert ws.sourcing_api_key_enc != api_key
     assert decrypt(ws.sourcing_api_key_enc) == api_key
+
+
+def test_default_language_code_is_null(authed_client, db):
+    r = authed_client.get("/api/workspaces/current")
+    assert r.status_code == 200, r.text
+    assert r.json()["data"]["sourcing_language_code"] is None
+
+    ws = db.get(Workspace, _current_workspace_id(authed_client))
+    assert ws is not None
+    assert ws.sourcing_language_code is None
+
+
+@pytest.mark.parametrize("language_code", VALID_LANGUAGE_CODES)
+def test_patch_valid_language_code_persists(authed_client, db, language_code):
+    r = authed_client.patch(
+        "/api/workspaces/current",
+        json={"sourcing_language_code": language_code},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["data"]["sourcing_language_code"] == language_code
+
+    ws = db.get(Workspace, _current_workspace_id(authed_client))
+    assert ws is not None
+    assert ws.sourcing_language_code == language_code
+
+
+def test_patch_invalid_language_code_returns_422(authed_client):
+    r = authed_client.patch(
+        "/api/workspaces/current",
+        json={"sourcing_language_code": "klingon"},
+    )
+
+    assert r.status_code == 422
+    body = r.json()
+    assert body["data"] is None
+    assert body["status"]["category"] == "validation_error"
+    assert any(
+        error["field"] == "body.sourcing_language_code"
+        for error in body.get("errors", [])
+    )
 
 
 def test_clear_sourcing_credential_with_empty_string(authed_client, db):

--- a/docs/api/workspaces.md
+++ b/docs/api/workspaces.md
@@ -66,6 +66,7 @@ Return the active workspace.
     "catalog_enabled": true, "catalog_token_set": true,
     "parts_provider": "mouser", "has_parts_provider_api_key": true, "has_parts_provider_api_secret": true,
     "active_currencies": ["EUR", "USD"], "active_countries": ["CZ", "DE"],
+    "sourcing_language_code": null,
     "active_distributors": ["DigiKey", "Mouser"],
     "scanner": "zxing", "has_scanner_license_key": false
 }, "status": { … } }
@@ -126,6 +127,7 @@ Update workspace settings, rotate provider/scanner credentials, and (re)mint the
 | `parts_provider_api_secret` | string | Same encrypt-or-clear (`workspaces.py:179-182`). |
 | `scanner` | string | `"zxing"` / `"scandit"`. |
 | `scanner_license_key` | string | Encrypt-or-clear (`workspaces.py:183-186`). |
+| `sourcing_language_code` | string \| null | Optional TrustedParts spec translation language. Allowed values: `de`, `en`, `es`, `fr`, `it`, `pt`, `ja`, `zh-hans`, `zh-hant`; `null` omits `LanguageCode` so TP uses its default (`schemas.py:31-41`, `client.py:171-173`). |
 | `active_currencies` | string[] | Non-empty ISO-4217 uppercase codes; each matches `^[A-Z]{3}$` (`schemas.py:26`, `schemas.py:68`). |
 | `active_countries` | string[] | Non-empty ISO-3166 alpha-2 uppercase codes; each matches `^[A-Z]{2}$` (`schemas.py:27`, `schemas.py:69`). |
 | `active_distributors` | string[] | Non-empty distributor names; each is trimmed and limited to 120 chars (`schemas.py:28-30`, `schemas.py:70`). |

--- a/web/src/routes/settings/SourcingCard.tsx
+++ b/web/src/routes/settings/SourcingCard.tsx
@@ -4,11 +4,27 @@ import { toast } from "sonner";
 import { api, ApiError } from "@/lib/api";
 import { wsKeyOf } from "@/lib/queryKeys";
 
+const LANGUAGE_OPTIONS = [
+  { value: "", label: "Default (en)" },
+  { value: "de", label: "German (de)" },
+  { value: "en", label: "English (en)" },
+  { value: "es", label: "Spanish (es)" },
+  { value: "fr", label: "French (fr)" },
+  { value: "it", label: "Italian (it)" },
+  { value: "pt", label: "Portuguese (pt)" },
+  { value: "ja", label: "Japanese (ja)" },
+  { value: "zh-hans", label: "Chinese, Simplified (zh-hans)" },
+  { value: "zh-hant", label: "Chinese, Traditional (zh-hant)" },
+] as const;
+
+type SourcingLanguageCode = typeof LANGUAGE_OPTIONS[number]["value"];
+
 export type SourcingWorkspace = {
   id: string;
   sourcing_provider: "none" | "trustedparts";
   sourcing_country_code: string | null;
   sourcing_currency_code: string | null;
+  sourcing_language_code: Exclude<SourcingLanguageCode, ""> | null;
   sourcing_preferred_distributors: string[] | null;
   sourcing_use_cached_for_dashboards: boolean;
   has_sourcing_company_id: boolean;
@@ -19,6 +35,7 @@ type SourcingPatch = {
   sourcing_provider: SourcingWorkspace["sourcing_provider"];
   sourcing_country_code: string | null;
   sourcing_currency_code: string | null;
+  sourcing_language_code: SourcingWorkspace["sourcing_language_code"];
   sourcing_preferred_distributors: string[];
   sourcing_use_cached_for_dashboards: boolean;
   sourcing_company_id?: string;
@@ -59,6 +76,7 @@ export function SourcingCard({
   const [apiKeyTouched, setApiKeyTouched] = useState(false);
   const [country, setCountry] = useState(workspace.sourcing_country_code ?? "");
   const [currency, setCurrency] = useState(workspace.sourcing_currency_code ?? "");
+  const [language, setLanguage] = useState<SourcingLanguageCode>(workspace.sourcing_language_code ?? "");
   const [distributors, setDistributors] = useState(
     (workspace.sourcing_preferred_distributors ?? []).join(", "),
   );
@@ -75,6 +93,7 @@ export function SourcingCard({
     setApiKeyTouched(false);
     setCountry(workspace.sourcing_country_code ?? "");
     setCurrency(workspace.sourcing_currency_code ?? "");
+    setLanguage(workspace.sourcing_language_code ?? "");
     setDistributors((workspace.sourcing_preferred_distributors ?? []).join(", "));
     setUseCache(workspace.sourcing_use_cached_for_dashboards);
     setHasCompanyId(workspace.has_sourcing_company_id);
@@ -126,6 +145,7 @@ export function SourcingCard({
       sourcing_provider: provider,
       sourcing_country_code: country.trim() ? country.trim().toUpperCase() : null,
       sourcing_currency_code: currency.trim() ? currency.trim().toUpperCase() : null,
+      sourcing_language_code: language || null,
       sourcing_preferred_distributors: splitDistributors(distributors),
       sourcing_use_cached_for_dashboards: useCache,
     };
@@ -218,6 +238,21 @@ export function SourcingCard({
             onChange={(e) => setCurrency(e.target.value.toUpperCase())}
             placeholder="USD"
           />
+        </div>
+        <div>
+          <label className="label" htmlFor="sourcing-language">Language</label>
+          <select
+            id="sourcing-language"
+            className="input"
+            value={language}
+            onChange={(e) => setLanguage(e.target.value as SourcingLanguageCode)}
+          >
+            {LANGUAGE_OPTIONS.map((option) => (
+              <option key={option.value || "default"} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
         </div>
         <div>
           <label className="label" htmlFor="sourcing-distributors">Preferred distributors</label>

--- a/web/src/routes/settings/Workspace.tsx
+++ b/web/src/routes/settings/Workspace.tsx
@@ -32,6 +32,7 @@ type Ws = {
   sourcing_provider: "none" | "trustedparts";
   sourcing_country_code: string | null;
   sourcing_currency_code: string | null;
+  sourcing_language_code: "de" | "en" | "es" | "fr" | "it" | "pt" | "ja" | "zh-hans" | "zh-hant" | null;
   sourcing_preferred_distributors: string[] | null;
   active_currencies: string[];
   active_countries: string[];

--- a/web/src/routes/settings/__dom__/SourcingCard.dom.test.tsx
+++ b/web/src/routes/settings/__dom__/SourcingCard.dom.test.tsx
@@ -18,6 +18,7 @@ const baseWorkspace: SourcingWorkspace = {
   sourcing_provider: "none",
   sourcing_country_code: null,
   sourcing_currency_code: null,
+  sourcing_language_code: null,
   sourcing_preferred_distributors: null,
   sourcing_use_cached_for_dashboards: true,
   has_sourcing_company_id: false,
@@ -53,6 +54,9 @@ describe("SourcingCard", () => {
     expect(screen.getByLabelText("API Key")).toBeDefined();
     expect(screen.getByLabelText("Country")).toBeDefined();
     expect(screen.getByLabelText("Currency")).toBeDefined();
+    expect(screen.getByLabelText("Language")).toBeDefined();
+    expect(screen.getByRole("option", { name: "Default (en)" })).toBeDefined();
+    expect(screen.getByRole("option", { name: "Chinese, Traditional (zh-hant)" })).toBeDefined();
     expect(screen.getByLabelText("Preferred distributors")).toBeDefined();
     expect(screen.getByLabelText("Use cached data for dashboards")).toBeDefined();
     expect(screen.queryByText("Configured ✓")).toBeNull();
@@ -65,6 +69,7 @@ describe("SourcingCard", () => {
       sourcing_provider: "trustedparts",
       sourcing_country_code: "CZ",
       sourcing_currency_code: "EUR",
+      sourcing_language_code: "de",
       sourcing_preferred_distributors: ["DigiKey", "Mouser"],
       sourcing_use_cached_for_dashboards: false,
       has_sourcing_company_id: true,
@@ -77,6 +82,7 @@ describe("SourcingCard", () => {
     await user.type(screen.getByLabelText("API Key"), "api-456");
     await user.type(screen.getByLabelText("Country"), "cz");
     await user.type(screen.getByLabelText("Currency"), "eur");
+    await user.selectOptions(screen.getByLabelText("Language"), "de");
     await user.type(screen.getByLabelText("Preferred distributors"), "DigiKey, Mouser");
     await user.click(screen.getByLabelText("Use cached data for dashboards"));
     await user.click(screen.getByRole("button", { name: "Save" }));
@@ -86,6 +92,7 @@ describe("SourcingCard", () => {
         sourcing_provider: "trustedparts",
         sourcing_country_code: "CZ",
         sourcing_currency_code: "EUR",
+        sourcing_language_code: "de",
         sourcing_preferred_distributors: ["DigiKey", "Mouser"],
         sourcing_use_cached_for_dashboards: false,
         sourcing_company_id: "company-123",
@@ -94,6 +101,22 @@ describe("SourcingCard", () => {
     });
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["ws", "ws-1", "ws", "current"] });
     expect(screen.getByText("Configured ✓")).toBeDefined();
+  });
+
+  it("maps the default language option to null on Save", async () => {
+    const user = userEvent.setup();
+    const patchSpy = vi.spyOn(api, "patch").mockResolvedValue(baseWorkspace);
+    renderCard({ ...baseWorkspace, sourcing_language_code: "fr" });
+
+    await user.selectOptions(screen.getByLabelText("Language"), "");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(patchSpy).toHaveBeenCalledWith(
+        "/workspaces/current",
+        expect.objectContaining({ sourcing_language_code: null }),
+      );
+    });
   });
 
   it("surfaces test-connection result on success", async () => {


### PR DESCRIPTION
## Summary
- Add migration `0046_workspace_sourcing_language.py` for nullable `workspaces.sourcing_language_code` with a CHECK constraint over `de,en,es,fr,it,pt,ja,zh-hans,zh-hant`.
- Expose `sourcing_language_code` through workspace serialization/PATCH validation and settings UI.
- Pass TrustedParts `LanguageCode` only when the workspace value is set; omit it when null so TP uses its default.
- Add backend and frontend tests plus API docs/CHANGELOG coverage.

## Validation
- Migration round trip on fresh local Postgres DB `stockmgr_migration_tps10`:
  - `DATABASE_URL=postgresql+psycopg://stockmgr:stockmgr@127.0.0.1:5432/stockmgr_migration_tps10 uv run alembic upgrade head` passed, including `0045 -> 0046`.
  - `... uv run alembic downgrade -1` passed, `0046 -> 0045`.
  - `... uv run alembic upgrade head` passed, `0045 -> 0046`.
- `uv run python -m pytest -q -k "workspace_sourcing_settings or sourcing_client"` passed: `57 passed, 1094 deselected, 3 warnings in 8.58s`.
- `uv run ruff check app/domain/workspaces/models.py app/api/routes/workspaces.py app/domain/workspaces/schemas.py app/domain/sourcing/client.py app/domain/sourcing/factory.py tests/test_workspace_sourcing_settings.py tests/test_sourcing_client.py alembic/versions/0046_workspace_sourcing_language.py` passed.
- `cd web && npm run typecheck && npm test -- SourcingCard` passed: SourcingCard suite `6 passed`.
- `cd web && npm run lint` did not pass due pre-existing repository lint findings outside this PR (`web/src/lib/bagCode.ts`, `web/src/components/scanner/ZxingScanner.tsx`, and other unrelated files). Touched frontend files pass direct lint: `npx eslint src/routes/settings/SourcingCard.tsx src/routes/settings/Workspace.tsx src/routes/settings/__dom__/SourcingCard.dom.test.tsx`.
- `git diff --check` passed.

## Screenshot
- Not captured: this worktree does not have a running authenticated app/backend session. The dropdown is covered by the SourcingCard DOM test, including all options and Default-to-null save behavior.

## Migration / Merge Order
- Migration number: `0046`.
- Merge order: after #460; can merge before #453 to reserve its migration number, or rebase if #453 lands first; independent of #452/#454.

Refs #457