### PR TITLE
TPS-5: New BOM risk flags from gap fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ the canonical record.
 
 ## 2026-05 — feedback brief fixes
 
+- **TPS-5 / #452** Project Sourcing BOM rows and the Sourcing Risk report now
+  flag TrustedParts lifecycle-risk text, supply-chain-risk text, tariff
+  exposure, and EU RoHS non-compliance from the TPS-4 gap fields.
 - **TPS-4 / #451** TrustedParts gap-field parsing now surfaces lifecycle
   risk, supply-chain risk, tariff status, manufacturer id, specifications,
   distributor id, RoHS compliance, availability text, quantity multiple,

--- a/backend/app/domain/reports/schemas.py
+++ b/backend/app/domain/reports/schemas.py
@@ -26,6 +26,10 @@ SourcingRiskFlag = Literal[
     "moq_overbuy",
     "lead_time_long",
     "preferred_distributor_unmet",
+    "lifecycle_risk_present",
+    "supply_chain_risk_present",
+    "tariff_affected",
+    "rohs_non_compliant",
     "price_delta",
 ]
 

--- a/backend/app/domain/reports/service.py
+++ b/backend/app/domain/reports/service.py
@@ -670,6 +670,7 @@ def _sourcing_risk_row(
         & {item.casefold() for item in distributors_with_stock}
     ):
         flags.append("preferred_distributor_unmet")
+    flags.extend(sourcing_service._gap_field_risk_flags(offers))  # noqa: SLF001
     if price_delta_pct is not None and price_delta_pct >= PRICE_DELTA_THRESHOLD:
         flags.append("price_delta")
 

--- a/backend/app/domain/sourcing/schemas.py
+++ b/backend/app/domain/sourcing/schemas.py
@@ -1,4 +1,5 @@
 """Pydantic DTOs for TrustedParts sourcing."""
+
 from __future__ import annotations
 
 from datetime import date, datetime
@@ -334,6 +335,7 @@ class SourcingBomOfferOut(BaseModel):
     lifecycle_risk: str | None = None
     supply_chain_risk: str | None = None
     is_affected_by_tariff: bool | None = None
+    rohs_compliance: list[SourcingRohsCompliance] = Field(default_factory=list)
     manufacturer_id: int | None = None
     specifications: list[SourcingSpecification] = Field(default_factory=list)
 
@@ -565,6 +567,10 @@ class SourcingBomLineOut(BaseModel):
             "moq_overbuy",
             "lead_time_long",
             "preferred_distributor_unmet",
+            "lifecycle_risk_present",
+            "supply_chain_risk_present",
+            "tariff_affected",
+            "rohs_non_compliant",
         ]
     ] = Field(default_factory=list)
 

--- a/backend/app/domain/sourcing/service.py
+++ b/backend/app/domain/sourcing/service.py
@@ -63,6 +63,7 @@ TRUSTEDPARTS_LINKS = SourcingAttributionLinks(
     primary="https://www.trustedparts.com/",
     attribution="https://www.trustedparts.com/en/about",
 )
