### PR TITLE
SX-3: Per-row BOM drill-down modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ the canonical record.
   refresh hint instead of a skeleton during refetches.
 - **SX-5 / #472** Project Sourcing coverage now shows lowest-price and
   fewest-distributor combination cards above the per-distributor matrix.
+- **SX-3 / #470** Project Sourcing BOM rows now open a TrustedParts distributor
+  drill-down with availability text, price breaks, MOQ, packaging, RoHS data, and
+  distributor links.
 - **SX-4 / #471** Project Sourcing capacity now separates total BOM cost
   from the short-quantity price to pay, with `est_purchase_cost` retained as
   a deprecated alias.

--- a/backend/app/domain/sourcing/schemas.py
+++ b/backend/app/domain/sourcing/schemas.py
@@ -351,6 +351,8 @@ class SourcingBomOfferOut(BaseModel):
     price_breaks: list[SourcingBomPriceBreakOut] = Field(default_factory=list)
     price_breaks_converted: list[SourcingBomPriceBreakOut] | None = None
     url: str | None = None
+    availability_text: str | None = None
+    quantity_multiple: int | None = None
     lifecycle_risk: str | None = None
     supply_chain_risk: str | None = None
     is_affected_by_tariff: bool | None = None

--- a/backend/app/domain/sourcing/service.py
+++ b/backend/app/domain/sourcing/service.py
@@ -1332,6 +1332,8 @@ def _joined_offers(
                         lead_time_days=distributor.lead_time_days,
                         price_breaks=_price_breaks_for_distributor(distributor),
                         url=distributor.product_url or offer.links.primary,
+                        availability_text=distributor.availability_text,
+                        quantity_multiple=distributor.quantity_multiple,
                         lifecycle_risk=offer.lifecycle_risk,
                         supply_chain_risk=offer.supply_chain_risk,
                         is_affected_by_tariff=offer.is_affected_by_tariff,

--- a/backend/tests/test_sourcing_bom_route.py
+++ b/backend/tests/test_sourcing_bom_route.py
@@ -63,6 +63,8 @@ def _offer(
     supply_chain_risk: str | None = None,
     is_affected_by_tariff: bool | None = None,
     rohs_compliance: list[SourcingRohsCompliance] | None = None,
+    availability_text: str | None = None,
+    quantity_multiple: int | None = None,
 ) -> SourcingOffer:
     return SourcingOffer(
         mpn=mpn,
@@ -85,6 +87,8 @@ def _offer(
                 price_breaks=[SourcingPriceBreak(quantity=1, unit_price=unit_price)],
                 product_url=f"https://www.trustedparts.com/{mpn}/{distributor}",
                 rohs_compliance=rohs_compliance or [],
+                availability_text=availability_text,
+                quantity_multiple=quantity_multiple,
             )
         ],
         links=SourcingLinks(primary=f"https://www.trustedparts.com/search/{mpn}"),
@@ -249,6 +253,29 @@ def test_bom_response_includes_is_affected_by_tariff_per_offer(authed_client):
     row = r.json()["data"]["rows"][0]
     assert row["offers"][0]["is_affected_by_tariff"] is True
     assert row["best_offer"]["is_affected_by_tariff"] is True
+
+
+def test_bom_response_includes_distributor_availability_and_quantity_multiple(authed_client):
+    _configure_sourcing(authed_client)
+    project_id = _single_line_project(authed_client, mpn="AVAIL-MPN")
+    _FakeTrustedPartsClient.offers_by_mpn = {
+        "AVAIL-MPN": [
+            _offer(
+                "AVAIL-MPN",
+                availability_text="Ships in 12 weeks",
+                quantity_multiple=5,
+            )
+        ]
+    }
+
+    r = _post_sourcing(authed_client, project_id)
+
+    assert r.status_code == 200, r.text
+    row = r.json()["data"]["rows"][0]
+    assert row["offers"][0]["availability_text"] == "Ships in 12 weeks"
+    assert row["offers"][0]["quantity_multiple"] == 5
+    assert row["best_offer"]["availability_text"] == "Ships in 12 weeks"
+    assert row["best_offer"]["quantity_multiple"] == 5
 
 
 def test_bom_response_offers_in_workspace_currency_when_currency_passed(

--- a/docs/api/sourcing.md
+++ b/docs/api/sourcing.md
@@ -206,6 +206,8 @@ Path: `project_id` is a project UUID in the current workspace.
           "fx_rate_date": null,
           "moq": 1,
           "lead_time_days": 3,
+          "availability_text": "In Stock",
+          "quantity_multiple": 5,
           "price_breaks_converted": null,
           "lifecycle_risk": "Low",
           "supply_chain_risk": null,
@@ -282,7 +284,7 @@ Sources: `backend/app/domain/sourcing/service.py:1322-1386`,
 - `coverage.lowest_total_price_combo` and `coverage.lowest_total_price_total` come from the optimizer's `lowest_total_price` per-line selections. `coverage.fewest_distributors_combo` and `coverage.fewest_distributors_total` choose the smallest distributor set that reaches `target_coverage_pct`; the implementation is exhaustive up to 10 distributors and greedy beyond that threshold.
 - When `currency` is supplied, BOM offer prices whose native distributor currency differs are display-converted through the global ECB daily snapshot. Native `unit_price` and `currency` stay unchanged; converted display values are exposed as `unit_price_converted`, `currency_displayed`, `fx_converted`, `fx_rate_date`, and `price_breaks_converted`.
 - Each row exposes sourcing diagnostics: `reason` is `ok`, `no_mpn`, or `no_offers`; `cache_hit` is `true`/`false` for searched rows and `null` when no MPN was searched; row `fx_status` is `unavailable` when any offer on the row could not be converted. Top-level `fx_status` is `ok`, `partial`, or `unavailable` when a request currency was supplied and `null` when conversion was not requested.
-- BOM offer projections carry offer-level TrustedParts gap fields for downstream risk/report consumers; distributor-level gap fields remain on part/search offer DTOs.
+- BOM offer projections carry offer-level TrustedParts gap fields for downstream risk/report consumers, plus distributor availability text and quantity multiple for per-BOM-line distributor drill-downs.
 - Source: `backend/app/api/routes/sourcing.py:253-315`.
 - Service: `backend/app/domain/sourcing/service.py:820-898`, `backend/app/domain/sourcing/service.py:1236-1270`.
 - Capacity: `backend/app/domain/sourcing/coverage.py:45-120`, `backend/app/domain/sourcing/schemas.py:382-407`.

--- a/docs/user/projects-and-bom.md
+++ b/docs/user/projects-and-bom.md
@@ -108,6 +108,8 @@ Bulk provider import processes up to 200 unmatched rows at a time; run it again 
 
 The **Source BOM** page can show TrustedParts sourcing context on each BOM line. Lifecycle, supply-chain, and RoHS details have their own BOM columns, while the legacy **Risk** column stays focused on operational flags such as single-source, stock, MOQ, lead-time, preferred-distributor, and tariff warnings. Lifecycle and supply-chain pills colour TrustedParts `Low` as green, `Medium` or `Moderate` as amber, and `High` or `Severe` as red. The **Lead time** column is available from the column menu when you need the raw per-row lead-time values.
 
+Click a sourced BOM row to compare every TrustedParts distributor offer for that line. The drill-down shows stock, raw availability text, price breaks, MOQ, quantity multiple, packaging, RoHS regions, and a distributor product link. Rows without distributor offers do not open a drill-down.
+
 ## Use meta-parts for "any 10k 0402 1%"
 
 If a row in your BOM doesn't need a specific manufacturer part — any 10k 0402 1% resistor will do — match it to a **meta-part** rather than a specific MPN. The build flow will then accept any of the meta-part's members at consume time. See [parts](parts.md#pick-a-part-type) for how meta-parts work.

--- a/web/src/routes/projects/sourcing/BomDistributorsModal.tsx
+++ b/web/src/routes/projects/sourcing/BomDistributorsModal.tsx
@@ -1,0 +1,402 @@
+import { useEffect, useMemo, useRef } from "react";
+import type { ReactNode } from "react";
+import { ExternalLink, Info, ShieldAlert, ShieldCheck, X } from "lucide-react";
+import { DataTable, type Column } from "@/components/DataTable";
+import { PoweredByTrustedParts } from "@/components/PoweredByTrustedParts";
+import { lifecycleRiskTone } from "@/lib/sourcing";
+import type {
+  SourcingBomLine,
+  SourcingBomOffer,
+  SourcingBomPriceBreak,
+  SourcingRohsCompliance,
+} from "./ProjectSourcingPage";
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  line: SourcingBomLine | null;
+  workspaceCurrency: string | null;
+};
+
+type DistributorRow = {
+  id: string;
+  offer: SourcingBomOffer;
+  distributor: string;
+  stock: number;
+  availabilityText: string | null;
+  unitPrice: number | null;
+  currency: string | null;
+  priceBreaks: { quantity: number; unitPrice: number; currency: string | null }[];
+  moq: number | null;
+  quantityMultiple: number | null;
+  packaging: string | null;
+  rohsCompliance: SourcingRohsCompliance[];
+  link: string | null;
+};
+
+function numberOrNull(value: string | number | null | undefined): number | null {
+  if (value == null || value === "") return null;
+  const parsed = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function positiveMultiple(value: number | null | undefined): number | null {
+  if (value == null || !Number.isFinite(value) || value <= 1) return null;
+  return Math.floor(value);
+}
+
+function formatNumber(value: number | null | undefined): string {
+  return value == null ? "—" : value.toLocaleString();
+}
+
+function formatPrice(value: number | null | undefined, currency: string | null | undefined): string {
+  if (value == null) return "—";
+  const formatted = value.toLocaleString(undefined, {
+    maximumFractionDigits: 6,
+    minimumFractionDigits: 0,
+  });
+  return currency ? `${formatted} ${currency}` : formatted;
+}
+
+function displayCurrency(offer: SourcingBomOffer, workspaceCurrency: string | null): string | null {
+  if (offer.fx_converted === true && offer.unit_price_converted != null) {
+    return offer.currency_displayed ?? workspaceCurrency ?? offer.currency ?? null;
+  }
+  return offer.currency_displayed ?? offer.currency ?? workspaceCurrency;
+}
+
+function displayUnitPrice(offer: SourcingBomOffer): number | null {
+  if (offer.fx_converted === true && offer.unit_price_converted != null) {
+    return numberOrNull(offer.unit_price_converted);
+  }
+  return numberOrNull(offer.unit_price);
+}
+
+function displayPriceBreaks(
+  offer: SourcingBomOffer,
+  currency: string | null,
+): { quantity: number; unitPrice: number; currency: string | null }[] {
+  const source = offer.fx_converted === true && offer.price_breaks_converted
+    ? offer.price_breaks_converted
+    : offer.price_breaks;
+
+  return normalisePriceBreaks(source, currency);
+}
+
+function normalisePriceBreaks(
+  breaks: SourcingBomPriceBreak[] | null | undefined,
+  fallbackCurrency: string | null,
+): { quantity: number; unitPrice: number; currency: string | null }[] {
+  return (breaks ?? []).flatMap(priceBreak => {
+    const unitPrice = numberOrNull(priceBreak.unit_price);
+    if (unitPrice == null) return [];
+    return [{
+      quantity: priceBreak.quantity,
+      unitPrice,
+      currency: priceBreak.currency ?? fallbackCurrency,
+    }];
+  });
+}
+
+function sortedRohs(values: SourcingRohsCompliance[]): SourcingRohsCompliance[] {
+  return [...values].sort((a, b) => a.region.localeCompare(b.region));
+}
+
+function RohsPills({ values }: { values: SourcingRohsCompliance[] }) {
+  if (values.length === 0) return <span className="text-muted">—</span>;
+  return (
+    <div className="flex flex-wrap gap-1">
+      {sortedRohs(values).map(item => (
+        <span
+          key={item.region}
+          className={`pill ${item.is_compliant ? "bg-success/10 text-success" : "bg-danger/10 text-danger"}`}
+          title={item.description ?? undefined}
+          aria-label={`${item.region}: ${item.is_compliant ? "RoHS compliant" : "RoHS non-compliant"}`}
+        >
+          {item.region}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function RiskPill({
+  label,
+  value,
+  icon,
+}: {
+  label: string;
+  value?: string | null;
+  icon: ReactNode;
+}) {
+  const trimmed = value?.trim();
+  if (!trimmed) return null;
+  return (
+    <span className={`pill inline-flex items-center gap-1 ${lifecycleRiskTone(trimmed)}`} aria-label={`${label}: ${trimmed}`}>
+      {icon}
+      {trimmed}
+    </span>
+  );
+}
+
+function PriceBreaksCell({ row }: { row: DistributorRow }) {
+  if (row.priceBreaks.length === 0) return <span className="text-muted">—</span>;
+  return (
+    <span className="flex flex-wrap justify-end gap-1">
+      {row.priceBreaks.map(priceBreak => (
+        <span key={`${priceBreak.quantity}:${priceBreak.unitPrice}:${priceBreak.currency ?? ""}`} className="pill font-mono">
+          {priceBreak.quantity.toLocaleString()}+ {formatPrice(priceBreak.unitPrice, priceBreak.currency)}
+        </span>
+      ))}
+    </span>
+  );
+}
+
+function uniqueTrimmed(values: Array<string | null | undefined>): string[] {
+  return Array.from(new Set(values.map(value => value?.trim()).filter((value): value is string => Boolean(value))))
+    .sort((a, b) => a.localeCompare(b));
+}
+
+function focusableElements(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>(
+    [
+      "a[href]",
+      "button:not([disabled])",
+      "input:not([disabled])",
+      "select:not([disabled])",
+      "textarea:not([disabled])",
+      "[tabindex]:not([tabindex='-1'])",
+    ].join(","),
+  )).filter(element => element.getAttribute("aria-hidden") !== "true");
+}
+
+export function BomDistributorsModal({ open, onClose, line, workspaceCurrency }: Props) {
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+  const closeButtonRef = useRef<HTMLButtonElement | null>(null);
+  const restoreFocusRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    restoreFocusRef.current = document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null;
+    window.setTimeout(() => {
+      closeButtonRef.current?.focus();
+    }, 0);
+
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        onClose();
+        return;
+      }
+      if (event.key !== "Tab") return;
+
+      const dialog = dialogRef.current;
+      if (!dialog) return;
+      const focusable = focusableElements(dialog);
+      if (focusable.length === 0) {
+        event.preventDefault();
+        dialog.focus();
+        return;
+      }
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement;
+      if (event.shiftKey && active === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && active === last) {
+        event.preventDefault();
+        first.focus();
+      } else if (!dialog.contains(active)) {
+        event.preventDefault();
+        first.focus();
+      }
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+      const restoreFocus = restoreFocusRef.current;
+      if (restoreFocus && document.contains(restoreFocus)) {
+        restoreFocus.focus();
+      }
+      restoreFocusRef.current = null;
+    };
+  }, [open, onClose]);
+
+  const rows = useMemo<DistributorRow[]>(() => {
+    if (!line) return [];
+    return line.offers.map((offer, index) => {
+      const currency = displayCurrency(offer, workspaceCurrency?.trim().toUpperCase() || null);
+      return {
+        id: [
+          offer.mpn,
+          offer.distributor,
+          offer.sku ?? "sku",
+          index,
+        ].join(":"),
+        offer,
+        distributor: offer.distributor,
+        stock: offer.stock,
+        availabilityText: offer.availability_text?.trim() || null,
+        unitPrice: displayUnitPrice(offer),
+        currency,
+        priceBreaks: displayPriceBreaks(offer, currency),
+        moq: offer.moq ?? null,
+        quantityMultiple: positiveMultiple(offer.quantity_multiple),
+        packaging: offer.packaging ?? null,
+        rohsCompliance: offer.rohs_compliance ?? [],
+        link: offer.url ?? null,
+      };
+    });
+  }, [line, workspaceCurrency]);
+
+  const statusPills = useMemo(() => {
+    const lifecycle = uniqueTrimmed(rows.map(row => row.offer.lifecycle_risk));
+    const supplyChain = uniqueTrimmed(rows.map(row => row.offer.supply_chain_risk));
+    const tariffAffected = rows.some(row => row.offer.is_affected_by_tariff === true);
+    return { lifecycle, supplyChain, tariffAffected };
+  }, [rows]);
+
+  const columns = useMemo<Column<DistributorRow>[]>(() => [
+    {
+      key: "distributor",
+      header: "Distributor",
+      accessor: row => row.distributor,
+      render: row => row.link ? (
+        <a
+          href={row.link}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1 text-accent hover:underline"
+        >
+          {row.distributor}
+          <ExternalLink size={14} aria-hidden="true" />
+        </a>
+      ) : row.distributor,
+    },
+    {
+      key: "stock",
+      header: "Stock",
+      accessor: row => row.stock,
+      render: row => row.stock.toLocaleString(),
+      align: "right",
+    },
+    {
+      key: "availability",
+      header: "Availability",
+      accessor: row => row.availabilityText ?? "",
+      render: row => row.availabilityText ?? <span className="text-muted">—</span>,
+    },
+    {
+      key: "price",
+      header: "Best unit price",
+      accessor: row => row.unitPrice,
+      render: row => formatPrice(row.unitPrice, row.currency),
+      align: "right",
+    },
+    {
+      key: "price_breaks",
+      header: "Price breaks",
+      accessor: row => row.priceBreaks.map(priceBreak => `${priceBreak.quantity}:${priceBreak.unitPrice}`).join(" "),
+      render: row => <PriceBreaksCell row={row} />,
+      align: "right",
+    },
+    {
+      key: "moq",
+      header: "MOQ",
+      accessor: row => row.moq,
+      render: row => formatNumber(row.moq),
+      align: "right",
+    },
+    {
+      key: "multiple",
+      header: "Qty multiple",
+      accessor: row => row.quantityMultiple,
+      render: row => row.quantityMultiple == null ? (
+        <span className="text-muted">—</span>
+      ) : (
+        <span className="pill" title="Order quantity should be a multiple of this value.">
+          {row.quantityMultiple.toLocaleString()}
+        </span>
+      ),
+      align: "right",
+    },
+    {
+      key: "packaging",
+      header: "Packaging",
+      accessor: row => row.packaging ?? "",
+      render: row => row.packaging ?? <span className="text-muted">—</span>,
+    },
+    {
+      key: "rohs",
+      header: "RoHS",
+      accessor: row => row.rohsCompliance.map(item => `${item.region}:${item.is_compliant}`).join(" "),
+      render: row => <RohsPills values={row.rohsCompliance} />,
+    },
+  ], []);
+
+  if (!open || !line) return null;
+
+  const totalDistributorCount = new Set(rows.map(row => row.distributor)).size;
+  const stockedDistributorCount = new Set(rows.filter(row => row.stock > 0).map(row => row.distributor)).size;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="bom-distributors-title"
+      tabIndex={-1}
+      ref={dialogRef}
+      onMouseDown={event => {
+        if (event.target === event.currentTarget) onClose();
+      }}
+    >
+      <div className="flex max-h-[90vh] w-full max-w-6xl flex-col rounded border border-border bg-panel shadow-lg">
+        <div className="flex flex-wrap items-start justify-between gap-3 border-b border-border p-4">
+          <div className="min-w-0">
+            <h2 id="bom-distributors-title" className="text-base font-semibold text-text">
+              {line.part_name} — {line.mpn ?? "No MPN"}
+            </h2>
+            <div className="mt-2 flex flex-wrap items-center gap-2">
+              <PoweredByTrustedParts />
+              {statusPills.lifecycle.map(value => (
+                <RiskPill key={`lifecycle:${value}`} label="Lifecycle risk" value={value} icon={<ShieldCheck size={12} aria-hidden="true" />} />
+              ))}
+              {statusPills.supplyChain.map(value => (
+                <RiskPill key={`supply:${value}`} label="Supply-chain risk" value={value} icon={<ShieldAlert size={12} aria-hidden="true" />} />
+              ))}
+              {statusPills.tariffAffected && (
+                <span className="pill inline-flex items-center gap-1 bg-danger/10 text-danger" aria-label="Tariff-affected (US)">
+                  <Info size={12} aria-hidden="true" />
+                  Tariff-affected (US)
+                </span>
+              )}
+            </div>
+          </div>
+          <button type="button" className="btn-ghost btn-sm" aria-label="Close" onClick={onClose} ref={closeButtonRef}>
+            <X size={16} aria-hidden="true" />
+          </button>
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-auto p-4">
+          <DataTable
+            rows={rows}
+            columns={columns}
+            rowKey={row => row.id}
+            tableId="project-sourcing-bom-distributors"
+            exportFilename="sourced-bom-distributors"
+            empty={<div className="text-muted">No distributor offers for this BOM line.</div>}
+          />
+        </div>
+
+        <div className="border-t border-border px-4 py-3 text-sm text-muted">
+          {stockedDistributorCount.toLocaleString()} distributor{stockedDistributorCount === 1 ? "" : "s"} with stock;{" "}
+          {totalDistributorCount.toLocaleString()} total
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/routes/projects/sourcing/ProjectSourcingPage.tsx
+++ b/web/src/routes/projects/sourcing/ProjectSourcingPage.tsx
@@ -12,11 +12,18 @@ import { useWsKey } from "@/lib/queryKeys";
 import { lifecycleRiskTone } from "@/lib/sourcing";
 import AlertFormModal from "@/routes/sourcing/alerts/AlertFormModal";
 import type { Project } from "@/types";
+import { BomDistributorsModal } from "./BomDistributorsModal";
 import PurchasePlanOptionsModal from "./PurchasePlanOptionsModal";
 import type { PurchasePlan, PurchasePlanRequest } from "./purchasePlanTypes";
 import type { SourcingWorkspaceSettings } from "./SourceBomButton";
 
-type SourcingBomOffer = {
+export type SourcingBomPriceBreak = {
+  quantity: number;
+  unit_price: string | number;
+  currency?: string | null;
+};
+
+export type SourcingBomOffer = {
   mpn: string;
   distributor: string;
   sku?: string | null;
@@ -30,14 +37,18 @@ type SourcingBomOffer = {
   packaging?: string | null;
   moq?: number | null;
   lead_time_days?: number | null;
+  price_breaks?: SourcingBomPriceBreak[] | null;
+  price_breaks_converted?: SourcingBomPriceBreak[] | null;
   url?: string | null;
+  availability_text?: string | null;
+  quantity_multiple?: number | null;
   lifecycle_risk?: string | null;
   supply_chain_risk?: string | null;
   is_affected_by_tariff?: boolean | null;
   rohs_compliance?: SourcingRohsCompliance[];
 };
 
-type SourcingRohsCompliance = {
+export type SourcingRohsCompliance = {
   region: string;
   is_compliant: boolean;
   description?: string | null;
@@ -54,7 +65,7 @@ type RiskFlag =
   | "tariff_affected"
   | "rohs_non_compliant";
 
-type SourcingBomLine = {
+export type SourcingBomLine = {
   project_entry_id: string;
   part_id: string;
   part_name: string;
@@ -624,7 +635,8 @@ function CoverageMatrix({ data, currency }: { data: SourcingBomResponse; currenc
   );
 }
 
-function BomRows({ rows }: { rows: SourcingBomLine[] }) {
+function BomRows({ rows, workspaceCurrency }: { rows: SourcingBomLine[]; workspaceCurrency: string | null }) {
+  const [selectedLine, setSelectedLine] = useState<SourcingBomLine | null>(null);
   const columns: Column<SourcingBomLine>[] = [
     { key: "part", header: "Part", accessor: row => row.part_name },
     { key: "mpn", header: "MPN", accessor: row => row.mpn ?? "", render: row => row.mpn ?? "—" },
@@ -646,7 +658,13 @@ function BomRows({ rows }: { rows: SourcingBomLine[] }) {
       header: "Distributor",
       accessor: row => row.best_offer?.distributor ?? "",
       render: row => row.best_offer?.url ? (
-        <a className="text-accent hover:underline" href={row.best_offer.url} target="_blank" rel="noopener noreferrer">
+        <a
+          className="text-accent hover:underline"
+          href={row.best_offer.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={event => event.stopPropagation()}
+        >
           {row.best_offer.distributor}
         </a>
       ) : row.best_offer?.distributor ?? "—",
@@ -726,8 +744,16 @@ function BomRows({ rows }: { rows: SourcingBomLine[] }) {
         rows={rows}
         columns={columns}
         rowKey={row => row.project_entry_id}
+        onRowClick={setSelectedLine}
+        rowCanClick={row => row.offers.length > 0}
         tableId="project-sourcing-bom"
         exportFilename="sourced-bom"
+      />
+      <BomDistributorsModal
+        open={selectedLine !== null}
+        onClose={() => setSelectedLine(null)}
+        line={selectedLine}
+        workspaceCurrency={workspaceCurrency}
       />
     </section>
   );
@@ -1034,7 +1060,7 @@ export default function ProjectSourcingPage() {
         <>
           <CapacityBanner data={query.data} currency={requestBody.currency} />
           <CoverageMatrix data={query.data} currency={requestBody.currency} />
-          <BomRows rows={query.data.rows} />
+          <BomRows rows={query.data.rows} workspaceCurrency={requestBody.currency ?? workspace?.sourcing_currency_code ?? null} />
           <div className="text-xs text-muted">
             {formatCount(query.data.rows.length)} line{query.data.rows.length === 1 ? "" : "s"} fetched from {query.data.powered_by}.
           </div>

--- a/web/src/routes/projects/sourcing/__tests__/BomDistributorsModal.test.tsx
+++ b/web/src/routes/projects/sourcing/__tests__/BomDistributorsModal.test.tsx
@@ -1,0 +1,203 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ComponentProps } from "react";
+import { useState } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { BomDistributorsModal } from "../BomDistributorsModal";
+import type { SourcingBomLine } from "../ProjectSourcingPage";
+
+function line(overrides: Partial<SourcingBomLine> = {}): SourcingBomLine {
+  return {
+    project_entry_id: "entry-1",
+    part_id: "part-1",
+    part_name: "STM32",
+    mpn: "STM32F103C8T6",
+    required: 20,
+    available: 0,
+    substitute_ids: [],
+    substitute_available: 0,
+    short_by: 20,
+    authorized_stock: 150,
+    offers: [
+      {
+        mpn: "STM32F103C8T6",
+        distributor: "DigiKey",
+        sku: "DK-1",
+        stock: 100,
+        unit_price: "2.00",
+        currency: "USD",
+        unit_price_converted: "1.80",
+        currency_displayed: "EUR",
+        fx_converted: true,
+        packaging: "Cut Tape",
+        moq: 1,
+        availability_text: "In Stock",
+        quantity_multiple: 5,
+        price_breaks: [
+          { quantity: 1, unit_price: "2.00" },
+          { quantity: 10, unit_price: "1.50" },
+        ],
+        price_breaks_converted: [
+          { quantity: 1, unit_price: "1.80" },
+          { quantity: 10, unit_price: "1.35" },
+        ],
+        url: "https://www.trustedparts.com/digikey/stm32",
+        lifecycle_risk: "Low",
+        supply_chain_risk: "Moderate",
+        is_affected_by_tariff: true,
+        rohs_compliance: [{ region: "EU", is_compliant: true, description: "Compliant" }],
+      },
+      {
+        mpn: "STM32F103C8T6",
+        distributor: "Mouser",
+        sku: "MO-1",
+        stock: 50,
+        unit_price: "1.70",
+        currency: "EUR",
+        currency_displayed: "EUR",
+        packaging: "Reel",
+        moq: 10,
+        availability_text: "Ships in 12 weeks",
+        quantity_multiple: 1,
+        price_breaks: [{ quantity: 10, unit_price: "1.70" }],
+        url: "https://www.trustedparts.com/mouser/stm32",
+        rohs_compliance: [{ region: "CN", is_compliant: false, description: "Missing" }],
+      },
+    ],
+    best_offer: null,
+    est_extended_cost: "36.00",
+    lead_time_days: null,
+    cache_hit: false,
+    reason: "ok",
+    risk_flags: [],
+    ...overrides,
+  };
+}
+
+function renderModal(props: Partial<ComponentProps<typeof BomDistributorsModal>> = {}) {
+  const onClose = vi.fn();
+  render(
+    <BomDistributorsModal
+      open
+      onClose={onClose}
+      line={line()}
+      workspaceCurrency="EUR"
+      {...props}
+    />,
+  );
+  return { onClose };
+}
+
+beforeEach(() => {
+  cleanup();
+  localStorage.clear();
+});
+
+describe("BomDistributorsModal", () => {
+  it("renders one row per distributor when offers populated", () => {
+    renderModal();
+
+    const dialog = screen.getByRole("dialog", { name: /STM32/ });
+    expect(within(dialog).getByText("DigiKey")).toBeDefined();
+    expect(within(dialog).getByText("Mouser")).toBeDefined();
+    expect(within(dialog).getByText("2 distributors with stock; 2 total")).toBeDefined();
+    expect(within(dialog).getByText("Powered by TrustedParts")).toBeDefined();
+  });
+
+  it("surfaces availability_text per row", () => {
+    renderModal();
+
+    expect(screen.getByText("In Stock")).toBeDefined();
+    expect(screen.getByText("Ships in 12 weeks")).toBeDefined();
+  });
+
+  it("links open in new tab with noopener noreferrer", () => {
+    renderModal();
+
+    const link = screen.getByRole("link", { name: /DigiKey/ });
+    expect(link.getAttribute("href")).toBe("https://www.trustedparts.com/digikey/stm32");
+    expect(link.getAttribute("target")).toBe("_blank");
+    expect(link.getAttribute("rel")).toBe("noopener noreferrer");
+  });
+
+  it("closes on Escape", async () => {
+    const user = userEvent.setup();
+    const { onClose } = renderModal();
+
+    await user.keyboard("{Escape}");
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes on backdrop click", () => {
+    const { onClose } = renderModal();
+
+    fireEvent.mouseDown(screen.getByRole("dialog", { name: /STM32/ }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes on X button click", async () => {
+    const user = userEvent.setup();
+    const { onClose } = renderModal();
+
+    await user.click(screen.getByRole("button", { name: "Close" }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("moves focus into the dialog, traps Tab, and restores focus on close", async () => {
+    const user = userEvent.setup();
+
+    function Harness() {
+      const [open, setOpen] = useState(false);
+      return (
+        <>
+          <button type="button" onClick={() => setOpen(true)}>Open drilldown</button>
+          <a href="/outside">Outside link</a>
+          <BomDistributorsModal
+            open={open}
+            onClose={() => setOpen(false)}
+            line={line()}
+            workspaceCurrency="EUR"
+          />
+        </>
+      );
+    }
+
+    render(<Harness />);
+    const openButton = screen.getByRole("button", { name: "Open drilldown" });
+    await user.click(openButton);
+
+    const dialog = screen.getByRole("dialog", { name: /STM32/ });
+    const closeButton = within(dialog).getByRole("button", { name: "Close" });
+    await waitFor(() => expect(document.activeElement).toBe(closeButton));
+
+    fireEvent.keyDown(window, { key: "Tab", shiftKey: true });
+    expect(dialog.contains(document.activeElement)).toBe(true);
+
+    screen.getByRole("link", { name: "Outside link" }).focus();
+    fireEvent.keyDown(window, { key: "Tab" });
+    expect(dialog.contains(document.activeElement)).toBe(true);
+
+    await user.click(closeButton);
+    await waitFor(() => expect(document.activeElement).toBe(openButton));
+  });
+
+  it("prices use workspace currency formatting", () => {
+    renderModal();
+
+    expect(screen.getByText("1.8 EUR")).toBeDefined();
+    expect(screen.getByText("1+ 1.8 EUR")).toBeDefined();
+    expect(screen.getByText("10+ 1.35 EUR")).toBeDefined();
+    expect(screen.queryByText("2 USD")).toBeNull();
+  });
+
+  it("renders empty-state when offers array is empty", () => {
+    renderModal({ line: line({ offers: [] }) });
+
+    expect(screen.getByText("No distributor offers for this BOM line.")).toBeDefined();
+    expect(screen.getByText("0 distributors with stock; 0 total")).toBeDefined();
+  });
+});

--- a/web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.test.tsx
+++ b/web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.test.tsx
@@ -508,6 +508,66 @@ describe("ProjectSourcingPage", () => {
     expect(screen.getAllByLabelText("Source: TrustedParts").length).toBeGreaterThan(0);
   });
 
+  it("clicking a BOM row with offers opens the BomDistributorsModal", async () => {
+    const user = userEvent.setup();
+    mockReads();
+    const base = sourcingResponse();
+    vi.spyOn(api, "post").mockResolvedValue(sourcingResponse({
+      rows: [
+        {
+          ...base.rows[0],
+          offers: [
+            {
+              ...base.rows[0].offers[0],
+              availability_text: "In Stock",
+              quantity_multiple: 5,
+              price_breaks: [{ quantity: 1, unit_price: "1.25" }],
+              rohs_compliance: [{ region: "EU", is_compliant: true }],
+            },
+          ],
+        },
+      ],
+    }));
+
+    renderPage();
+
+    await screen.findByText("BOM rows");
+    const bomRowsTable = screen.getAllByRole("table")[1];
+    await user.click(within(bomRowsTable).getByRole("row", { name: /Open STM32/ }));
+
+    const dialog = await screen.findByRole("dialog", { name: /STM32 — STM32F103C8T6/ });
+    expect(within(dialog).getByText("In Stock")).toBeDefined();
+    expect(within(dialog).getByText("EU")).toBeDefined();
+  });
+
+  it("clicking an unmatched BOM row does not open the modal", async () => {
+    const user = userEvent.setup();
+    mockReads();
+    const base = sourcingResponse();
+    vi.spyOn(api, "post").mockResolvedValue(sourcingResponse({
+      rows: [
+        {
+          ...base.rows[0],
+          offers: [],
+          best_offer: null,
+          authorized_stock: 0,
+          est_extended_cost: null,
+          lead_time_days: null,
+          reason: "no_offers",
+          risk_flags: [],
+        },
+      ],
+    }));
+
+    renderPage();
+
+    await screen.findByText("BOM rows");
+    const bomRowsTable = screen.getAllByRole("table")[1];
+    await user.click(within(bomRowsTable).getByRole("row", { name: /STM32/ }));
+
+    expect(screen.queryByRole("dialog", { name: /STM32 — STM32F103C8T6/ })).toBeNull();
+  });
+
   it("splits lifecycle, supply-chain, and RoHS out of the legacy risk column", async () => {
     mockReads();
     const base = sourcingResponse();


### PR DESCRIPTION
## Summary
- Adds per-row Project Sourcing BOM drill-down modal that lists each distributor offer with stock, raw availability text, workspace-display prices, price breaks, MOQ, quantity multiple, packaging, RoHS pills, lifecycle/supply-chain/tariff status, and TrustedParts attribution.
- Wires sourced BOM rows to open the modal only when `offers` are present; unmatched/no-offer rows remain inactive.
- Extends `SourcingBomOfferOut` to carry distributor `availability_text` and `quantity_multiple`, populated from the TrustedParts distributor source data.
- Updates API/user docs and changelog for the new response fields and drill-down behavior.

## Tests
- `cd web && npm run typecheck` — passed (`tsc -b`).
- `cd web && npm test -- src/routes/projects/sourcing/__tests__/BomDistributorsModal.test.tsx src/routes/projects/sourcing/__tests__/ProjectSourcingPage.test.tsx` — passed: 2 files, 40 tests.
- `cd web && npm test -- --testNamePattern "BomDistributorsModal|ProjectSourcingPage"` — passed: 2 files, 40 tests, 45 files skipped by name pattern.
- `cd web && npx eslint src/routes/projects/sourcing/BomDistributorsModal.tsx src/routes/projects/sourcing/ProjectSourcingPage.tsx src/routes/projects/sourcing/__tests__/BomDistributorsModal.test.tsx src/routes/projects/sourcing/__tests__/ProjectSourcingPage.test.tsx` — passed.
- `cd backend && uv run python -m pytest -q tests/test_sourcing_bom_route.py` — passed: 31 tests, 2 existing deprecation warnings.
- `cd backend && uv run ruff check app/domain/sourcing/schemas.py app/domain/sourcing/service.py tests/test_sourcing_bom_route.py` — passed.
- `git diff --check` and `git diff --cached --check` — passed.

Validation note: the issue's literal `cd web && npm test -- "BomDistributorsModal|ProjectSourcingPage"` command was attempted, but Vitest treated the quoted pipe string as a file filter and returned `No test files found`; the path-targeted and test-name targeted equivalents above passed.

## Screenshots
Not captured in this worktree; the modal behavior is covered by jsdom interaction tests.

## Merge Order
After #472 if #472 lands first, otherwise #472 must rebase on #470. This branch was rebased on current `origin/main` before push.

Refs #470
