### PR TITLE
SX-1: BOM table column split + lifecycle colour + lead-time hide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ the canonical record.
 
 ## 2026-05 — feedback brief fixes
 
+- **SX-1 / #468** Project Sourcing now splits BOM lifecycle,
+  supply-chain, and RoHS details into dedicated columns, hides the crowded
+  lead-time column by default, and colours TrustedParts Low/Medium/High
+  lifecycle risk text.
 - **SX-2 / #469** Project Sourcing now requests the workspace currency for BOM
   coverage and exposes converted BOM offer display prices with top-level FX status.
 - **TPS-5 / #452** Project Sourcing BOM rows and the Sourcing Risk report now

--- a/docs/user/projects-and-bom.md
+++ b/docs/user/projects-and-bom.md
@@ -106,7 +106,7 @@ Bulk provider import processes up to 200 unmatched rows at a time; run it again 
 
 ## Source BOM coverage
 
-The **Source BOM** page can show TrustedParts risk pills on each BOM line when authorized offers carry lifecycle, supply-chain, tariff, or RoHS warnings. The table also has an optional **Lifecycle** column in the column menu; turn it on when you need to see the exact lifecycle text TrustedParts returned.
+The **Source BOM** page can show TrustedParts sourcing context on each BOM line. Lifecycle, supply-chain, and RoHS details have their own BOM columns, while the legacy **Risk** column stays focused on operational flags such as single-source, stock, MOQ, lead-time, preferred-distributor, and tariff warnings. Lifecycle and supply-chain pills colour TrustedParts `Low` as green, `Medium` or `Moderate` as amber, and `High` or `Severe` as red. The **Lead time** column is available from the column menu when you need the raw per-row lead-time values.
 
 ## Use meta-parts for "any 10k 0402 1%"
 

--- a/web/src/lib/__tests__/sourcing.test.ts
+++ b/web/src/lib/__tests__/sourcing.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { bestUnitPriceAtQty, extendedPrice } from "../sourcing";
+import { bestUnitPriceAtQty, extendedPrice, lifecycleRiskTone } from "../sourcing";
 
 describe("bestUnitPriceAtQty", () => {
   it("returns null when qty < smallest break", () => {
@@ -52,5 +52,21 @@ describe("extendedPrice", () => {
         12,
       ),
     ).toBe(27);
+  });
+});
+
+describe("lifecycleRiskTone", () => {
+  it("maps TrustedParts risk levels to semantic colours", () => {
+    expect(lifecycleRiskTone("  LOW risk  ")).toContain("text-success");
+    expect(lifecycleRiskTone("Medium")).toContain("text-warning");
+    expect(lifecycleRiskTone("moderate supply risk")).toContain("text-warning");
+    expect(lifecycleRiskTone("High")).toContain("text-danger");
+    expect(lifecycleRiskTone("Severe")).toContain("text-danger");
+  });
+
+  it("keeps lifecycle vocabulary precedence before generic risk levels", () => {
+    expect(lifecycleRiskTone("Active high volume")).toContain("text-success");
+    expect(lifecycleRiskTone("Obsolete - low supply")).toContain("text-danger");
+    expect(lifecycleRiskTone("NRND low risk")).toContain("text-warning");
   });
 });

--- a/web/src/lib/sourcing.ts
+++ b/web/src/lib/sourcing.ts
@@ -55,6 +55,10 @@ export function lifecycleRiskTone(value: string | null | undefined): string {
   ) {
     return "bg-danger/10 text-danger";
   }
+  // SX-1: TPS-7 lifecycle vocabulary takes precedence over generic TrustedParts risk levels.
+  if (normalized.includes("low")) return "bg-success/10 text-success";
+  if (normalized.includes("medium") || normalized.includes("moderate")) return "bg-warning/10 text-warning";
+  if (normalized.includes("high") || normalized.includes("severe")) return "bg-danger/10 text-danger";
   return "bg-panel2 text-muted";
 }
 

