### PR TITLE
SX-2: FX conversion on BOM coverage + workspace currency in request body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ the canonical record.
 
 ## 2026-05 — feedback brief fixes
 
+- **SX-2 / #469** Project Sourcing now requests the workspace currency for BOM
+  coverage and exposes converted BOM offer display prices with top-level FX status.
 - **TPS-5 / #452** Project Sourcing BOM rows and the Sourcing Risk report now
   flag TrustedParts lifecycle-risk text, supply-chain-risk text, tariff
   exposure, and EU RoHS non-compliance from the TPS-4 gap fields.

--- a/backend/app/api/routes/sourcing.py
+++ b/backend/app/api/routes/sourcing.py
@@ -15,6 +15,7 @@ from app.core.ratelimit import limiter, workspace_key
 from app.core.responses import err, ok
 from app.core.time import utcnow
 from app.domain.fx import rates as fx_rates
+from app.domain.fx._apply import apply_fx_to_offer
 from app.domain.parts.models import Part
 from app.domain.projects.models import Project
 from app.domain.sourcing import (
@@ -34,7 +35,6 @@ from app.domain.sourcing.schemas import (
     SourcingAlertPatch,
     SourcingAlertType,
     SourcingBomIn,
-    SourcingConvertedPriceBreak,
     SourcingQuery,
     SourcingSearchIn,
 )
@@ -652,79 +652,34 @@ def _apply_fx_conversion(
     *,
     requested_currency: str | None,
 ) -> str | None:
-    if db is None or requested_currency is None:
-        return None
-
     rates: dict[str, Decimal] | None = None
     rate_date = utcnow().date()
     fx_status: str | None = None
-    fetch_failed = False
+    fetch_error: fx_rates.FxRateError | None = None
+
+    def fetch_today_rates() -> dict[str, Decimal]:
+        nonlocal rates, fetch_error
+        if db is None:
+            raise fx_rates.FxRateError("database session unavailable")
+        if fetch_error is not None:
+            raise fetch_error
+        if rates is None:
+            try:
+                rates = fx_rates.get_or_fetch_today(db, on_date=rate_date)
+            except fx_rates.FxRateError as exc:
+                fetch_error = exc
+                raise
+        return rates
 
     for offer in offers:
         for distributor in offer.distributors:
-            original_currency = _clean_currency(distributor.currency)
-            if original_currency is None:
-                continue
-            distributor.currency_displayed = distributor.currency
-            if original_currency == requested_currency:
-                distributor.currency_displayed = requested_currency
-                continue
-            if distributor.unit_price is None:
-                continue
-            if fetch_failed:
-                fx_status = "unavailable"
-                distributor.fx_converted = None
-                continue
-            if rates is None:
-                try:
-                    rates = fx_rates.get_or_fetch_today(db, on_date=rate_date)
-                except fx_rates.FxRateError:
-                    fetch_failed = True
-                    fx_status = "unavailable"
-                    distributor.fx_converted = None
-                    continue
-
-            converted = fx_rates.convert(
-                Decimal(str(distributor.unit_price)),
-                from_currency=original_currency,
-                to_currency=requested_currency,
-                rates=rates,
-                on_date=rate_date,
+            _, status = apply_fx_to_offer(
+                distributor,
+                requested_currency=requested_currency,
+                fetch_today_rates=fetch_today_rates,
             )
-            if converted is None:
+            if status == "unavailable":
                 fx_status = "unavailable"
-                distributor.fx_converted = None
-                continue
-
-            converted_breaks: list[SourcingConvertedPriceBreak] = []
-            missing_break = False
-            for price_break in distributor.price_breaks:
-                converted_break = fx_rates.convert(
-                    Decimal(str(price_break.unit_price)),
-                    from_currency=original_currency,
-                    to_currency=requested_currency,
-                    rates=rates,
-                    on_date=rate_date,
-                )
-                if converted_break is None:
-                    missing_break = True
-                    break
-                converted_breaks.append(
-                    SourcingConvertedPriceBreak(
-                        quantity=price_break.quantity,
-                        unit_price=converted_break,
-                    )
-                )
-            if missing_break:
-                fx_status = "unavailable"
-                distributor.fx_converted = None
-                continue
-
-            distributor.unit_price_converted = converted
-            distributor.currency_displayed = requested_currency
-            distributor.fx_converted = True
-            distributor.fx_rate_date = rate_date
-            distributor.price_breaks_converted = converted_breaks
 
     return fx_status
 

--- a/backend/app/domain/fx/README.md
+++ b/backend/app/domain/fx/README.md
@@ -4,4 +4,5 @@ ECB daily reference-rate snapshots for display-only currency conversion.
 
 - `models.py` owns the global `fx_rate_snapshots` table.
 - `rates.py` fetches the ECB daily XML, caches one JSONB snapshot per UTC date, and converts through EUR cross-rates.
+- `_apply.py` annotates sourcing offers with converted display fields while preserving native prices.
 - Snapshots are not workspace-owned because ECB rates are public reference data; see `docs/domain/sourcing.md`.

--- a/backend/app/domain/fx/_apply.py
+++ b/backend/app/domain/fx/_apply.py
@@ -1,0 +1,128 @@
+"""Apply display FX conversion to sourcing offers."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import date
+from decimal import Decimal
+from typing import Literal, TypeVar
+
+from app.core.time import utcnow
+from app.domain.fx import rates as fx_rates
+from app.domain.sourcing.schemas import (
+    SourcingBomOfferOut,
+    SourcingBomPriceBreakOut,
+    SourcingConvertedPriceBreak,
+    SourcingDistributor,
+)
+
+FxStatus = Literal["ok", "unavailable"]
+FxOffer = TypeVar("FxOffer", SourcingDistributor, SourcingBomOfferOut)
+
+
+def apply_fx_to_offer(
+    offer: FxOffer,
+    *,
+    requested_currency: str | None,
+    fetch_today_rates: Callable[[], dict[str, Decimal]] | None = None,
+) -> tuple[FxOffer, FxStatus]:
+    """Return an offer annotated with display-currency conversion fields."""
+    requested = _clean_currency(requested_currency)
+    native = _clean_currency(offer.currency)
+    offer.currency_displayed = native
+    if requested is None or native is None:
+        return offer, "ok"
+    if native == requested:
+        offer.currency_displayed = requested
+        return offer, "ok"
+    if offer.unit_price is None:
+        return offer, "ok"
+    if fetch_today_rates is None:
+        offer.fx_converted = None
+        return offer, "unavailable"
+
+    rate_date = utcnow().date()
+    try:
+        rates = fetch_today_rates()
+    except fx_rates.FxRateError:
+        offer.fx_converted = None
+        return offer, "unavailable"
+
+    converted = fx_rates.convert(
+        _as_decimal(offer.unit_price),
+        from_currency=native,
+        to_currency=requested,
+        rates=rates,
+        on_date=rate_date,
+    )
+    if converted is None:
+        offer.fx_converted = None
+        return offer, "unavailable"
+
+    converted_breaks = _converted_price_breaks(
+        offer,
+        from_currency=native,
+        to_currency=requested,
+        rates=rates,
+        rate_date=rate_date,
+    )
+    if converted_breaks is None:
+        offer.fx_converted = None
+        return offer, "unavailable"
+
+    offer.unit_price_converted = converted
+    offer.currency_displayed = requested
+    offer.fx_converted = True
+    offer.fx_rate_date = rate_date
+    offer.price_breaks_converted = converted_breaks
+    return offer, "ok"
+
+
+def _converted_price_breaks(
+    offer: SourcingDistributor | SourcingBomOfferOut,
+    *,
+    from_currency: str,
+    to_currency: str,
+    rates: dict[str, Decimal],
+    rate_date: date,
+) -> list[SourcingConvertedPriceBreak] | list[SourcingBomPriceBreakOut] | None:
+    converted_breaks: list[SourcingConvertedPriceBreak] | list[SourcingBomPriceBreakOut]
+    converted_breaks = []
+    for price_break in offer.price_breaks:
+        converted_break = fx_rates.convert(
+            _as_decimal(price_break.unit_price),
+            from_currency=from_currency,
+            to_currency=to_currency,
+            rates=rates,
+            on_date=rate_date,
+        )
+        if converted_break is None:
+            return None
+        if isinstance(offer, SourcingBomOfferOut):
+            converted_breaks.append(
+                SourcingBomPriceBreakOut(
+                    quantity=price_break.quantity,
+                    unit_price=converted_break,
+                )
+            )
+        else:
+            converted_breaks.append(
+                SourcingConvertedPriceBreak(
+                    quantity=price_break.quantity,
+                    unit_price=converted_break,
+                )
+            )
+    return converted_breaks
+
+
+def _clean_currency(value: str | None) -> str | None:
+    if value is None:
+        return None
+    cleaned = value.strip().upper()
+    return cleaned or None
+
+
+def _as_decimal(value: Decimal | float | int | str) -> Decimal:
+    if isinstance(value, Decimal):
+        return value
+    return Decimal(str(value))

--- a/backend/app/domain/sourcing/schemas.py
+++ b/backend/app/domain/sourcing/schemas.py
@@ -341,10 +341,15 @@ class SourcingBomOfferOut(BaseModel):
     stock: int
     unit_price: Decimal | None = None
     currency: str | None = None
+    unit_price_converted: Decimal | None = None
+    currency_displayed: str | None = None
+    fx_converted: bool | None = None
+    fx_rate_date: date | None = None
     packaging: str | None = None
     moq: int | None = None
     lead_time_days: int | None = None
     price_breaks: list[SourcingBomPriceBreakOut] = Field(default_factory=list)
+    price_breaks_converted: list[SourcingBomPriceBreakOut] | None = None
     url: str | None = None
     lifecycle_risk: str | None = None
     supply_chain_risk: str | None = None
@@ -612,3 +617,4 @@ class SourcingBomOut(BaseModel):
     fetched_at: datetime
     partial: bool
     links: SourcingAttributionLinks
+    fx_status: Literal["ok", "partial", "unavailable"] | None = None

--- a/backend/app/domain/sourcing/service.py
+++ b/backend/app/domain/sourcing/service.py
@@ -18,6 +18,8 @@ from app.api._helpers import assert_in_workspace
 from app.core.errors import ErrorCodes, raise_http
 from app.core.time import utcnow
 from app.domain.builds.service import shortage_analysis
+from app.domain.fx import rates as fx_rates
+from app.domain.fx._apply import apply_fx_to_offer
 from app.domain.orders.models import Order, OrderEntry
 from app.domain.parts.models import Part
 from app.domain.projects.models import Project
@@ -874,6 +876,11 @@ def source_bom(
         )
         for row in shortage
     ]
+    fx_status = _apply_fx_to_bom_rows(
+        db,
+        rows,
+        requested_currency=currency,
+    )
     return SourcingBomOut(
         rows=rows,
         coverage=DistributorCoverageMatrixOut.model_validate(
@@ -888,7 +895,63 @@ def source_bom(
         fetched_at=max(fetched_at_values, default=utcnow()),
         partial=partial,
         links=TRUSTEDPARTS_LINKS,
+        fx_status=fx_status,
     )
+
+
+def _apply_fx_to_bom_rows(
+    db: Session,
+    rows: list[SourcingBomLineOut],
+    *,
+    requested_currency: str | None,
+) -> str | None:
+    requested = _clean_code(requested_currency)
+    rates: dict[str, Decimal] | None = None
+    rate_date = utcnow().date()
+    fetch_error: fx_rates.FxRateError | None = None
+    statuses: list[str] = []
+
+    def fetch_today_rates() -> dict[str, Decimal]:
+        nonlocal rates, fetch_error
+        if fetch_error is not None:
+            raise fetch_error
+        if rates is None:
+            try:
+                rates = fx_rates.get_or_fetch_today(db, on_date=rate_date)
+            except fx_rates.FxRateError as exc:
+                fetch_error = exc
+                raise
+        return rates
+
+    for row in rows:
+        row_unavailable = False
+        for offer in row.offers:
+            _, status = apply_fx_to_offer(
+                offer,
+                requested_currency=requested,
+                fetch_today_rates=fetch_today_rates,
+            )
+            statuses.append(status)
+            row_unavailable = row_unavailable or status == "unavailable"
+        if row.best_offer is not None and all(
+            row.best_offer is not offer for offer in row.offers
+        ):
+            _, status = apply_fx_to_offer(
+                row.best_offer,
+                requested_currency=requested,
+                fetch_today_rates=fetch_today_rates,
+            )
+            statuses.append(status)
+            row_unavailable = row_unavailable or status == "unavailable"
+        row.fx_status = "unavailable" if row_unavailable else None
+
+    if requested is None:
+        return None
+    if not statuses or all(status == "ok" for status in statuses):
+        return "ok"
+    if all(status == "unavailable" for status in statuses):
+        return "unavailable"
+    return "partial"
 
 
 def search(

--- a/backend/tests/test_fx_apply.py
+++ b/backend/tests/test_fx_apply.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+from app.domain.fx._apply import apply_fx_to_offer
+from app.domain.sourcing.schemas import SourcingDistributor, SourcingPriceBreak
+
+
+def _rates() -> dict[str, Decimal]:
+    return {
+        "EUR": Decimal("1"),
+        "USD": Decimal("2"),
+        "GBP": Decimal("0.5"),
+    }
+
+
+def test_apply_fx_converts_unit_price():
+    offer = SourcingDistributor(name="DigiKey", unit_price=2.0, currency="USD")
+
+    converted, status = apply_fx_to_offer(
+        offer,
+        requested_currency="EUR",
+        fetch_today_rates=_rates,
+    )
+
+    assert status == "ok"
+    assert converted.unit_price == 2.0
+    assert converted.unit_price_converted == Decimal("1.0000")
+    assert converted.currency == "USD"
+    assert converted.currency_displayed == "EUR"
+    assert converted.fx_converted is True
+    assert converted.fx_rate_date is not None
+
+
+def test_apply_fx_converts_each_price_break():
+    offer = SourcingDistributor(
+        name="DigiKey",
+        unit_price=2.0,
+        currency="USD",
+        price_breaks=[
+            SourcingPriceBreak(quantity=1, unit_price=2.0),
+            SourcingPriceBreak(quantity=10, unit_price=1.5),
+        ],
+    )
+
+    converted, status = apply_fx_to_offer(
+        offer,
+        requested_currency="EUR",
+        fetch_today_rates=_rates,
+    )
+
+    assert status == "ok"
+    assert converted.price_breaks_converted is not None
+    assert [item.quantity for item in converted.price_breaks_converted] == [1, 10]
+    assert [item.unit_price for item in converted.price_breaks_converted] == [
+        Decimal("1.0000"),
+        Decimal("0.7500"),
+    ]
+
+
+def test_apply_fx_preserves_native_when_rate_unavailable():
+    offer = SourcingDistributor(
+        name="DigiKey",
+        unit_price=2.0,
+        currency="AUD",
+    )
+
+    converted, status = apply_fx_to_offer(
+        offer,
+        requested_currency="EUR",
+        fetch_today_rates=_rates,
+    )
+
+    assert status == "unavailable"
+    assert converted.unit_price == 2.0
+    assert converted.unit_price_converted is None
+    assert converted.currency_displayed == "AUD"
+    assert converted.fx_converted is None
+
+
+def test_apply_fx_no_op_when_currencies_already_match():
+    offer = SourcingDistributor(
+        name="DigiKey",
+        unit_price=2.0,
+        currency="EUR",
+    )
+
+    converted, status = apply_fx_to_offer(
+        offer,
+        requested_currency="EUR",
+        fetch_today_rates=_rates,
+    )
+
+    assert status == "ok"
+    assert converted.unit_price == 2.0
+    assert converted.unit_price_converted is None
+    assert converted.currency_displayed == "EUR"
+    assert converted.fx_converted is None

--- a/backend/tests/test_sourcing_bom_route.py
+++ b/backend/tests/test_sourcing_bom_route.py
@@ -166,10 +166,19 @@ def _single_line_project(client: TestClient, *, mpn: str = "BOM-MPN", quantity: 
     )
 
 
-def _post_sourcing(client: TestClient, project_id: str, build_quantity: int = 1):
+def _post_sourcing(
+    client: TestClient,
+    project_id: str,
+    build_quantity: int = 1,
+    *,
+    currency: str | None = None,
+):
+    body: dict[str, Any] = {"build_quantity": build_quantity}
+    if currency is not None:
+        body["currency"] = currency
     return client.post(
         f"/api/projects/{project_id}/sourcing",
-        json={"build_quantity": build_quantity},
+        json=body,
     )
 
 
@@ -238,6 +247,109 @@ def test_bom_response_includes_is_affected_by_tariff_per_offer(authed_client):
     row = r.json()["data"]["rows"][0]
     assert row["offers"][0]["is_affected_by_tariff"] is True
     assert row["best_offer"]["is_affected_by_tariff"] is True
+
+
+def test_bom_response_offers_in_workspace_currency_when_currency_passed(
+    authed_client,
+    monkeypatch,
+):
+    _configure_sourcing(authed_client)
+    project_id = _single_line_project(authed_client, mpn="FX-MPN")
+    _FakeTrustedPartsClient.offers_by_mpn = {
+        "FX-MPN": [
+            _offer("FX-MPN", distributor="DigiKey", unit_price=2.0, currency="USD"),
+            _offer("FX-MPN", distributor="Mouser", unit_price=1.5, currency="GBP"),
+        ]
+    }
+    calls = 0
+
+    def fake_rates(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        return {
+            "EUR": Decimal("1"),
+            "USD": Decimal("2"),
+            "GBP": Decimal("0.5"),
+        }
+
+    monkeypatch.setattr("app.domain.sourcing.service.fx_rates.get_or_fetch_today", fake_rates)
+
+    r = _post_sourcing(authed_client, project_id, currency="EUR")
+
+    assert r.status_code == 200, r.text
+    data = r.json()["data"]
+    assert data["fx_status"] == "ok"
+    row = data["rows"][0]
+    assert row["fx_status"] is None
+    offers = {offer["distributor"]: offer for offer in row["offers"]}
+    assert Decimal(offers["DigiKey"]["unit_price"]) == Decimal("2.0")
+    assert Decimal(offers["DigiKey"]["unit_price_converted"]) == Decimal("1.0000")
+    assert offers["DigiKey"]["currency"] == "USD"
+    assert offers["DigiKey"]["currency_displayed"] == "EUR"
+    assert offers["DigiKey"]["fx_converted"] is True
+    assert Decimal(offers["DigiKey"]["price_breaks_converted"][0]["unit_price"]) == Decimal(
+        "1.0000"
+    )
+    assert Decimal(offers["Mouser"]["unit_price_converted"]) == Decimal("3.0000")
+    assert row["best_offer"]["currency_displayed"] == "EUR"
+    assert calls == 1
+
+
+def test_bom_response_preserves_native_currency_when_fx_unavailable_and_surfaces_partial(
+    authed_client,
+    monkeypatch,
+):
+    _configure_sourcing(authed_client)
+    project_id = _single_line_project(authed_client, mpn="FX-PARTIAL")
+    _FakeTrustedPartsClient.offers_by_mpn = {
+        "FX-PARTIAL": [
+            _offer("FX-PARTIAL", distributor="DigiKey", unit_price=2.0, currency="USD"),
+            _offer("FX-PARTIAL", distributor="Local", unit_price=9.0, currency="AUD"),
+        ]
+    }
+    monkeypatch.setattr(
+        "app.domain.sourcing.service.fx_rates.get_or_fetch_today",
+        lambda *_args, **_kwargs: {"EUR": Decimal("1"), "USD": Decimal("2")},
+    )
+
+    r = _post_sourcing(authed_client, project_id, currency="EUR")
+
+    assert r.status_code == 200, r.text
+    data = r.json()["data"]
+    assert data["fx_status"] == "partial"
+    row = data["rows"][0]
+    assert row["fx_status"] == "unavailable"
+    offers = {offer["distributor"]: offer for offer in row["offers"]}
+    assert offers["DigiKey"]["currency_displayed"] == "EUR"
+    assert Decimal(offers["DigiKey"]["unit_price_converted"]) == Decimal("1.0000")
+    assert offers["Local"]["currency"] == "AUD"
+    assert offers["Local"]["currency_displayed"] == "AUD"
+    assert offers["Local"]["unit_price_converted"] is None
+    assert offers["Local"]["fx_converted"] is None
+
+
+def test_bom_response_no_conversion_when_currency_omitted(authed_client, monkeypatch):
+    _configure_sourcing(authed_client)
+    project_id = _single_line_project(authed_client, mpn="FX-NATIVE")
+    _FakeTrustedPartsClient.offers_by_mpn = {
+        "FX-NATIVE": [_offer("FX-NATIVE", unit_price=2.0, currency="USD")]
+    }
+
+    def fail_fetch(*_args, **_kwargs):
+        raise AssertionError("FX rates should not be fetched without a requested currency")
+
+    monkeypatch.setattr("app.domain.sourcing.service.fx_rates.get_or_fetch_today", fail_fetch)
+
+    r = _post_sourcing(authed_client, project_id)
+
+    assert r.status_code == 200, r.text
+    data = r.json()["data"]
+    assert data["fx_status"] is None
+    offer = data["rows"][0]["offers"][0]
+    assert offer["currency"] == "USD"
+    assert offer["currency_displayed"] == "USD"
+    assert offer["unit_price_converted"] is None
+    assert offer["price_breaks_converted"] is None
 
 
 def test_bom_row_reports_no_mpn_without_provider_call(authed_client):

--- a/backend/tests/test_sourcing_part_route.py
+++ b/backend/tests/test_sourcing_part_route.py
@@ -438,7 +438,7 @@ def test_sourcing_response_skips_conversion_when_workspace_currency_null(authed_
     assert data["fx_status"] is None
     assert distributor["currency"] == "USD"
     assert distributor["unit_price_converted"] is None
-    assert distributor["currency_displayed"] is None
+    assert distributor["currency_displayed"] == "USD"
     assert distributor["fx_converted"] is None
 
 

--- a/docs/api/sourcing.md
+++ b/docs/api/sourcing.md
@@ -200,8 +200,13 @@ Path: `project_id` is a project UUID in the current workspace.
           "distributor": "Mouser",
           "unit_price": "0.10",
           "currency": "EUR",
+          "unit_price_converted": null,
+          "currency_displayed": "EUR",
+          "fx_converted": null,
+          "fx_rate_date": null,
           "moq": 1,
           "lead_time_days": 3,
+          "price_breaks_converted": null,
           "lifecycle_risk": "Low",
           "supply_chain_risk": null,
           "is_affected_by_tariff": false,
@@ -214,7 +219,8 @@ Path: `project_id` is a project UUID in the current workspace.
     ],
     "powered_by": "TrustedParts",
     "fetched_at": "2026-05-08T12:00:00+00:00",
-    "partial": false
+    "partial": false,
+    "fx_status": "ok"
   },
   "status": { "category": "ok", "message": "OK" }
 }
@@ -251,7 +257,8 @@ Sources: `backend/app/domain/sourcing/service.py:1322-1386`,
 - The route validates `project_id` with `assert_in_workspace()` before calling the sourcing service.
 - The service reuses `shortage_analysis()`, `dedupe_mpns()`, `chunk_mpns()`, and per-MPN `search()` cache rows; BOM chunks use `ttl_seconds=600`.
 - Decimal prices and extended costs serialize as strings.
-- Each row exposes sourcing diagnostics: `reason` is `ok`, `no_mpn`, or `no_offers`; `cache_hit` is `true`/`false` for searched rows and `null` when no MPN was searched; `fx_status` is reserved for row-level conversion failures and is `null` unless represented.
+- When `currency` is supplied, BOM offer prices whose native distributor currency differs are display-converted through the global ECB daily snapshot. Native `unit_price`, `currency`, and existing coverage/capacity calculations stay unchanged; converted display values are exposed as `unit_price_converted`, `currency_displayed`, `fx_converted`, `fx_rate_date`, and `price_breaks_converted`.
+- Each row exposes sourcing diagnostics: `reason` is `ok`, `no_mpn`, or `no_offers`; `cache_hit` is `true`/`false` for searched rows and `null` when no MPN was searched; row `fx_status` is `unavailable` when any offer on the row could not be converted. Top-level `fx_status` is `ok`, `partial`, or `unavailable` when a request currency was supplied and `null` when conversion was not requested.
 - BOM offer projections carry offer-level TrustedParts gap fields for downstream risk/report consumers; distributor-level gap fields remain on part/search offer DTOs.
 - Source: `backend/app/api/routes/sourcing.py:253-315`.
 - Service: `backend/app/domain/sourcing/service.py:820-882`, `backend/app/domain/sourcing/service.py:1236-1270`.

--- a/docs/domain/sourcing.md
+++ b/docs/domain/sourcing.md
@@ -309,11 +309,13 @@ Source: `backend/app/domain/sourcing/cache.py:23`
 
 ## FX Conversion
 
-The part-detail Authorized Supply route can request display conversion into the
-workspace sourcing currency. TrustedParts still owns the native offer payload:
-`unit_price`, `currency`, and native price breaks are preserved. Converted display
-fields are added only for rows whose distributor currency differs from the requested
-currency.
+The part-detail Authorized Supply route and Project Sourcing BOM coverage route can
+request display conversion into the workspace sourcing currency. TrustedParts still owns
+the native offer payload: `unit_price`, `currency`, and native price breaks are
+preserved. Converted display fields are added only for offers whose distributor currency
+differs from the requested currency. BOM coverage and capacity summaries keep their
+existing calculations; SX-2 only adds converted offer display fields and response-level
+FX status.
 
 ECB daily reference rates are cached in `fx_rate_snapshots` with one JSONB snapshot
 per UTC date. The table is global, not workspace-owned, because ECB rates are public
@@ -323,4 +325,5 @@ price-trend reporting.
 
 Sources: `backend/app/domain/fx/models.py:15`,
 `backend/app/domain/fx/rates.py:46`,
-`backend/app/api/routes/sourcing.py:534`
+`backend/app/domain/fx/_apply.py:20`,
+`backend/app/domain/sourcing/service.py:889`

--- a/web/src/routes/projects/sourcing/ProjectSourcingPage.tsx
+++ b/web/src/routes/projects/sourcing/ProjectSourcingPage.tsx
@@ -23,6 +23,10 @@ type SourcingBomOffer = {
   stock: number;
   unit_price?: string | number | null;
   currency?: string | null;
+  unit_price_converted?: string | number | null;
+  currency_displayed?: string | null;
+  fx_converted?: boolean | null;
+  fx_rate_date?: string | null;
   packaging?: string | null;
   moq?: number | null;
   lead_time_days?: number | null;
@@ -91,6 +95,7 @@ type SourcingBomResponse = {
   powered_by: "TrustedParts";
   fetched_at: string;
   partial: boolean;
+  fx_status?: "ok" | "partial" | "unavailable" | null;
   links: {
     primary: string;
     attribution: string;
@@ -100,7 +105,7 @@ type SourcingBomResponse = {
 type SourcingRequest = {
   build_quantity: number;
   country?: string;
-  currency?: string;
+  currency?: string | null;
   distributors?: string[];
 };
 
@@ -122,6 +127,18 @@ function formatMoney(value: string | number | null | undefined, currency?: strin
     minimumFractionDigits: numeric % 1 === 0 ? 0 : 2,
   });
   return currency ? `${formatted} ${currency}` : formatted;
+}
+
+function offerDisplayUnitPrice(offer: SourcingBomOffer | null | undefined): string | number | null | undefined {
+  if (!offer) return null;
+  return offer.fx_converted === true && offer.unit_price_converted != null
+    ? offer.unit_price_converted
+    : offer.unit_price;
+}
+
+function offerDisplayCurrency(offer: SourcingBomOffer | null | undefined): string | null | undefined {
+  if (!offer) return null;
+  return offer.currency_displayed ?? offer.currency;
 }
 
 function formatLeadTime(days: number | null | undefined): string {
@@ -432,9 +449,9 @@ function BomRows({ rows }: { rows: SourcingBomLine[] }) {
     {
       key: "offer",
       header: "Best offer",
-      accessor: row => numberOrNull(row.best_offer?.unit_price),
+      accessor: row => numberOrNull(offerDisplayUnitPrice(row.best_offer)),
       render: row => row.best_offer
-        ? formatMoney(row.best_offer.unit_price, row.best_offer.currency)
+        ? formatMoney(offerDisplayUnitPrice(row.best_offer), offerDisplayCurrency(row.best_offer))
         : <span className="text-muted">—</span>,
       align: "right",
     },
@@ -584,15 +601,19 @@ export default function ProjectSourcingPage() {
   }, [workspace]);
 
   const requestBody = useMemo<SourcingRequest>(() => {
-    const body: SourcingRequest = { build_quantity: Math.max(1, Math.floor(buildQuantity || 1)) };
+    const cleanWorkspaceCurrency = workspace?.sourcing_currency_code?.trim().toUpperCase() || null;
+    const body: SourcingRequest = {
+      build_quantity: Math.max(1, Math.floor(buildQuantity || 1)),
+      currency: cleanWorkspaceCurrency,
+    };
     const cleanCountry = country.trim().toUpperCase();
     const cleanCurrency = currency.trim().toUpperCase();
     const cleanDistributors = distributors.filter(item => item.trim());
     if (cleanCountry) body.country = cleanCountry;
-    if (cleanCurrency) body.currency = cleanCurrency;
+    if (cleanWorkspaceCurrency && cleanCurrency) body.currency = cleanCurrency;
     if (cleanDistributors.length > 0) body.distributors = cleanDistributors;
     return body;
-  }, [buildQuantity, country, currency, distributors]);
+  }, [buildQuantity, country, currency, distributors, workspace?.sourcing_currency_code]);
 
   const query = useQuery({
     queryKey: useWsKey("sourcing", "project", projectId, requestBody),
@@ -600,6 +621,11 @@ export default function ProjectSourcingPage() {
       api.post<SourcingBomResponse, SourcingRequest>(`/projects/${projectId}/sourcing`, requestBody, { signal }),
     enabled: !!projectId && buildQuantity >= 1 && defaultsApplied && activeListErrors.length === 0,
   });
+  const purchasePlanBaseRequest = useMemo<Omit<PurchasePlanRequest, "strategy">>(() => {
+    const body = { ...requestBody };
+    if (body.currency == null) delete body.currency;
+    return body as Omit<PurchasePlanRequest, "strategy">;
+  }, [requestBody]);
   const queryIsError = query.isError;
   const queryError = query.error;
   const refetchSourcing = query.refetch;
@@ -804,7 +830,7 @@ export default function ProjectSourcingPage() {
       <PurchasePlanOptionsModal
         open={planModalOpen}
         buildQuantity={buildQuantity}
-        baseRequest={requestBody}
+        baseRequest={purchasePlanBaseRequest}
         pending={planPending}
         onClose={() => setPlanModalOpen(false)}
         onSubmit={generatePurchasePlan}

--- a/web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.test.tsx
+++ b/web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.test.tsx
@@ -556,6 +556,73 @@ describe("ProjectSourcingPage", () => {
     expect(await screen.findByText("Partial — some chunks served from cache")).toBeDefined();
   });
 
+  it("BOM request body includes currency from workspace settings", async () => {
+    mockReads({ sourcing_currency_code: "EUR", active_currencies: ["USD", "EUR"] });
+    const post = vi.spyOn(api, "post").mockResolvedValue(sourcingResponse());
+
+    renderPage();
+
+    await screen.findByText("BOM rows");
+    await waitFor(() => {
+      expect(post).toHaveBeenCalledWith(
+        `/projects/${projectId}/sourcing`,
+        expect.objectContaining({
+          build_quantity: 1,
+          country: "US",
+          currency: "EUR",
+          distributors: ["DigiKey", "Mouser"],
+        }),
+        expect.anything(),
+      );
+    });
+  });
+
+  it("BOM request body sends null currency when workspace has no currency set", async () => {
+    mockReads({ sourcing_currency_code: null });
+    const post = vi.spyOn(api, "post").mockResolvedValue(sourcingResponse());
+
+    renderPage();
+
+    await screen.findByText("BOM rows");
+    await waitFor(() => {
+      expect(post).toHaveBeenCalledWith(
+        `/projects/${projectId}/sourcing`,
+        expect.objectContaining({
+          build_quantity: 1,
+          currency: null,
+        }),
+        expect.anything(),
+      );
+    });
+  });
+
+  it("renders BOM offer prices from converted display fields when present", async () => {
+    mockReads({ sourcing_currency_code: "EUR", active_currencies: ["EUR", "USD"] });
+    const base = sourcingResponse();
+    vi.spyOn(api, "post").mockResolvedValue(sourcingResponse({
+      rows: [
+        {
+          ...base.rows[0],
+          best_offer: {
+            ...(base.rows[0].best_offer as Record<string, unknown>),
+            unit_price: "2.00",
+            currency: "USD",
+            unit_price_converted: "1.00",
+            currency_displayed: "EUR",
+            fx_converted: true,
+          },
+          est_extended_cost: "20.00",
+        },
+      ],
+    }));
+
+    renderPage();
+
+    expect(await screen.findByText("1 EUR")).toBeDefined();
+    expect(screen.queryByText("2 USD")).toBeNull();
+    expect(screen.getByText("20 USD")).toBeDefined();
+  });
+
   it("Generate purchase plan posts default strategy from current sourcing filters", async () => {
     mockReads();
     const post = vi.spyOn(api, "post");


### PR DESCRIPTION
## Summary
- extracted reusable FX offer application helper and rewired the per-part sourcing response to use it
- added BOM offer display conversion fields plus top-level BOM fx_status aggregation without changing existing coverage/capacity calculations
- ProjectSourcingPage now sends the workspace currency/null in the BOM request and renders converted BOM offer unit prices when provided, with native fallback
- updated sourcing API/domain docs and changelog

## Tests
- docker validation unavailable: docker command is not installed in this environment
- cd backend && uv run python -m pytest -q -k "sourcing or fx_apply" -> 306 passed, 886 deselected, 6 warnings
- cd backend && uv run ruff check app/api/routes/sourcing.py app/domain/fx/_apply.py app/domain/sourcing/schemas.py app/domain/sourcing/service.py tests/test_fx_apply.py tests/test_sourcing_bom_route.py tests/test_sourcing_part_route.py -> All checks passed
- cd web && npm run typecheck -> passed
- cd web && npm test -- ProjectSourcingPage -- --run -> 26 passed
- cd web && npx eslint src/routes/projects/sourcing/ProjectSourcingPage.tsx src/routes/projects/sourcing/__tests__/ProjectSourcingPage.test.tsx -> passed
- git diff --check -> passed

## Deviations
- The current BOM response flattens distributors into SourcingBomOfferOut, so the shared helper supports both SourcingDistributor and SourcingBomOfferOut while preserving native price/currency fields.
- Existing BOM coverage/capacity calculations intentionally remain unchanged for SX-2; converted values are display fields for offers.

## Merge order
After #466/current main; before #470 and #471; recommended before #468/#472/#473 if their PRs touch ProjectSourcingPage request/response shape, otherwise rebase siblings on this PR.

Refs #469