+TARGET_ROHS_REGION = "EU"
 _SOURCING_FILTER_ALERT_TYPES = {
     "back_in_stock",
     "out_of_authorized_stock",
@@ -1263,6 +1264,7 @@ def _joined_offers(
                         lifecycle_risk=offer.lifecycle_risk,
                         supply_chain_risk=offer.supply_chain_risk,
                         is_affected_by_tariff=offer.is_affected_by_tariff,
+                        rohs_compliance=distributor.rohs_compliance,
                         manufacturer_id=offer.manufacturer_id,
                         specifications=offer.specifications,
                     )
@@ -1354,7 +1356,34 @@ def _risk_flags(
         preferred = {item.casefold() for item in preferred_distributors}
         if not (preferred & stocked_distributors):
             flags.append("preferred_distributor_unmet")
+    flags.extend(_gap_field_risk_flags(offers))
     return flags
+
+
+def _gap_field_risk_flags(offers: list[SourcingBomOfferOut]) -> list[str]:
+    flags: list[str] = []
+    if any(_has_text(offer.lifecycle_risk) for offer in offers):
+        flags.append("lifecycle_risk_present")
+    if any(_has_text(offer.supply_chain_risk) for offer in offers):
+        flags.append("supply_chain_risk_present")
+    if any(offer.is_affected_by_tariff is True for offer in offers):
+        flags.append("tariff_affected")
+    # Workspace-level RoHS target regions do not exist yet; default to EU for TPS-5.
+    if offers and all(not _has_compliant_rohs_region(offer) for offer in offers):
+        flags.append("rohs_non_compliant")
+    return flags
+
+
+def _has_text(value: str | None) -> bool:
+    return value is not None and value.strip() != ""
+
+
+def _has_compliant_rohs_region(offer: SourcingBomOfferOut) -> bool:
+    target = TARGET_ROHS_REGION.casefold()
+    return any(
+        item.region.casefold() == target and item.is_compliant is True
+        for item in offer.rohs_compliance
+    )
 
 
 def _clean_code(value: str | None) -> str | None:

--- a/backend/tests/test_sourcing_bom_route.py
+++ b/backend/tests/test_sourcing_bom_route.py
@@ -16,6 +16,7 @@ from app.domain.sourcing.schemas import (
     SourcingOffer,
     SourcingPriceBreak,
     SourcingQuery,
+    SourcingRohsCompliance,
     SourcingSearchRaw,
     SourcingSpecification,
 )
@@ -61,6 +62,7 @@ def _offer(
     lifecycle_risk: str | None = None,
     supply_chain_risk: str | None = None,
     is_affected_by_tariff: bool | None = None,
+    rohs_compliance: list[SourcingRohsCompliance] | None = None,
 ) -> SourcingOffer:
     return SourcingOffer(
         mpn=mpn,
@@ -82,6 +84,7 @@ def _offer(
                 lead_time_days=lead_time_days,
                 price_breaks=[SourcingPriceBreak(quantity=1, unit_price=unit_price)],
                 product_url=f"https://www.trustedparts.com/{mpn}/{distributor}",
+                rohs_compliance=rohs_compliance or [],
             )
         ],
         links=SourcingLinks(primary=f"https://www.trustedparts.com/search/{mpn}"),
@@ -419,9 +422,7 @@ def test_risk_flag_no_authorized_stock(authed_client):
         "No authorized stock",
         [{"part_id": part_id, "quantity": 10}],
     )
-    _FakeTrustedPartsClient.offers_by_mpn = {
-        "NO-STOCK": [_offer("NO-STOCK", stock=0)]
-    }
+    _FakeTrustedPartsClient.offers_by_mpn = {"NO-STOCK": [_offer("NO-STOCK", stock=0)]}
 
     r = _post_sourcing(authed_client, project_id)
 
@@ -432,9 +433,7 @@ def test_risk_flag_no_authorized_stock(authed_client):
 def test_risk_flag_moq_overbuy(authed_client):
     _configure_sourcing(authed_client)
     project_id = _single_line_project(authed_client, mpn="MOQ", quantity=5)
-    _FakeTrustedPartsClient.offers_by_mpn = {
-        "MOQ": [_offer("MOQ", stock=100, moq=100)]
-    }
+    _FakeTrustedPartsClient.offers_by_mpn = {"MOQ": [_offer("MOQ", stock=100, moq=100)]}
 
     r = _post_sourcing(authed_client, project_id)
 
@@ -445,9 +444,7 @@ def test_risk_flag_moq_overbuy(authed_client):
 def test_risk_flag_lead_time_long(authed_client):
     _configure_sourcing(authed_client)
     project_id = _single_line_project(authed_client, mpn="SLOW")
-    _FakeTrustedPartsClient.offers_by_mpn = {
-        "SLOW": [_offer("SLOW", stock=100, lead_time_days=45)]
-    }
+    _FakeTrustedPartsClient.offers_by_mpn = {"SLOW": [_offer("SLOW", stock=100, lead_time_days=45)]}
 
     r = _post_sourcing(authed_client, project_id)
 
@@ -466,6 +463,161 @@ def test_risk_flag_preferred_distributor_unmet(authed_client):
 
     assert r.status_code == 200, r.text
     assert "preferred_distributor_unmet" in r.json()["data"]["rows"][0]["risk_flags"]
+
+
+def test_risk_flag_lifecycle_risk_present_fires_when_field_populated(authed_client):
+    _configure_sourcing(authed_client)
+    project_id = _single_line_project(authed_client, mpn="LIFE-RISK")
+    _FakeTrustedPartsClient.offers_by_mpn = {
+        "LIFE-RISK": [_offer("LIFE-RISK", lifecycle_risk="NRND")]
+    }
+
+    r = _post_sourcing(authed_client, project_id)
+
+    assert r.status_code == 200, r.text
+    assert "lifecycle_risk_present" in r.json()["data"]["rows"][0]["risk_flags"]
+
+
+def test_risk_flag_lifecycle_risk_present_does_not_fire_when_field_null(authed_client):
+    _configure_sourcing(authed_client)
+    project_id = _single_line_project(authed_client, mpn="NO-LIFE-RISK")
+    _FakeTrustedPartsClient.offers_by_mpn = {
+        "NO-LIFE-RISK": [_offer("NO-LIFE-RISK", lifecycle_risk=None)]
+    }
+
+    r = _post_sourcing(authed_client, project_id)
+
+    assert r.status_code == 200, r.text
+    assert "lifecycle_risk_present" not in r.json()["data"]["rows"][0]["risk_flags"]
+
+
+def test_risk_flag_supply_chain_risk_present_fires_when_field_populated(authed_client):
+    _configure_sourcing(authed_client)
+    project_id = _single_line_project(authed_client, mpn="SUPPLY-RISK")
+    _FakeTrustedPartsClient.offers_by_mpn = {
+        "SUPPLY-RISK": [_offer("SUPPLY-RISK", supply_chain_risk="Limited supply")]
+    }
+
+    r = _post_sourcing(authed_client, project_id)
+
+    assert r.status_code == 200, r.text
+    assert "supply_chain_risk_present" in r.json()["data"]["rows"][0]["risk_flags"]
+
+
+def test_risk_flag_supply_chain_risk_present_does_not_fire_when_field_null(authed_client):
+    _configure_sourcing(authed_client)
+    project_id = _single_line_project(authed_client, mpn="NO-SUPPLY-RISK")
+    _FakeTrustedPartsClient.offers_by_mpn = {
+        "NO-SUPPLY-RISK": [_offer("NO-SUPPLY-RISK", supply_chain_risk=None)]
+    }
+
+    r = _post_sourcing(authed_client, project_id)
+
+    assert r.status_code == 200, r.text
+    assert "supply_chain_risk_present" not in r.json()["data"]["rows"][0]["risk_flags"]
+
+
+def test_risk_flag_tariff_affected_fires_for_true(authed_client):
+    _configure_sourcing(authed_client)
+    project_id = _single_line_project(authed_client, mpn="TARIFF-TRUE")
+    _FakeTrustedPartsClient.offers_by_mpn = {
+        "TARIFF-TRUE": [_offer("TARIFF-TRUE", is_affected_by_tariff=True)]
+    }
+
+    r = _post_sourcing(authed_client, project_id)
+
+    assert r.status_code == 200, r.text
+    assert "tariff_affected" in r.json()["data"]["rows"][0]["risk_flags"]
+
+
+def test_risk_flag_tariff_affected_does_not_fire_for_false_or_none(authed_client):
+    _configure_sourcing(authed_client)
+    project_id = create_project_with_bom(
+        authed_client,
+        "Tariff false or none",
+        [
+            {
+                "part_id": create_part(authed_client, name="False tariff", mpn="TARIFF-FALSE"),
+                "quantity": 1,
+            },
+            {
+                "part_id": create_part(authed_client, name="None tariff", mpn="TARIFF-NONE"),
+                "quantity": 1,
+            },
+        ],
+    )
+    _FakeTrustedPartsClient.offers_by_mpn = {
+        "TARIFF-FALSE": [_offer("TARIFF-FALSE", is_affected_by_tariff=False)],
+        "TARIFF-NONE": [_offer("TARIFF-NONE", is_affected_by_tariff=None)],
+    }
+
+    r = _post_sourcing(authed_client, project_id)
+
+    assert r.status_code == 200, r.text
+    rows = r.json()["data"]["rows"]
+    assert all("tariff_affected" not in row["risk_flags"] for row in rows)
+
+
+def test_risk_flag_rohs_non_compliant_fires_when_no_distributor_has_eu_compliant_entry(
+    authed_client,
+):
+    _configure_sourcing(authed_client)
+    project_id = _single_line_project(authed_client, mpn="ROHS-BAD")
+    _FakeTrustedPartsClient.offers_by_mpn = {
+        "ROHS-BAD": [
+            _offer(
+                "ROHS-BAD",
+                distributor="DigiKey",
+                rohs_compliance=[SourcingRohsCompliance(region="EU", is_compliant=False)],
+            ),
+            _offer("ROHS-BAD", distributor="Mouser"),
+        ]
+    }
+
+    r = _post_sourcing(authed_client, project_id)
+
+    assert r.status_code == 200, r.text
+    assert "rohs_non_compliant" in r.json()["data"]["rows"][0]["risk_flags"]
+
+
+def test_risk_flag_rohs_non_compliant_does_not_fire_when_at_least_one_distributor_is_compliant(
+    authed_client,
+):
+    _configure_sourcing(authed_client)
+    project_id = _single_line_project(authed_client, mpn="ROHS-GOOD")
+    _FakeTrustedPartsClient.offers_by_mpn = {
+        "ROHS-GOOD": [
+            _offer("ROHS-GOOD", distributor="DigiKey"),
+            _offer(
+                "ROHS-GOOD",
+                distributor="Mouser",
+                rohs_compliance=[SourcingRohsCompliance(region="EU", is_compliant=True)],
+            ),
+        ]
+    }
+
+    r = _post_sourcing(authed_client, project_id)
+
+    assert r.status_code == 200, r.text
+    assert "rohs_non_compliant" not in r.json()["data"]["rows"][0]["risk_flags"]
+
+
+def test_risk_flag_rohs_non_compliant_uses_eu_default_when_no_workspace_setting(authed_client):
+    _configure_sourcing(authed_client)
+    project_id = _single_line_project(authed_client, mpn="ROHS-EU-DEFAULT")
+    _FakeTrustedPartsClient.offers_by_mpn = {
+        "ROHS-EU-DEFAULT": [
+            _offer(
+                "ROHS-EU-DEFAULT",
+                rohs_compliance=[SourcingRohsCompliance(region="US", is_compliant=True)],
+            )
+        ]
+    }
+
+    r = _post_sourcing(authed_client, project_id)
+
+    assert r.status_code == 200, r.text
+    assert "rohs_non_compliant" in r.json()["data"]["rows"][0]["risk_flags"]
 
 
 def test_workspace_isolation_two_projects_same_mpns(authed_client):

--- a/backend/tests/test_sourcing_risk_report.py
+++ b/backend/tests/test_sourcing_risk_report.py
@@ -15,6 +15,7 @@ from app.domain.sourcing.schemas import (
     SourcingOffer,
     SourcingPriceBreak,
     SourcingQuery,
+    SourcingRohsCompliance,
     SourcingSearchRaw,
 )
 from app.infra.db import Base
@@ -58,11 +59,18 @@ def _offer(
     moq: int | None = 1,
     lead_time_days: int | None = 3,
     currency: str = "EUR",
+    lifecycle_risk: str | None = None,
+    supply_chain_risk: str | None = None,
+    is_affected_by_tariff: bool | None = None,
+    rohs_compliance: list[SourcingRohsCompliance] | None = None,
 ) -> SourcingOffer:
     return SourcingOffer(
         mpn=mpn,
         manufacturer="TestCo",
         description=f"Offer for {mpn}",
+        lifecycle_risk=lifecycle_risk,
+        supply_chain_risk=supply_chain_risk,
+        is_affected_by_tariff=is_affected_by_tariff,
         distributors=[
             SourcingDistributor(
                 name=distributor,
@@ -74,6 +82,7 @@ def _offer(
                 lead_time_days=lead_time_days,
                 price_breaks=[SourcingPriceBreak(quantity=1, unit_price=unit_price)],
                 product_url=f"https://www.trustedparts.com/{mpn}/{distributor}",
+                rohs_compliance=rohs_compliance or [],
             )
         ],
         links=SourcingLinks(primary=f"https://www.trustedparts.com/search/{mpn}"),
@@ -155,7 +164,7 @@ def test_single_source_flag(authed_client):
 
     row = _report(authed_client)["rows"][0]
 
-    assert row["risk_flags"] == ["single_source"]
+    assert row["risk_flags"] == ["single_source", "rohs_non_compliant"]
     assert row["distributors_with_stock"] == ["DigiKey"]
 
 
@@ -169,7 +178,7 @@ def test_no_authorized_stock_flag(authed_client):
     row = _report(authed_client)["rows"][0]
 
     assert row["on_hand"] == 3
-    assert row["risk_flags"] == ["no_authorized_stock"]
+    assert row["risk_flags"] == ["no_authorized_stock", "rohs_non_compliant"]
 
 
 def test_moq_overbuy_uses_workspace_threshold(authed_client):
@@ -234,7 +243,12 @@ def test_only_with_flags_filters_clean_parts(authed_client):
     _FakeTrustedPartsClient.offers_by_mpn = {
         "RISKY": [_offer("RISKY", distributor="DigiKey", stock=10)],
         "CLEAN": [
-            _offer("CLEAN", distributor="DigiKey", stock=10),
+            _offer(
+                "CLEAN",
+                distributor="DigiKey",
+                stock=10,
+                rohs_compliance=[SourcingRohsCompliance(region="EU", is_compliant=True)],
+            ),
             _offer("CLEAN", distributor="Mouser", stock=10),
         ],
     }
@@ -258,8 +272,46 @@ def test_sort_by_flag_count_then_alpha(authed_client):
     rows = _report(authed_client)["rows"]
 
     assert [row["name"] for row in rows] == ["Bravo", "Alpha"]
-    assert len(rows[0]["risk_flags"]) == 3
-    assert len(rows[1]["risk_flags"]) == 2
+    assert len(rows[0]["risk_flags"]) == 4
+    assert len(rows[1]["risk_flags"]) == 3
+
+
+def test_risk_report_counts_new_flags_in_default_sort(authed_client):
+    _configure_sourcing(authed_client)
+    create_part(authed_client, name="Bravo", mpn="BRAVO")
+    create_part(authed_client, name="Alpha", mpn="ALPHA")
+    _FakeTrustedPartsClient.offers_by_mpn = {
+        "BRAVO": [
+            _offer(
+                "BRAVO",
+                distributor="DigiKey",
+                stock=10,
+                lifecycle_risk="NRND",
+                supply_chain_risk="Limited supply",
+                is_affected_by_tariff=True,
+            ),
+            _offer("BRAVO", distributor="Mouser", stock=10),
+        ],
+        "ALPHA": [
+            _offer(
+                "ALPHA",
+                distributor="DigiKey",
+                stock=10,
+                rohs_compliance=[SourcingRohsCompliance(region="EU", is_compliant=True)],
+            ),
+            _offer("ALPHA", distributor="Mouser", stock=10),
+        ],
+    }
+
+    rows = _report(authed_client)["rows"]
+
+    assert [row["name"] for row in rows] == ["Bravo"]
+    assert rows[0]["risk_flags"] == [
+        "lifecycle_risk_present",
+        "supply_chain_risk_present",
+        "tariff_affected",
+        "rohs_non_compliant",
+    ]
 
 
 def test_workspace_isolation(authed_client):

--- a/docs/api/sourcing.md
+++ b/docs/api/sourcing.md
@@ -220,6 +220,23 @@ Path: `project_id` is a project UUID in the current workspace.
 }
 ```
 
+Risk flags are emitted in this order when their condition is true:
+
+| Flag | Condition |
+|---|---|
+| `single_source` | Exactly one distributor has stock for the BOM row. |
+| `no_authorized_stock` | No distributor has stock for the BOM row. |
+| `moq_overbuy` | The best offer MOQ is more than three times the row shortage. |
+| `lead_time_long` | The best offer lead time is more than 30 days. |
+| `preferred_distributor_unmet` | Preferred distributors are configured, but none has stock. |
+| `lifecycle_risk_present` | TrustedParts populated `lifecycle_risk` with non-whitespace text. |
+| `supply_chain_risk_present` | TrustedParts populated `supply_chain_risk` with non-whitespace text. |
+| `tariff_affected` | TrustedParts returned `is_affected_by_tariff: true`. |
+| `rohs_non_compliant` | No distributor has a compliant RoHS entry for the target region. The target region is hardcoded to `EU` until workspaces have a setting. |
+
+Sources: `backend/app/domain/sourcing/service.py:1322-1386`,
+`backend/app/domain/sourcing/schemas.py:321-340`
+
 **Errors**
 
 - `404 Not Found` — `project_id` is missing or belongs to another workspace.

--- a/docs/domain/sourcing.md
+++ b/docs/domain/sourcing.md
@@ -48,6 +48,27 @@ Sources: `backend/app/domain/sourcing/client.py:285-418`,
 `backend/app/domain/sourcing/service.py:951-1007`,
 `backend/app/domain/sourcing/schemas.py:19-110`
 
+## BOM Risk Flags
+
+Project sourcing keeps the five original BOM risk flags in order, then appends
+TrustedParts gap-field flags. `lifecycle_risk_present` and
+`supply_chain_risk_present` fire when TrustedParts sends non-whitespace text for
+the corresponding offer field. `tariff_affected` fires only when
+`is_affected_by_tariff is True`.
+
+`rohs_non_compliant` evaluates distributor RoHS entries against the target region.
+There is no workspace `target_rohs_region` setting yet, so the service hardcodes
+`EU`. The flag fires when every distributor either lacks an `EU` entry or has an
+`EU` entry whose `is_compliant` value is false. At least one compliant `EU` entry
+suppresses the flag.
+
+The Sourcing Risk report reuses the same gap-field flag helper and counts those
+flags in its default flag-count sort before applying the existing alphabetical
+tie-breaker.
+
+Sources: `backend/app/domain/sourcing/service.py:1322-1386`,
+`backend/app/domain/reports/service.py:651-675`
+
 ## Cache Table
 
 `sourcing_cache` stores one response per `(workspace_id, query_hash)`.


### PR DESCRIPTION
## Summary

- Adds four TrustedParts gap-field BOM risk flags after the existing five flags:
  - `lifecycle_risk_present`: `lifecycle_risk` is non-null and non-empty after strip.
  - `supply_chain_risk_present`: `supply_chain_risk` is non-null and non-empty after strip.
  - `tariff_affected`: `is_affected_by_tariff is True`.
  - `rohs_non_compliant`: every distributor lacks a compliant `EU` RoHS entry, using hardcoded `EU` until a workspace setting exists.
- Carries distributor RoHS compliance into flattened BOM offers so BOM rows and Sourcing Risk rows can evaluate the same heuristic.
- Updates Sourcing Risk flag typing/report aggregation and docs/changelog.

## Existing Flags

Existing BOM flags are unchanged and keep their order: `single_source`, `no_authorized_stock`, `moq_overbuy`, `lead_time_long`, `preferred_distributor_unmet`. The new TPS-5 flags are appended after them.

## Validation

```text
$ cd backend && uv run python -m pytest -q tests/test_sourcing_bom_route.py tests/test_sourcing_risk_report.py
40 passed, 2 warnings in 14.95s
```

```text
$ cd backend && uv run python -m pytest -q -k "sourcing_bom_route or sourcing_risk_report or sourcing_capacity"
52 passed, 1095 deselected, 2 warnings in 16.10s
```

```text
$ cd backend && uv run ruff check app/domain/sourcing/service.py app/domain/sourcing/schemas.py app/domain/reports/service.py app/domain/reports/schemas.py tests/test_sourcing_bom_route.py tests/test_sourcing_risk_report.py
All checks passed!
```

```text
$ git diff --check
<no output>
```

## Merge Order

After #460; before #453 and #455; independent of #454.

Refs #452