--- a/web/src/routes/projects/sourcing/ProjectSourcingPage.tsx
+++ b/web/src/routes/projects/sourcing/ProjectSourcingPage.tsx
@@ -34,6 +34,13 @@ type SourcingBomOffer = {
   lifecycle_risk?: string | null;
   supply_chain_risk?: string | null;
   is_affected_by_tariff?: boolean | null;
+  rohs_compliance?: SourcingRohsCompliance[];
+};
+
+type SourcingRohsCompliance = {
+  region: string;
+  is_compliant: boolean;
+  description?: string | null;
 };
 
 type RiskFlag =
@@ -190,12 +197,52 @@ function riskTooltip(flag: RiskFlag): string | undefined {
   }
 }
 
-function LifecycleRiskPill({ value }: { value?: string | null }) {
+const legacyRiskFlags: RiskFlag[] = [
+  "single_source",
+  "no_authorized_stock",
+  "moq_overbuy",
+  "lead_time_long",
+  "preferred_distributor_unmet",
+  "tariff_affected",
+];
+
+function LifecycleRiskPill({ label = "Lifecycle risk", value }: { label?: string; value?: string | null }) {
   const trimmed = value?.trim();
   if (!trimmed) return null;
   return (
-    <span className={`pill ${lifecycleRiskTone(trimmed)}`} aria-label={`Lifecycle risk: ${trimmed}`}>
+    <span className={`pill ${lifecycleRiskTone(trimmed)}`} aria-label={`${label}: ${trimmed}`}>
       {trimmed}
+    </span>
+  );
+}
+
+function rohsTone(row: SourcingBomLine): "good" | "danger" | "neutral" {
+  if (row.risk_flags.includes("rohs_non_compliant")) return "danger";
+  const euEntries = row.offers
+    .flatMap(offer => offer.rohs_compliance ?? [])
+    .filter(item => item.region.trim().toLowerCase() === "eu");
+  if (euEntries.length === 0) return "neutral";
+  if (euEntries.some(item => item.is_compliant === false)) return "danger";
+  return "good";
+}
+
+function RohsRiskPill({ tone }: { tone: "good" | "danger" | "neutral" }) {
+  if (tone === "neutral") return <span className="text-muted">—</span>;
+  return tone === "danger" ? (
+    <span
+      className="pill bg-danger/10 text-danger"
+      title={riskTooltip("rohs_non_compliant")}
+      aria-label={riskTooltip("rohs_non_compliant")}
+    >
+      Non-compliant
+    </span>
+  ) : (
+    <span
+      className="pill bg-success/10 text-success"
+      title="TrustedParts found compliant EU RoHS data for this BOM line."
+      aria-label="TrustedParts found compliant EU RoHS data for this BOM line."
+    >
+      Compliant
     </span>
   );
 }
@@ -478,23 +525,40 @@ function BomRows({ rows }: { rows: SourcingBomLine[] }) {
       accessor: row => row.lead_time_days,
       render: row => formatLeadTime(row.lead_time_days),
       align: "right",
+      // SX-1/TPS-9: keep lead-time response data, but hide this crowded BOM column by default.
+      hidden: true,
     },
     {
       key: "lifecycle",
       header: "Lifecycle",
       accessor: row => row.best_offer?.lifecycle_risk?.trim() ?? "",
       render: row => <LifecycleRiskPill value={row.best_offer?.lifecycle_risk} />,
-      hidden: true,
+    },
+    {
+      key: "supply_chain",
+      header: "Supply chain",
+      accessor: row => row.best_offer?.supply_chain_risk?.trim() ?? "",
+      render: row => (
+        <LifecycleRiskPill label="Supply-chain risk" value={row.best_offer?.supply_chain_risk} />
+      ),
+    },
+    {
+      key: "rohs",
+      header: "RoHS",
+      accessor: row => rohsTone(row),
+      render: row => <RohsRiskPill tone={rohsTone(row)} />,
     },
     {
       key: "risk",
       header: "Risk",
       accessor: row => row.risk_flags.join(" "),
-      render: row => (
+      render: row => {
+        const displayFlags = row.risk_flags.filter(flag => legacyRiskFlags.includes(flag));
+        return (
         <span className="flex flex-wrap gap-1">
-          {row.risk_flags.length === 0 ? (
+          {displayFlags.length === 0 ? (
             <span className="text-muted">—</span>
-          ) : row.risk_flags.map(flag => (
+          ) : displayFlags.map(flag => (
             <span
               key={flag}
               className={riskClass(flag)}
@@ -505,7 +569,8 @@ function BomRows({ rows }: { rows: SourcingBomLine[] }) {
             </span>
           ))}
         </span>
-      ),
+        );
+      },
     },
     {
       key: "source",

--- a/web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.test.tsx
+++ b/web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.test.tsx
@@ -331,13 +331,26 @@ describe("ProjectSourcingPage", () => {
     expect(screen.getAllByLabelText("Source: TrustedParts").length).toBeGreaterThan(0);
   });
 
-  it("renders new risk pills with tooltip text and colours", async () => {
+  it("splits lifecycle, supply-chain, and RoHS out of the legacy risk column", async () => {
     mockReads();
     const base = sourcingResponse();
     vi.spyOn(api, "post").mockResolvedValue(sourcingResponse({
       rows: [
         {
           ...base.rows[0],
+          best_offer: {
+            ...base.rows[0].best_offer,
+            lifecycle_risk: "High",
+            supply_chain_risk: "Medium",
+          },
+          offers: [
+            {
+              ...base.rows[0].offers[0],
+              lifecycle_risk: "High",
+              supply_chain_risk: "Medium",
+              rohs_compliance: [{ region: "EU", is_compliant: false }],
+            },
+          ],
           risk_flags: [
             "lifecycle_risk_present",
             "supply_chain_risk_present",
@@ -350,18 +363,54 @@ describe("ProjectSourcingPage", () => {
 
     renderPage();
 
-    expect(await screen.findByText("lifecycle")).toBeDefined();
-    expect(screen.getByText("supply chain")).toBeDefined();
+    await screen.findByText("BOM rows");
+    const bomRowsTable = screen.getAllByRole("table")[1];
+    expect(within(bomRowsTable).getByRole("columnheader", { name: "Lifecycle" })).toBeDefined();
+    expect(within(bomRowsTable).getByRole("columnheader", { name: "Supply chain" })).toBeDefined();
+    expect(within(bomRowsTable).getByRole("columnheader", { name: "RoHS" })).toBeDefined();
+
+    const lifecycle = screen.getByLabelText("Lifecycle risk: High");
+    const supplyChain = screen.getByLabelText("Supply-chain risk: Medium");
     const tariff = screen.getByText("tariff");
-    const rohs = screen.getByText("RoHS");
+    const rohs = screen.getByText("Non-compliant");
+    expect(lifecycle.className).toContain("text-danger");
+    expect(supplyChain.className).toContain("text-warning");
     expect(tariff.className).toContain("text-warning");
     expect(rohs.className).toContain("text-danger");
-    expect(screen.getByLabelText("TrustedParts returned lifecycle risk text for this BOM line.")).toBeDefined();
+
+    const riskCell = within(bomRowsTable).getByRole("row", { name: /STM32/ }).querySelectorAll("td")[12];
+    expect(within(riskCell as HTMLElement).queryByText("lifecycle")).toBeNull();
+    expect(within(riskCell as HTMLElement).queryByText("supply chain")).toBeNull();
+    expect(within(riskCell as HTMLElement).queryByText("RoHS")).toBeNull();
     expect(screen.getByLabelText("TrustedParts did not find a compliant RoHS region for this BOM line.")).toBeDefined();
   });
 
-  it("lifecycle column is hidden by default and renders Obsolete as red when enabled", async () => {
-    const user = userEvent.setup();
+  it("renders compliant RoHS data as a green pill", async () => {
+    mockReads();
+    const base = sourcingResponse();
+    vi.spyOn(api, "post").mockResolvedValue(sourcingResponse({
+      rows: [
+        {
+          ...base.rows[0],
+          offers: [
+            {
+              ...base.rows[0].offers[0],
+              rohs_compliance: [{ region: "EU", is_compliant: true }],
+            },
+          ],
+          risk_flags: [],
+        },
+      ],
+    }));
+
+    renderPage();
+
+    await screen.findByText("BOM rows");
+    const rohs = screen.getByText("Compliant");
+    expect(rohs.className).toContain("text-success");
+  });
+
+  it("lifecycle column is visible by default and renders Obsolete as red", async () => {
     mockReads();
     const base = sourcingResponse();
     vi.spyOn(api, "post").mockResolvedValue(sourcingResponse({
@@ -380,17 +429,35 @@ describe("ProjectSourcingPage", () => {
 
     await screen.findByText("BOM rows");
     const bomRowsTable = screen.getAllByRole("table")[1];
-    expect(within(bomRowsTable).queryByRole("columnheader", { name: "Lifecycle" })).toBeNull();
-
-    await user.click(screen.getAllByText("Columns")[1]);
-    await user.click(screen.getByRole("checkbox", { name: "Lifecycle" }));
-
     expect(within(bomRowsTable).getByRole("columnheader", { name: "Lifecycle" })).toBeDefined();
     const lifecycle = screen.getByLabelText("Lifecycle risk: Obsolete");
     expect(lifecycle.className).toContain("text-danger");
   });
 
-  it("renders per-row lead time values in the BOM rows table", async () => {
+  it("renders Low lifecycle risk as a green pill in the BOM table", async () => {
+    mockReads();
+    const base = sourcingResponse();
+    vi.spyOn(api, "post").mockResolvedValue(sourcingResponse({
+      rows: [
+        {
+          ...base.rows[0],
+          best_offer: {
+            ...base.rows[0].best_offer,
+            lifecycle_risk: " Low risk ",
+          },
+        },
+      ],
+    }));
+
+    renderPage();
+
+    await screen.findByText("BOM rows");
+    const lifecycle = screen.getByLabelText("Lifecycle risk: Low risk");
+    expect(lifecycle.className).toContain("text-success");
+  });
+
+  it("hides lead time by default but keeps per-row values available from the column menu", async () => {
+    const user = userEvent.setup();
     mockReads();
     const base = sourcingResponse();
     vi.spyOn(api, "post").mockResolvedValue(sourcingResponse({
@@ -416,6 +483,11 @@ describe("ProjectSourcingPage", () => {
 
     await screen.findByText("BOM rows");
     const bomRowsTable = screen.getAllByRole("table")[1];
+    expect(within(bomRowsTable).queryByRole("columnheader", { name: "Lead time" })).toBeNull();
+
+    await user.click(screen.getAllByText("Columns")[1]);
+    await user.click(screen.getByRole("checkbox", { name: "Lead time" }));
+
     const leadTimeCellText = (rowName: RegExp) =>
       within(within(bomRowsTable).getByRole("row", { name: rowName })).getAllByRole("cell")[9].textContent;
 


### PR DESCRIPTION
## Summary
- Split Project Sourcing BOM lifecycle, supply-chain, and RoHS indicators into dedicated visible columns.
- Kept lifecycle/supply/RoHS risk flag data intact while filtering those dimensions out of the legacy Risk column rendering.
- Hid the BOM Lead time column by default without removing response fields, and added TrustedParts Low/Medium/Moderate/High/Severe lifecycle risk colouring.
- Updated user docs and changelog.

## Tests / output
- `cd web && npm run typecheck` passed.
- `cd web && npm test -- "sourcing|ProjectSourcingPage"` did not match files in this Vitest setup (`No test files found`). Equivalent targeted run passed: `cd web && npm test -- src/lib/__tests__/sourcing.test.ts src/routes/projects/sourcing/__tests__/ProjectSourcingPage.test.tsx` (2 files, 34 tests).
- `cd web && npm run lint` is blocked by existing baseline issues in `src/lib/bagCode.ts` plus unrelated warnings. Touched-file lint passed: `npx eslint src/lib/sourcing.ts src/lib/__tests__/sourcing.test.ts src/routes/projects/sourcing/ProjectSourcingPage.tsx src/routes/projects/sourcing/__tests__/ProjectSourcingPage.test.tsx`.
- `git diff --check` passed.

## Deviations
- No runtime screenshot captured; validation is via typecheck, focused component tests, touched-file ESLint, and diff whitespace check.

## Merge order
After #474/#469; before #471/#470/#472/#473 unless those sibling PRs rebase on this column layout.

Refs #468