### PR TITLE
TPS-8: Gap fields + new risk flags on BOM coverage + Risk report

### DIFF
--- a/docs/user/projects-and-bom.md
+++ b/docs/user/projects-and-bom.md
@@ -104,6 +104,10 @@ When your workspace has a Mouser or DigiKey parts provider configured, the BOM t
 This provider flow does not create stub parts. Failed lookups stay on the BOM so you can retry later or match them by hand.
 Bulk provider import processes up to 200 unmatched rows at a time; run it again if the page reports remaining rows.
 
+## Source BOM coverage
+
+The **Source BOM** page can show TrustedParts risk pills on each BOM line when authorized offers carry lifecycle, supply-chain, tariff, or RoHS warnings. The table also has an optional **Lifecycle** column in the column menu; turn it on when you need to see the exact lifecycle text TrustedParts returned.
+
 ## Use meta-parts for "any 10k 0402 1%"
 
 If a row in your BOM doesn't need a specific manufacturer part — any 10k 0402 1% resistor will do — match it to a **meta-part** rather than a specific MPN. The build flow will then accept any of the meta-part's members at consume time. See [parts](parts.md#pick-a-part-type) for how meta-parts work.

--- a/docs/user/reports.md
+++ b/docs/user/reports.md
@@ -70,6 +70,10 @@ Columns:
 
 If you don't track lot expiration dates this view is empty. Add expiration dates when adding stock under **Lot name** + (TODO(verify-ui): the Add stock form's Lot section captures name and serial — confirm whether expiration date is a separate per-lot edit on the lot detail page rather than on Add stock).
 
+## Sourcing risk
+
+The **Sourcing risk** report lists parts whose current authorized supply needs attention. Use the filter chips to narrow the table to lifecycle, supply-chain, tariff, RoHS, price, stock, MOQ, lead-time, single-source, or preferred-distributor risks. The **Lifecycle** column shows the exact TrustedParts lifecycle text when available and sorts worst-first so obsolete, end-of-life, and last-time-buy parts rise above NRND, active, and blank rows.
+
 ## Export to CSV
 
 Each table has an **Export CSV** option (in the column-toggle/search bar above the table) — useful for sharing with someone who doesn't have access to the workspace, or pasting into a spreadsheet for further filtering.

