### PR TITLE
SX-5: Preserve legacy coverage semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ the canonical record.
 
 ## 2026-05 — feedback brief fixes
 
+- **SX-5 / #480** Project Sourcing keeps the legacy distributor coverage matrix
+  shortfall-based while the fewest-distributors variant continues to apply MOQ
+  selected quantities for feasibility and totals.
 - **SX-6 / #473** Project Sourcing BOM coverage now keeps TanStack Query
   display data warm for instant remounts and shows a non-blocking background
   refresh hint instead of a skeleton during refetches.

--- a/backend/app/domain/sourcing/coverage.py
+++ b/backend/app/domain/sourcing/coverage.py
@@ -280,6 +280,15 @@ def compute_coverage(
         row_costs[key] = total_cost
         row_lead_times[key] = worst_lead_time
 
+    purchaseable_by_distributor = {
+        key: {
+            line.project_entry_id
+            for line in bom_rows
+            if _best_purchaseable_offer(key, line) is not None
+        }
+        for key in offers_by_distributor
+    }
+
     rows = [
         DistributorCoverageRow(
             distributor=display_names[key],
@@ -304,7 +313,7 @@ def compute_coverage(
     fewest = _fewest_distributors_variant(
         rows,
         bom_rows=bom_rows,
-        covered_by_distributor=covered_by_distributor,
+        covered_by_distributor=purchaseable_by_distributor,
         target_coverage_pct=target_coverage_pct,
     )
 
@@ -451,7 +460,7 @@ def _combo_total_cost(
         offers = [
             offer
             for key in combo_keys
-            if (offer := _best_covering_offer(key, line)) is not None
+            if (offer := _best_purchaseable_offer(key, line)) is not None
         ]
         if not offers:
             continue
@@ -482,18 +491,42 @@ def _best_covering_offer(
     distributor_key: str,
     line: SourcingBomLineOut,
 ) -> SourcingBomOfferOut | None:
+    return _best_offer_for_quantity(
+        distributor_key,
+        line,
+        quantity_for_offer=lambda _offer: line.short_by,
+    )
+
+
+def _best_purchaseable_offer(
+    distributor_key: str,
+    line: SourcingBomLineOut,
+) -> SourcingBomOfferOut | None:
+    return _best_offer_for_quantity(
+        distributor_key,
+        line,
+        quantity_for_offer=lambda offer: _selected_qty(line.short_by, offer.moq),
+    )
+
+
+def _best_offer_for_quantity(
+    distributor_key: str,
+    line: SourcingBomLineOut,
+    *,
+    quantity_for_offer: Callable[[SourcingBomOfferOut], int],
+) -> SourcingBomOfferOut | None:
     candidates = [
         offer
         for offer in line.offers
         if offer.distributor.casefold() == distributor_key
-        and offer.stock >= _selected_qty(line.short_by, offer.moq)
+        and offer.stock >= quantity_for_offer(offer)
     ]
     if not candidates:
         return None
     return min(
         candidates,
         key=lambda offer: (
-            _price_sort_value(_offer_unit_price(offer, line.short_by)),
+            _price_sort_value(_offer_unit_price(offer, quantity_for_offer(offer))),
             offer.lead_time_days if offer.lead_time_days is not None else 10**9,
             offer.mpn.casefold(),
         ),

--- a/backend/tests/test_sourcing_coverage.py
+++ b/backend/tests/test_sourcing_coverage.py
@@ -288,9 +288,38 @@ def test_fewest_distributors_respects_moq_stock_and_totals_selected_qty():
         ]
     )
 
-    assert "BulkOnly" not in [row.distributor for row in matrix.rows if row.lines_covered]
+    legacy_rows = {row.distributor: row for row in matrix.rows}
+    assert legacy_rows["BulkOnly"].lines_covered == 1
     assert matrix.fewest_distributors_combo == ["EnoughBulk"]
     assert matrix.fewest_distributors_total == Decimal("100.00")
+
+
+def test_legacy_coverage_matrix_uses_shortfall_not_moq_for_coverage():
+    matrix = compute_coverage(
+        [
+            _line(
+                1,
+                short_by=10,
+                offers=[
+                    _offer("BulkOnly", stock=50, unit_price="1.00", moq=100),
+                    _offer("EnoughBulk", stock=100, unit_price="1.00", moq=100),
+                ],
+            ),
+            _line(
+                2,
+                short_by=10,
+                offers=[_offer("Partner", stock=10, unit_price="2.00")],
+            ),
+        ]
+    )
+
+    legacy_rows = {row.distributor: row for row in matrix.rows}
+    assert matrix.best_single_distributor == "BulkOnly"
+    assert matrix.best_two_distributor_combo == ("BulkOnly", "Partner")
+    assert legacy_rows["BulkOnly"].lines_covered == 1
+    assert legacy_rows["BulkOnly"].lines_uncovered == [_uuid(2)]
+    assert matrix.fewest_distributors_combo == ["EnoughBulk", "Partner"]
+    assert matrix.fewest_distributors_total == Decimal("120.00")
 
 
 def test_greedy_threshold_30_distributors_near_optimal():

--- a/docs/api/sourcing.md
+++ b/docs/api/sourcing.md
@@ -281,7 +281,15 @@ Sources: `backend/app/domain/sourcing/service.py:1322-1386`,
 - Decimal prices and extended costs serialize as strings.
 - `capacity.total_bom_cost` sums `required * best_offer.unit_price` for priced rows and ignores on-hand stock. `capacity.purchase_to_pay_cost` sums `short_by * best_offer.unit_price` for priced rows that are not blocking after authorized supply. `capacity.est_purchase_cost` is a deprecated alias of `purchase_to_pay_cost` for one release.
 - Capacity totals use converted/display prices when available and skip rows whose displayed currency does not match the selected total currency, so mixed native currencies are not added together.
-- `coverage.lowest_total_price_combo` and `coverage.lowest_total_price_total` come from the optimizer's `lowest_total_price` per-line selections. `coverage.fewest_distributors_combo` and `coverage.fewest_distributors_total` choose the smallest distributor set that reaches `target_coverage_pct`; the implementation is exhaustive up to 10 distributors and greedy beyond that threshold.
+- `coverage.best_single_distributor`, `coverage.best_two_distributor_combo`, and the
+  per-distributor matrix rows use legacy shortfall coverage: an offer covers a row
+  when distributor stock is at least `short_by`. `coverage.lowest_total_price_combo`
+  and `coverage.lowest_total_price_total` come from the optimizer's
+  `lowest_total_price` per-line selections. `coverage.fewest_distributors_combo`
+  and `coverage.fewest_distributors_total` choose the smallest distributor set that
+  reaches `target_coverage_pct`; this variant evaluates offer feasibility and totals
+  with the MOQ-aware selected quantity `max(short_by, moq)`. The implementation is
+  exhaustive up to 10 distributors and greedy beyond that threshold.
 - When `currency` is supplied, BOM offer prices whose native distributor currency differs are display-converted through the global ECB daily snapshot. Native `unit_price` and `currency` stay unchanged; converted display values are exposed as `unit_price_converted`, `currency_displayed`, `fx_converted`, `fx_rate_date`, and `price_breaks_converted`.
 - Each row exposes sourcing diagnostics: `reason` is `ok`, `no_mpn`, or `no_offers`; `cache_hit` is `true`/`false` for searched rows and `null` when no MPN was searched; row `fx_status` is `unavailable` when any offer on the row could not be converted. Top-level `fx_status` is `ok`, `partial`, or `unavailable` when a request currency was supplied and `null` when conversion was not requested.
 - BOM offer projections carry offer-level TrustedParts gap fields for downstream risk/report consumers, plus distributor availability text and quantity multiple for per-BOM-line distributor drill-downs.

--- a/docs/domain/sourcing.md
+++ b/docs/domain/sourcing.md
@@ -94,6 +94,13 @@ exhaustive through 10 distributors, then switches to a deterministic greedy set-
 heuristic that picks the distributor covering the most remaining lines and breaks ties
 by combo cost and distributor name.
 
+The legacy per-distributor coverage matrix remains shortfall-based: a distributor
+covers a line when its stock can satisfy `short_by`, and `best_single_distributor`
+and `best_two_distributor_combo` use that same definition. Purchase-oriented
+variant totals account for MOQ by using the selected quantity
+`max(short_by, moq)`, and the fewest-distributors variant only treats an offer as
+feasible when stock can satisfy that selected quantity.
+
 Sources: `backend/app/domain/sourcing/coverage.py:216-464`,
 `backend/app/domain/sourcing/optimizer.py:69-93`
 


### PR DESCRIPTION
## Summary
- restore legacy shortfall-based semantics for per-distributor coverage rows, best_single_distributor, and best_two_distributor_combo
- keep MOQ-aware feasibility and selected-quantity totals for the fewest-distributors variant
- document the legacy-vs-purchase-oriented coverage distinction and add regression tests

## Tests
- uv run --extra dev python -m pytest -q tests/test_sourcing_coverage.py
- uv run --extra dev ruff check app/domain/sourcing/coverage.py tests/test_sourcing_coverage.py
- git diff --check

## Merge order
- Based on current main after #479. No sibling PRs are currently open, so merge after CI is green.

Closes #480