### PR TITLE
TPS-9: Lead-time reframe (Option A: won't-fix-in-v2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,6 +214,10 @@ them, that's the bug.
 - **Sourcing `est_purchase_cost` still prices the requested build when
   after-purchase capacity floors to zero.** Do not let integer capacity
   floors suppress a priced offer at low build quantities.
+- **TrustedParts v2 has no structured lead time.** The pinned schema exposes
+  unstructured `Stock.Availability` only; `lead_time_days=None` from the TP
+  adapter is intentional. Do not re-file this as a bug or add availability-text
+  regex heuristics without a new product decision.
 - **Sentry auth token must not enter the Docker build context.** Source-map
   upload is handled by the CI `web-build` job (`npx @sentry/cli sourcemaps
   upload`) after `npm run build`, gated on push to `main`. `SENTRY_AUTH_TOKEN`

--- a/backend/tests/test_sourcing_client.py
+++ b/backend/tests/test_sourcing_client.py
@@ -258,6 +258,20 @@ def test_availability_text_parsed_when_present(monkeypatch):
     assert result.offers[0].distributors[0].availability_text == "In Stock"
 
 
+def test_lead_time_days_remains_none_when_tp_omits_field(monkeypatch):
+    response = deepcopy(_trustedparts_response())
+    stock = response["PartResults"][0]["Distributors"][0]["DistributorResults"][0][
+        "Stock"
+    ]
+    stock["Availability"] = "Ships in 12 weeks"
+
+    result = _search_response(monkeypatch, response)
+    distributor = result.offers[0].distributors[0]
+
+    assert distributor.availability_text == "Ships in 12 weeks"
+    assert distributor.lead_time_days is None
+
+
 def test_quantity_multiple_rounded_to_int(monkeypatch):
     result = _search_response(monkeypatch, _trustedparts_response())
 

--- a/docs/adr/0022-trustedparts-schema-version-pinning.md
+++ b/docs/adr/0022-trustedparts-schema-version-pinning.md
@@ -19,6 +19,12 @@ loads `inventory-api-v2/swagger.json` (`Makefile:3`). The generated models live
 under the sourcing domain because ADR-0020 keeps procurement sourcing separate
 from catalog enrichment.
 
+The pinned v2 schema confirms a TrustedParts lead-time limitation: it exposes only
+`/v2/search`, and `StockInfo` contains unstructured `Availability` text plus
+`QuantityOnHand`; it does not expose a structured `LeadTime` field or a separate
+lead-time endpoint. The sourcing adapter therefore keeps `lead_time_days=None` for
+TrustedParts offers unless a future schema refresh introduces a real field.
+
 ## Decision
 
 Bundle the official TrustedParts Inventory API v2 OpenAPI document at

--- a/docs/domain/sourcing.md
+++ b/docs/domain/sourcing.md
@@ -48,6 +48,28 @@ Sources: `backend/app/domain/sourcing/client.py:285-418`,
 `backend/app/domain/sourcing/service.py:951-1007`,
 `backend/app/domain/sourcing/schemas.py:19-110`
 
+## Lead Time
+
+TrustedParts Inventory API v2 does not expose lead time as a structured field. The
+bundled schema contains only `/v2/search`; distributor stock includes
+`Stock.Availability`, which the app maps to `availability_text`, but there is no
+`LeadTime` or equivalent numeric field to populate `lead_time_days`.
+
+`availability_text` is operator-readable free text such as `In Stock` or vendor-specific
+shipping language. It is not machine-comparable, so the adapter intentionally leaves
+`SourcingDistributor.lead_time_days` as `None` instead of deriving values with regex
+heuristics. If structured lead time becomes important, file a TrustedParts feature
+request or integrate a provider that exposes it explicitly.
+
+When every candidate has unknown lead time, the optimizer's `fastest_availability`
+strategy treats all candidates as tied on lead time and falls through to its existing
+deterministic secondary keys: unit price, then the alphabetical candidate key. That
+fallback is documented behaviour for TP v2 data, not a sourcing bug.
+
+Sources: `docs/schemas/trustedparts-v2.json`,
+`backend/app/domain/sourcing/client.py:373`,
+`backend/app/domain/sourcing/optimizer.py:291`
+
 ## BOM Risk Flags
 
 Project sourcing keeps the five original BOM risk flags in order, then appends


### PR DESCRIPTION
## Summary

Chosen option: Option A, won't-fix-in-v2. The bundled TrustedParts v2 schema exposes only `/v2/search` and `StockInfo.Availability`; there is no structured `LeadTime` field or separate lead-time endpoint. Keeping `lead_time_days=None` avoids fragile regex heuristics over operator-facing availability text and preserves current optimizer semantics.

Docs changed:
- `docs/domain/sourcing.md`: added Lead Time section documenting TP v2 limitation, `availability_text`, and `fastest_availability` fallback behavior.
- `docs/adr/0022-trustedparts-schema-version-pinning.md`: noted the confirmed schema limitation.
- `CLAUDE.md`: added a Things that have bitten us note to avoid re-filing this as a bug.

Regression coverage:
- Added `test_lead_time_days_remains_none_when_tp_omits_field()` in `backend/tests/test_sourcing_client.py`.

#443 is already closed as superseded by #456; I did not reopen it.

Merge order: after #465; before closing #447.

## Tests

- `cd backend && uv run --extra dev python -m pytest -q -k "sourcing_client or sourcing_optimizer"`
  - `55 passed, 1130 deselected, 1 warning in 5.64s`
- `cd backend && uv run ruff check tests/test_sourcing_client.py`
  - `All checks passed!`
- `git diff --check`
  - no output

Refs #456
