### PR TITLE
SX-5: Two coverage variants (lowest-price + fewest-distributors)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ the canonical record.
 - **SX-6 / #473** Project Sourcing BOM coverage now keeps TanStack Query
   display data warm for instant remounts and shows a non-blocking background
   refresh hint instead of a skeleton during refetches.
+- **SX-5 / #472** Project Sourcing coverage now shows lowest-price and
+  fewest-distributor combination cards above the per-distributor matrix.
 - **SX-4 / #471** Project Sourcing capacity now separates total BOM cost
   from the short-quantity price to pay, with `est_purchase_cost` retained as
   a deprecated alias.

--- a/backend/app/domain/sourcing/coverage.py
+++ b/backend/app/domain/sourcing/coverage.py
@@ -5,12 +5,15 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from decimal import Decimal
 from itertools import combinations
+from math import ceil
 from uuid import UUID
 
+from app.domain.sourcing.optimizer import optimize
 from app.domain.sourcing.pricing import best_unit_price_at_qty
 from app.domain.sourcing.schemas import SourcingBomLineOut, SourcingBomOfferOut
 
 EXHAUSTIVE_COMBO_DISTRIBUTOR_LIMIT = 30
+FEWEST_DISTRIBUTORS_EXHAUSTIVE_LIMIT = 10
 
 
 @dataclass(frozen=True)
@@ -29,6 +32,11 @@ class DistributorCoverageMatrix:
     total_lines: int
     best_single_distributor: str | None
     best_two_distributor_combo: tuple[str, str] | None
+    lowest_total_price_combo: list[str]
+    lowest_total_price_total: Decimal | None
+    fewest_distributors_combo: list[str]
+    fewest_distributors_total: Decimal | None
+    target_coverage_pct: float
 
 
 @dataclass(frozen=True)
@@ -208,6 +216,7 @@ def compute_coverage(
     bom_rows: list[SourcingBomLineOut],
     *,
     preferred_distributors: list[str] | None = None,
+    target_coverage_pct: float = 1.0,
 ) -> DistributorCoverageMatrix:
     """Compute per-distributor BOM line coverage.
 
@@ -215,6 +224,9 @@ def compute_coverage(
     Above that threshold it uses the documented greedy fallback: pick the
     distributor covering the most lines, then the distributor covering the most
     remaining uncovered lines.
+
+    The fewest-distributors variant uses exhaustive set search up to 10
+    distributors, then a deterministic greedy set-cover fallback.
     """
     total_lines = len(bom_rows)
     if total_lines == 0:
@@ -223,6 +235,11 @@ def compute_coverage(
             total_lines=0,
             best_single_distributor=None,
             best_two_distributor_combo=None,
+            lowest_total_price_combo=[],
+            lowest_total_price_total=None,
+            fewest_distributors_combo=[],
+            fewest_distributors_total=None,
+            target_coverage_pct=target_coverage_pct,
         )
 
     offers_by_distributor: dict[str, list[SourcingBomOfferOut]] = {}
@@ -283,13 +300,171 @@ def compute_coverage(
         preferred_rank=preferred_rank,
         total_lines=total_lines,
     )
+    lowest_price = _lowest_total_price_variant(bom_rows)
+    fewest = _fewest_distributors_variant(
+        rows,
+        bom_rows=bom_rows,
+        covered_by_distributor=covered_by_distributor,
+        target_coverage_pct=target_coverage_pct,
+    )
 
     return DistributorCoverageMatrix(
         rows=rows,
         total_lines=total_lines,
         best_single_distributor=best_single,
         best_two_distributor_combo=best_two,
+        lowest_total_price_combo=lowest_price[0],
+        lowest_total_price_total=lowest_price[1],
+        fewest_distributors_combo=fewest[0],
+        fewest_distributors_total=fewest[1],
+        target_coverage_pct=target_coverage_pct,
     )
