### PR TITLE
SX-10: Cost per single BOM (third capacity number)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ the canonical record.
 
 ## 2026-05 — feedback brief fixes
 
+- **SX-10 / #485** Project Sourcing capacity now shows cost per single BOM
+  alongside total BOM cost and short-quantity price to pay.
 - **SX-5 / #480** Project Sourcing keeps the legacy distributor coverage matrix
   shortfall-based while the fewest-distributors variant continues to apply MOQ
   selected quantities for feasibility and totals.

--- a/backend/app/domain/sourcing/coverage.py
+++ b/backend/app/domain/sourcing/coverage.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from decimal import Decimal
+from decimal import ROUND_HALF_UP, Decimal
 from itertools import combinations
 from math import ceil
 from uuid import UUID
@@ -44,6 +44,7 @@ class BuildCapacity:
     can_build_now: int
     can_build_after_purchase: int
     total_bom_cost: Decimal | None
+    cost_per_single_bom: Decimal | None
     purchase_to_pay_cost: Decimal | None
     est_purchase_cost: Decimal | None
     blocking_lines_now: list[UUID]
@@ -62,6 +63,7 @@ def compute_build_capacity(
             can_build_now=0,
             can_build_after_purchase=0,
             total_bom_cost=None,
+            cost_per_single_bom=None,
             purchase_to_pay_cost=None,
             est_purchase_cost=None,
             blocking_lines_now=[],
@@ -103,6 +105,10 @@ def compute_build_capacity(
         effective_rows,
         quantity_for_row=lambda row: row.required,
     )
+    cost_per_single_bom = _cost_per_single_bom(
+        total_bom_cost,
+        requested_build_quantity=requested_build_quantity,
+    )
     payable_rows = [
         row for row in effective_rows if row.project_entry_id not in blocking_after
     ]
@@ -121,10 +127,24 @@ def compute_build_capacity(
         can_build_now=can_build_now,
         can_build_after_purchase=can_build_after_purchase,
         total_bom_cost=total_bom_cost,
+        cost_per_single_bom=cost_per_single_bom,
         purchase_to_pay_cost=purchase_to_pay_cost,
         est_purchase_cost=purchase_to_pay_cost,
         blocking_lines_now=blocking_lines_now,
         blocking_lines_after_purchase=blocking_lines_after_purchase,
+    )
+
+
+def _cost_per_single_bom(
+    total_bom_cost: Decimal | None,
+    *,
+    requested_build_quantity: int,
+) -> Decimal | None:
+    if total_bom_cost is None or requested_build_quantity <= 0:
+        return None
+    return (total_bom_cost / Decimal(requested_build_quantity)).quantize(
+        Decimal("0.01"),
+        rounding=ROUND_HALF_UP,
     )
 
 

--- a/backend/app/domain/sourcing/schemas.py
+++ b/backend/app/domain/sourcing/schemas.py
@@ -398,6 +398,13 @@ class BuildCapacityOut(BaseModel):
             "BOM lines, independent of on-hand stock."
         ),
     )