--- a/web/src/components/DataTable.tsx
+++ b/web/src/components/DataTable.tsx
@@ -154,9 +154,10 @@ export function DataTable<T>({
   const [search, setSearch] = useState(initialSearch ?? "");
   const [sort, setSort] = useState<{ key: string; dir: "asc" | "desc" } | null>(null);
   const [hidden, setHidden] = useState<Record<string, boolean>>(
-    () =>
-      persisted.hidden ??
-      Object.fromEntries(columns.filter(c => c.hidden).map(c => [c.key, true]))
+    () => ({
+      ...Object.fromEntries(columns.filter(c => c.hidden).map(c => [c.key, true])),
+      ...(persisted.hidden ?? {}),
+    })
   );
   const [density, setDensity] = useState<Density>(() => persisted.density ?? "comfortable");
   const [selected, setSelected] = useState<Set<string>>(() => new Set());

--- a/web/src/lib/sourcing.ts
+++ b/web/src/lib/sourcing.ts
@@ -39,3 +39,38 @@ export function extendedPrice(
   if (best === null) return null;
   return best.unitPrice * Math.floor(qty);
 }
+
+export function lifecycleRiskTone(value: string | null | undefined): string {
+  const normalized = value?.trim().toLowerCase() ?? "";
+  if (normalized.startsWith("active")) return "bg-success/10 text-success";
+  if (normalized.includes("nrnd") || normalized.includes("not recommended")) {
+    return "bg-warning/10 text-warning";
+  }
+  if (
+    normalized.includes("obsolete") ||
+    normalized.includes("eol") ||
+    normalized.includes("end of life") ||
+    normalized.includes("last time buy") ||
+    normalized.includes("ltb")
+  ) {
+    return "bg-danger/10 text-danger";
+  }
+  return "bg-panel2 text-muted";
+}
+
+export function lifecycleRiskRank(value: string | null | undefined): number {
+  const normalized = value?.trim().toLowerCase() ?? "";
+  if (!normalized) return 3;
+  if (
+    normalized.includes("obsolete") ||
+    normalized.includes("eol") ||
+    normalized.includes("end of life") ||
+    normalized.includes("last time buy") ||
+    normalized.includes("ltb")
+  ) {
+    return 0;
+  }
+  if (normalized.includes("nrnd") || normalized.includes("not recommended")) return 1;
+  if (normalized.startsWith("active")) return 2;
+  return 2.5;
+}

--- a/web/src/routes/parts/detail/AuthorizedSupplyTab.tsx
+++ b/web/src/routes/parts/detail/AuthorizedSupplyTab.tsx
@@ -8,7 +8,12 @@ import { useAuth } from "@/lib/auth";
 import { formatDateTime } from "@/lib/format";
 import { useApiMutation } from "@/lib/mutations";
 import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
-import { bestUnitPriceAtQty, extendedPrice, type SourcingPriceBreak } from "@/lib/sourcing";
+import {
+  bestUnitPriceAtQty,
+  extendedPrice,
+  lifecycleRiskTone,
+  type SourcingPriceBreak,
+} from "@/lib/sourcing";
 import type { Column } from "@/components/DataTable";
 import { DataTable } from "@/components/DataTable";
 import { PoweredByTrustedParts } from "@/components/PoweredByTrustedParts";
@@ -161,24 +166,6 @@ function normalisePositiveInt(value: number | null | undefined): number | null {
   return Math.floor(value);
 }
 
-function riskTone(value: string): string {
-  const normalized = value.trim().toLowerCase();
-  if (normalized.startsWith("active")) return "bg-success/10 text-success";
-  if (normalized.includes("nrnd") || normalized.includes("not recommended")) {
-    return "bg-warning/10 text-warning";
-  }
-  if (
-    normalized.includes("obsolete") ||
-    normalized.includes("eol") ||
-    normalized.includes("end of life") ||
-    normalized.includes("last time buy") ||
-    normalized.includes("ltb")
-  ) {
-    return "bg-danger/10 text-danger";
-  }
-  return "bg-panel2 text-muted";
-}
-
 function sortedRohs(value: SourcingRohsCompliance[]): SourcingRohsCompliance[] {
   return [...value].sort((a, b) => a.region.localeCompare(b.region));
 }
@@ -314,7 +301,10 @@ function RiskBadge({
   const trimmed = value?.trim();
   if (!trimmed) return null;
   return (
-    <span className={`pill inline-flex items-center gap-1 ${riskTone(trimmed)}`} aria-label={`${label}: ${trimmed}`}>
+    <span
+      className={`pill inline-flex items-center gap-1 ${lifecycleRiskTone(trimmed)}`}
+      aria-label={`${label}: ${trimmed}`}
+    >
       {icon}
       {trimmed}
     </span>

--- a/web/src/routes/projects/sourcing/ProjectSourcingPage.tsx
+++ b/web/src/routes/projects/sourcing/ProjectSourcingPage.tsx
@@ -9,6 +9,7 @@ import { PoweredByTrustedParts } from "@/components/PoweredByTrustedParts";
 import { SourcingSourceLabel } from "@/components/SourcingSourceLabel";
 import { ApiError, api } from "@/lib/api";
 import { useWsKey } from "@/lib/queryKeys";
+import { lifecycleRiskTone } from "@/lib/sourcing";
 import AlertFormModal from "@/routes/sourcing/alerts/AlertFormModal";
 import type { Project } from "@/types";
 import PurchasePlanOptionsModal from "./PurchasePlanOptionsModal";
@@ -26,6 +27,9 @@ type SourcingBomOffer = {
   moq?: number | null;
   lead_time_days?: number | null;
   url?: string | null;
+  lifecycle_risk?: string | null;
+  supply_chain_risk?: string | null;
+  is_affected_by_tariff?: boolean | null;
 };
 
 type RiskFlag =
@@ -33,7 +37,11 @@ type RiskFlag =
   | "no_authorized_stock"
   | "moq_overbuy"
   | "lead_time_long"
-  | "preferred_distributor_unmet";
+  | "preferred_distributor_unmet"
+  | "lifecycle_risk_present"
+  | "supply_chain_risk_present"
+  | "tariff_affected"
+  | "rohs_non_compliant";
 
 type SourcingBomLine = {
   project_entry_id: string;
@@ -133,7 +141,46 @@ function riskLabel(flag: RiskFlag): string {
       return "Long lead time";
     case "preferred_distributor_unmet":
       return "Preferred unmet";
+    case "lifecycle_risk_present":
+      return "lifecycle";
+    case "supply_chain_risk_present":
+      return "supply chain";
+    case "tariff_affected":
+      return "tariff";
+    case "rohs_non_compliant":
+      return "RoHS";
   }
+}
+
+function riskClass(flag: RiskFlag): string {
+  return flag === "rohs_non_compliant"
+    ? "pill bg-danger/10 text-danger"
+    : "pill bg-warning/10 text-warning";
+}
+
+function riskTooltip(flag: RiskFlag): string | undefined {
+  switch (flag) {
+    case "lifecycle_risk_present":
+      return "TrustedParts returned lifecycle risk text for this BOM line.";
+    case "supply_chain_risk_present":
+      return "TrustedParts returned supply-chain risk text for this BOM line.";
+    case "tariff_affected":
+      return "TrustedParts distributors indicated this BOM line may be affected by United States tariffs.";
+    case "rohs_non_compliant":
+      return "TrustedParts did not find a compliant RoHS region for this BOM line.";
+    default:
+      return undefined;
+  }
+}
+
+function LifecycleRiskPill({ value }: { value?: string | null }) {
+  const trimmed = value?.trim();
+  if (!trimmed) return null;
+  return (
+    <span className={`pill ${lifecycleRiskTone(trimmed)}`} aria-label={`Lifecycle risk: ${trimmed}`}>
+      {trimmed}
+    </span>
+  );
 }
 
 function errorStatus(error: unknown): number | null {
@@ -416,6 +463,13 @@ function BomRows({ rows }: { rows: SourcingBomLine[] }) {
       align: "right",
     },
     {
+      key: "lifecycle",
+      header: "Lifecycle",
+      accessor: row => row.best_offer?.lifecycle_risk?.trim() ?? "",
+      render: row => <LifecycleRiskPill value={row.best_offer?.lifecycle_risk} />,
+      hidden: true,
+    },
+    {
       key: "risk",
       header: "Risk",
       accessor: row => row.risk_flags.join(" "),
@@ -424,7 +478,12 @@ function BomRows({ rows }: { rows: SourcingBomLine[] }) {
           {row.risk_flags.length === 0 ? (
             <span className="text-muted">—</span>
           ) : row.risk_flags.map(flag => (
-            <span key={flag} className="pill bg-warning/10 text-warning">
+            <span
+              key={flag}
+              className={riskClass(flag)}
+              title={riskTooltip(flag)}
+              aria-label={riskTooltip(flag)}
+            >
               {riskLabel(flag)}
             </span>
           ))}

--- a/web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.test.tsx
+++ b/web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.test.tsx
@@ -331,6 +331,65 @@ describe("ProjectSourcingPage", () => {
     expect(screen.getAllByLabelText("Source: TrustedParts").length).toBeGreaterThan(0);
   });
 
+  it("renders new risk pills with tooltip text and colours", async () => {
+    mockReads();
+    const base = sourcingResponse();
+    vi.spyOn(api, "post").mockResolvedValue(sourcingResponse({
+      rows: [
+        {
+          ...base.rows[0],
+          risk_flags: [
+            "lifecycle_risk_present",
+            "supply_chain_risk_present",
+            "tariff_affected",
+            "rohs_non_compliant",
+          ],
+        },
+      ],
+    }));
+
+    renderPage();
+
+    expect(await screen.findByText("lifecycle")).toBeDefined();
+    expect(screen.getByText("supply chain")).toBeDefined();
+    const tariff = screen.getByText("tariff");
+    const rohs = screen.getByText("RoHS");
+    expect(tariff.className).toContain("text-warning");
+    expect(rohs.className).toContain("text-danger");
+    expect(screen.getByLabelText("TrustedParts returned lifecycle risk text for this BOM line.")).toBeDefined();
+    expect(screen.getByLabelText("TrustedParts did not find a compliant RoHS region for this BOM line.")).toBeDefined();
+  });
+
+  it("lifecycle column is hidden by default and renders Obsolete as red when enabled", async () => {
+    const user = userEvent.setup();
+    mockReads();
+    const base = sourcingResponse();
+    vi.spyOn(api, "post").mockResolvedValue(sourcingResponse({
+      rows: [
+        {
+          ...base.rows[0],
+          best_offer: {
+            ...base.rows[0].best_offer,
+            lifecycle_risk: "Obsolete",
+          },
+        },
+      ],
+    }));
+
+    renderPage();
+
+    await screen.findByText("BOM rows");
+    const bomRowsTable = screen.getAllByRole("table")[1];
+    expect(within(bomRowsTable).queryByRole("columnheader", { name: "Lifecycle" })).toBeNull();
+
+    await user.click(screen.getAllByText("Columns")[1]);
+    await user.click(screen.getByRole("checkbox", { name: "Lifecycle" }));
+
+    expect(within(bomRowsTable).getByRole("columnheader", { name: "Lifecycle" })).toBeDefined();
+    const lifecycle = screen.getByLabelText("Lifecycle risk: Obsolete");
+    expect(lifecycle.className).toContain("text-danger");
+  });
+
   it("renders per-row lead time values in the BOM rows table", async () => {
     mockReads();
     const base = sourcingResponse();

--- a/web/src/routes/reports/SourcingRiskReport.tsx
+++ b/web/src/routes/reports/SourcingRiskReport.tsx
@@ -9,6 +9,7 @@ import { SourcingSourceLabel } from "@/components/SourcingSourceLabel";
 import { api, ApiError } from "@/lib/api";
 import { formatMoney } from "@/lib/format";
 import { useWsKey } from "@/lib/queryKeys";
+import { lifecycleRiskRank, lifecycleRiskTone } from "@/lib/sourcing";
 
 type SourcingRiskFlag =
   | "single_source"
@@ -16,6 +17,10 @@ type SourcingRiskFlag =
   | "moq_overbuy"
   | "lead_time_long"
   | "preferred_distributor_unmet"
+  | "lifecycle_risk_present"
+  | "supply_chain_risk_present"
+  | "tariff_affected"
+  | "rohs_non_compliant"
   | "price_delta";
 
 type SourcingRiskOffer = {
@@ -29,6 +34,9 @@ type SourcingRiskOffer = {
   moq: number | null;
   lead_time_days: number | null;
   url: string | null;
+  lifecycle_risk?: string | null;
+  supply_chain_risk?: string | null;
+  is_affected_by_tariff?: boolean | null;
 };
 
 type SourcingRiskRow = {
@@ -70,13 +78,46 @@ const flagLabels: Record<SourcingRiskFlag, string> = {
   moq_overbuy: "MOQ overbuy",
   lead_time_long: "Long lead time",
   preferred_distributor_unmet: "Preferred unmet",
+  lifecycle_risk_present: "Lifecycle",
+  supply_chain_risk_present: "Supply chain",
+  tariff_affected: "Tariff",
+  rohs_non_compliant: "RoHS",
   price_delta: "Price delta",
 };
+
+const filterFlags: SourcingRiskFlag[] = [
+  "single_source",
+  "no_authorized_stock",
+  "moq_overbuy",
+  "lead_time_long",
+  "preferred_distributor_unmet",
+  "lifecycle_risk_present",
+  "supply_chain_risk_present",
+  "tariff_affected",
+  "rohs_non_compliant",
+  "price_delta",
+];
 
 function bestOfferLabel(offer: SourcingRiskOffer | null): string {
   if (!offer) return "—";
   const price = offer.unit_price ? formatMoney(Number(offer.unit_price), offer.currency) : "—";
   return `${offer.distributor} · ${price}`;
+}
+
+function flagClass(flag: SourcingRiskFlag): string {
+  return flag === "rohs_non_compliant"
+    ? "pill bg-danger/10 text-danger"
+    : "pill bg-warning/15 text-warning";
+}
+
+function LifecycleRiskPill({ value }: { value?: string | null }) {
+  const trimmed = value?.trim();
+  if (!trimmed) return null;
+  return (
+    <span className={`pill ${lifecycleRiskTone(trimmed)}`} aria-label={`Lifecycle risk: ${trimmed}`}>
+      {trimmed}
+    </span>
+  );
 }
 
 function statusTone(state: SourcingRiskReportOut["sourcing_status"]["state"]): string {
@@ -92,6 +133,7 @@ function statusTone(state: SourcingRiskReportOut["sourcing_status"]["state"]): s
 
 export default function SourcingRiskReport() {
   const [onlyWithFlags, setOnlyWithFlags] = useState(true);
+  const [selectedFlags, setSelectedFlags] = useState<SourcingRiskFlag[]>([]);
   const { data, isLoading, isError, error } = useQuery({
     queryKey: useWsKey("report", "sourcing-risk", onlyWithFlags),
     queryFn: () =>
@@ -102,13 +144,21 @@ export default function SourcingRiskReport() {
 
   const rows = useMemo(
     () =>
-      [...(data?.rows ?? [])].sort((a, b) => {
+      (data?.rows ?? []).filter(row =>
+        selectedFlags.every(flag => row.risk_flags.includes(flag))
+      ).sort((a, b) => {
         const byFlags = b.risk_flags.length - a.risk_flags.length;
         if (byFlags !== 0) return byFlags;
         return a.name.localeCompare(b.name);
       }),
-    [data?.rows],
+    [data?.rows, selectedFlags],
   );
+
+  function toggleFlag(flag: SourcingRiskFlag) {
+    setSelectedFlags(current =>
+      current.includes(flag) ? current.filter(item => item !== flag) : [...current, flag]
+    );
+  }
 
   if (isError) {
     return (
@@ -130,6 +180,23 @@ export default function SourcingRiskReport() {
           Show only flagged
         </label>
         {data && <PoweredByTrustedParts primaryUrl={data.links.primary} />}
+      </div>
+
+      <div className="flex flex-wrap gap-2" aria-label="Sourcing risk filters">
+        {filterFlags.map(flag => {
+          const active = selectedFlags.includes(flag);
+          return (
+            <button
+              key={flag}
+              type="button"
+              className={active ? "pill bg-accent/15 text-accent" : "pill"}
+              aria-pressed={active}
+              onClick={() => toggleFlag(flag)}
+            >
+              {flagLabels[flag]}
+            </button>
+          );
+        })}
       </div>
 
       {data && (
@@ -199,6 +266,13 @@ export default function SourcingRiskReport() {
               render: r => r.lead_time_days == null ? <span className="text-muted">—</span> : <span>{r.lead_time_days}d</span>,
             },
             {
+              key: "lifecycle",
+              header: "Lifecycle",
+              accessor: r => lifecycleRiskRank(r.best_offer?.lifecycle_risk),
+              render: r => <LifecycleRiskPill value={r.best_offer?.lifecycle_risk} />,
+              width: "110px",
+            },
+            {
               key: "flags",
               header: "Flags",
               accessor: r => r.risk_flags.length,
@@ -206,7 +280,7 @@ export default function SourcingRiskReport() {
                 <div className="flex flex-wrap gap-1">
                   {r.risk_flags.length
                     ? r.risk_flags.map(flag => (
-                      <span key={flag} className="pill bg-warning/15 text-warning">{flagLabels[flag]}</span>
+                      <span key={flag} className={flagClass(flag)}>{flagLabels[flag]}</span>
                     ))
                     : <span className="text-muted">—</span>}
                 </div>

--- a/web/src/routes/reports/__tests__/SourcingRiskReport.test.tsx
+++ b/web/src/routes/reports/__tests__/SourcingRiskReport.test.tsx
@@ -84,11 +84,34 @@ describe("SourcingRiskReport", () => {
 
     renderPage();
 
-    expect(await screen.findByText("Single source")).toBeDefined();
-    expect(screen.getByText("Long lead time")).toBeDefined();
-    expect(screen.getByText("Price delta")).toBeDefined();
+    expect(await screen.findByRole("link", { name: "Powered by TrustedParts" })).toBeDefined();
+    expect(screen.getAllByText("Single source").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Long lead time").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Price delta").length).toBeGreaterThan(0);
     expect(screen.getByLabelText("Source: TrustedParts")).toBeDefined();
-    expect(screen.getByRole("link", { name: "Powered by TrustedParts" })).toBeDefined();
+  });
+
+  it("renders the four new filter chips alongside existing chips", async () => {
+    vi.spyOn(api, "get").mockResolvedValue(report([
+      row({
+        risk_flags: [
+          "single_source",
+          "lifecycle_risk_present",
+          "supply_chain_risk_present",
+          "tariff_affected",
+          "rohs_non_compliant",
+        ],
+      }),
+    ]));
+
+    renderPage();
+
+    const filters = await screen.findByLabelText("Sourcing risk filters");
+    expect(within(filters).getByRole("button", { name: "Single source" })).toBeDefined();
+    expect(within(filters).getByRole("button", { name: "Lifecycle" })).toBeDefined();
+    expect(within(filters).getByRole("button", { name: "Supply chain" })).toBeDefined();
+    expect(within(filters).getByRole("button", { name: "Tariff" })).toBeDefined();
+    expect(within(filters).getByRole("button", { name: "RoHS" })).toBeDefined();
   });
 
   it("show only flagged toggle filters list through the report query", async () => {
@@ -127,5 +150,68 @@ describe("SourcingRiskReport", () => {
       expect(within(bodyRows[0]).getByText("Risky")).toBeDefined();
       expect(within(bodyRows[1]).getByText("Clean")).toBeDefined();
     });
+  });
+
+  it("lifecycle sort orders Obsolete before NRND, Active, and null", async () => {
+    const user = userEvent.setup();
+    vi.spyOn(api, "get").mockResolvedValue(report([
+      row({
+        part_id: "part-active",
+        name: "Active Part",
+        mpn: "ACTIVE",
+        risk_flags: ["lifecycle_risk_present"],
+        best_offer: { ...row({}).best_offer, lifecycle_risk: "Active" },
+      }),
+      row({
+        part_id: "part-null",
+        name: "Null Part",
+        mpn: "NULL",
+        risk_flags: [],
+        best_offer: { ...row({}).best_offer, lifecycle_risk: null },
+      }),
+      row({
+        part_id: "part-nrnd",
+        name: "NRND Part",
+        mpn: "NRND",
+        risk_flags: ["lifecycle_risk_present"],
+        best_offer: { ...row({}).best_offer, lifecycle_risk: "NRND" },
+      }),
+      row({
+        part_id: "part-obsolete",
+        name: "Obsolete Part",
+        mpn: "OBS",
+        risk_flags: ["lifecycle_risk_present"],
+        best_offer: { ...row({}).best_offer, lifecycle_risk: "Obsolete" },
+      }),
+    ]));
+
+    renderPage();
+
+    await user.click(await screen.findByRole("columnheader", { name: "Lifecycle" }));
+
+    const bodyRows = screen.getAllByRole("row").slice(1);
+    expect(within(bodyRows[0]).getByText("Obsolete Part")).toBeDefined();
+    expect(within(bodyRows[1]).getByText("NRND Part")).toBeDefined();
+    expect(within(bodyRows[2]).getByText("Active Part")).toBeDefined();
+    expect(within(bodyRows[3]).getByText("Null Part")).toBeDefined();
+    expect(screen.getByLabelText("Lifecycle risk: Obsolete").className).toContain("text-danger");
+  });
+
+  it("chip filter narrows visible rows by flag", async () => {
+    const user = userEvent.setup();
+    vi.spyOn(api, "get").mockResolvedValue(report([
+      row({ part_id: "part-tariff", name: "Tariff Part", mpn: "TARIFF", risk_flags: ["tariff_affected"] }),
+      row({ part_id: "part-rohs", name: "RoHS Part", mpn: "ROHS", risk_flags: ["rohs_non_compliant"] }),
+    ]));
+
+    renderPage();
+
+    expect(await screen.findByText("Tariff Part")).toBeDefined();
+    expect(screen.getByText("RoHS Part")).toBeDefined();
+
+    await user.click(screen.getByRole("button", { name: "Tariff" }));
+
+    expect(screen.getByText("Tariff Part")).toBeDefined();
+    expect(screen.queryByText("RoHS Part")).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- Added TPS-8 risk flags to BOM coverage risk pills with tooltips and RoHS red styling.
- Added hidden-by-default BOM Lifecycle column using the shared TrustedParts lifecycle palette.
- Added Sourcing Risk report filter chips, Lifecycle column, and worst-first lifecycle sort.
- Shared the lifecycle colour helper with the Part Sourcing tab so TPS-7/TPS-8 do not fork the heuristic.
- Documented the new BOM coverage and Sourcing Risk report UI.

## Validation
```text
cd web && npm run typecheck
PASS
```

```text
cd web && npm test -- "ProjectSourcingPage|SourcingRiskReport"
No test files found, exiting with code 1
Note: the issue command does not select files with the current Vitest positional filter.
```

```text
cd web && npm test -- src/routes/projects/sourcing/__tests__/ProjectSourcingPage.test.tsx src/routes/reports/__tests__/SourcingRiskReport.test.tsx src/routes/parts/detail/__tests__/AuthorizedSupplyTab.test.tsx
Test Files  3 passed (3)
Tests  59 passed (59)
```

```text
cd web && npm run lint
Blocked by pre-existing unrelated lint errors:
web/src/lib/bagCode.ts:91:22 no-control-regex
web/src/lib/bagCode.ts:164:14 no-control-regex
plus existing warnings in scanner/responsive/orders/parts/storage files.
```

```text
cd web && npx eslint src/components/DataTable.tsx src/lib/sourcing.ts src/routes/projects/sourcing/ProjectSourcingPage.tsx src/routes/projects/sourcing/__tests__/ProjectSourcingPage.test.tsx src/routes/reports/SourcingRiskReport.tsx src/routes/reports/__tests__/SourcingRiskReport.test.tsx src/routes/parts/detail/AuthorizedSupplyTab.tsx src/routes/parts/detail/__tests__/AuthorizedSupplyTab.test.tsx
PASS

git diff --check
PASS
```

## Screenshots
Not captured locally: these screens require an authenticated workspace with TrustedParts-backed sourcing/report data. The UI states are covered by RTL tests for the new pills, hidden column, filter chips, lifecycle sort, and shared Part Sourcing lifecycle palette.

## Merge Order
After #462 and #463; independent of #461; before closing epic #447.

Refs #455
