### PR TITLE
TPS-7: Render TP gap fields on Part Sourcing tab

### DIFF
--- a/docs/frontend/components.md
+++ b/docs/frontend/components.md
@@ -235,6 +235,13 @@ with `<PoweredByTrustedParts/>`, labels the table with
 `<SourcingSourceLabel/>`, filters distributors client-side, and refreshes
 with `POST /api/parts/{part_id}/sourcing/refresh`.
 
+The tab also renders TrustedParts gap fields from the same response:
+lifecycle and supply-chain risk pills use existing `pill` plus
+`text-success` / `text-warning` / `text-danger` / `text-muted` token
+classes, tariff and RoHS pills use the same semantic palette, and the
+specifications block is a native collapsed `<details>` panel. No new
+global utility or pill variant is introduced.
+
 ## MpnLookup
 
 `web/src/components/MpnLookup.tsx`. Affordance attached to MPN inputs that

--- a/docs/user/parts.md
+++ b/docs/user/parts.md
@@ -56,6 +56,8 @@ Open a part. The tabs along the top group what you can do:
 
 Editable text fields use **Settings**. Custom field values use **Specs**. Identity fields (name, MPN, manufacturer, footprint) — TODO(verify-ui): there's no edit form on Part info; check whether identity edits live in a separate "Edit part" route or only via supplier refresh and attachments.
 
+The **Sourcing** tab can show TrustedParts lifecycle, supply-chain, and tariff badges above the distributor table when TrustedParts returns them. Distributor rows can include RoHS region pills, availability text next to stock, and a quantity hint when TrustedParts requires buying in multiples; custom quantities are rounded up to that multiple when you leave the field.
+
 ### Refresh from supplier
 
 Linked parts show a banner with the supplier name and "last refreshed". Click **Refresh** to re-pull data. Provider-sourced fields are re-written; values you marked **Locally edited** are kept.

--- a/web/src/routes/parts/detail/AuthorizedSupplyTab.tsx
+++ b/web/src/routes/parts/detail/AuthorizedSupplyTab.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { BellPlus, ExternalLink, Plus, RefreshCw } from "lucide-react";
+import { BellPlus, ExternalLink, Info, Plus, RefreshCw, ShieldAlert, ShieldCheck } from "lucide-react";
 import { toast } from "sonner";
 import { InlineQueryError } from "@/components/QueryStateBoundary";
 import { ApiError, api } from "@/lib/api";
@@ -33,6 +33,17 @@ type SourcingPriceBreakWire = {
   unit_price: WirePrice;
 };
 