+
+
+def _lowest_total_price_variant(
+    bom_rows: list[SourcingBomLineOut],
+) -> tuple[list[str], Decimal | None]:
+    outcome = optimize(bom_rows, strategy="lowest_total_price")
+    return outcome.distributors_used, outcome.est_total_cost
+
+
+def _fewest_distributors_variant(
+    rows: list[DistributorCoverageRow],
+    *,
+    bom_rows: list[SourcingBomLineOut],
+    covered_by_distributor: dict[str, set[UUID]],
+    target_coverage_pct: float,
+) -> tuple[list[str], Decimal | None]:
+    keys = [row.distributor.casefold() for row in rows]
+    if not keys or not bom_rows:
+        return [], None
+
+    coverable_lines = set().union(*covered_by_distributor.values())
+    target_count = min(ceil(len(bom_rows) * target_coverage_pct), len(coverable_lines))
+    if target_count <= 0:
+        return [], None
+
+    rows_by_key = {row.distributor.casefold(): row for row in rows}
+    if len(keys) <= FEWEST_DISTRIBUTORS_EXHAUSTIVE_LIMIT:
+        best = _fewest_exhaustive_combo(
+            keys,
+            bom_rows=bom_rows,
+            covered_by_distributor=covered_by_distributor,
+            rows_by_key=rows_by_key,
+            target_count=target_count,
+        )
+    else:
+        best = _fewest_greedy_combo(
+            keys,
+            bom_rows=bom_rows,
+            covered_by_distributor=covered_by_distributor,
+            rows_by_key=rows_by_key,
+            target_count=target_count,
+        )
+    if not best:
+        return [], None
+
+    names = sorted((rows_by_key[key].distributor for key in best), key=str.casefold)
+    return names, _combo_total_cost(best, bom_rows)
+
+
+def _fewest_exhaustive_combo(
+    keys: list[str],
+    *,
+    bom_rows: list[SourcingBomLineOut],
+    covered_by_distributor: dict[str, set[UUID]],
+    rows_by_key: dict[str, DistributorCoverageRow],
+    target_count: int,
+) -> tuple[str, ...]:
+    for size in range(1, len(keys) + 1):
+        matching = [
+            combo
+            for combo in combinations(keys, size)
+            if len(_combo_covered(combo, covered_by_distributor)) >= target_count
+        ]
+        if matching:
+            return min(
+                matching,
+                key=lambda combo: _combo_sort_key(combo, bom_rows, rows_by_key),
+            )
+    return ()
+
+
+def _fewest_greedy_combo(
+    keys: list[str],
+    *,
+    bom_rows: list[SourcingBomLineOut],
+    covered_by_distributor: dict[str, set[UUID]],
+    rows_by_key: dict[str, DistributorCoverageRow],
+    target_count: int,
+) -> tuple[str, ...]:
+    selected: list[str] = []
+    uncovered = set().union(*covered_by_distributor.values())
+    while len(_combo_covered(tuple(selected), covered_by_distributor)) < target_count:
+        remaining = [key for key in keys if key not in selected]
+        if not remaining:
+            break
+        next_key = min(
+            remaining,
+            key=lambda key: (
+                -len(covered_by_distributor[key] & uncovered),
+                _price_sort_value(_combo_total_cost(tuple([*selected, key]), bom_rows)),
+                rows_by_key[key].distributor.casefold(),
+            ),
+        )
+        if not (covered_by_distributor[next_key] & uncovered):
+            break
+        selected.append(next_key)
+        uncovered -= covered_by_distributor[next_key]
+    return tuple(selected)
+
+
+def _combo_sort_key(
+    combo: tuple[str, ...],
+    bom_rows: list[SourcingBomLineOut],
+    rows_by_key: dict[str, DistributorCoverageRow],
+) -> tuple[Decimal, tuple[str, ...]]:
+    return (
+        _price_sort_value(_combo_total_cost(combo, bom_rows)),
+        tuple(sorted((rows_by_key[key].distributor.casefold() for key in combo))),
+    )
+
+
+def _combo_covered(
+    combo: tuple[str, ...],
+    covered_by_distributor: dict[str, set[UUID]],
+) -> set[UUID]:
+    covered: set[UUID] = set()
+    for key in combo:
+        covered |= covered_by_distributor[key]
+    return covered
+
+
+def _combo_total_cost(
+    combo: tuple[str, ...],
+    bom_rows: list[SourcingBomLineOut],
+) -> Decimal | None:
+    running = Decimal("0")
+    has_priced_line = False
+    combo_keys = set(combo)
+    for line in bom_rows:
+        offers = [
+            offer
+            for key in combo_keys
+            if (offer := _best_covering_offer(key, line)) is not None
+        ]
+        if not offers:
+            continue
+        costs = [
+            _offer_extended_cost(offer, _selected_qty(line.short_by, offer.moq))
+            for offer in offers
+        ]
+        priced_costs = [cost for cost in costs if cost is not None]
+        if not priced_costs:
+            return None
+        running += min(priced_costs)
+        has_priced_line = True
+    return running if has_priced_line else None
 
 
 def _supported_builds(
@@ -310,7 +485,8 @@ def _best_covering_offer(
     candidates = [
         offer
         for offer in line.offers
-        if offer.distributor.casefold() == distributor_key and offer.stock >= line.short_by
+        if offer.distributor.casefold() == distributor_key
+        and offer.stock >= _selected_qty(line.short_by, offer.moq)
     ]
     if not candidates:
         return None
@@ -325,6 +501,8 @@ def _best_covering_offer(
 
 
 def _offer_extended_cost(offer: SourcingBomOfferOut, qty: int) -> Decimal | None:
+    if qty <= 0:
+        return Decimal("0")
     unit_price = _offer_unit_price(offer, qty)
     if unit_price is None:
         return None
@@ -332,10 +510,17 @@ def _offer_extended_cost(offer: SourcingBomOfferOut, qty: int) -> Decimal | None
 
 
 def _offer_unit_price(offer: SourcingBomOfferOut, qty: int) -> Decimal | None:
-    best = best_unit_price_at_qty(offer.price_breaks, qty)
+    price_breaks = offer.price_breaks_converted or offer.price_breaks
+    best = best_unit_price_at_qty(price_breaks, qty)
     if best is not None:
         return best[0]
-    return offer.unit_price
+    return offer.unit_price_converted or offer.unit_price
+
+
+def _selected_qty(short_by: int, moq: int | None) -> int:
+    if short_by <= 0:
+        return 0
+    return max(short_by, int(moq or 1))
 
 
 def _best_two_distributors(

--- a/backend/app/domain/sourcing/schemas.py
+++ b/backend/app/domain/sourcing/schemas.py
@@ -377,6 +377,11 @@ class DistributorCoverageMatrixOut(BaseModel):
     total_lines: int
     best_single_distributor: str | None
     best_two_distributor_combo: tuple[str, str] | None
+    lowest_total_price_combo: list[str]
+    lowest_total_price_total: Decimal | None
+    fewest_distributors_combo: list[str]
+    fewest_distributors_total: Decimal | None
+    target_coverage_pct: float
 
 
 class BuildCapacityOut(BaseModel):

--- a/backend/tests/test_sourcing_coverage.py
+++ b/backend/tests/test_sourcing_coverage.py
@@ -22,6 +22,7 @@ def _offer(
     mpn: str = "MPN",
     stock: int = 10,
     unit_price: str = "1.00",
+    moq: int | None = None,
     lead_time_days: int | None = 3,
     price_breaks: list[tuple[int, str]] | None = None,
 ) -> SourcingBomOfferOut:
@@ -30,6 +31,7 @@ def _offer(
         distributor=distributor,
         stock=stock,
         unit_price=Decimal(unit_price),
+        moq=moq,
         lead_time_days=lead_time_days,
         price_breaks=[
             SourcingBomPriceBreakOut(quantity=quantity, unit_price=Decimal(price))
@@ -59,6 +61,11 @@ def test_empty_bom_returns_empty_matrix():
     assert matrix.rows == []
     assert matrix.best_single_distributor is None
     assert matrix.best_two_distributor_combo is None
+    assert matrix.lowest_total_price_combo == []
+    assert matrix.lowest_total_price_total is None
+    assert matrix.fewest_distributors_combo == []
+    assert matrix.fewest_distributors_total is None
+    assert matrix.target_coverage_pct == 1.0
 
 
 def test_single_distributor_covers_all():
@@ -84,6 +91,8 @@ def test_single_distributor_covers_all():
     assert matrix.rows[0].coverage_pct == 1
     assert matrix.rows[0].est_total_cost == Decimal("22.50")
     assert matrix.rows[0].worst_lead_time_days == 8
+    assert matrix.fewest_distributors_combo == ["DigiKey"]
+    assert matrix.fewest_distributors_total == Decimal("22.50")
 
 
 def test_two_distributors_needed_finds_optimal_pair():
@@ -177,3 +186,127 @@ def test_decimal_serialisation():
 
     assert payload["rows"][0]["est_total_cost"] == "6.25"
     assert isinstance(payload["rows"][0]["est_total_cost"], str)
+    assert payload["lowest_total_price_total"] == "6.25"
+    assert payload["fewest_distributors_total"] == "6.25"
+
+
+def test_lowest_total_price_combo_uses_optimizer_selections():
+    matrix = compute_coverage(
+        [
+            _line(
+                1,
+                offers=[
+                    _offer("OneStop", unit_price="9.00"),
+                    _offer("Alpha", unit_price="1.00"),
+                ],
+            ),
+            _line(
+                2,
+                offers=[
+                    _offer("OneStop", unit_price="9.00"),
+                    _offer("Beta", unit_price="2.00"),
+                ],
+            ),
+            _line(
+                3,
+                offers=[
+                    _offer("OneStop", unit_price="9.00"),
+                    _offer("Gamma", unit_price="3.00"),
+                ],
+            ),
+        ]
+    )
+
+    assert matrix.lowest_total_price_combo == ["Alpha", "Beta", "Gamma"]
+    assert matrix.lowest_total_price_total == Decimal("30.00")
+    assert matrix.fewest_distributors_combo == ["OneStop"]
+    assert matrix.fewest_distributors_total == Decimal("135.00")
+
+
+def test_fewest_distributors_combo_returns_minimum_set():
+    matrix = compute_coverage(
+        [
+            _line(1, offers=[_offer("Single", unit_price="5.00"), _offer("Alpha")]),
+            _line(2, offers=[_offer("Single", unit_price="5.00"), _offer("Beta")]),
+            _line(3, offers=[_offer("Single", unit_price="5.00"), _offer("Gamma")]),
+        ]
+    )
+
+    assert matrix.fewest_distributors_combo == ["Single"]
+    assert matrix.fewest_distributors_total == Decimal("75.00")
+
+
+def test_fewest_distributors_combo_with_two_distributors_needed():
+    matrix = compute_coverage(
+        [
+            _line(1, offers=[_offer("Alpha")]),
+            _line(2, offers=[_offer("Alpha"), _offer("Beta")]),
+            _line(3, offers=[_offer("Beta")]),
+        ]
+    )
+
+    assert matrix.fewest_distributors_combo == ["Alpha", "Beta"]
+    assert matrix.fewest_distributors_total == Decimal("15.00")
+
+
+def test_fewest_distributors_combo_tiebreak_by_total_cost():
+    matrix = compute_coverage(
+        [
+            _line(
+                1,
+                offers=[
+                    _offer("Alpha", unit_price="1.00"),
+                    _offer("Gamma", unit_price="9.00"),
+                ],
+            ),
+            _line(
+                2,
+                offers=[
+                    _offer("Beta", unit_price="1.00"),
+                    _offer("Delta", unit_price="9.00"),
+                ],
+            ),
+        ]
+    )
+
+    assert matrix.fewest_distributors_combo == ["Alpha", "Beta"]
+    assert matrix.fewest_distributors_total == Decimal("10.00")
+
+
+def test_fewest_distributors_respects_moq_stock_and_totals_selected_qty():
+    matrix = compute_coverage(
+        [
+            _line(
+                1,
+                short_by=10,
+                offers=[
+                    _offer("BulkOnly", stock=50, unit_price="1.00", moq=100),
+                    _offer("EnoughBulk", stock=100, unit_price="1.00", moq=100),
+                    _offer("Eaches", stock=10, unit_price="20.00"),
+                ],
+            )
+        ]
+    )
+
+    assert "BulkOnly" not in [row.distributor for row in matrix.rows if row.lines_covered]
+    assert matrix.fewest_distributors_combo == ["EnoughBulk"]
+    assert matrix.fewest_distributors_total == Decimal("100.00")
+
+
+def test_greedy_threshold_30_distributors_near_optimal():
+    rows = [
+        _line(
+            index,
+            offers=[
+                _offer("D00", unit_price="2.00"),
+                _offer(f"D{index:02d}", unit_price="1.00"),
+            ],
+        )
+        for index in range(1, 31)
+    ]
+
+    matrix = compute_coverage(rows)
+
+    assert len(matrix.rows) == 31
+    assert matrix.fewest_distributors_combo == ["D00"]
+    assert matrix.fewest_distributors_total == Decimal("300.00")

--- a/docs/api/sourcing.md
+++ b/docs/api/sourcing.md
@@ -221,7 +221,12 @@ Path: `project_id` is a project UUID in the current workspace.
       "rows": [],
       "total_lines": 1,
       "best_single_distributor": null,
-      "best_two_distributor_combo": null
+      "best_two_distributor_combo": null,
+      "lowest_total_price_combo": ["Mouser"],
+      "lowest_total_price_total": "2.00",
+      "fewest_distributors_combo": ["Mouser"],
+      "fewest_distributors_total": "2.00",
+      "target_coverage_pct": 1.0
     },
     "capacity": {
       "can_build_now": 0,
@@ -274,12 +279,14 @@ Sources: `backend/app/domain/sourcing/service.py:1322-1386`,
 - Decimal prices and extended costs serialize as strings.
 - `capacity.total_bom_cost` sums `required * best_offer.unit_price` for priced rows and ignores on-hand stock. `capacity.purchase_to_pay_cost` sums `short_by * best_offer.unit_price` for priced rows that are not blocking after authorized supply. `capacity.est_purchase_cost` is a deprecated alias of `purchase_to_pay_cost` for one release.
 - Capacity totals use converted/display prices when available and skip rows whose displayed currency does not match the selected total currency, so mixed native currencies are not added together.
+- `coverage.lowest_total_price_combo` and `coverage.lowest_total_price_total` come from the optimizer's `lowest_total_price` per-line selections. `coverage.fewest_distributors_combo` and `coverage.fewest_distributors_total` choose the smallest distributor set that reaches `target_coverage_pct`; the implementation is exhaustive up to 10 distributors and greedy beyond that threshold.
 - When `currency` is supplied, BOM offer prices whose native distributor currency differs are display-converted through the global ECB daily snapshot. Native `unit_price` and `currency` stay unchanged; converted display values are exposed as `unit_price_converted`, `currency_displayed`, `fx_converted`, `fx_rate_date`, and `price_breaks_converted`.
 - Each row exposes sourcing diagnostics: `reason` is `ok`, `no_mpn`, or `no_offers`; `cache_hit` is `true`/`false` for searched rows and `null` when no MPN was searched; row `fx_status` is `unavailable` when any offer on the row could not be converted. Top-level `fx_status` is `ok`, `partial`, or `unavailable` when a request currency was supplied and `null` when conversion was not requested.
 - BOM offer projections carry offer-level TrustedParts gap fields for downstream risk/report consumers; distributor-level gap fields remain on part/search offer DTOs.
 - Source: `backend/app/api/routes/sourcing.py:253-315`.
 - Service: `backend/app/domain/sourcing/service.py:820-898`, `backend/app/domain/sourcing/service.py:1236-1270`.
 - Capacity: `backend/app/domain/sourcing/coverage.py:45-120`, `backend/app/domain/sourcing/schemas.py:382-407`.
+- Coverage variants: `backend/app/domain/sourcing/coverage.py:216-464`, `backend/app/domain/sourcing/schemas.py:373-384`.
 - Pricing: `backend/app/domain/sourcing/pricing.py:9-40`.
 
 ### `POST /api/projects/{project_id}/purchase-plan`

--- a/docs/domain/sourcing.md
+++ b/docs/domain/sourcing.md
@@ -84,6 +84,19 @@ Sources: `backend/app/domain/sourcing/coverage.py:45-120`,
 `backend/app/domain/sourcing/coverage.py:123-196`,
 `backend/app/domain/sourcing/schemas.py:382-407`
 
+## Coverage Variants
+
+Project BOM coverage returns two combination summaries above the per-distributor
+matrix: `lowest_total_price_combo` reuses the purchase-plan optimizer's
+`lowest_total_price` strategy, while `fewest_distributors_combo` finds the smallest
+distributor set that reaches the target coverage. The fewest-distributors search is
+exhaustive through 10 distributors, then switches to a deterministic greedy set-cover
+heuristic that picks the distributor covering the most remaining lines and breaks ties
+by combo cost and distributor name.
+
+Sources: `backend/app/domain/sourcing/coverage.py:216-464`,
+`backend/app/domain/sourcing/optimizer.py:69-93`
+
 ## BOM Risk Flags
 
 Project sourcing keeps the five original BOM risk flags in order, then appends

--- a/web/src/routes/projects/sourcing/ProjectSourcingPage.tsx
+++ b/web/src/routes/projects/sourcing/ProjectSourcingPage.tsx
@@ -91,6 +91,11 @@ type SourcingBomResponse = {
     total_lines: number;
     best_single_distributor?: string | null;
     best_two_distributor_combo?: [string, string] | null;
+    lowest_total_price_combo: string[];
+    lowest_total_price_total?: string | number | null;
+    fewest_distributors_combo: string[];
+    fewest_distributors_total?: string | number | null;
+    target_coverage_pct: number;
   };
   capacity: {
     can_build_now: number;
@@ -457,9 +462,103 @@ function CapacityBanner({ data, currency }: { data: SourcingBomResponse; currenc
   );
 }
 
-function CoverageMatrix({ data }: { data: SourcingBomResponse }) {
+type CoverageVariant = {
+  labels: string[];
+  combo: string[];
+  total?: string | number | null;
+};
+
+function normalizedCombo(combo: string[]): string[] {
+  return [...combo].sort((a, b) => a.localeCompare(b, undefined, { sensitivity: "base" }));
+}
+
+function sameCombo(left: string[], right: string[]): boolean {
+  const leftSorted = normalizedCombo(left);
+  const rightSorted = normalizedCombo(right);
+  return leftSorted.length === rightSorted.length && leftSorted.every((item, index) => item === rightSorted[index]);
+}
+
+function coverageForCombo(data: SourcingBomResponse, combo: string[]): { pct: number | null; shortLines: number | null } {
+  if (combo.length === 0 || data.coverage.total_lines === 0) return { pct: null, shortLines: null };
+  const comboSet = new Set(combo.map(item => item.toLocaleLowerCase()));
+  const uncovered = new Set<string>();
+  for (const row of data.coverage.rows) {
+    if (!comboSet.has(row.distributor.toLocaleLowerCase())) continue;
+    for (const lineId of row.lines_uncovered) uncovered.add(lineId);
+  }
+  const totalLineIds = new Set(data.rows.map(row => row.project_entry_id));
+  for (const row of data.rows) {
+    if (!uncovered.has(row.project_entry_id)) continue;
+    const coveredByCombo = data.coverage.rows.some(coverageRow =>
+      comboSet.has(coverageRow.distributor.toLocaleLowerCase()) &&
+      !coverageRow.lines_uncovered.includes(row.project_entry_id),
+    );
+    if (coveredByCombo) uncovered.delete(row.project_entry_id);
+  }
+  const shortLines = [...totalLineIds].filter(lineId => uncovered.has(lineId)).length;
+  return {
+    pct: (data.coverage.total_lines - shortLines) / data.coverage.total_lines,
+    shortLines,
+  };
+}
+
+function CoverageVariantCard({
+  data,
+  variant,
+  currency,
+}: {
+  data: SourcingBomResponse;
+  variant: CoverageVariant;
+  currency?: string | null;
+}) {
+  const { pct, shortLines } = coverageForCombo(data, variant.combo);
+  const comboText = variant.combo.length > 0 ? normalizedCombo(variant.combo).join(" + ") : "—";
+  const coverageText = pct == null ? "—" : `${Math.round(pct * 100)}%`;
+  const shortText = shortLines && shortLines > 0
+    ? ` (${shortLines.toLocaleString()} line${shortLines === 1 ? "" : "s"} short)`
+    : "";
+
+  return (
+    <div className="card p-4 space-y-3">
+      <div className="flex flex-wrap gap-2">
+        {variant.labels.map(label => (
+          <span key={label} className="pill bg-accent/15 text-accent">{label}</span>
+        ))}
+      </div>
+      <div className="text-lg font-semibold leading-snug">{comboText}</div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-sm">
+        <div>
+          <div className="section-title">Price</div>
+          <div className="font-mono tabular-nums">{formatMoney(variant.total, currency)}</div>
+        </div>
+        <div>
+          <div className="section-title">Coverage</div>
+          <div className="font-mono tabular-nums">{coverageText}{shortText}</div>
+        </div>
+      </div>
+      {variant.combo.length === 0 && (
+        <div className="text-xs text-muted">No priced distributor combination is available for these BOM lines.</div>
+      )}
+    </div>
+  );
+}
+
+function CoverageMatrix({ data, currency }: { data: SourcingBomResponse; currency?: string | null }) {
   const bestSingle = data.coverage.best_single_distributor;
   const bestTwo: string[] = data.coverage.best_two_distributor_combo ?? [];
+  const lowestPrice: CoverageVariant = {
+    labels: ["Lowest total price"],
+    combo: data.coverage.lowest_total_price_combo ?? [],
+    total: data.coverage.lowest_total_price_total,
+  };
+  const fewest: CoverageVariant = {
+    labels: ["Fewest distributors"],
+    combo: data.coverage.fewest_distributors_combo ?? [],
+    total: data.coverage.fewest_distributors_total,
+  };
+  const variants = sameCombo(lowestPrice.combo, fewest.combo)
+    ? [{ ...lowestPrice, labels: [...lowestPrice.labels, ...fewest.labels] }]
+    : [lowestPrice, fewest];
   const columns: Column<CoverageRow>[] = [
     {
       key: "distributor",
@@ -485,7 +584,7 @@ function CoverageMatrix({ data }: { data: SourcingBomResponse }) {
       key: "cost",
       header: "Est. total cost",
       accessor: row => numberOrNull(row.est_total_cost),
-      render: row => formatMoney(row.est_total_cost),
+      render: row => formatMoney(row.est_total_cost, currency),
       align: "right",
     },
     {
@@ -500,6 +599,19 @@ function CoverageMatrix({ data }: { data: SourcingBomResponse }) {
   return (
     <section className="space-y-2">
       <h2 className="text-md font-semibold">Coverage matrix</h2>
+      <div className={`grid grid-cols-1 ${variants.length > 1 ? "lg:grid-cols-2" : ""} gap-3`}>
+        {variants.map(variant => (
+          <CoverageVariantCard
+            key={variant.labels.join("-")}
+            data={data}
+            variant={variant}
+            currency={currency}
+          />
+        ))}
+      </div>
+      <div className="text-xs text-muted">
+        Coverage is the primary criterion; the two variants above optimize for cost vs. simplicity within full-coverage solutions.
+      </div>
       <DataTable
         rows={data.coverage.rows}
         columns={columns}
@@ -921,7 +1033,7 @@ export default function ProjectSourcingPage() {
       {query.data && hasRows && (
         <>
           <CapacityBanner data={query.data} currency={requestBody.currency} />
-          <CoverageMatrix data={query.data} />
+          <CoverageMatrix data={query.data} currency={requestBody.currency} />
           <BomRows rows={query.data.rows} />
           <div className="text-xs text-muted">
             {formatCount(query.data.rows.length)} line{query.data.rows.length === 1 ? "" : "s"} fetched from {query.data.powered_by}.

--- a/web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.test.tsx
+++ b/web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.test.tsx
@@ -146,6 +146,11 @@ function sourcingResponse(overrides: Record<string, unknown> = {}) {
       total_lines: 2,
       best_single_distributor: "DigiKey",
       best_two_distributor_combo: ["DigiKey", "Mouser"],
+      lowest_total_price_combo: ["DigiKey", "Mouser"],
+      lowest_total_price_total: "25.00",
+      fewest_distributors_combo: ["DigiKey", "Mouser"],
+      fewest_distributors_total: "25.00",
+      target_coverage_pct: 1,
     },
     capacity: {
       can_build_now: 0,
@@ -325,7 +330,7 @@ describe("ProjectSourcingPage", () => {
     renderPage();
 
     expect(await screen.findByText("Price to pay:")).toBeDefined();
-    expect(screen.getByText("25 USD")).toBeDefined();
+    expect(screen.getAllByText("25 USD").length).toBeGreaterThan(0);
     expect(screen.getByText("short qty only, excluding blocking lines")).toBeDefined();
   });
 
@@ -418,6 +423,77 @@ describe("ProjectSourcingPage", () => {
     expect(screen.queryByRole("status", { name: "Loading sourced BOM" })).toBeNull();
 
     filteredLoad.resolve(sourcingResponse());
+  });
+
+  it("Coverage card renders Lowest total price variant with distributor names + total", async () => {
+    mockReads();
+    vi.spyOn(api, "post").mockResolvedValue(sourcingResponse({
+      coverage: {
+        ...sourcingResponse().coverage,
+        rows: [
+          ...sourcingResponse().coverage.rows,
+          {
+            distributor: "Arrow",
+            lines_covered: 2,
+            lines_uncovered: [],
+            coverage_pct: 1,
+            est_total_cost: "40.00",
+            worst_lead_time_days: 5,
+          },
+        ],
+        lowest_total_price_combo: ["DigiKey", "Mouser"],
+        lowest_total_price_total: "25.00",
+        fewest_distributors_combo: ["Arrow"],
+        fewest_distributors_total: "40.00",
+      },
+    }));
+
+    renderPage();
+
+    expect(await screen.findByText("Lowest total price")).toBeDefined();
+    expect(screen.getByText("DigiKey + Mouser")).toBeDefined();
+    expect(screen.getAllByText("25 USD").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("100%").length).toBeGreaterThan(0);
+  });
+
+  it("Coverage card renders Fewest distributors variant", async () => {
+    mockReads();
+    vi.spyOn(api, "post").mockResolvedValue(sourcingResponse({
+      coverage: {
+        ...sourcingResponse().coverage,
+        rows: [
+          ...sourcingResponse().coverage.rows,
+          {
+            distributor: "Arrow",
+            lines_covered: 2,
+            lines_uncovered: [],
+            coverage_pct: 1,
+            est_total_cost: "40.00",
+            worst_lead_time_days: 5,
+          },
+        ],
+        lowest_total_price_combo: ["DigiKey", "Mouser"],
+        lowest_total_price_total: "25.00",
+        fewest_distributors_combo: ["Arrow"],
+        fewest_distributors_total: "40.00",
+      },
+    }));
+
+    renderPage();
+
+    expect(await screen.findByText("Fewest distributors")).toBeDefined();
+    expect(screen.getAllByText("40 USD").length).toBeGreaterThan(0);
+  });
+
+  it("When both variants are the same set, only one card renders with both labels", async () => {
+    mockReads();
+    vi.spyOn(api, "post").mockResolvedValue(sourcingResponse());
+
+    renderPage();
+
+    expect(await screen.findByText("Lowest total price")).toBeDefined();
+    expect(screen.getByText("Fewest distributors")).toBeDefined();
+    expect(screen.getAllByText("DigiKey + Mouser")).toHaveLength(1);
   });
 
   it("renders risk pills for each flag returned", async () => {


### PR DESCRIPTION
## Summary
- Adds coverage response fields for lowest-price and fewest-distributor combinations, including Decimal totals and target coverage.
- Reuses the sourcing optimizer for lowest-price selections and adds coverage-local fewest-distributor selection with exhaustive search through 10 distributors, then deterministic greedy selection above that.
- Updates Project Sourcing to show named coverage variant cards above the existing per-distributor matrix, with merged display when both variants choose the same distributor set.
- Documents the new fields/design in sourcing API/domain docs and CHANGELOG.

## Tests
- `cd backend && .venv/bin/pytest -q -k "sourcing_coverage"` → 12 passed, 1193 deselected, 1 Alembic deprecation warning.
- `cd backend && .venv/bin/ruff check app/domain/sourcing/coverage.py app/domain/sourcing/schemas.py tests/test_sourcing_coverage.py` → all checks passed.
- `cd web && npm run typecheck` → passed.
- `cd web && npm test -- "ProjectSourcingPage"` → 33 passed.
- `cd web && npx eslint src/routes/projects/sourcing/ProjectSourcingPage.tsx src/routes/projects/sourcing/__tests__/ProjectSourcingPage.test.tsx` → passed.
- `git diff --check` → passed.

Note: `cd web && npm run lint -- src/routes/projects/sourcing/ProjectSourcingPage.tsx src/routes/projects/sourcing/__tests__/ProjectSourcingPage.test.tsx` still prepends `src` from the package script and fails on pre-existing baseline issues in unrelated files (`bagCode.ts`, scanner/routes warnings), so targeted ESLint was run directly with `npx eslint` for touched frontend files.

## Merge Order
After #476/#471, before #470/#473 unless those PRs rebase on this coverage card.

Refs #472