+    cost_per_single_bom: Decimal | None = Field(
+        default=None,
+        description=(
+            "Cost of building one complete BOM unit, derived from total_bom_cost "
+            "divided by the requested build quantity."
+        ),
+    )
     purchase_to_pay_cost: Decimal | None = Field(
         default=None,
         description=(
@@ -638,6 +645,7 @@ class SourcingBomOut(BaseModel):
     rows: list[SourcingBomLineOut]
     coverage: DistributorCoverageMatrixOut
     capacity: BuildCapacityOut
+    build_quantity: int
     powered_by: Literal["TrustedParts"] = "TrustedParts"
     fetched_at: datetime
     partial: bool

--- a/backend/app/domain/sourcing/service.py
+++ b/backend/app/domain/sourcing/service.py
@@ -892,6 +892,7 @@ def source_bom(
                 requested_build_quantity=build_quantity,
             )
         ),
+        build_quantity=build_quantity,
         fetched_at=max(fetched_at_values, default=utcnow()),
         partial=partial,
         links=TRUSTEDPARTS_LINKS,

--- a/backend/tests/test_sourcing_bom_route.py
+++ b/backend/tests/test_sourcing_bom_route.py
@@ -205,11 +205,13 @@ def test_basic_bom_returns_enriched_lines(authed_client):
     datetime.fromisoformat(data["fetched_at"])
     assert data["powered_by"] == "TrustedParts"
     assert data["partial"] is False
+    assert data["build_quantity"] == 2
     assert data["coverage"]["total_lines"] == 1
     assert data["coverage"]["best_single_distributor"] == "DigiKey"
     assert data["capacity"]["can_build_now"] == 0
     assert data["capacity"]["can_build_after_purchase"] == 6
     assert Decimal(data["capacity"]["total_bom_cost"]) == Decimal("2.00")
+    assert Decimal(data["capacity"]["cost_per_single_bom"]) == Decimal("1.00")
     assert Decimal(data["capacity"]["purchase_to_pay_cost"]) == Decimal("2.00")
     assert data["capacity"]["est_purchase_cost"] == data["capacity"]["purchase_to_pay_cost"]
     row = data["rows"][0]

--- a/backend/tests/test_sourcing_capacity.py
+++ b/backend/tests/test_sourcing_capacity.py
@@ -263,6 +263,55 @@ def test_total_bom_cost_sums_required_quantity_unit_price():
     assert capacity.total_bom_cost == Decimal("9.00")
 
 
+def test_cost_per_single_bom_divides_total_by_build_quantity():
+    capacity = compute_build_capacity(
+        [
+            _line(1, required=400, best_offer=_offer(unit_price="2.50")),
+        ],
+        requested_build_quantity=4,
+    )
+
+    assert capacity.total_bom_cost == Decimal("1000.00")
+    assert capacity.cost_per_single_bom == Decimal("250.00")
+
+
+def test_cost_per_single_bom_none_when_total_bom_cost_none():
+    capacity = compute_build_capacity(
+        [
+            _line(1, required=10),
+            _line(2, required=5),
+        ],
+        requested_build_quantity=3,
+    )
+
+    assert capacity.total_bom_cost is None
+    assert capacity.cost_per_single_bom is None
+
+
+def test_cost_per_single_bom_none_when_build_quantity_zero():
+    capacity = compute_build_capacity(
+        [
+            _line(1, required=10, best_offer=_offer(unit_price="2.00")),
+        ],
+        requested_build_quantity=0,
+    )
+
+    assert capacity.total_bom_cost == Decimal("20.00")
+    assert capacity.cost_per_single_bom is None
+
+
+def test_cost_per_single_bom_decimal_precision():
+    capacity = compute_build_capacity(
+        [
+            _line(1, required=1, best_offer=_offer(unit_price="333.33")),
+        ],
+        requested_build_quantity=3,
+    )
+
+    assert capacity.total_bom_cost == Decimal("333.33")
+    assert capacity.cost_per_single_bom == Decimal("111.11")
+
+
 def test_total_bom_cost_ignores_stock_on_hand():
     capacity = compute_build_capacity(
         [
@@ -387,6 +436,8 @@ def test_decimal_serialisation_for_both_costs():
 
     assert payload["total_bom_cost"] == "125.00"
     assert isinstance(payload["total_bom_cost"], str)
+    assert payload["cost_per_single_bom"] == "1.25"
+    assert isinstance(payload["cost_per_single_bom"], str)
     assert payload["purchase_to_pay_cost"] == "62.50"
     assert isinstance(payload["purchase_to_pay_cost"], str)
     assert payload["est_purchase_cost"] == "62.50"

--- a/docs/api/sourcing.md
+++ b/docs/api/sourcing.md
@@ -234,11 +234,13 @@ Path: `project_id` is a project UUID in the current workspace.
       "can_build_now": 0,
       "can_build_after_purchase": 3,
       "total_bom_cost": "2.00",
+      "cost_per_single_bom": "1.00",
       "purchase_to_pay_cost": "2.00",
       "est_purchase_cost": "2.00",
       "blocking_lines_now": [],
       "blocking_lines_after_purchase": []
     },
+    "build_quantity": 2,
     "powered_by": "TrustedParts",
     "fetched_at": "2026-05-08T12:00:00+00:00",
     "partial": false,
@@ -279,7 +281,14 @@ Sources: `backend/app/domain/sourcing/service.py:1322-1386`,
 - The route validates `project_id` with `assert_in_workspace()` before calling the sourcing service.
 - The service reuses `shortage_analysis()`, `dedupe_mpns()`, `chunk_mpns()`, and per-MPN `search()` cache rows; BOM chunks use `ttl_seconds=600`.
 - Decimal prices and extended costs serialize as strings.
-- `capacity.total_bom_cost` sums `required * best_offer.unit_price` for priced rows and ignores on-hand stock. `capacity.purchase_to_pay_cost` sums `short_by * best_offer.unit_price` for priced rows that are not blocking after authorized supply. `capacity.est_purchase_cost` is a deprecated alias of `purchase_to_pay_cost` for one release.
+- `build_quantity` echoes the requested build quantity. `capacity.total_bom_cost`
+  sums `required * best_offer.unit_price` for priced rows and ignores on-hand
+  stock. `capacity.cost_per_single_bom` is `total_bom_cost / build_quantity`,
+  rounded half-up to 2 decimal places, or `null` when no priced BOM cost is
+  available. `capacity.purchase_to_pay_cost` sums
+  `short_by * best_offer.unit_price` for priced rows that are not blocking after
+  authorized supply. `capacity.est_purchase_cost` is a deprecated alias of
+  `purchase_to_pay_cost` for one release.
 - Capacity totals use converted/display prices when available and skip rows whose displayed currency does not match the selected total currency, so mixed native currencies are not added together.
 - `coverage.best_single_distributor`, `coverage.best_two_distributor_combo`, and the
   per-distributor matrix rows use legacy shortfall coverage: an offer covers a row

--- a/web/src/routes/projects/sourcing/ProjectSourcingPage.tsx
+++ b/web/src/routes/projects/sourcing/ProjectSourcingPage.tsx
@@ -112,11 +112,13 @@ type SourcingBomResponse = {
     can_build_now: number;
     can_build_after_purchase: number;
     total_bom_cost?: string | number | null;
+    cost_per_single_bom?: string | number | null;
     purchase_to_pay_cost?: string | number | null;
     est_purchase_cost?: string | number | null;
     blocking_lines_now: string[];
     blocking_lines_after_purchase: string[];
   };
+  build_quantity: number;
   powered_by: "TrustedParts";
   fetched_at: string;
   partial: boolean;
@@ -416,7 +418,10 @@ function CapacityBanner({ data, currency }: { data: SourcingBomResponse; currenc
   ) ?? null;
   const totalCostNote = data.capacity.total_bom_cost == null
     ? "no pricing available on any line"
-    : "if bought every line";
+    : `x ${data.build_quantity.toLocaleString()} build${data.build_quantity === 1 ? "" : "s"}`;
+  const singleBomCostNote = data.capacity.cost_per_single_bom == null
+    ? "no pricing available on any line"
+    : "one full build";
   const purchaseCostNote = data.capacity.purchase_to_pay_cost == null
     ? "no non-blocking priced shortages"
     : "short qty only, excluding blocking lines";
@@ -435,6 +440,11 @@ function CapacityBanner({ data, currency }: { data: SourcingBomResponse; currenc
         <div className="sm:col-span-2 lg:col-span-2 min-w-0">
           <div className="section-title">Costs</div>
           <div className="mt-1 flex flex-col gap-1 text-sm">
+            <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+              <span className="text-muted">Cost per 1 BOM:</span>
+              <span className="font-mono tabular-nums">{formatMoney(data.capacity.cost_per_single_bom, purchaseCurrency)}</span>
+              <span className="text-xs text-muted">{singleBomCostNote}</span>
+            </div>
             <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
               <span className="text-muted">Total BOM cost:</span>
               <span className="font-mono tabular-nums">{formatMoney(data.capacity.total_bom_cost, purchaseCurrency)}</span>

--- a/web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.test.tsx
+++ b/web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.test.tsx
@@ -156,11 +156,13 @@ function sourcingResponse(overrides: Record<string, unknown> = {}) {
       can_build_now: 0,
       can_build_after_purchase: 3,
       total_bom_cost: "30.00",
+      cost_per_single_bom: "15.00",
       purchase_to_pay_cost: "25.00",
       est_purchase_cost: "25.00",
       blocking_lines_now: ["entry-2"],
       blocking_lines_after_purchase: ["entry-1"],
     },
+    build_quantity: 2,
     powered_by: "TrustedParts" as const,
     fetched_at: "2026-05-08T12:00:00+00:00",
     partial: false,
@@ -320,7 +322,18 @@ describe("ProjectSourcingPage", () => {
     expect(screen.getByText("3")).toBeDefined();
     expect(screen.getByText("Total BOM cost:")).toBeDefined();
     expect(screen.getByText("30 USD")).toBeDefined();
-    expect(screen.getByText("if bought every line")).toBeDefined();
+    expect(screen.getByText("x 2 builds")).toBeDefined();
+  });
+
+  it("CapacityBanner renders Cost per 1 BOM when capacity.cost_per_single_bom is non-null", async () => {
+    mockReads();
+    vi.spyOn(api, "post").mockResolvedValue(sourcingResponse());
+
+    renderPage();
+
+    expect(await screen.findByText("Cost per 1 BOM:")).toBeDefined();
+    expect(screen.getByText("15 USD")).toBeDefined();
+    expect(screen.getByText("one full build")).toBeDefined();
   });
 
   it("CapacityBanner renders Price to pay when capacity.purchase_to_pay_cost is non-null", async () => {
@@ -341,6 +354,7 @@ describe("ProjectSourcingPage", () => {
         can_build_now: 0,
         can_build_after_purchase: 0,
         total_bom_cost: null,
+        cost_per_single_bom: null,
         purchase_to_pay_cost: null,
         est_purchase_cost: null,
         blocking_lines_now: ["entry-1"],
@@ -351,9 +365,9 @@ describe("ProjectSourcingPage", () => {
     renderPage();
 
     expect(await screen.findByText("Total BOM cost:")).toBeDefined();
-    expect(screen.getByText("no pricing available on any line")).toBeDefined();
+    expect(screen.getAllByText("no pricing available on any line").length).toBeGreaterThanOrEqual(2);
     expect(screen.getByText("no non-blocking priced shortages")).toBeDefined();
-    expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(2);
+    expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(3);
   });
 
   it("renders coverage matrix with best-single + best-two highlights", async () => {


### PR DESCRIPTION
## Summary
- add capacity.cost_per_single_bom, rounded half-up from total_bom_cost / build_quantity
- echo build_quantity in the BOM sourcing response so the UI can label total cost precisely
- render Cost per 1 BOM as the third CapacityBanner cost row and document the field

## Tests
- `uv run --extra dev python -m pytest -q tests/test_sourcing_capacity.py tests/test_sourcing_bom_route.py -k "sourcing_capacity or basic_bom_returns_enriched_lines"` -> 25 passed, 30 deselected, 1 warning
- `uv run --extra dev ruff check app/domain/sourcing/coverage.py app/domain/sourcing/schemas.py app/domain/sourcing/service.py tests/test_sourcing_capacity.py tests/test_sourcing_bom_route.py` -> passed
- `npm run typecheck` -> passed
- `npm test -- "ProjectSourcingPage"` -> 39 passed
- `npx eslint src/routes/projects/sourcing/ProjectSourcingPage.tsx src/routes/projects/sourcing/__tests__/ProjectSourcingPage.test.tsx` -> passed
- `LINT_CMD="npm run lint -- --format=unix" BASELINE_FILE="../.eslint-baseline.txt" WORK_DIR="." bash ../scripts/lint-delta.sh` -> no new violations
- `git diff --check` -> passed

Note: full `npm run lint` still reports the existing repo baseline issues in unrelated files; lint-delta is clean.

## Decimal precision
Uses `Decimal` only and quantizes with `ROUND_HALF_UP` to 2 decimal places. Returns null when `total_bom_cost` is null or build quantity is zero.

## Screenshot
Not captured locally; the Vitest coverage verifies the rendered CapacityBanner labels and values.

## Merge order
Merge order: #487 first, then #485, then #486; rebase later siblings after this lands because ProjectSourcingPage/test/CHANGELOG overlap.

Refs #485