+type SourcingRohsCompliance = {
+  region: string;
+  is_compliant: boolean;
+  description?: string | null;
+};
+
+type SourcingSpecification = {
+  key: string;
+  value: string;
+};
+
 type SourcingDistributor = {
   name: string;
   sku?: string | null;
@@ -49,6 +60,9 @@ type SourcingDistributor = {
   price_breaks?: SourcingPriceBreakWire[] | null;
   price_breaks_converted?: SourcingPriceBreakWire[] | null;
   product_url?: string | null;
+  rohs_compliance?: SourcingRohsCompliance[] | null;
+  availability_text?: string | null;
+  quantity_multiple?: number | null;
 };
 
 type SourcingOffer = {
@@ -56,6 +70,11 @@ type SourcingOffer = {
   manufacturer?: string | null;
   description?: string | null;
   distributors: SourcingDistributor[];
+  lifecycle_risk?: string | null;
+  supply_chain_risk?: string | null;
+  is_affected_by_tariff?: boolean | null;
+  manufacturer_id?: number | null;
+  specifications?: SourcingSpecification[] | null;
   links?: {
     primary?: string | null;
     manufacturer?: string | null;
@@ -93,12 +112,22 @@ type SupplyRow = {
   originalCurrency: string | null;
   fxConverted: boolean;
   fxRateDate: string | null;
+  rohsCompliance: SourcingRohsCompliance[];
+  availabilityText: string | null;
+  quantityMultiple: number | null;
 };
 
 const QUANTITY_PRESETS = [1, 10, 100, 1000] as const;
+const TARIFF_TOOLTIP = "TrustedParts distributors indicated this part is affected by United States tariffs.";
 
 function formatNumber(value: number | null): string {
   return value == null ? "—" : value.toLocaleString();
+}
+
+function formatStock(row: SupplyRow): string {
+  if (row.stock == null) return row.availabilityText ?? "—";
+  const stock = row.stock.toLocaleString();
+  return row.availabilityText ? `${stock} (${row.availabilityText})` : stock;
 }
 
 function formatPrice(row: SupplyRow): string {
@@ -125,6 +154,61 @@ function normalisePriceBreaks(value: SourcingPriceBreakWire[] | null | undefined
     const unitPrice = toFiniteNumber(priceBreak.unit_price);
     return unitPrice == null ? [] : [{ quantity: priceBreak.quantity, unit_price: unitPrice }];
   });
+}
+
+function normalisePositiveInt(value: number | null | undefined): number | null {
+  if (value == null || !Number.isFinite(value) || value <= 1) return null;
+  return Math.floor(value);
+}
+
+function riskTone(value: string): string {
+  const normalized = value.trim().toLowerCase();
+  if (normalized.startsWith("active")) return "bg-success/10 text-success";
+  if (normalized.includes("nrnd") || normalized.includes("not recommended")) {
+    return "bg-warning/10 text-warning";
+  }
+  if (
+    normalized.includes("obsolete") ||
+    normalized.includes("eol") ||
+    normalized.includes("end of life") ||
+    normalized.includes("last time buy") ||
+    normalized.includes("ltb")
+  ) {
+    return "bg-danger/10 text-danger";
+  }
+  return "bg-panel2 text-muted";
+}
+
+function sortedRohs(value: SourcingRohsCompliance[]): SourcingRohsCompliance[] {
+  return [...value].sort((a, b) => a.region.localeCompare(b.region));
+}
+
+function roundUpToMultiple(quantityValue: number, multiple: number): number {
+  return Math.ceil(quantityValue / multiple) * multiple;
+}
+
+function greatestCommonDivisor(a: number, b: number): number {
+  let x = Math.abs(a);
+  let y = Math.abs(b);
+  while (y !== 0) {
+    const next = x % y;
+    x = y;
+    y = next;
+  }
+  return x;
+}
+
+function leastCommonMultiple(a: number, b: number): number {
+  return (a / greatestCommonDivisor(a, b)) * b;
+}
+
+function activeQuantityMultiple(rows: SupplyRow[]): number | null {
+  const multiples = Array.from(new Set(
+    rows
+      .map(row => row.quantityMultiple)
+      .filter((value): value is number => value !== null && value > 1),
+  ));
+  return multiples.length === 0 ? null : multiples.reduce(leastCommonMultiple);
 }
 
 function fxTooltip(row: SupplyRow): string {
@@ -178,6 +262,9 @@ function flattenOffers(data: SourcingResponse | undefined): SupplyRow[] {
         originalCurrency: distributor.currency ?? null,
         fxConverted,
         fxRateDate: distributor.fx_rate_date ?? null,
+        rohsCompliance: distributor.rohs_compliance ?? [],
+        availabilityText: distributor.availability_text?.trim() || null,
+        quantityMultiple: normalisePositiveInt(distributor.quantity_multiple),
       };
     }),
   );
@@ -212,6 +299,124 @@ function EmptyState({
       <PoweredByTrustedParts primaryUrl={primaryUrl ?? undefined} />
       <div className="text-sm text-muted">{children}</div>
     </div>
+  );
+}
+
+function RiskBadge({
+  icon,
+  label,
+  value,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value?: string | null;
+}) {
+  const trimmed = value?.trim();
+  if (!trimmed) return null;
+  return (
+    <span className={`pill inline-flex items-center gap-1 ${riskTone(trimmed)}`} aria-label={`${label}: ${trimmed}`}>
+      {icon}
+      {trimmed}
+    </span>
+  );
+}
+
+function OfferStatusRows({ offers }: { offers: SourcingOffer[] }) {
+  const visibleOffers = offers.filter(offer =>
+    Boolean(offer.lifecycle_risk?.trim()) ||
+    Boolean(offer.supply_chain_risk?.trim()) ||
+    offer.is_affected_by_tariff === true ||
+    offer.manufacturer_id != null,
+  );
+  if (visibleOffers.length === 0) return null;
+
+  return (
+    <div className="space-y-2" aria-label="Risk and status">
+      {visibleOffers.map((offer, index) => (
+        <div
+          key={`${offer.mpn}:${offer.manufacturer_id ?? index}`}
+          className="flex flex-wrap items-center gap-2 text-sm"
+        >
+          {visibleOffers.length > 1 && (
+            <span className="text-xs font-medium text-muted">{offer.mpn}</span>
+          )}
+          <RiskBadge
+            label="Lifecycle risk"
+            value={offer.lifecycle_risk}
+            icon={<ShieldCheck size={12} aria-hidden="true" />}
+          />
+          <RiskBadge
+            label="Supply-chain risk"
+            value={offer.supply_chain_risk}
+            icon={<ShieldAlert size={12} aria-hidden="true" />}
+          />
+          {offer.is_affected_by_tariff === true && (
+            <span
+              className="pill inline-flex items-center gap-1 bg-danger/10 text-danger"
+              title={TARIFF_TOOLTIP}
+              aria-label="Tariff-affected (US)"
+            >
+              <Info size={12} aria-hidden="true" />
+              Tariff-affected (US)
+            </span>
+          )}
+          {offer.manufacturer_id != null && (
+            <span className="text-xs text-muted">TP mfr id: {offer.manufacturer_id}</span>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function RohsPills({ values }: { values: SourcingRohsCompliance[] }) {
+  if (values.length === 0) return null;
+  return (
+    <div className="flex flex-wrap gap-1">
+      {sortedRohs(values).map(item => (
+        <span
+          key={item.region}
+          className={`pill ${item.is_compliant ? "bg-success/10 text-success" : "bg-danger/10 text-danger"}`}
+          title={item.description ?? undefined}
+          aria-label={`${item.region}: ${item.is_compliant ? "RoHS compliant" : "RoHS non-compliant"}`}
+        >
+          {item.region}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function SpecificationsPanel({ offers }: { offers: SourcingOffer[] }) {
+  const specs = offers.flatMap((offer, offerIndex) =>
+    (offer.specifications ?? [])
+      .filter(spec => spec.key.trim() !== "" && spec.value.trim() !== "")
+      .map(spec => ({
+        id: `${offer.mpn}:${offerIndex}:${spec.key}`,
+        mpn: offer.mpn,
+        key: spec.key,
+        value: spec.value,
+      })),
+  );
+  if (specs.length === 0) return null;
+
+  return (
+    <details className="card p-3">
+      <summary className="cursor-pointer text-sm font-medium">
+        Specifications ({specs.length})
+      </summary>
+      <dl className="mt-3 grid grid-cols-[minmax(8rem,16rem)_1fr] gap-x-4 gap-y-2 text-sm">
+        {specs.map(spec => (
+          <div key={spec.id} className="contents">
+            <dt className="text-muted">{spec.key}</dt>
+            <dd>
+              {spec.value}
+              {offers.length > 1 && <span className="ml-2 text-xs text-muted">{spec.mpn}</span>}
+            </dd>
+          </div>
+        ))}
+      </dl>
+    </details>
   );
 }
 
@@ -284,6 +489,7 @@ export function AuthorizedSupplyTab({ partId }: { partId: string }) {
     if (selectedDistributors.size === 0) return rows;
     return rows.filter(row => selectedDistributors.has(row.distributor));
   }, [rows, selectedDistributors]);
+  const quantityMultiple = useMemo(() => activeQuantityMultiple(filteredRows), [filteredRows]);
 
   useEffect(() => {
     setSelectedDistributors(prev => {
@@ -348,8 +554,14 @@ export function AuthorizedSupplyTab({ partId }: { partId: string }) {
         key: "stock",
         header: "Stock",
         accessor: row => row.stock,
-        render: row => formatNumber(row.stock),
+        render: row => formatStock(row),
         align: "right",
+      },
+      {
+        key: "rohs",
+        header: "RoHS",
+        accessor: row => row.rohsCompliance.map(item => item.region).join(" "),
+        render: row => <RohsPills values={row.rohsCompliance} />,
       },
       {
         key: "moq",
@@ -585,8 +797,11 @@ export function AuthorizedSupplyTab({ partId }: { partId: string }) {
                       setCustomQuantity(String(quantity));
                       return;
                     }
-                    setQuantity(nextQuantity);
-                    setCustomQuantity(String(nextQuantity));
+                    const roundedQuantity = quantityMultiple === null
+                      ? nextQuantity
+                      : roundUpToMultiple(nextQuantity, quantityMultiple);
+                    setQuantity(roundedQuantity);
+                    setCustomQuantity(String(roundedQuantity));
                   }}
                   onKeyDown={event => {
                     if (event.key === "Enter") {
@@ -596,9 +811,16 @@ export function AuthorizedSupplyTab({ partId }: { partId: string }) {
                 />
               </label>
             </div>
+            {quantityMultiple !== null && (
+              <div className="text-xs text-muted">
+                Rounded to multiples of {quantityMultiple.toLocaleString()}
+              </div>
+            )}
           </div>
         </div>
       )}
+
+      <OfferStatusRows offers={query.data?.offers ?? []} />
 
       <DataTable
         tableId={`part-authorized-supply-${partId}`}
@@ -609,6 +831,7 @@ export function AuthorizedSupplyTab({ partId }: { partId: string }) {
         exportFilename="authorized-supply"
         empty="No authorized-distributor offers."
       />
+      <SpecificationsPanel offers={query.data?.offers ?? []} />
       <CreateOrderLineModal
         open={orderLineSource !== null}
         source={orderLineSource}

--- a/web/src/routes/parts/detail/__tests__/AuthorizedSupplyTab.test.tsx
+++ b/web/src/routes/parts/detail/__tests__/AuthorizedSupplyTab.test.tsx
@@ -80,6 +80,26 @@ function sourcingResponse() {
   };
 }
 
+function gapResponse(overrides: Record<string, unknown> = {}) {
+  const response = sourcingResponse();
+  response.offers[0] = {
+    ...response.offers[0],
+    ...overrides,
+  };
+  return response;
+}
+
+function distributorGapResponse(overrides: Record<string, unknown> = {}) {
+  const response = sourcingResponse();
+  response.offers[0].distributors = [
+    {
+      ...response.offers[0].distributors[0],
+      ...overrides,
+    },
+  ];
+  return response;
+}
+
 function convertedSourcingResponse() {
   const response = sourcingResponse();
   Object.assign(response.offers[0].distributors[0], {
@@ -461,5 +481,142 @@ describe("AuthorizedSupplyTab", () => {
     const rows = within(screen.getByRole("table")).getAllByRole("row").slice(1);
     expect(within(rows[0]).getByText("Mouser")).toBeDefined();
     expect(within(rows[1]).getByText("DigiKey")).toBeDefined();
+  });
+
+  it("lifecycle badge renders with green colour for Active", async () => {
+    mockApiGet(gapResponse({ lifecycle_risk: "Active" }));
+
+    renderTab();
+
+    const badge = await screen.findByLabelText("Lifecycle risk: Active");
+    expect(badge.className).toContain("text-success");
+  });
+
+  it("lifecycle badge renders with red colour for Obsolete", async () => {
+    mockApiGet(gapResponse({ lifecycle_risk: "Obsolete" }));
+
+    renderTab();
+
+    const badge = await screen.findByLabelText("Lifecycle risk: Obsolete");
+    expect(badge.className).toContain("text-danger");
+  });
+
+  it("lifecycle badge hidden when field is null", async () => {
+    mockApiGet(gapResponse({ lifecycle_risk: null }));
+
+    renderTab();
+
+    await screen.findByText("Powered by TrustedParts");
+    expect(screen.queryByLabelText(/Lifecycle risk:/)).toBeNull();
+  });
+
+  it("supply-chain badge follows same colour rules", async () => {
+    mockApiGet(gapResponse({ supply_chain_risk: "Not Recommended for New Designs" }));
+
+    renderTab();
+
+    const badge = await screen.findByLabelText("Supply-chain risk: Not Recommended for New Designs");
+    expect(badge.className).toContain("text-warning");
+  });
+
+  it("tariff badge renders for true and is absent for false or null", async () => {
+    mockApiGet(gapResponse({ is_affected_by_tariff: true }));
+    renderTab();
+
+    expect(await screen.findByLabelText("Tariff-affected (US)")).toBeDefined();
+    cleanup();
+    vi.restoreAllMocks();
+
+    mockApiGet(gapResponse({ is_affected_by_tariff: false }));
+    renderTab();
+    await screen.findByText("Powered by TrustedParts");
+    expect(screen.queryByLabelText("Tariff-affected (US)")).toBeNull();
+    cleanup();
+    vi.restoreAllMocks();
+
+    mockApiGet(gapResponse({ is_affected_by_tariff: null }));
+    renderTab();
+    await screen.findByText("Powered by TrustedParts");
+    expect(screen.queryByLabelText("Tariff-affected (US)")).toBeNull();
+  });
+
+  it("manufacturer id caption renders only when present", async () => {
+    mockApiGet(gapResponse({ manufacturer_id: 12345 }));
+
+    renderTab();
+
+    expect(await screen.findByText("TP mfr id: 12345")).toBeDefined();
+  });
+
+  it("specifications panel hidden when array empty and visible plus collapsible when populated", async () => {
+    const user = userEvent.setup();
+    mockApiGet(gapResponse({ specifications: [] }));
+
+    renderTab();
+
+    await screen.findByText("Powered by TrustedParts");
+    expect(screen.queryByText("Specifications (1)")).toBeNull();
+    cleanup();
+
+    mockApiGet(gapResponse({ specifications: [{ key: "Package", value: "LQFP-48" }] }));
+    renderTab();
+
+    const summary = await screen.findByText("Specifications (1)");
+    const details = summary.closest("details");
+    expect(details?.hasAttribute("open")).toBe(false);
+    await user.click(summary);
+    expect(details?.hasAttribute("open")).toBe(true);
+    expect(screen.getByText("Package")).toBeDefined();
+    expect(screen.getByText("LQFP-48")).toBeDefined();
+  });
+
+  it("RoHS pills render per region with correct colour", async () => {
+    mockApiGet(distributorGapResponse({
+      rohs_compliance: [
+        { region: "EU", is_compliant: true, description: "Compliant in the EU" },
+        { region: "CN", is_compliant: false, description: "Not compliant in China" },
+      ],
+    }));
+
+    renderTab();
+
+    const eu = await screen.findByLabelText("EU: RoHS compliant");
+    const cn = screen.getByLabelText("CN: RoHS non-compliant");
+    expect(eu.className).toContain("text-success");
+    expect(eu.getAttribute("title")).toBe("Compliant in the EU");
+    expect(cn.className).toContain("text-danger");
+    expect(cn.getAttribute("title")).toBe("Not compliant in China");
+  });
+
+  it("availability text appended to QuantityOnHand cell", async () => {
+    mockApiGet(distributorGapResponse({ stock: 1234, availability_text: "In Stock" }));
+
+    renderTab();
+
+    expect(await screen.findByText("1,234 (In Stock)")).toBeDefined();
+  });
+
+  it("availability text renders when quantity is absent", async () => {
+    mockApiGet(distributorGapResponse({ stock: null, availability_text: "Factory stock" }));
+
+    renderTab();
+
+    expect(await screen.findByText("Factory stock")).toBeDefined();
+  });
+
+  it("quantity input rounds to multiple of N on blur", async () => {
+    const user = userEvent.setup();
+    mockApiGet(distributorGapResponse({ quantity_multiple: 5 }));
+
+    renderTab();
+
+    await screen.findByText("Rounded to multiples of 5");
+    const customInput = screen.getByLabelText("Custom:");
+    await user.clear(customInput);
+    await user.type(customInput, "12");
+    await user.tab();
+
+    expect(screen.getByRole("columnheader", { name: "Unit price @ 15" })).toBeDefined();
+    expect((customInput as HTMLInputElement).value).toBe("15");
   });
 });


### PR DESCRIPTION
## Summary
- Renders TrustedParts lifecycle, supply-chain, tariff, and manufacturer-id status above the authorized supply table only when values are present.
- Adds RoHS region pills, availability text in the stock cell, and quantity-multiple rounding/hinting for the shared quantity selector.
- Adds a default-collapsed specifications panel and updates the user/frontend docs without introducing new Tailwind utilities.

## Validation
- `cd web && npm test -- AuthorizedSupplyTab`
  - Passed: `Test Files 1 passed (1)`, `Tests 30 passed (30)`.
- `cd web && npm run typecheck`
  - Passed: `tsc -b` completed with exit code 0.
- `cd web && npm run lint`
  - Blocked by pre-existing lint outside this PR scope:
    - `web/src/lib/bagCode.ts:91:22` and `web/src/lib/bagCode.ts:164:14` `no-control-regex` errors.
    - Existing warnings in `ZxingScanner.tsx`, `responsive-grids.test.ts`, `OrderDetail.tsx`, `PartsList.tsx`, `PartLayout.navigation.dom.test.tsx`, and `StorageDetail.tsx`.
  - Touched-file ESLint passed: `npx eslint src/routes/parts/detail/AuthorizedSupplyTab.tsx src/routes/parts/detail/__tests__/AuthorizedSupplyTab.test.tsx`.
- `git diff --check`
  - Passed with no output.

## Screenshots
Captured locally with Vite and mocked API responses:
- `tps-7-authorized-supply-badges-rohs.png` — lifecycle/supply/tariff badges, RoHS pills, availability text, quantity-multiple hint.
- `tps-7-authorized-supply-specifications.png` — expanded collapsible specifications panel.

## Merge Order
After #460; independent of #452; before frontend report work #455 if #455 consumes these UI conventions.

Refs #454
