### PR TITLE
TPS-6: New alert types from gap fields (lifecycle/supply-chain/tariff)

### DIFF
--- a/backend/alembic/versions/0047_alerts_add_data_alerts.py
+++ b/backend/alembic/versions/0047_alerts_add_data_alerts.py
@@ -1,0 +1,77 @@
+"""Add TrustedParts gap-field sourcing alerts.
+
+Revision ID: 0047
+Revises: 0046
+Create Date: 2026-05-10
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "0047"
+down_revision = "0046"
+branch_labels = None
+depends_on = None
+
+_ORIGINAL_ALERT_TYPES = (
+    "stock_below",
+    "stock_above",
+    "back_in_stock",
+    "out_of_authorized_stock",
+    "price_changed",
+    "bom_buyable",
+)
+_NEW_ALERT_TYPES = (
+    "lifecycle_risk_changed",
+    "supply_chain_risk_changed",
+    "tariff_status_changed",
+)
+
+
+def _alert_type_check(values: tuple[str, ...]) -> str:
+    quoted = ", ".join(f"'{value}'" for value in values)
+    return f"alert_type IN ({quoted})"
+
+
+def upgrade() -> None:
+    op.drop_constraint(
+        "sourcing_alerts_alert_type_check",
+        "sourcing_alerts",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "sourcing_alerts_alert_type_check",
+        "sourcing_alerts",
+        _alert_type_check(_ORIGINAL_ALERT_TYPES + _NEW_ALERT_TYPES),
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    rows = bind.execute(
+        sa.text(
+            "SELECT count(*) FROM sourcing_alerts "
+            "WHERE alert_type IN :alert_types"
+        ).bindparams(sa.bindparam("alert_types", expanding=True)),
+        {"alert_types": _NEW_ALERT_TYPES},
+    ).scalar_one()
+    if rows:
+        raise RuntimeError(
+            "Cannot downgrade while sourcing_alerts rows use "
+            "lifecycle_risk_changed, supply_chain_risk_changed, or "
+            "tariff_status_changed. Delete those alerts first."
+        )
+
+    op.drop_constraint(
+        "sourcing_alerts_alert_type_check",
+        "sourcing_alerts",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "sourcing_alerts_alert_type_check",
+        "sourcing_alerts",
+        _alert_type_check(_ORIGINAL_ALERT_TYPES),
+    )

--- a/backend/app/domain/sourcing/alerts_evaluator.py
+++ b/backend/app/domain/sourcing/alerts_evaluator.py
@@ -279,6 +279,62 @@ def _evaluate_bom_buyable(
     )
 
 
+def _evaluate_lifecycle_risk_changed(
+    db: Session,
+    workspace: Workspace,
+    alert: SourcingAlert,
+) -> AlertVerdict:
+    part = _part_for_alert(db, workspace, alert)
+    current = _gap_field_for_part(db, workspace, alert, part, "lifecycle_risk")
+    return _string_changed_verdict(
+        alert=alert,
+        part=part,
+        current=current,
+        state_key="lifecycle_risk",
+        label="lifecycle risk",
+    )
+
+
+def _evaluate_supply_chain_risk_changed(
+    db: Session,
+    workspace: Workspace,
+    alert: SourcingAlert,
+) -> AlertVerdict:
+    part = _part_for_alert(db, workspace, alert)
+    current = _gap_field_for_part(db, workspace, alert, part, "supply_chain_risk")
+    return _string_changed_verdict(
+        alert=alert,
+        part=part,
+        current=current,
+        state_key="supply_chain_risk",
+        label="supply-chain risk",
+    )
+
+
+def _evaluate_tariff_status_changed(
+    db: Session,
+    workspace: Workspace,
+    alert: SourcingAlert,
+) -> AlertVerdict:
+    part = _part_for_alert(db, workspace, alert)
+    current = _gap_field_for_part(db, workspace, alert, part, "is_affected_by_tariff")
+    previous_state = alert.last_evaluation_state
+    previous = previous_state.get("tariff") if previous_state is not None else None
+    triggered = previous_state is not None and current != previous
+    return AlertVerdict(
+        triggered=triggered,
+        summary=f"{part.name} tariff status changed",
+        detail={
+            "part_id": str(part.id),
+            "part_name": part.name,
+            "mpn": part.mpn,
+            "from": previous,
+            "to": current,
+        },
+        new_state={"tariff": current},
+    )
+
+
 EVALUATORS: dict[str, EvaluatorFn] = {
     "stock_below": _evaluate_stock_below,
     "stock_above": _evaluate_stock_above,
@@ -286,6 +342,9 @@ EVALUATORS: dict[str, EvaluatorFn] = {
     "out_of_authorized_stock": _evaluate_out_of_authorized_stock,
     "price_changed": _evaluate_price_changed,
     "bom_buyable": _evaluate_bom_buyable,
+    "lifecycle_risk_changed": _evaluate_lifecycle_risk_changed,
+    "supply_chain_risk_changed": _evaluate_supply_chain_risk_changed,
+    "tariff_status_changed": _evaluate_tariff_status_changed,
 }
 
 
@@ -455,6 +514,89 @@ def _best_price_for_part(
                 if best is None or price < best[0]:
                     best = (price, currency)
     return best
+
+
+def _gap_field_for_part(
+    db: Session,
+    workspace: Workspace,
+    alert: SourcingAlert,
+    part: Part,
+    field_name: str,
+) -> Any:
+    offer = _first_matching_offer(db, workspace, alert, part)
+    if offer is None:
+        return None
+    return getattr(offer, field_name, None)
+
+
+def _first_matching_offer(
+    db: Session,
+    workspace: Workspace,
+    alert: SourcingAlert,
+    part: Part,
+) -> Any | None:
+    if not part.mpn:
+        return None
+    result = sourcing_service.search(
+        db,
+        workspace=workspace,
+        mpns=[part.mpn],
+        country=alert.country_code,
+        currency=alert.currency_code,
+        distributors=_distributor_filter(alert),
+        use_cached_data=True,
+    )
+    expected = part.mpn.casefold()
+    for item in result.results:
+        item_mpn = getattr(item, "mpn", None)
+        if item_mpn is not None and str(item_mpn).casefold() != expected:
+            continue
+        for offer in item.offers:
+            offer_mpn = getattr(offer, "mpn", None)
+            if offer_mpn is None or str(offer_mpn).casefold() == expected:
+                return offer
+    return None
+
+
+def _string_changed_verdict(
+    *,
+    alert: SourcingAlert,
+    part: Part,
+    current: str | None,
+    state_key: str,
+    label: str,
+) -> AlertVerdict:
+    previous_state = alert.last_evaluation_state
+    previous = previous_state.get(state_key) if previous_state is not None else None
+    triggered = previous_state is not None and current != previous
+    if triggered and not _string_threshold_matches(alert, current):
+        triggered = False
+    return AlertVerdict(
+        triggered=triggered,
+        summary=f"{part.name} {label} changed",
+        detail={
+            "part_id": str(part.id),
+            "part_name": part.name,
+            "mpn": part.mpn,
+            "from": previous,
+            "to": current,
+        },
+        new_state={state_key: current},
+    )
+
+
+def _string_threshold_matches(alert: SourcingAlert, current: str | None) -> bool:
+    must_contain = (alert.threshold or {}).get("must_contain")
+    if must_contain in (None, ""):
+        return True
+    if current is None:
+        return False
+    needle = str(must_contain)
+    haystack = str(current)
+    if not bool((alert.threshold or {}).get("case_sensitive", False)):
+        needle = needle.casefold()
+        haystack = haystack.casefold()
+    return needle in haystack
 
 
 def _unit_price_for_distributor(distributor: Any) -> tuple[Decimal, str | None] | None:

--- a/backend/app/domain/sourcing/models.py
+++ b/backend/app/domain/sourcing/models.py
@@ -233,7 +233,10 @@ class SourcingAlert(WorkspaceOwned, Base):
             "'back_in_stock', "
             "'out_of_authorized_stock', "
             "'price_changed', "
-            "'bom_buyable'"
+            "'bom_buyable', "
+            "'lifecycle_risk_changed', "
+            "'supply_chain_risk_changed', "
+            "'tariff_status_changed'"
             ")",
             name="sourcing_alerts_alert_type_check",
         ),

--- a/backend/app/domain/sourcing/schemas.py
+++ b/backend/app/domain/sourcing/schemas.py
@@ -210,6 +210,9 @@ SourcingAlertType = Literal[
     "out_of_authorized_stock",
     "price_changed",
     "bom_buyable",
+    "lifecycle_risk_changed",
+    "supply_chain_risk_changed",
+    "tariff_status_changed",
 ]
 
 
@@ -243,6 +246,17 @@ class BomBuyableThreshold(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     build_quantity: int = Field(ge=1)
+
+
+class StringChangedThreshold(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    must_contain: str | None = None
+    case_sensitive: bool = False
+
+
+class TariffStatusChangedThreshold(BaseModel):
+    model_config = ConfigDict(extra="forbid")
 
 
 class SourcingAlertIn(BaseModel):

--- a/backend/app/domain/sourcing/service.py
+++ b/backend/app/domain/sourcing/service.py
@@ -52,6 +52,8 @@ from app.domain.sourcing.schemas import (
     SourcingSearchResult,
     StockAboveThreshold,
     StockBelowThreshold,
+    StringChangedThreshold,
+    TariffStatusChangedThreshold,
 )
 from app.domain.workspaces.models import WorkspaceMember
 
@@ -68,6 +70,9 @@ _SOURCING_FILTER_ALERT_TYPES = {
     "back_in_stock",
     "out_of_authorized_stock",
     "price_changed",
+    "lifecycle_risk_changed",
+    "supply_chain_risk_changed",
+    "tariff_status_changed",
 }
 _THRESHOLD_SCHEMAS: dict[SourcingAlertType, type[BaseModel]] = {
     "stock_below": StockBelowThreshold,
@@ -76,6 +81,9 @@ _THRESHOLD_SCHEMAS: dict[SourcingAlertType, type[BaseModel]] = {
     "out_of_authorized_stock": OutOfAuthorizedStockThreshold,
     "price_changed": PriceChangedThreshold,
     "bom_buyable": BomBuyableThreshold,
+    "lifecycle_risk_changed": StringChangedThreshold,
+    "supply_chain_risk_changed": StringChangedThreshold,
+    "tariff_status_changed": TariffStatusChangedThreshold,
 }
 
 

--- a/backend/tests/test_sourcing_alert_models.py
+++ b/backend/tests/test_sourcing_alert_models.py
@@ -93,6 +93,27 @@ def test_check_constraint_rejects_invalid_alert_type(db: Session) -> None:
     db.rollback()
 
 
+@pytest.mark.parametrize(
+    "alert_type",
+    [
+        "lifecycle_risk_changed",
+        "supply_chain_risk_changed",
+        "tariff_status_changed",
+    ],
+)
+def test_check_constraint_accepts_gap_field_alert_types(
+    db: Session,
+    alert_type: str,
+) -> None:
+    workspace, user = _workspace_user(db)
+    part = _part(db, workspace, user)
+    db.add(_alert(workspace, user, part=part, alert_type=alert_type, threshold={}))
+
+    db.flush()
+
+    assert db.execute(select(func.count()).select_from(SourcingAlert)).scalar_one() == 1
+
+
 def test_check_constraint_rejects_short_cooldown(db: Session) -> None:
     workspace, user = _workspace_user(db)
     part = _part(db, workspace, user)

--- a/backend/tests/test_sourcing_alerts_evaluator.py
+++ b/backend/tests/test_sourcing_alerts_evaluator.py
@@ -140,6 +140,10 @@ def _search_out(
     stock: int,
     price: str | None = None,
     currency: str | None = "USD",
+    mpn: str = "MPN",
+    lifecycle_risk: str | None = None,
+    supply_chain_risk: str | None = None,
+    is_affected_by_tariff: bool | None = None,
 ) -> Any:
     distributor = SimpleNamespace(
         stock=stock,
@@ -153,8 +157,13 @@ def _search_out(
     return SimpleNamespace(
         results=[
             SimpleNamespace(
+                mpn=mpn,
                 offers=[
                     SimpleNamespace(
+                        mpn=mpn,
+                        lifecycle_risk=lifecycle_risk,
+                        supply_chain_risk=supply_chain_risk,
+                        is_affected_by_tariff=is_affected_by_tariff,
                         distributors=[distributor],
                     )
                 ]
@@ -403,6 +412,380 @@ def test_bom_buyable_triggers_on_not_buyable_to_buyable_transition(
     assert len(sent) == 1
 
 
+def test_lifecycle_risk_changed_initial_run_records_state_without_triggering(
+    db: Session,
+    monkeypatch,
+) -> None:
+    workspace, user = _workspace(db)
+    part = _part(db, workspace, user, mpn="RISK-MPN")
+    alert = _alert(
+        db,
+        workspace,
+        user,
+        part=part,
+        alert_type="lifecycle_risk_changed",
+        threshold={},
+        last_state=None,
+    )
+    monkeypatch.setattr(
+        alerts_evaluator.sourcing_service,
+        "search",
+        lambda *args, **kwargs: _search_out(
+            stock=1,
+            mpn="RISK-MPN",
+            lifecycle_risk="Active",
+        ),
+    )
+    sent = _capture_mail(monkeypatch)
+
+    assert evaluate_all_alerts(db) == 1
+
+    db.refresh(alert)
+    assert sent == []
+    assert alert.last_evaluation_state == {"lifecycle_risk": "Active"}
+
+
+def test_lifecycle_risk_changed_triggers_on_value_change(
+    db: Session,
+    monkeypatch,
+) -> None:
+    workspace, user = _workspace(db)
+    part = _part(db, workspace, user, mpn="RISK-MPN")
+    _alert(
+        db,
+        workspace,
+        user,
+        part=part,
+        alert_type="lifecycle_risk_changed",
+        threshold={},
+        last_state={"lifecycle_risk": "Active"},
+    )
+    monkeypatch.setattr(
+        alerts_evaluator.sourcing_service,
+        "search",
+        lambda *args, **kwargs: _search_out(
+            stock=1,
+            mpn="RISK-MPN",
+            lifecycle_risk="Obsolete",
+        ),
+    )
+    sent = _capture_mail(monkeypatch)
+
+    assert evaluate_all_alerts(db) == 1
+
+    assert len(sent) == 1
+    assert "lifecycle risk changed" in sent[0]["subject"]
+    assert "- from: Active" in sent[0]["text_body"]
+    assert "- to: Obsolete" in sent[0]["text_body"]
+
+
+def test_lifecycle_risk_changed_does_not_trigger_when_value_unchanged(
+    db: Session,
+    monkeypatch,
+) -> None:
+    workspace, user = _workspace(db)
+    part = _part(db, workspace, user, mpn="RISK-MPN")
+    alert = _alert(
+        db,
+        workspace,
+        user,
+        part=part,
+        alert_type="lifecycle_risk_changed",
+        threshold={},
+        last_state={"lifecycle_risk": "Active"},
+    )
+    monkeypatch.setattr(
+        alerts_evaluator.sourcing_service,
+        "search",
+        lambda *args, **kwargs: _search_out(
+            stock=1,
+            mpn="RISK-MPN",
+            lifecycle_risk="Active",
+        ),
+    )
+    sent = _capture_mail(monkeypatch)
+
+    assert evaluate_all_alerts(db) == 1
+
+    db.refresh(alert)
+    assert sent == []
+    assert alert.last_evaluation_state == {"lifecycle_risk": "Active"}
+
+
+def test_lifecycle_risk_changed_must_contain_filter_narrows_triggers(
+    db: Session,
+    monkeypatch,
+) -> None:
+    workspace, user = _workspace(db)
+    part = _part(db, workspace, user, mpn="RISK-MPN")
+    alert = _alert(
+        db,
+        workspace,
+        user,
+        part=part,
+        alert_type="lifecycle_risk_changed",
+        threshold={"must_contain": "obsolete", "case_sensitive": False},
+        last_state={"lifecycle_risk": "Active"},
+    )
+    monkeypatch.setattr(
+        alerts_evaluator.sourcing_service,
+        "search",
+        lambda *args, **kwargs: _search_out(
+            stock=1,
+            mpn="RISK-MPN",
+            lifecycle_risk="NRND",
+        ),
+    )
+    sent = _capture_mail(monkeypatch)
+
+    assert evaluate_all_alerts(db) == 1
+
+    db.refresh(alert)
+    assert sent == []
+    assert alert.last_evaluation_state == {"lifecycle_risk": "NRND"}
+
+    alert.last_evaluation_state = {"lifecycle_risk": "NRND"}
+    db.flush()
+    monkeypatch.setattr(
+        alerts_evaluator.sourcing_service,
+        "search",
+        lambda *args, **kwargs: _search_out(
+            stock=1,
+            mpn="RISK-MPN",
+            lifecycle_risk="Obsolete",
+        ),
+    )
+
+    assert evaluate_all_alerts(db) == 1
+
+    assert len(sent) == 1
+
+
+def test_supply_chain_risk_changed_initial_run_records_state_without_triggering(
+    db: Session,
+    monkeypatch,
+) -> None:
+    workspace, user = _workspace(db)
+    part = _part(db, workspace, user, mpn="SUPPLY-MPN")
+    alert = _alert(
+        db,
+        workspace,
+        user,
+        part=part,
+        alert_type="supply_chain_risk_changed",
+        threshold={},
+        last_state=None,
+    )
+    monkeypatch.setattr(
+        alerts_evaluator.sourcing_service,
+        "search",
+        lambda *args, **kwargs: _search_out(
+            stock=1,
+            mpn="SUPPLY-MPN",
+            supply_chain_risk="Stable",
+        ),
+    )
+    sent = _capture_mail(monkeypatch)
+
+    assert evaluate_all_alerts(db) == 1
+
+    db.refresh(alert)
+    assert sent == []
+    assert alert.last_evaluation_state == {"supply_chain_risk": "Stable"}
+
+
+def test_supply_chain_risk_changed_triggers_on_value_change(
+    db: Session,
+    monkeypatch,
+) -> None:
+    workspace, user = _workspace(db)
+    part = _part(db, workspace, user, mpn="SUPPLY-MPN")
+    _alert(
+        db,
+        workspace,
+        user,
+        part=part,
+        alert_type="supply_chain_risk_changed",
+        threshold={},
+        last_state={"supply_chain_risk": "Stable"},
+    )
+    monkeypatch.setattr(
+        alerts_evaluator.sourcing_service,
+        "search",
+        lambda *args, **kwargs: _search_out(
+            stock=1,
+            mpn="SUPPLY-MPN",
+            supply_chain_risk="Allocation",
+        ),
+    )
+    sent = _capture_mail(monkeypatch)
+
+    assert evaluate_all_alerts(db) == 1
+
+    assert len(sent) == 1
+
+
+def test_supply_chain_risk_changed_does_not_trigger_when_value_unchanged(
+    db: Session,
+    monkeypatch,
+) -> None:
+    workspace, user = _workspace(db)
+    part = _part(db, workspace, user, mpn="SUPPLY-MPN")
+    alert = _alert(
+        db,
+        workspace,
+        user,
+        part=part,
+        alert_type="supply_chain_risk_changed",
+        threshold={},
+        last_state={"supply_chain_risk": "Stable"},
+    )
+    monkeypatch.setattr(
+        alerts_evaluator.sourcing_service,
+        "search",
+        lambda *args, **kwargs: _search_out(
+            stock=1,
+            mpn="SUPPLY-MPN",
+            supply_chain_risk="Stable",
+        ),
+    )
+    sent = _capture_mail(monkeypatch)
+
+    assert evaluate_all_alerts(db) == 1
+
+    db.refresh(alert)
+    assert sent == []
+    assert alert.last_evaluation_state == {"supply_chain_risk": "Stable"}
+
+
+def test_tariff_status_changed_initial_run_records_state_without_triggering(
+    db: Session,
+    monkeypatch,
+) -> None:
+    workspace, user = _workspace(db)
+    part = _part(db, workspace, user, mpn="TARIFF-MPN")
+    alert = _alert(
+        db,
+        workspace,
+        user,
+        part=part,
+        alert_type="tariff_status_changed",
+        threshold={},
+        last_state=None,
+    )
+    monkeypatch.setattr(
+        alerts_evaluator.sourcing_service,
+        "search",
+        lambda *args, **kwargs: _search_out(
+            stock=1,
+            mpn="TARIFF-MPN",
+            is_affected_by_tariff=False,
+        ),
+    )
+    sent = _capture_mail(monkeypatch)
+
+    assert evaluate_all_alerts(db) == 1
+
+    db.refresh(alert)
+    assert sent == []
+    assert alert.last_evaluation_state == {"tariff": False}
+
+
+def test_tariff_status_changed_triggers_on_value_change(
+    db: Session,
+    monkeypatch,
+) -> None:
+    workspace, user = _workspace(db)
+    part = _part(db, workspace, user, mpn="TARIFF-MPN")
+    _alert(
+        db,
+        workspace,
+        user,
+        part=part,
+        alert_type="tariff_status_changed",
+        threshold={},
+        last_state={"tariff": True},
+    )
+    monkeypatch.setattr(
+        alerts_evaluator.sourcing_service,
+        "search",
+        lambda *args, **kwargs: _search_out(
+            stock=1,
+            mpn="TARIFF-MPN",
+            is_affected_by_tariff=False,
+        ),
+    )
+    sent = _capture_mail(monkeypatch)
+
+    assert evaluate_all_alerts(db) == 1
+
+    assert len(sent) == 1
+
+
+def test_tariff_status_changed_does_not_trigger_when_value_unchanged(
+    db: Session,
+    monkeypatch,
+) -> None:
+    workspace, user = _workspace(db)
+    part = _part(db, workspace, user, mpn="TARIFF-MPN")
+    alert = _alert(
+        db,
+        workspace,
+        user,
+        part=part,
+        alert_type="tariff_status_changed",
+        threshold={},
+        last_state={"tariff": False},
+    )
+    monkeypatch.setattr(
+        alerts_evaluator.sourcing_service,
+        "search",
+        lambda *args, **kwargs: _search_out(
+            stock=1,
+            mpn="TARIFF-MPN",
+            is_affected_by_tariff=False,
+        ),
+    )
+    sent = _capture_mail(monkeypatch)
+
+    assert evaluate_all_alerts(db) == 1
+
+    db.refresh(alert)
+    assert sent == []
+    assert alert.last_evaluation_state == {"tariff": False}
+
+
+def test_tariff_status_changed_fires_on_none_to_true_transition(
+    db: Session,
+    monkeypatch,
+) -> None:
+    workspace, user = _workspace(db)
+    part = _part(db, workspace, user, mpn="TARIFF-MPN")
+    _alert(
+        db,
+        workspace,
+        user,
+        part=part,
+        alert_type="tariff_status_changed",
+        threshold={},
+        last_state={"tariff": None},
+    )
+    monkeypatch.setattr(
+        alerts_evaluator.sourcing_service,
+        "search",
+        lambda *args, **kwargs: _search_out(
+            stock=1,
+            mpn="TARIFF-MPN",
+            is_affected_by_tariff=True,
+        ),
+    )
+    sent = _capture_mail(monkeypatch)
+
+    assert evaluate_all_alerts(db) == 1
+
+    assert len(sent) == 1
+
+
 def test_cooldown_suppresses_second_notification(db: Session, monkeypatch) -> None:
     workspace, user = _workspace(db)
     part = _part(db, workspace, user)
@@ -558,6 +941,33 @@ def test_evaluator_uses_cache_default_true_for_sourcing_alerts(
         db,
         workspace,
         user,
+        part=part,
+        alert_type="lifecycle_risk_changed",
+        threshold={},
+        last_state={"lifecycle_risk": "Active"},
+    )
+    _alert(
+        db,
+        workspace,
+        user,
+        part=part,
+        alert_type="supply_chain_risk_changed",
+        threshold={},
+        last_state={"supply_chain_risk": "Stable"},
+    )
+    _alert(
+        db,
+        workspace,
+        user,
+        part=part,
+        alert_type="tariff_status_changed",
+        threshold={},
+        last_state={"tariff": False},
+    )
+    _alert(
+        db,
+        workspace,
+        user,
         project=project,
         alert_type="bom_buyable",
         threshold={"build_quantity": 2},
@@ -568,7 +978,13 @@ def test_evaluator_uses_cache_default_true_for_sourcing_alerts(
 
     def fake_search(*args: Any, **kwargs: Any) -> Any:
         search_cached.append(kwargs.get("use_cached_data"))
-        return _search_out(stock=1)
+        return _search_out(
+            stock=1,
+            mpn=part.mpn or "MPN",
+            lifecycle_risk="Obsolete",
+            supply_chain_risk="Allocation",
+            is_affected_by_tariff=True,
+        )
 
     def fake_source_bom(*args: Any, **kwargs: Any) -> Any:
         bom_cached.append(kwargs.get("use_cached_data"))
@@ -580,9 +996,9 @@ def test_evaluator_uses_cache_default_true_for_sourcing_alerts(
     monkeypatch.setattr(alerts_evaluator.sourcing_service, "source_bom", fake_source_bom)
     _capture_mail(monkeypatch)
 
-    assert evaluate_all_alerts(db) == 2
+    assert evaluate_all_alerts(db) == 5
 
-    assert search_cached == [True]
+    assert search_cached == [True, True, True, True]
     assert bom_cached == [True]
 
 

--- a/backend/tests/test_sourcing_alerts_route.py
+++ b/backend/tests/test_sourcing_alerts_route.py
@@ -101,6 +101,52 @@ def test_create_stock_below_alert(authed_client):
     assert data["archived_at"] is None
 
 
+def test_create_lifecycle_risk_changed_alert_with_must_contain_threshold(
+    authed_client,
+):
+    part_id = create_part(authed_client, name="Lifecycle target")
+
+    r = authed_client.post(
+        "/api/sourcing/alerts",
+        json={
+            "alert_type": "lifecycle_risk_changed",
+            "part_id": part_id,
+            "threshold": {"must_contain": "EOL", "case_sensitive": True},
+            "country_code": "us",
+            "currency_code": "usd",
+            "distributor_filter": ["DigiKey"],
+        },
+    )
+
+    assert r.status_code == 200, r.text
+    data = r.json()["data"]
+    assert data["alert_type"] == "lifecycle_risk_changed"
+    assert data["part_id"] == part_id
+    assert data["project_id"] is None
+    assert data["threshold"] == {"must_contain": "EOL", "case_sensitive": True}
+    assert data["country_code"] == "US"
+    assert data["currency_code"] == "USD"
+    assert data["distributor_filter"] == ["DigiKey"]
+
+
+def test_create_tariff_status_changed_alert_empty_threshold(authed_client):
+    part_id = create_part(authed_client, name="Tariff target")
+
+    r = authed_client.post(
+        "/api/sourcing/alerts",
+        json={
+            "alert_type": "tariff_status_changed",
+            "part_id": part_id,
+            "threshold": {},
+        },
+    )
+
+    assert r.status_code == 200, r.text
+    data = r.json()["data"]
+    assert data["alert_type"] == "tariff_status_changed"
+    assert data["threshold"] == {}
+
+
 @pytest.mark.parametrize(
     ("alert_type", "threshold"),
     [
@@ -110,6 +156,9 @@ def test_create_stock_below_alert(authed_client):
         ("out_of_authorized_stock", {"qty": 1}),
         ("price_changed", {"delta_pct": 150}),
         ("bom_buyable", {"build_quantity": 0}),
+        ("lifecycle_risk_changed", {"to_states": ["Obsolete"]}),
+        ("supply_chain_risk_changed", {"must_contain": "NRND", "unexpected": True}),
+        ("tariff_status_changed", {"must_contain": "yes"}),
     ],
 )
 def test_create_with_invalid_threshold_returns_422(
@@ -128,6 +177,33 @@ def test_create_with_invalid_threshold_returns_422(
         payload["part_id"] = part_id
 
     r = authed_client.post("/api/sourcing/alerts", json=payload)
+
+    assert r.status_code == 422, r.text
+    assert r.json()["status"]["category"] == "validation_error"
+
+
+@pytest.mark.parametrize(
+    "alert_type",
+    [
+        "lifecycle_risk_changed",
+        "supply_chain_risk_changed",
+        "tariff_status_changed",
+    ],
+)
+def test_gap_field_alerts_require_part_id_not_project_id(
+    authed_client,
+    alert_type: str,
+):
+    project_id, _part_id = _single_line_project(authed_client)
+
+    r = authed_client.post(
+        "/api/sourcing/alerts",
+        json={
+            "alert_type": alert_type,
+            "project_id": project_id,
+            "threshold": {},
+        },
+    )
 
     assert r.status_code == 422, r.text
     assert r.json()["status"]["category"] == "validation_error"

--- a/docs/adr/0020-trustedparts-sourcing-provider-split.md
+++ b/docs/adr/0020-trustedparts-sourcing-provider-split.md
@@ -27,6 +27,9 @@ expired plan rows alongside cache rows (`backend/alembic/versions/0039_purchase_
 
 Phase 5b sourcing alerts use the same domain boundary; see
 [sourcing alerts](../domain/sourcing.md#alerts).
+TrustedParts gap-field alerts detect lifecycle-risk, supply-chain-risk, and tariff
+transitions from the short-lived sourcing result shape rather than creating a separate
+history table.
 
 TrustedParts results must stay visibly distinct from catalog-provider data. Public or UI surfaces that combine distributor data from multiple origins need an explicit future decision before launch.
 

--- a/docs/domain/sourcing.md
+++ b/docs/domain/sourcing.md
@@ -176,14 +176,20 @@ Phase 5b evaluator. Each row targets exactly one part or one project and uses
 | `out_of_authorized_stock` | part | `{}` |
 | `price_changed` | part | `{ "delta_pct": Decimal }` |
 | `bom_buyable` | project | `{ "build_quantity": int }` |
+| `lifecycle_risk_changed` | part | `{ "must_contain": str \| null, "case_sensitive": bool }` |
+| `supply_chain_risk_changed` | part | `{ "must_contain": str \| null, "case_sensitive": bool }` |
+| `tariff_status_changed` | part | `{}` |
 
-The database pins the six MVP alert types with a CHECK constraint, enforces one active
-target via `(part_id IS NOT NULL) <> (project_id IS NOT NULL)`, and prevents duplicate
-active alerts with a partial unique index over workspace, type, target, and threshold.
+The database pins alert types with a CHECK constraint, enforces one active target via
+`(part_id IS NOT NULL) <> (project_id IS NOT NULL)`, and prevents duplicate active
+alerts with a partial unique index over workspace, type, target, and threshold.
 `cooldown_seconds` defaults to 24 hours and has a 60-second minimum. Evaluator state
-lives on `last_checked_at`, `last_notified_at`, and `last_evaluation_state`.
+lives on `last_checked_at`, `last_notified_at`, and `last_evaluation_state`. Gap-field
+alerts were added by migration 0047, whose downgrade refuses while rows of those types
+exist.
 
-Source: `backend/alembic/versions/0044_sourcing_alerts.py:20`
+Sources: `backend/alembic/versions/0044_sourcing_alerts.py:20`,
+`backend/alembic/versions/0047_alerts_add_data_alerts.py:28`
 
 ### Evaluator Behaviour
 
@@ -206,6 +212,9 @@ workspace, and sourcing calls receive the current alert workspace. Sources:
 | `out_of_authorized_stock` | authorized stock crosses from positive to zero | `{ "had_stock": bool }` |
 | `price_changed` | same-currency best authorized unit price changes by at least `threshold.delta_pct` percent | `{ "last_price": str, "last_currency": str }` |
 | `bom_buyable` | `can_build_after_purchase >= threshold.build_quantity` after a prior not-buyable state | `{ "is_buyable": bool }` |
+| `lifecycle_risk_changed` | first matching offer's lifecycle risk string changes; optional `must_contain` filters on the new string | `{ "lifecycle_risk": str \| null }` |
+| `supply_chain_risk_changed` | first matching offer's supply-chain risk string changes; optional `must_contain` filters on the new string | `{ "supply_chain_risk": str \| null }` |
+| `tariff_status_changed` | first matching offer's tariff status flips among `null`, `true`, and `false` | `{ "tariff": bool \| null }` |
 
 First evaluation records state and does not notify because no prior state exists.
 Stock alerts read quantity only through `domain/stock/service.py::current_quantity`.
@@ -214,6 +223,12 @@ BOM buyability calls `sourcing.service.source_bom(..., use_cached_data=True)` an
 the returned capacity computed by `compute_build_capacity`. Sources:
 `backend/app/domain/sourcing/alerts_evaluator.py:91-279`,
 `backend/app/domain/sourcing/alerts_evaluator.py:405-457`
+
+`must_contain` defaults to no filter for lifecycle and supply-chain alerts. Matching is
+case-insensitive unless `case_sensitive` is true. The fields are free strings from
+TrustedParts, so these alerts detect transitions rather than validating against an enum.
+Sources: `backend/app/domain/sourcing/schemas.py:236-244`,
+`backend/app/domain/sourcing/alerts_evaluator.py:280-357`
 
 Cooldown is DB-backed: notification is allowed when `last_notified_at IS NULL` or when
 the elapsed wall time is at least `cooldown_seconds`. `last_notified_at` updates only

--- a/docs/user/alerts.md
+++ b/docs/user/alerts.md
@@ -16,7 +16,7 @@ Alerts live under **Alerts** in the sidebar. Use them when you want Stock Manage
 6. Choose recipients, or leave recipients empty to notify workspace admins.
 7. Click **Create alert**.
 
-Part alerts can watch internal stock, authorized stock availability, or price movement. Project alerts can watch when a BOM becomes buyable for a build quantity.
+Part alerts can watch internal stock, authorized stock availability, price movement, lifecycle risk, supply-chain risk, or tariff status. Project alerts can watch when a BOM becomes buyable for a build quantity.
 
 > _Screenshot: the Alerts page with the create modal open._
 
@@ -38,6 +38,14 @@ The part is already selected in the form.
 5. Save the alert.
 
 The project and build quantity are already selected in the form.
+
+## Risk and tariff alerts
+
+Lifecycle risk alerts watch the lifecycle text TrustedParts returns for a part. Leave **Must contain** empty to notify on any change, or enter text such as `EOL` or `Obsolete` to notify only when the new value contains that text.
+
+Supply-chain risk alerts work the same way, but watch the TrustedParts supply-chain risk text. Use **Case sensitive** only when exact capitalization matters.
+
+Tariff status alerts notify when TrustedParts changes the tariff flag for the part. There is no threshold field; the alert watches any change between unknown, affected, and not affected.
 
 ## Manage existing alerts
 

--- a/web/src/lib/sourcingAlerts.ts
+++ b/web/src/lib/sourcingAlerts.ts
@@ -7,6 +7,9 @@ export const ALERT_TYPES = [
   "out_of_authorized_stock",
   "price_changed",
   "bom_buyable",
+  "lifecycle_risk_changed",
+  "supply_chain_risk_changed",
+  "tariff_status_changed",
 ] as const;
 
 export type SourcingAlertType = typeof ALERT_TYPES[number];
@@ -15,6 +18,7 @@ export type SourcingAlertThreshold =
   | { qty: number }
   | { delta_pct: number }
   | { build_quantity: number }
+  | { must_contain?: string | null; case_sensitive?: boolean }
   | Record<string, never>;
 
 export type SourcingAlert = {
@@ -91,6 +95,12 @@ export function alertTypeLabel(type: SourcingAlertType): string {
       return "Price changed";
     case "bom_buyable":
       return "BOM buyable";
+    case "lifecycle_risk_changed":
+      return "Lifecycle risk changed";
+    case "supply_chain_risk_changed":
+      return "Supply-chain risk changed";
+    case "tariff_status_changed":
+      return "Tariff status changed";
   }
 }
 
@@ -99,7 +109,12 @@ export function isProjectAlert(type: SourcingAlertType): boolean {
 }
 
 export function isSourcingFilteredAlert(type: SourcingAlertType): boolean {
-  return type === "back_in_stock" || type === "out_of_authorized_stock" || type === "price_changed";
+  return type === "back_in_stock"
+    || type === "out_of_authorized_stock"
+    || type === "price_changed"
+    || type === "lifecycle_risk_changed"
+    || type === "supply_chain_risk_changed"
+    || type === "tariff_status_changed";
 }
 
 export function listSourcingAlerts(filters: SourcingAlertFilters = {}, opts?: ApiOptions) {

--- a/web/src/routes/parts/detail/AuthorizedSupplyTab.tsx
+++ b/web/src/routes/parts/detail/AuthorizedSupplyTab.tsx
@@ -470,6 +470,26 @@ export function AuthorizedSupplyTab({ partId }: { partId: string }) {
   });
 
   const rows = useMemo(() => flattenOffers(query.data), [query.data]);
+  const alertTypes = useMemo(() => {
+    const types: SourcingAlertType[] = [
+      "back_in_stock",
+      "out_of_authorized_stock",
+      "price_changed",
+      "stock_below",
+      "stock_above",
+    ];
+    const offers = query.data?.offers ?? [];
+    if (offers.some(offer => Boolean(offer.lifecycle_risk?.trim()))) {
+      types.push("lifecycle_risk_changed");
+    }
+    if (offers.some(offer => Boolean(offer.supply_chain_risk?.trim()))) {
+      types.push("supply_chain_risk_changed");
+    }
+    if (offers.some(offer => offer.is_affected_by_tariff !== null && offer.is_affected_by_tariff !== undefined)) {
+      types.push("tariff_status_changed");
+    }
+    return types;
+  }, [query.data?.offers]);
   const refetch = query.refetch;
   const distributors = useMemo(
     () => Array.from(new Set(rows.map(row => row.distributor))).sort((a, b) => a.localeCompare(b)),
@@ -831,7 +851,7 @@ export function AuthorizedSupplyTab({ partId }: { partId: string }) {
         open={alertModalOpen}
         title="Set alert on this part"
         initialValues={{ part_id: partId, alert_type: "back_in_stock" }}
-        allowedTypes={["back_in_stock", "out_of_authorized_stock", "price_changed", "stock_below", "stock_above"] satisfies SourcingAlertType[]}
+        allowedTypes={alertTypes}
         onClose={() => setAlertModalOpen(false)}
         onSaved={() => {
           queryClient.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "sourcing-alerts") });

--- a/web/src/routes/parts/detail/__tests__/AuthorizedSupplyTab.test.tsx
+++ b/web/src/routes/parts/detail/__tests__/AuthorizedSupplyTab.test.tsx
@@ -273,6 +273,43 @@ describe("AuthorizedSupplyTab", () => {
     expect((screen.getByRole("radio", { name: /STM32/ }) as HTMLInputElement).checked).toBe(true);
   });
 
+  it("Set-alert options include gap alerts only when gap data is populated", async () => {
+    const user = userEvent.setup();
+    mockApiGetWithAlertPicker(gapResponse({
+      lifecycle_risk: "Obsolete",
+      supply_chain_risk: "Allocation",
+      is_affected_by_tariff: false,
+    }));
+
+    renderTab();
+
+    await screen.findByText("Powered by TrustedParts");
+    await user.click(screen.getByRole("button", { name: "Set alert" }));
+
+    const alertType = await screen.findByLabelText("Alert type");
+    expect(within(alertType).getByRole("option", { name: "Lifecycle risk changed" })).toBeDefined();
+    expect(within(alertType).getByRole("option", { name: "Supply-chain risk changed" })).toBeDefined();
+    expect(within(alertType).getByRole("option", { name: "Tariff status changed" })).toBeDefined();
+
+    cleanup();
+    vi.restoreAllMocks();
+    mockApiGetWithAlertPicker(gapResponse({
+      lifecycle_risk: null,
+      supply_chain_risk: "",
+      is_affected_by_tariff: null,
+    }));
+
+    renderTab();
+
+    await screen.findByText("Powered by TrustedParts");
+    await user.click(screen.getByRole("button", { name: "Set alert" }));
+
+    const filteredAlertType = await screen.findByLabelText("Alert type");
+    expect(within(filteredAlertType).queryByRole("option", { name: "Lifecycle risk changed" })).toBeNull();
+    expect(within(filteredAlertType).queryByRole("option", { name: "Supply-chain risk changed" })).toBeNull();
+    expect(within(filteredAlertType).queryByRole("option", { name: "Tariff status changed" })).toBeNull();
+  });
+
   it("distributor filter narrows visible rows", async () => {
     const user = userEvent.setup();
     const getSpy = mockApiGet(sourcingResponse());

--- a/web/src/routes/sourcing/alerts/AlertFormModal.tsx
+++ b/web/src/routes/sourcing/alerts/AlertFormModal.tsx
@@ -42,6 +42,11 @@ const DEFAULT_COOLDOWN_SECONDS = 86400;
 const EMPTY_THRESHOLD_TYPES = new Set<SourcingAlertType>([
   "back_in_stock",
   "out_of_authorized_stock",
+  "tariff_status_changed",
+]);
+const STRING_CHANGED_TYPES = new Set<SourcingAlertType>([
+  "lifecycle_risk_changed",
+  "supply_chain_risk_changed",
 ]);
 
 function positiveInt(value: string, fallback: number): number {
@@ -53,6 +58,11 @@ function positiveInt(value: string, fallback: number): number {
 function thresholdFromAlert(alert: SourcingAlert | null | undefined, key: string, fallback: string): string {
   const value = alert?.threshold?.[key as keyof typeof alert.threshold];
   return value == null ? fallback : String(value);
+}
+
+function thresholdBoolFromAlert(alert: SourcingAlert | null | undefined, key: string): boolean {
+  const value = alert?.threshold?.[key as keyof typeof alert.threshold];
+  return value === true;
 }
 
 function defaultFromActiveList(saved: string | null | undefined, active: string[]): string {
@@ -92,6 +102,8 @@ export default function AlertFormModal({
   const [buildQuantity, setBuildQuantity] = useState(
     String(initialValues?.build_quantity ?? thresholdFromAlert(alert, "build_quantity", "1")),
   );
+  const [mustContain, setMustContain] = useState(thresholdFromAlert(alert, "must_contain", ""));
+  const [caseSensitive, setCaseSensitive] = useState(thresholdBoolFromAlert(alert, "case_sensitive"));
   const [countryCode, setCountryCode] = useState(alert?.country_code ?? "");
   const [currencyCode, setCurrencyCode] = useState(alert?.currency_code ?? "");
   const [distributorFilter, setDistributorFilter] = useState<string[]>(alert?.distributor_filter ?? []);
@@ -111,6 +123,8 @@ export default function AlertFormModal({
     setQty(thresholdFromAlert(alert, "qty", "0"));
     setDeltaPct(thresholdFromAlert(alert, "delta_pct", "5"));
     setBuildQuantity(String(initialValues?.build_quantity ?? thresholdFromAlert(alert, "build_quantity", "1")));
+    setMustContain(thresholdFromAlert(alert, "must_contain", ""));
+    setCaseSensitive(thresholdBoolFromAlert(alert, "case_sensitive"));
     setCountryCode(alert?.country_code ?? "");
     setCurrencyCode(alert?.currency_code ?? "");
     setDistributorFilter(alert?.distributor_filter ?? []);
@@ -226,6 +240,11 @@ export default function AlertFormModal({
         return null;
       }
       threshold = { build_quantity: parsedBuild };
+    } else if (STRING_CHANGED_TYPES.has(alertType)) {
+      threshold = {
+        must_contain: mustContain.trim() || null,
+        case_sensitive: caseSensitive,
+      };
     }
 
     const payload: SourcingAlertInput = {
@@ -444,9 +463,33 @@ export default function AlertFormModal({
                 />
               </label>
             )}
+            {STRING_CHANGED_TYPES.has(alertType) && (
+              <div className="space-y-3">
+                <label className="label">
+                  Must contain
+                  <input
+                    className="input"
+                    value={mustContain}
+                    onChange={event => setMustContain(event.currentTarget.value)}
+                    disabled={mutation.isPending}
+                  />
+                </label>
+                <label className="label flex-row items-center gap-2">
+                  <input
+                    type="checkbox"
+                    checked={caseSensitive}
+                    onChange={event => setCaseSensitive(event.currentTarget.checked)}
+                    disabled={mutation.isPending}
+                  />
+                  Case sensitive
+                </label>
+              </div>
+            )}
             {EMPTY_THRESHOLD_TYPES.has(alertType) && (
               <div className="rounded border border-border p-3 text-sm text-muted">
-                This alert triggers on an availability transition; no numeric threshold is needed.
+                {alertType === "tariff_status_changed"
+                  ? "This alert triggers on any tariff status transition; no threshold is needed."
+                  : "This alert triggers on an availability transition; no numeric threshold is needed."}
               </div>
             )}
             <label className="label">

--- a/web/src/routes/sourcing/alerts/AlertsPage.tsx
+++ b/web/src/routes/sourcing/alerts/AlertsPage.tsx
@@ -38,6 +38,15 @@ function formatThreshold(alert: SourcingAlert): string {
       return "Authorized stock returns";
     case "out_of_authorized_stock":
       return "Authorized stock reaches zero";
+    case "lifecycle_risk_changed":
+    case "supply_chain_risk_changed": {
+      const threshold = alert.threshold as { must_contain?: string | null; case_sensitive?: boolean };
+      return threshold.must_contain
+        ? `New value contains ${threshold.must_contain}`
+        : "Any value change";
+    }
+    case "tariff_status_changed":
+      return "Any status change";
   }
 }
 

--- a/web/src/routes/sourcing/alerts/__tests__/AlertFormModal.test.tsx
+++ b/web/src/routes/sourcing/alerts/__tests__/AlertFormModal.test.tsx
@@ -140,6 +140,36 @@ describe("AlertFormModal", () => {
     expect(screen.queryByLabelText("Build quantity")).toBeNull();
   });
 
+  it("lifecycle_risk_changed shows must_contain and case_sensitive fields", async () => {
+    mockApiReads();
+
+    renderModal({
+      initialValues: { alert_type: "lifecycle_risk_changed", part_id: part.id },
+      allowedTypes: ["lifecycle_risk_changed"],
+    });
+
+    expect(await screen.findByLabelText("Must contain")).toBeDefined();
+    expect(screen.getByLabelText("Case sensitive")).toBeDefined();
+    expect(screen.queryByLabelText("Quantity")).toBeNull();
+    expect(screen.queryByLabelText("Delta percent")).toBeNull();
+  });
+
+  it("tariff_status_changed shows no threshold fields", async () => {
+    mockApiReads();
+
+    renderModal({
+      initialValues: { alert_type: "tariff_status_changed", part_id: part.id },
+      allowedTypes: ["tariff_status_changed"],
+    });
+
+    expect(await screen.findByText("This alert triggers on any tariff status transition; no threshold is needed.")).toBeDefined();
+    expect(screen.queryByLabelText("Must contain")).toBeNull();
+    expect(screen.queryByLabelText("Case sensitive")).toBeNull();
+    expect(screen.queryByLabelText("Quantity")).toBeNull();
+    expect(screen.queryByLabelText("Delta percent")).toBeNull();
+    expect(screen.queryByLabelText("Build quantity")).toBeNull();
+  });
+
   it("cooldown < 60 surfaces validation error", async () => {
     const user = userEvent.setup();
     mockApiReads();
@@ -191,6 +221,31 @@ describe("AlertFormModal", () => {
         currency_code: "EUR",
         distributor_filter: ["DigiKey", "Mouser"],
       });
+    });
+  });
+
+  it("submit posts lifecycle string-change threshold", async () => {
+    const user = userEvent.setup();
+    mockApiReads();
+    const post = vi.spyOn(api, "post").mockResolvedValue({ id: "alert-1" } as never);
+
+    renderModal({
+      initialValues: { alert_type: "lifecycle_risk_changed", part_id: part.id },
+      allowedTypes: ["lifecycle_risk_changed"],
+    });
+
+    await screen.findByText("STM32");
+    await user.type(screen.getByLabelText("Must contain"), "EOL");
+    await user.click(screen.getByLabelText("Case sensitive"));
+    await user.click(screen.getByRole("button", { name: "Create alert" }));
+
+    await waitFor(() => {
+      expect(post).toHaveBeenCalledWith("/sourcing/alerts", expect.objectContaining({
+        alert_type: "lifecycle_risk_changed",
+        part_id: part.id,
+        project_id: null,
+        threshold: { must_contain: "EOL", case_sensitive: true },
+      }));
     });
   });
 


### PR DESCRIPTION
## Summary

- Adds three TrustedParts gap-field alert types: `lifecycle_risk_changed`, `supply_chain_risk_changed`, and `tariff_status_changed`.
- Adds migration `0047_alerts_add_data_alerts.py` to widen the `sourcing_alerts.alert_type` CHECK constraint to the original six plus the three new types; downgrade refuses while rows of the new types exist.
- Adds backend threshold validation, cached first-offer transition evaluators, route/model/evaluator coverage, frontend form controls, per-part shortcut narrowing, and docs.
- Rebased onto current `origin/main` after #464 (`d4d2316`); #464's shared `lifecycleRiskTone` / `lifecycleRiskRank` helpers in `web/src/lib/sourcing.ts` are preserved.

## Migration validation

Local Postgres test DB: `postgresql+psycopg://stockmgr:stockmgr@127.0.0.1:5432/stockmgr_test`.

```text
alembic downgrade 0046
INFO  [alembic.runtime.migration] Running downgrade 0047 -> 0046, Add TrustedParts gap-field sourcing alerts.

alembic upgrade head
INFO  [alembic.runtime.migration] Running upgrade 0046 -> 0047, Add TrustedParts gap-field sourcing alerts.

inserted lifecycle_risk_changed alert aae7decf-392e-4283-bf58-5e0fa387cfbe

alembic downgrade -1
RuntimeError: Cannot downgrade while sourcing_alerts rows use lifecycle_risk_changed, supply_chain_risk_changed, or tariff_status_changed. Delete those alerts first.

deleted 1 gap-field alert row(s)

alembic downgrade -1
INFO  [alembic.runtime.migration] Running downgrade 0047 -> 0046, Add TrustedParts gap-field sourcing alerts.

alembic upgrade head
INFO  [alembic.runtime.migration] Running upgrade 0046 -> 0047, Add TrustedParts gap-field sourcing alerts.

alembic current
0047 (head)
```

Post-rebase Alembic check:

```text
alembic current
0047 (head)
```

## Validation

```text
uv run python -m pytest -q -k "sourcing_alert"
77 passed, 1107 deselected, 1 warning in 13.40s

uv run ruff check app/domain/sourcing/alerts_evaluator.py app/domain/sourcing/models.py app/domain/sourcing/schemas.py app/domain/sourcing/service.py alembic/versions/0047_alerts_add_data_alerts.py tests/test_sourcing_alert_models.py tests/test_sourcing_alerts_route.py tests/test_sourcing_alerts_evaluator.py
All checks passed!

cd web && npm run typecheck
passed

cd web && npm test -- AlertFormModal AuthorizedSupplyTab -- --run
2 files passed, 39 tests passed

cd web && npx eslint src/lib/sourcingAlerts.ts src/routes/sourcing/alerts/AlertFormModal.tsx src/routes/sourcing/alerts/AlertsPage.tsx src/routes/parts/detail/AuthorizedSupplyTab.tsx src/routes/sourcing/alerts/__tests__/AlertFormModal.test.tsx src/routes/parts/detail/__tests__/AuthorizedSupplyTab.test.tsx --format=unix
passed

git diff --check
passed
```

Full `npm run lint -- --format=unix` still reports existing unrelated baseline issues in `ZxingScanner.tsx`, `bagCode.ts`, responsive-grid tests, orders/parts/storage files, and a PartLayout DOM test. I did not touch those files.

Docker migration commands were not run because this environment has no `docker` binary. The same migration round-trip was run against the local Postgres test DB.

## Sample emails

Lifecycle risk:

```text
Subject: [stockManager] Migration Part lifecycle risk changed

Migration Part lifecycle risk changed

Workspace: migration-gap-alert-ws
Alert type: lifecycle_risk_changed

Details:
- from: Active
- mpn: MIGRATION-MPN
- part_id: <part uuid>
- part_name: Migration Part
- to: Obsolete

Open target: <APP_BASE_URL>/parts/<part uuid>
Manage this alert: <APP_BASE_URL>/sourcing/alerts?alert_id=<alert uuid>
```

Supply-chain risk:

```text
Subject: [stockManager] Migration Part supply-chain risk changed

Migration Part supply-chain risk changed

Workspace: migration-gap-alert-ws
Alert type: supply_chain_risk_changed

Details:
- from: Stable
- mpn: MIGRATION-MPN
- part_id: <part uuid>
- part_name: Migration Part
- to: Allocation

Open target: <APP_BASE_URL>/parts/<part uuid>
Manage this alert: <APP_BASE_URL>/sourcing/alerts?alert_id=<alert uuid>
```

Tariff status:

```text
Subject: [stockManager] Migration Part tariff status changed

Migration Part tariff status changed

Workspace: migration-gap-alert-ws
Alert type: tariff_status_changed

Details:
- from: False
- mpn: MIGRATION-MPN
- part_id: <part uuid>
- part_name: Migration Part
- to: True

Open target: <APP_BASE_URL>/parts/<part uuid>
Manage this alert: <APP_BASE_URL>/sourcing/alerts?alert_id=<alert uuid>
```

## Merge order

After #460/#462/#463/#461/#464. Before #456 and before closing #447.

Refs #453

