### PR TITLE
SX-4: Two cost numbers (total BOM cost + price to pay)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ the canonical record.
 
 ## 2026-05 — feedback brief fixes
 
+- **SX-4 / #471** Project Sourcing capacity now separates total BOM cost
+  from the short-quantity price to pay, with `est_purchase_cost` retained as
+  a deprecated alias.
 - **SX-1 / #468** Project Sourcing now splits BOM lifecycle,
   supply-chain, and RoHS details into dedicated columns, hides the crowded
   lead-time column by default, and colours TrustedParts Low/Medium/High

--- a/backend/app/domain/sourcing/coverage.py
+++ b/backend/app/domain/sourcing/coverage.py
@@ -1,6 +1,7 @@
 """Distributor coverage matrix computation for sourced BOM rows."""
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from decimal import Decimal
 from itertools import combinations
@@ -34,6 +35,8 @@ class DistributorCoverageMatrix:
 class BuildCapacity:
     can_build_now: int
     can_build_after_purchase: int
+    total_bom_cost: Decimal | None
+    purchase_to_pay_cost: Decimal | None
     est_purchase_cost: Decimal | None
     blocking_lines_now: list[UUID]
     blocking_lines_after_purchase: list[UUID]
@@ -50,6 +53,8 @@ def compute_build_capacity(
         return BuildCapacity(
             can_build_now=0,
             can_build_after_purchase=0,
+            total_bom_cost=None,
+            purchase_to_pay_cost=None,
             est_purchase_cost=None,
             blocking_lines_now=[],
             blocking_lines_after_purchase=[],
@@ -85,44 +90,118 @@ def compute_build_capacity(
         if ratios_after_purchase[row.project_entry_id] == can_build_after_purchase
     ]
 
-    est_purchase_cost = Decimal("0")
     blocking_after = set(blocking_lines_after_purchase)
-    priced_builds = (
-        can_build_after_purchase
-        if can_build_after_purchase > 0
-        else requested_build_quantity
+    total_bom_cost = _sum_best_offer_cost(
+        effective_rows,
+        quantity_for_row=lambda row: row.required,
     )
-    for row in effective_rows:
-        purchase_qty = max(
-            0,
-            _required_for_builds(
-                row.required,
-                builds=priced_builds,
-                requested_build_quantity=requested_build_quantity,
-            )
-            - (row.available + row.substitute_available),
+    payable_rows = [
+        row for row in effective_rows if row.project_entry_id not in blocking_after
+    ]
+    if not payable_rows and any(row.short_by > 0 for row in effective_rows):
+        payable_rows = effective_rows
+    purchase_to_pay_cost = (
+        Decimal("0")
+        if all(row.short_by == 0 for row in effective_rows)
+        else _sum_best_offer_cost(
+            payable_rows,
+            quantity_for_row=lambda row: row.short_by,
         )
-        if purchase_qty == 0:
-            if (
-                row.project_entry_id in blocking_after
-                and ratios_after_purchase[row.project_entry_id] < requested_build_quantity
-                and row.best_offer is None
-            ):
-                est_purchase_cost = None
-            continue
-        if row.best_offer is None or row.best_offer.unit_price is None:
-            est_purchase_cost = None
-            continue
-        if est_purchase_cost is not None:
-            est_purchase_cost += row.best_offer.unit_price * Decimal(purchase_qty)
+    )
 
     return BuildCapacity(
         can_build_now=can_build_now,
         can_build_after_purchase=can_build_after_purchase,
-        est_purchase_cost=est_purchase_cost,
+        total_bom_cost=total_bom_cost,
+        purchase_to_pay_cost=purchase_to_pay_cost,
+        est_purchase_cost=purchase_to_pay_cost,
         blocking_lines_now=blocking_lines_now,
         blocking_lines_after_purchase=blocking_lines_after_purchase,
     )
+
+
+def _sum_best_offer_cost(
+    rows: list[SourcingBomLineOut],
+    *,
+    quantity_for_row: Callable[[SourcingBomLineOut], int],
+) -> Decimal | None:
+    running = Decimal("0")
+    priced = False
+    total_currency = _total_currency(rows)
+    for row in rows:
+        qty = quantity_for_row(row)
+        if not isinstance(qty, int) or qty <= 0:
+            continue
+        priced_offer = _best_offer_priced_for_total(row.best_offer, total_currency)
+        if priced_offer is None:
+            continue
+        unit_price, _currency = priced_offer
+        running += unit_price * Decimal(qty)
+        priced = True
+    return running if priced else None
+
+
+def _total_currency(rows: list[SourcingBomLineOut]) -> str | None:
+    converted = [
+        _clean_currency(row.best_offer.currency_displayed)
+        for row in rows
+        if row.best_offer is not None
+        and row.best_offer.unit_price_converted is not None
+        and row.best_offer.currency_displayed is not None
+    ]
+    if converted:
+        return converted[0]
+
+    currencies = [
+        currency
+        for row in rows
+        if row.best_offer is not None
+        and (currency := _offer_display_currency(row.best_offer)) is not None
+    ]
+    if not currencies:
+        return None
+    first = currencies[0]
+    return first if all(currency == first for currency in currencies) else first
+
+
+def _best_offer_priced_for_total(
+    offer: SourcingBomOfferOut | None,
+    total_currency: str | None,
+) -> tuple[Decimal, str | None] | None:
+    if offer is None:
+        return None
+
+    offer_currency = _offer_display_currency(offer)
+    if total_currency is not None and offer_currency is not None:
+        if offer_currency != total_currency:
+            return None
+
+    if offer.unit_price_converted is not None and offer.currency_displayed is not None:
+        return offer.unit_price_converted, _clean_currency(offer.currency_displayed)
+
+    native_currency = _clean_currency(offer.currency)
+    displayed_currency = _clean_currency(offer.currency_displayed)
+    if (
+        native_currency is not None
+        and displayed_currency is not None
+        and native_currency != displayed_currency
+    ):
+        return None
+
+    if offer.unit_price is None:
+        return None
+    return offer.unit_price, offer_currency
+
+
+def _offer_display_currency(offer: SourcingBomOfferOut) -> str | None:
+    return _clean_currency(offer.currency_displayed) or _clean_currency(offer.currency)
+
+
+def _clean_currency(value: str | None) -> str | None:
+    if value is None:
+        return None
+    cleaned = value.strip().upper()
+    return cleaned or None
 
 
 def compute_coverage(
@@ -222,17 +301,6 @@ def _supported_builds(
     if available <= 0 or requested_build_quantity <= 0:
         return 0
     return available * requested_build_quantity // required
-
-
-def _required_for_builds(
-    required: int,
-    *,
-    builds: int,
-    requested_build_quantity: int,
-) -> int:
-    if builds <= 0 or requested_build_quantity <= 0:
-        return 0
-    return (required * builds + requested_build_quantity - 1) // requested_build_quantity
 
 
 def _best_covering_offer(

--- a/backend/app/domain/sourcing/schemas.py
+++ b/backend/app/domain/sourcing/schemas.py
@@ -384,7 +384,25 @@ class BuildCapacityOut(BaseModel):
 
     can_build_now: int
     can_build_after_purchase: int
-    est_purchase_cost: Decimal | None
+    total_bom_cost: Decimal | None = Field(
+        default=None,
+        description=(
+            "Sum of required quantity times best-offer unit price across priced "
+            "BOM lines, independent of on-hand stock."
+        ),
+    )
+    purchase_to_pay_cost: Decimal | None = Field(
+        default=None,
+        description=(
+            "Sum of short quantity times best-offer unit price across priced "
+            "lines that are not blocking after authorized supply."
+        ),
+    )
+    est_purchase_cost: Decimal | None = Field(
+        default=None,
+        deprecated=True,
+        description="Deprecated alias for purchase_to_pay_cost; remove after SX-8.",
+    )
     blocking_lines_now: list[UUID]
     blocking_lines_after_purchase: list[UUID]
 

--- a/backend/tests/test_sourcing_bom_route.py
+++ b/backend/tests/test_sourcing_bom_route.py
@@ -205,7 +205,9 @@ def test_basic_bom_returns_enriched_lines(authed_client):
     assert data["coverage"]["best_single_distributor"] == "DigiKey"
     assert data["capacity"]["can_build_now"] == 0
     assert data["capacity"]["can_build_after_purchase"] == 6
-    assert Decimal(data["capacity"]["est_purchase_cost"]) == Decimal("6.00")
+    assert Decimal(data["capacity"]["total_bom_cost"]) == Decimal("2.00")
+    assert Decimal(data["capacity"]["purchase_to_pay_cost"]) == Decimal("2.00")
+    assert data["capacity"]["est_purchase_cost"] == data["capacity"]["purchase_to_pay_cost"]
     row = data["rows"][0]
     assert row["required"] == 20
     assert row["available"] == 0

--- a/backend/tests/test_sourcing_capacity.py
+++ b/backend/tests/test_sourcing_capacity.py
@@ -21,12 +21,22 @@ def _offer(
     stock: int = 100,
     unit_price: str = "1.00",
     distributor: str = "DigiKey",
+    currency: str | None = None,
+    unit_price_converted: str | None = None,
+    currency_displayed: str | None = None,
+    fx_converted: bool | None = None,
 ) -> SourcingBomOfferOut:
     return SourcingBomOfferOut(
         mpn="MPN",
         distributor=distributor,
         stock=stock,
         unit_price=Decimal(unit_price),
+        currency=currency,
+        unit_price_converted=(
+            Decimal(unit_price_converted) if unit_price_converted is not None else None
+        ),
+        currency_displayed=currency_displayed,
+        fx_converted=fx_converted,
         price_breaks=[
             SourcingBomPriceBreakOut(quantity=1, unit_price=Decimal(unit_price))
         ],
@@ -61,6 +71,8 @@ def test_empty_bom():
 
     assert capacity.can_build_now == 0
     assert capacity.can_build_after_purchase == 0
+    assert capacity.total_bom_cost is None
+    assert capacity.purchase_to_pay_cost is None
     assert capacity.est_purchase_cost is None
     assert capacity.blocking_lines_now == []
     assert capacity.blocking_lines_after_purchase == []
@@ -77,6 +89,8 @@ def test_fully_stocked_internal():
 
     assert capacity.can_build_now == 100
     assert capacity.can_build_after_purchase == 100
+    assert capacity.total_bom_cost is None
+    assert capacity.purchase_to_pay_cost == Decimal("0")
     assert capacity.est_purchase_cost == Decimal("0")
 
 
@@ -97,6 +111,8 @@ def test_partially_stocked_with_authorized_supply():
 
     assert capacity.can_build_now == 50
     assert capacity.can_build_after_purchase == 100
+    assert capacity.total_bom_cost == Decimal("25.00")
+    assert capacity.purchase_to_pay_cost == Decimal("12.50")
     assert capacity.est_purchase_cost == Decimal("12.50")
     assert capacity.blocking_lines_now == [_uuid(1)]
 
@@ -112,9 +128,10 @@ def test_authorized_supply_zero_blocks_after_purchase():
 
     assert capacity.can_build_after_purchase == 50
     assert capacity.blocking_lines_after_purchase == [_uuid(1)]
+    assert capacity.purchase_to_pay_cost is None
 
 
-def test_est_purchase_cost_none_when_blocker_has_no_offer():
+def test_purchase_to_pay_cost_excludes_blocking_lines():
     capacity = compute_build_capacity(
         [
             _line(1, required=100, available=50),
@@ -131,7 +148,8 @@ def test_est_purchase_cost_none_when_blocker_has_no_offer():
 
     assert capacity.can_build_after_purchase == 50
     assert capacity.blocking_lines_after_purchase == [_uuid(1)]
-    assert capacity.est_purchase_cost is None
+    assert capacity.purchase_to_pay_cost == Decimal("25.00")
+    assert capacity.est_purchase_cost == Decimal("25.00")
 
 
 def test_est_purchase_cost_correct_at_build_quantity_1():
@@ -149,6 +167,7 @@ def test_est_purchase_cost_correct_at_build_quantity_1():
 
     assert capacity.can_build_now == 0
     assert capacity.can_build_after_purchase == 0
+    assert capacity.purchase_to_pay_cost == Decimal("2.50")
     assert capacity.est_purchase_cost == Decimal("2.50")
 
 
@@ -167,6 +186,7 @@ def test_est_purchase_cost_correct_at_build_quantity_2():
 
     assert capacity.can_build_now == 0
     assert capacity.can_build_after_purchase == 0
+    assert capacity.purchase_to_pay_cost == Decimal("5.00")
     assert capacity.est_purchase_cost == Decimal("5.00")
 
 
@@ -186,6 +206,8 @@ def test_est_purchase_cost_unchanged_at_build_quantity_100():
 
     assert capacity.can_build_now == 0
     assert capacity.can_build_after_purchase == 100
+    assert capacity.total_bom_cost == Decimal("250.00")
+    assert capacity.purchase_to_pay_cost == Decimal("250.00")
     assert capacity.est_purchase_cost == Decimal("250.00")
 
 
@@ -225,10 +247,129 @@ def test_required_zero_line_ignored():
     )
 
     assert capacity.can_build_now == 100
+    assert capacity.purchase_to_pay_cost == Decimal("0")
     assert capacity.blocking_lines_now == [_uuid(2)]
 
 
-def test_decimal_serialisation():
+def test_total_bom_cost_sums_required_quantity_unit_price():
+    capacity = compute_build_capacity(
+        [
+            _line(1, required=2, best_offer=_offer(unit_price="1.50")),
+            _line(2, required=3, best_offer=_offer(unit_price="2.00")),
+        ],
+        requested_build_quantity=1,
+    )
+
+    assert capacity.total_bom_cost == Decimal("9.00")
+
+
+def test_total_bom_cost_ignores_stock_on_hand():
+    capacity = compute_build_capacity(
+        [
+            _line(1, required=10, available=25, best_offer=_offer(unit_price="0.25")),
+            _line(2, required=5, available=10, best_offer=_offer(unit_price="2.00")),
+        ],
+        requested_build_quantity=1,
+    )
+
+    assert capacity.total_bom_cost == Decimal("12.50")
+
+
+def test_total_bom_cost_skips_unpriced_lines():
+    capacity = compute_build_capacity(
+        [
+            _line(1, required=10, best_offer=_offer(unit_price="0.25")),
+            _line(2, required=5),
+        ],
+        requested_build_quantity=1,
+    )
+
+    assert capacity.total_bom_cost == Decimal("2.50")
+
+
+def test_total_bom_cost_none_when_no_line_has_pricing():
+    capacity = compute_build_capacity(
+        [
+            _line(1, required=10),
+            _line(2, required=5),
+        ],
+        requested_build_quantity=1,
+    )
+
+    assert capacity.total_bom_cost is None
+
+
+def test_purchase_to_pay_cost_sums_short_by_unit_price():
+    capacity = compute_build_capacity(
+        [
+            _line(1, required=100, available=0),
+            _line(2, required=100, available=50, best_offer=_offer(unit_price="2.00")),
+            _line(3, required=100, available=75, best_offer=_offer(unit_price="1.00")),
+        ],
+        requested_build_quantity=100,
+    )
+
+    assert capacity.blocking_lines_after_purchase == [_uuid(1)]
+    assert capacity.purchase_to_pay_cost == Decimal("125.00")
+
+
+def test_purchase_to_pay_cost_none_when_no_non_blocking_line_has_pricing():
+    capacity = compute_build_capacity(
+        [
+            _line(1, required=100, available=0),
+            _line(2, required=100, available=50),
+        ],
+        requested_build_quantity=100,
+    )
+
+    assert capacity.blocking_lines_after_purchase == [_uuid(1)]
+    assert capacity.purchase_to_pay_cost is None
+
+
+def test_est_purchase_cost_alias_equals_purchase_to_pay_cost():
+    capacity = compute_build_capacity(
+        [
+            _line(1, required=100, available=0),
+            _line(2, required=100, available=50, best_offer=_offer(unit_price="2.00")),
+        ],
+        requested_build_quantity=100,
+    )
+
+    assert capacity.est_purchase_cost == capacity.purchase_to_pay_cost
+
+
+def test_cost_totals_skip_incompatible_display_currency_rows():
+    capacity = compute_build_capacity(
+        [
+            _line(
+                1,
+                required=10,
+                best_offer=_offer(
+                    unit_price="2.00",
+                    currency="USD",
+                    unit_price_converted="1.50",
+                    currency_displayed="EUR",
+                    fx_converted=True,
+                ),
+            ),
+            _line(
+                2,
+                required=10,
+                best_offer=_offer(
+                    unit_price="3.00",
+                    currency="USD",
+                    currency_displayed="USD",
+                ),
+            ),
+        ],
+        requested_build_quantity=1,
+    )
+
+    assert capacity.total_bom_cost == Decimal("15.00")
+    assert capacity.purchase_to_pay_cost == Decimal("15.00")
+
+
+def test_decimal_serialisation_for_both_costs():
     capacity = compute_build_capacity(
         [
             _line(
@@ -244,5 +385,9 @@ def test_decimal_serialisation():
 
     payload = BuildCapacityOut.model_validate(capacity).model_dump(mode="json")
 
+    assert payload["total_bom_cost"] == "125.00"
+    assert isinstance(payload["total_bom_cost"], str)
+    assert payload["purchase_to_pay_cost"] == "62.50"
+    assert isinstance(payload["purchase_to_pay_cost"], str)
     assert payload["est_purchase_cost"] == "62.50"
     assert isinstance(payload["est_purchase_cost"], str)

--- a/docs/api/sourcing.md
+++ b/docs/api/sourcing.md
@@ -217,6 +217,21 @@ Path: `project_id` is a project UUID in the current workspace.
         "risk_flags": []
       }
     ],
+    "coverage": {
+      "rows": [],
+      "total_lines": 1,
+      "best_single_distributor": null,
+      "best_two_distributor_combo": null
+    },
+    "capacity": {
+      "can_build_now": 0,
+      "can_build_after_purchase": 3,
+      "total_bom_cost": "2.00",
+      "purchase_to_pay_cost": "2.00",
+      "est_purchase_cost": "2.00",
+      "blocking_lines_now": [],
+      "blocking_lines_after_purchase": []
+    },
     "powered_by": "TrustedParts",
     "fetched_at": "2026-05-08T12:00:00+00:00",
     "partial": false,
@@ -257,11 +272,14 @@ Sources: `backend/app/domain/sourcing/service.py:1322-1386`,
 - The route validates `project_id` with `assert_in_workspace()` before calling the sourcing service.
 - The service reuses `shortage_analysis()`, `dedupe_mpns()`, `chunk_mpns()`, and per-MPN `search()` cache rows; BOM chunks use `ttl_seconds=600`.
 - Decimal prices and extended costs serialize as strings.
-- When `currency` is supplied, BOM offer prices whose native distributor currency differs are display-converted through the global ECB daily snapshot. Native `unit_price`, `currency`, and existing coverage/capacity calculations stay unchanged; converted display values are exposed as `unit_price_converted`, `currency_displayed`, `fx_converted`, `fx_rate_date`, and `price_breaks_converted`.
+- `capacity.total_bom_cost` sums `required * best_offer.unit_price` for priced rows and ignores on-hand stock. `capacity.purchase_to_pay_cost` sums `short_by * best_offer.unit_price` for priced rows that are not blocking after authorized supply. `capacity.est_purchase_cost` is a deprecated alias of `purchase_to_pay_cost` for one release.
+- Capacity totals use converted/display prices when available and skip rows whose displayed currency does not match the selected total currency, so mixed native currencies are not added together.
+- When `currency` is supplied, BOM offer prices whose native distributor currency differs are display-converted through the global ECB daily snapshot. Native `unit_price` and `currency` stay unchanged; converted display values are exposed as `unit_price_converted`, `currency_displayed`, `fx_converted`, `fx_rate_date`, and `price_breaks_converted`.
 - Each row exposes sourcing diagnostics: `reason` is `ok`, `no_mpn`, or `no_offers`; `cache_hit` is `true`/`false` for searched rows and `null` when no MPN was searched; row `fx_status` is `unavailable` when any offer on the row could not be converted. Top-level `fx_status` is `ok`, `partial`, or `unavailable` when a request currency was supplied and `null` when conversion was not requested.
 - BOM offer projections carry offer-level TrustedParts gap fields for downstream risk/report consumers; distributor-level gap fields remain on part/search offer DTOs.
 - Source: `backend/app/api/routes/sourcing.py:253-315`.
-- Service: `backend/app/domain/sourcing/service.py:820-882`, `backend/app/domain/sourcing/service.py:1236-1270`.
+- Service: `backend/app/domain/sourcing/service.py:820-898`, `backend/app/domain/sourcing/service.py:1236-1270`.
+- Capacity: `backend/app/domain/sourcing/coverage.py:45-120`, `backend/app/domain/sourcing/schemas.py:382-407`.
 - Pricing: `backend/app/domain/sourcing/pricing.py:9-40`.
 
 ### `POST /api/projects/{project_id}/purchase-plan`

--- a/docs/domain/sourcing.md
+++ b/docs/domain/sourcing.md
@@ -70,6 +70,20 @@ Sources: `docs/schemas/trustedparts-v2.json`,
 `backend/app/domain/sourcing/client.py:373`,
 `backend/app/domain/sourcing/optimizer.py:291`
 
+## BOM Cost Totals
+
+Project BOM capacity reports two response-level cost numbers. `total_bom_cost`
+sums required quantity times best-offer unit price for every priced row and ignores
+on-hand stock. `purchase_to_pay_cost` sums short quantity times best-offer unit
+price for priced rows that are not blocking after authorized supply; the deprecated
+`est_purchase_cost` field is the same value for one release. Both totals use Decimal
+math, prefer converted/display prices from BOM FX conversion, and skip rows whose
+display currency does not match the selected total currency.
+
+Sources: `backend/app/domain/sourcing/coverage.py:45-120`,
+`backend/app/domain/sourcing/coverage.py:123-196`,
+`backend/app/domain/sourcing/schemas.py:382-407`
+
 ## BOM Risk Flags
 
 Project sourcing keeps the five original BOM risk flags in order, then appends

--- a/web/src/routes/projects/sourcing/ProjectSourcingPage.tsx
+++ b/web/src/routes/projects/sourcing/ProjectSourcingPage.tsx
@@ -95,6 +95,8 @@ type SourcingBomResponse = {
   capacity: {
     can_build_now: number;
     can_build_after_purchase: number;
+    total_bom_cost?: string | number | null;
+    purchase_to_pay_cost?: string | number | null;
     est_purchase_cost?: string | number | null;
     blocking_lines_now: string[];
     blocking_lines_after_purchase: string[];
@@ -384,16 +386,25 @@ function BudgetState({
   );
 }
 
-function CapacityBanner({ data }: { data: SourcingBomResponse }) {
+function CapacityBanner({ data, currency }: { data: SourcingBomResponse; currency?: string | null }) {
   const blocking = data.capacity.blocking_lines_after_purchase.length > 0
     ? data.capacity.blocking_lines_after_purchase
     : data.capacity.blocking_lines_now;
   const linesById = new Map(data.rows.map(row => [row.project_entry_id, row]));
-  const purchaseCurrency = data.rows.find(row => row.best_offer?.currency)?.best_offer?.currency ?? null;
+  const purchaseCurrency = (
+    currency?.trim().toUpperCase() ||
+    data.rows.map(row => offerDisplayCurrency(row.best_offer)).find(Boolean)
+  ) ?? null;
+  const totalCostNote = data.capacity.total_bom_cost == null
+    ? "no pricing available on any line"
+    : "if bought every line";
+  const purchaseCostNote = data.capacity.purchase_to_pay_cost == null
+    ? "no non-blocking priced shortages"
+    : "short qty only, excluding blocking lines";
 
   return (
     <div className="card p-4">
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-3">
         <div>
           <div className="section-title">Can build now</div>
           <div className="text-2xl font-semibold tabular-nums">{data.capacity.can_build_now}</div>
@@ -402,9 +413,22 @@ function CapacityBanner({ data }: { data: SourcingBomResponse }) {
           <div className="section-title">After purchase</div>
           <div className="text-2xl font-semibold tabular-nums">{data.capacity.can_build_after_purchase}</div>
         </div>
-        <div>
-          <div className="section-title">Est. cost</div>
-          <div className="text-2xl font-semibold tabular-nums">{formatMoney(data.capacity.est_purchase_cost, purchaseCurrency)}</div>
+        <div className="sm:col-span-2 lg:col-span-2 min-w-0">
+          <div className="section-title">Costs</div>
+          <div className="mt-1 flex flex-col gap-1 text-sm">
+            <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+              <span className="text-muted">Total BOM cost:</span>
+              <span className="font-mono tabular-nums">{formatMoney(data.capacity.total_bom_cost, purchaseCurrency)}</span>
+              <span className="text-xs text-muted">{totalCostNote}</span>
+            </div>
+            <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+              <span className="text-muted">Price to pay:</span>
+              <span className="font-mono font-semibold tabular-nums">
+                {formatMoney(data.capacity.purchase_to_pay_cost, purchaseCurrency)}
+              </span>
+              <span className="text-xs text-muted">{purchaseCostNote}</span>
+            </div>
+          </div>
         </div>
         <div>
           <div className="section-title">Blocking lines</div>
@@ -884,7 +908,7 @@ export default function ProjectSourcingPage() {
 
       {query.data && hasRows && (
         <>
-          <CapacityBanner data={query.data} />
+          <CapacityBanner data={query.data} currency={requestBody.currency} />
           <CoverageMatrix data={query.data} />
           <BomRows rows={query.data.rows} />
           <div className="text-xs text-muted">

--- a/web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.test.tsx
+++ b/web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.test.tsx
@@ -150,6 +150,8 @@ function sourcingResponse(overrides: Record<string, unknown> = {}) {
     capacity: {
       can_build_now: 0,
       can_build_after_purchase: 3,
+      total_bom_cost: "30.00",
+      purchase_to_pay_cost: "25.00",
       est_purchase_cost: "25.00",
       blocking_lines_now: ["entry-2"],
       blocking_lines_after_purchase: ["entry-1"],
@@ -292,7 +294,7 @@ describe("ProjectSourcingPage", () => {
     expect(await screen.findByText("Workspace default currency is not active; using EUR.")).toBeDefined();
   });
 
-  it("renders capacity banner with both numbers from server response", async () => {
+  it("CapacityBanner renders Total BOM cost when capacity.total_bom_cost is non-null", async () => {
     mockReads();
     vi.spyOn(api, "post").mockResolvedValue(sourcingResponse());
 
@@ -301,8 +303,42 @@ describe("ProjectSourcingPage", () => {
     expect(await screen.findByText("Can build now")).toBeDefined();
     expect(screen.getByText("After purchase")).toBeDefined();
     expect(screen.getByText("3")).toBeDefined();
-    expect(screen.getAllByText("Est. cost").length).toBeGreaterThan(0);
+    expect(screen.getByText("Total BOM cost:")).toBeDefined();
+    expect(screen.getByText("30 USD")).toBeDefined();
+    expect(screen.getByText("if bought every line")).toBeDefined();
+  });
+
+  it("CapacityBanner renders Price to pay when capacity.purchase_to_pay_cost is non-null", async () => {
+    mockReads();
+    vi.spyOn(api, "post").mockResolvedValue(sourcingResponse());
+
+    renderPage();
+
+    expect(await screen.findByText("Price to pay:")).toBeDefined();
     expect(screen.getByText("25 USD")).toBeDefined();
+    expect(screen.getByText("short qty only, excluding blocking lines")).toBeDefined();
+  });
+
+  it("CapacityBanner shows em-dash when both values are null", async () => {
+    mockReads();
+    vi.spyOn(api, "post").mockResolvedValue(sourcingResponse({
+      capacity: {
+        can_build_now: 0,
+        can_build_after_purchase: 0,
+        total_bom_cost: null,
+        purchase_to_pay_cost: null,
+        est_purchase_cost: null,
+        blocking_lines_now: ["entry-1"],
+        blocking_lines_after_purchase: ["entry-1"],
+      },
+    }));
+
+    renderPage();
+
+    expect(await screen.findByText("Total BOM cost:")).toBeDefined();
+    expect(screen.getByText("no pricing available on any line")).toBeDefined();
+    expect(screen.getByText("no non-blocking priced shortages")).toBeDefined();
+    expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(2);
   });
 
   it("renders coverage matrix with best-single + best-two highlights", async () => {


### PR DESCRIPTION
## Summary

- Adds `capacity.total_bom_cost` and `capacity.purchase_to_pay_cost` to the BOM sourcing response, with `est_purchase_cost` retained as a deprecated alias of `purchase_to_pay_cost`.
- Computes total BOM cost from required quantity across priced rows, and price-to-pay from short quantity across priced rows that are not blocking after authorized supply; Decimal math is preserved and incompatible display-currency rows are skipped.
- Updates the Project Sourcing CapacityBanner to render both labels and to prefer the active request currency for the response-level totals.
- Adds backend/frontend tests plus sourcing docs and changelog updates.

## Tests

Post-rebase on #475 / current main:
- `cd backend && .venv/bin/pytest -q -k "sourcing_capacity"` — 20 passed.
- `cd backend && .venv/bin/ruff check app/domain/sourcing/coverage.py app/domain/sourcing/schemas.py tests/test_sourcing_capacity.py tests/test_sourcing_bom_route.py` — passed.
- `cd web && npm run typecheck && npm test -- "ProjectSourcingPage" && npx eslint src/routes/projects/sourcing/ProjectSourcingPage.tsx src/routes/projects/sourcing/__tests__/ProjectSourcingPage.test.tsx` — typecheck passed; ProjectSourcingPage 30 tests passed; targeted ESLint passed.
- `git diff --check` — passed.

Pre-rebase worker validation:
- `cd backend && .venv/bin/pytest tests/test_sourcing_bom_route.py tests/test_sourcing_bom_integration.py -q` — 38 passed.
- Backend and frontend lint-delta checks — no new violations.

## Limitations

- Docker is not installed in this environment, so `docker compose -f docker-compose.dev.yml exec backend ...` could not be run.
- After rebasing onto #475, the local rerun of `tests/test_sourcing_bom_route.py tests/test_sourcing_bom_integration.py` was blocked in test setup before sourcing tests executed: Alembic migration `0020_partial_bag_signature_index` attempted `CREATE INDEX ... ON stock_entries`, but the local test DB schema was missing `stock_entries`. CI backend-tests will provide the clean container-backed validation.
- Direct full `ruff check app` and `npm run lint` still report pre-existing baseline violations outside this change; the repo lint-delta gates and targeted changed-file checks are clean.
- No manual before/after screenshot was captured in this headless run; CapacityBanner rendering is covered by ProjectSourcingPage tests.

## Compatibility

`est_purchase_cost` is still emitted and equals `purchase_to_pay_cost` for existing callers during the SX-8 transition window.

## Merge Order

- After #475/#468 and #474/#469; this branch is rebased on current `origin/main` containing both.
- Before #470/#472/#473 unless those PRs rebase on this response/banner shape.

Refs #471