### PR TITLE
SX-6: TanStack Query display cache for instant Sourcing reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ the canonical record.
 
 ## 2026-05 — feedback brief fixes
 
+- **SX-6 / #473** Project Sourcing BOM coverage now keeps TanStack Query
+  display data warm for instant remounts and shows a non-blocking background
+  refresh hint instead of a skeleton during refetches.
 - **SX-4 / #471** Project Sourcing capacity now separates total BOM cost
   from the short-quantity price to pay, with `est_purchase_cost` retained as
   a deprecated alias.

--- a/docs/frontend/tanstack-patterns.md
+++ b/docs/frontend/tanstack-patterns.md
@@ -127,6 +127,38 @@ The same key shape is reused across mounts so the cache stays shared
 (e.g. the scanner's `useWsKey("ws", "current")` matches the Settings →
 Workspace page's read of the same shape — `web/src/components/scanner/Scanner.tsx:43-46`).
 
+## Display-cache reads
+
+Use per-query display-cache options when a read is expensive enough that
+showing a full skeleton on every remount harms the workflow, and the key
+already contains every filter that changes the response. Project Sourcing's
+BOM coverage query is the reference case (`web/src/routes/projects/sourcing/ProjectSourcingPage.tsx:710-719`).
+
+```tsx
+// web/src/routes/projects/sourcing/ProjectSourcingPage.tsx
+const query = useQuery({
+  queryKey: useWsKey("sourcing", "project", projectId, requestBody),
+  queryFn: ({ signal }) => api.post(path, requestBody, { signal }),
+  staleTime: 5 * 60 * 1000,
+  gcTime: 30 * 60 * 1000,
+  placeholderData: previousData => previousData,
+  refetchOnWindowFocus: false,
+});
+```
+
+- `staleTime` is the trust window. Within it, remounts render from memory
+  without a network request.
+- `gcTime` is the retention window after the last component unmounts.
+- `placeholderData: previousData => previousData` is the TanStack Query 5
+  replacement for v4 `keepPreviousData`; use it when filter changes should
+  keep the previous table visible while the new key loads.
+- `refetchOnWindowFocus: false` belongs on expensive reads even though the
+  global default already disables focus refetches (`web/src/main.tsx:45-49`).
+
+Initial loads still render their skeleton. Background refetches render the
+existing data plus a small `isFetching && !isLoading` status hint
+(`web/src/routes/projects/sourcing/ProjectSourcingPage.tsx:895-900`).
+
 ## QueryClient defaults
 
 `web/src/main.tsx:45-49`:

--- a/web/src/routes/projects/sourcing/ProjectSourcingPage.tsx
+++ b/web/src/routes/projects/sourcing/ProjectSourcingPage.tsx
@@ -118,6 +118,9 @@ type SourcingRequest = {
   distributors?: string[];
 };
 
+const SOURCING_BOM_STALE_TIME_MS = 5 * 60 * 1000;
+const SOURCING_BOM_GC_TIME_MS = 30 * 60 * 1000;
+
 function numberOrNull(value: string | number | null | undefined): number | null {
   if (value == null || value === "") return null;
   const parsed = typeof value === "number" ? value : Number(value);
@@ -709,6 +712,10 @@ export default function ProjectSourcingPage() {
     queryFn: ({ signal }) =>
       api.post<SourcingBomResponse, SourcingRequest>(`/projects/${projectId}/sourcing`, requestBody, { signal }),
     enabled: !!projectId && buildQuantity >= 1 && defaultsApplied && activeListErrors.length === 0,
+    staleTime: SOURCING_BOM_STALE_TIME_MS,
+    gcTime: SOURCING_BOM_GC_TIME_MS,
+    placeholderData: previousData => previousData,
+    refetchOnWindowFocus: false,
   });
   const purchasePlanBaseRequest = useMemo<Omit<PurchasePlanRequest, "strategy">>(() => {
     const body = { ...requestBody };
@@ -886,6 +893,11 @@ export default function ProjectSourcingPage() {
       </div>
 
       {query.isLoading && <SourcingSkeleton />}
+      {query.isFetching && !query.isLoading && (
+        <div className="text-xs text-muted" role="status">
+          Refreshing prices in the background...
+        </div>
+      )}
       {status === 503 && <BudgetState disabledUntil={budgetDisabledUntil} onRetry={() => query.refetch()} />}
       {status === 502 && (
         <div className="card p-4" role="status">

--- a/web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.test.tsx
+++ b/web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.test.tsx
@@ -181,6 +181,16 @@ function apiError(status: number, message: string) {
   );
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 function mockReads(workspaceOverrides: Record<string, unknown> = {}) {
   vi.spyOn(api, "get").mockImplementation(async path => {
     if (path === "/workspaces/current") return workspace(workspaceOverrides) as never;
@@ -353,6 +363,61 @@ describe("ProjectSourcingPage", () => {
     expect(within(table).getByText("DigiKey")).toBeDefined();
     expect(within(table).getByText("Best single distributor")).toBeDefined();
     expect(within(table).getAllByText("Best two-distributor combo")).toHaveLength(2);
+  });
+
+  it("cold load shows the sourced BOM skeleton without the background refresh hint", async () => {
+    mockReads();
+    const firstLoad = deferred<ReturnType<typeof sourcingResponse>>();
+    vi.spyOn(api, "post").mockReturnValue(firstLoad.promise as never);
+
+    renderPage();
+
+    expect(await screen.findByRole("status", { name: "Loading sourced BOM" })).toBeDefined();
+    expect(screen.queryByText("Refreshing prices in the background...")).toBeNull();
+
+    firstLoad.resolve(sourcingResponse());
+  });
+
+  it("refetching state shows a muted refresh hint while keeping loaded rows visible", async () => {
+    const user = userEvent.setup();
+    mockReads();
+    const refetch = deferred<ReturnType<typeof sourcingResponse>>();
+    const post = vi.spyOn(api, "post");
+    post.mockResolvedValueOnce(sourcingResponse());
+    post.mockReturnValueOnce(refetch.promise as never);
+
+    renderPage();
+
+    expect(await screen.findByText("BOM rows")).toBeDefined();
+    await user.click(screen.getByRole("button", { name: "Source" }));
+
+    expect(await screen.findByText("Refreshing prices in the background...")).toBeDefined();
+    expect(screen.getAllByText("STM32").length).toBeGreaterThan(0);
+    expect(screen.queryByRole("status", { name: "Loading sourced BOM" })).toBeNull();
+
+    refetch.resolve(sourcingResponse());
+  });
+
+  it("placeholderData renders previous result during a filter refetch", async () => {
+    const user = userEvent.setup();
+    mockReads();
+    const filteredLoad = deferred<ReturnType<typeof sourcingResponse>>();
+    const post = vi.spyOn(api, "post");
+    post.mockResolvedValueOnce(sourcingResponse());
+    post.mockReturnValueOnce(filteredLoad.promise as never);
+
+    renderPage();
+
+    expect(await screen.findByText("BOM rows")).toBeDefined();
+    await user.click(screen.getByRole("checkbox", { name: "Mouser" }));
+
+    await waitFor(() => expect(post).toHaveBeenCalledTimes(2));
+    expect(await screen.findByText("Refreshing prices in the background...")).toBeDefined();
+    expect(screen.getAllByText("STM32").length).toBeGreaterThan(0);
+    expect(screen.getByText("Regulator")).toBeDefined();
+    expect(screen.queryByRole("status", { name: "Loading sourced BOM" })).toBeNull();
+
+    filteredLoad.resolve(sourcingResponse());
   });
 
   it("renders risk pills for each flag returned", async () => {


### PR DESCRIPTION
## Summary
- Add per-query TanStack Query display-cache options to Project Sourcing BOM coverage: 5 minute staleTime, 30 minute gcTime, v5 placeholderData: previousData => previousData, and refetchOnWindowFocus: false.
- Show a small non-blocking background refresh hint only when isFetching && !isLoading, while keeping the cold-load skeleton unchanged.
- Document the frontend display-cache pattern and add a changelog entry.

## TanStack Query confirmation
- Verified @tanstack/react-query is ^5.59.0, so this uses the TanStack Query v5 placeholderData callback rather than v4 keepPreviousData.
- No raw fetch was added; the BOM coverage call still goes through web/src/lib/api.ts. No global QueryClient defaults were changed.

## Before / after observation
- Before: a remount or filter change could show the sourcing skeleton while the BOM coverage request was pending.
- After: cold load still shows the skeleton; warm/background refetch keeps existing BOM rows visible and shows "Refreshing prices in the background..." until the request resolves. This is pinned in ProjectSourcingPage tests.

## Validation
- cd web && npm run typecheck: passed.
- cd web && npm test -- "ProjectSourcingPage": passed, 33 tests.
- cd web && npx eslint src/routes/projects/sourcing/ProjectSourcingPage.tsx src/routes/projects/sourcing/__tests__/ProjectSourcingPage.test.tsx: passed.
- git diff --check HEAD~1..HEAD: passed.

Note: npm ci on local Node v18.19.1 emitted engine warnings for packages requiring Node 20+, but install completed and validation passed.

## Merge order
- This branch is based on current origin/main, which already includes #476/#471.
- If #472 and/or #470 land first, merge this PR after them and rebase if needed because they touch ProjectSourcingPage coverage UI/tests.
- If this PR lands first, #472/#470 should rebase on #473 before merging.

Refs #473