### PR TITLE
SX-12: 4-level risk vocabulary + hover legend popover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ the canonical record.
 
 - **SX-10 / #485** Project Sourcing capacity now shows cost per single BOM
   alongside total BOM cost and short-quantity price to pay.
+- **SX-12 / #487** Project Sourcing now uses the four-level TrustedParts
+  risk vocabulary, including a light-green Low-Med band and header popover
+  legends for Lifecycle and Supply chain risk columns.
 - **SX-5 / #480** Project Sourcing keeps the legacy distributor coverage matrix
   shortfall-based while the fewest-distributors variant continues to apply MOQ
   selected quantities for feasibility and totals.

--- a/docs/user/projects-and-bom.md
+++ b/docs/user/projects-and-bom.md
@@ -106,7 +106,7 @@ Bulk provider import processes up to 200 unmatched rows at a time; run it again 
 
 ## Source BOM coverage
 
-The **Source BOM** page can show TrustedParts sourcing context on each BOM line. Lifecycle, supply-chain, and RoHS details have their own BOM columns, while the legacy **Risk** column stays focused on operational flags such as single-source, stock, MOQ, lead-time, preferred-distributor, and tariff warnings. Lifecycle and supply-chain pills colour TrustedParts `Low` as green, `Medium` or `Moderate` as amber, and `High` or `Severe` as red. The **Lead time** column is available from the column menu when you need the raw per-row lead-time values.
+The **Source BOM** page can show TrustedParts sourcing context on each BOM line. Lifecycle, supply-chain, and RoHS details have their own BOM columns, while the legacy **Risk** column stays focused on operational flags such as single-source, stock, MOQ, lead-time, preferred-distributor, and tariff warnings. Lifecycle and supply-chain pills colour TrustedParts `Low` as green, `Low-Med` as light green, `Medium` or `Moderate` as amber, and `High` or `Severe` as red. Click the info icon next to **Lifecycle** or **Supply chain** to see the four-level risk legend with wording tailored to that column. The **Lead time** column is available from the column menu when you need the raw per-row lead-time values.
 
 Click a sourced BOM row to compare every TrustedParts distributor offer for that line. The drill-down shows stock, raw availability text, price breaks, MOQ, quantity multiple, packaging, RoHS regions, and a distributor product link. Rows without distributor offers do not open a drill-down.
 

--- a/web/src/components/DataTable.tsx
+++ b/web/src/components/DataTable.tsx
@@ -77,7 +77,8 @@ export type Align = "left" | "right" | "center";
 
 export type Column<T> = {
   key: string;
-  header: string;
+  header: ReactNode;
+  headerLabel?: string;
   render?: (row: T) => ReactNode;
   accessor?: (row: T) => string | number | boolean | null | undefined;
   width?: string;
@@ -132,6 +133,11 @@ function defaultAlignFor<T>(col: Column<T>, sample: T | undefined): Align {
   if (!sample || !col.accessor) return "left";
   const v = col.accessor(sample);
   return typeof v === "number" ? "right" : "left";
+}
+
+function columnHeaderLabel<T>(col: Column<T>): string {
+  if (col.headerLabel) return col.headerLabel;
+  return typeof col.header === "string" ? col.header : col.key;
 }
 
 export function DataTable<T>({
@@ -261,7 +267,7 @@ export function DataTable<T>({
   }
 
   function exportCsv() {
-    const head = visibleCols.map(c => c.header);
+    const head = visibleCols.map(c => columnHeaderLabel(c));
     const body = sorted.map(r => visibleCols.map(c => cellText(c, r)));
     const csv = buildCsv(head, body);
     const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
@@ -328,7 +334,7 @@ export function DataTable<T>({
                   checked={!hidden[c.key]}
                   onChange={() => setHidden(h => ({ ...h, [c.key]: !h[c.key] }))}
                 />
-                {c.header}
+                {columnHeaderLabel(c)}
               </label>
             ))}
           </div>

--- a/web/src/components/RiskLegendPopover.tsx
+++ b/web/src/components/RiskLegendPopover.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useId, useRef, useState } from "react";
+import { Info } from "lucide-react";
+import type { LegendRow } from "@/lib/riskLegends";
+import { riskToneClass } from "@/lib/sourcing";
+
+type Props = {
+  legend: LegendRow[];
+  title: string;
+};
+
+export function RiskLegendPopover({ legend, title }: Props) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLSpanElement | null>(null);
+  const popoverId = useId();
+
+  useEffect(() => {
+    if (!open) return undefined;
+
+    function onPointerDown(event: PointerEvent) {
+      if (rootRef.current?.contains(event.target as Node)) return;
+      setOpen(false);
+    }
+
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") setOpen(false);
+    }
+
+    document.addEventListener("pointerdown", onPointerDown);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [open]);
+
+  return (
+    <span
+      ref={rootRef}
+      className="relative inline-flex"
+      onMouseEnter={() => setOpen(true)}
+      onClick={event => event.stopPropagation()}
+    >
+      <button
+        type="button"
+        className="inline-flex h-5 w-5 items-center justify-center rounded-full text-muted hover:bg-panel2 hover:text-text focus:outline-none focus:ring-2 focus:ring-accent/40"
+        aria-label={`Show ${title}`}
+        aria-expanded={open}
+        aria-controls={popoverId}
+        onClick={() => setOpen(true)}
+      >
+        <Info className="h-3.5 w-3.5" aria-hidden="true" />
+      </button>
+      {open && (
+        <span
+          id={popoverId}
+          role="dialog"
+          aria-label={title}
+          className="absolute left-0 top-full z-50 mt-1 w-80 max-w-[calc(100vw-2rem)] rounded-md border border-border bg-panel p-3 text-left normal-case tracking-normal text-text shadow-lg"
+        >
+          <span className="mb-2 block text-sm font-semibold">{title}</span>
+          <span className="block space-y-2">
+            {legend.map(row => (
+              <span key={row.label} role="listitem" className="flex items-start gap-2 text-xs">
+                <span className={`pill shrink-0 ${riskToneClass(row.tone)}`}>{row.label}</span>
+                <span className="text-muted">{row.description}</span>
+              </span>
+            ))}
+          </span>
+        </span>
+      )}
+    </span>
+  );
+}

--- a/web/src/lib/__tests__/sourcing.test.ts
+++ b/web/src/lib/__tests__/sourcing.test.ts
@@ -57,16 +57,32 @@ describe("extendedPrice", () => {
 
 describe("lifecycleRiskTone", () => {
   it("maps TrustedParts risk levels to semantic colours", () => {
-    expect(lifecycleRiskTone("  LOW risk  ")).toContain("text-success");
-    expect(lifecycleRiskTone("Medium")).toContain("text-warning");
-    expect(lifecycleRiskTone("moderate supply risk")).toContain("text-warning");
-    expect(lifecycleRiskTone("High")).toContain("text-danger");
-    expect(lifecycleRiskTone("Severe")).toContain("text-danger");
+    expect(lifecycleRiskTone("  LOW risk  ")).toBe("good");
+    expect(lifecycleRiskTone("Medium")).toBe("warning");
+    expect(lifecycleRiskTone("Med")).toBe("warning");
+    expect(lifecycleRiskTone("moderate supply risk")).toBe("warning");
+    expect(lifecycleRiskTone("High")).toBe("danger");
+    expect(lifecycleRiskTone("Severe")).toBe("danger");
   });
 
   it("keeps lifecycle vocabulary precedence before generic risk levels", () => {
-    expect(lifecycleRiskTone("Active high volume")).toContain("text-success");
-    expect(lifecycleRiskTone("Obsolete - low supply")).toContain("text-danger");
-    expect(lifecycleRiskTone("NRND low risk")).toContain("text-warning");
+    expect(lifecycleRiskTone("Active high volume")).toBe("good");
+    expect(lifecycleRiskTone("Obsolete - low supply")).toBe("danger");
+    expect(lifecycleRiskTone("NRND low risk")).toBe("warning");
+  });
+
+  it("maps the TrustedParts Low-Med band to low-warning", () => {
+    expect(lifecycleRiskTone("Low-Med")).toBe("low-warning");
+    expect(lifecycleRiskTone("Low/Med")).toBe("low-warning");
+  });
+
+  it("maps descriptive Low-Med fallbacks to low-warning", () => {
+    expect(lifecycleRiskTone("This product may be special order")).toBe("low-warning");
+    expect(lifecycleRiskTone("Limited stock")).toBe("low-warning");
+    expect(lifecycleRiskTone("Long lead times")).toBe("low-warning");
+  });
+
+  it("returns neutral for unknown vocabulary", () => {
+    expect(lifecycleRiskTone("unknown status")).toBe("neutral");
   });
 });

--- a/web/src/lib/riskLegends.ts
+++ b/web/src/lib/riskLegends.ts
@@ -1,0 +1,25 @@
+import type { RiskTone } from "./sourcing";
+
+export type LegendRow = {
+  label: string;
+  tone: RiskTone;
+  description: string;
+};
+
+export const LIFECYCLE_LEGEND: LegendRow[] = [
+  { label: "Low", tone: "good", description: "This product is active." },
+  {
+    label: "Low-Med",
+    tone: "low-warning",
+    description: "This product may be a special order, NRND (not recommended for new design), or a known equivalent.",
+  },
+  { label: "Med", tone: "warning", description: "This product may be EOL (end of life) or NRND." },
+  { label: "High", tone: "danger", description: "This product is end of life." },
+];
+
+export const SUPPLY_CHAIN_LEGEND: LegendRow[] = [
+  { label: "Low", tone: "good", description: "Available stock with short lead times." },
+  { label: "Low-Med", tone: "low-warning", description: "Limited stock or long lead times." },
+  { label: "Med", tone: "warning", description: "Out of stock with short lead times." },
+  { label: "High", tone: "danger", description: "Out of stock with long lead times." },
+];

--- a/web/src/lib/sourcing.ts
+++ b/web/src/lib/sourcing.ts
@@ -40,11 +40,27 @@ export function extendedPrice(
   return best.unitPrice * Math.floor(qty);
 }
 
-export function lifecycleRiskTone(value: string | null | undefined): string {
+export type RiskTone = "good" | "low-warning" | "warning" | "danger" | "neutral";
+
+export const RISK_TONE_CLASSES: Record<RiskTone, string> = {
+  good: "bg-success/10 text-success",
+  "low-warning": "bg-success/30 text-success",
+  warning: "bg-warning/10 text-warning",
+  danger: "bg-danger/10 text-danger",
+  neutral: "bg-panel2 text-muted",
+};
+
+export function riskToneClass(tone: RiskTone): string {
+  return RISK_TONE_CLASSES[tone];
+}
+
+export function lifecycleRiskTone(value: string | null | undefined): RiskTone {
   const normalized = value?.trim().toLowerCase() ?? "";
-  if (normalized.startsWith("active")) return "bg-success/10 text-success";
+  // First match wins: TPS-7 lifecycle keywords outrank generic TrustedParts risk levels,
+  // then Low-Med canonical labels, Low/Med/High labels, and finally descriptive fallbacks.
+  if (normalized.startsWith("active")) return "good";
   if (normalized.includes("nrnd") || normalized.includes("not recommended")) {
-    return "bg-warning/10 text-warning";
+    return "warning";
   }
   if (
     normalized.includes("obsolete") ||
@@ -53,13 +69,20 @@ export function lifecycleRiskTone(value: string | null | undefined): string {
     normalized.includes("last time buy") ||
     normalized.includes("ltb")
   ) {
-    return "bg-danger/10 text-danger";
+    return "danger";
   }
-  // SX-1: TPS-7 lifecycle vocabulary takes precedence over generic TrustedParts risk levels.
-  if (normalized.includes("low")) return "bg-success/10 text-success";
-  if (normalized.includes("medium") || normalized.includes("moderate")) return "bg-warning/10 text-warning";
-  if (normalized.includes("high") || normalized.includes("severe")) return "bg-danger/10 text-danger";
-  return "bg-panel2 text-muted";
+  if (normalized.includes("low-med") || normalized.includes("low/med")) return "low-warning";
+  if (normalized.includes("low")) return "good";
+  if (normalized.includes("medium") || /\bmed\b/.test(normalized) || normalized.includes("moderate")) return "warning";
+  if (normalized.includes("high") || normalized.includes("severe")) return "danger";
+  if (
+    normalized.includes("may be special order") ||
+    normalized.includes("limited stock") ||
+    normalized.includes("long lead times")
+  ) {
+    return "low-warning";
+  }
+  return "neutral";
 }
 
 export function lifecycleRiskRank(value: string | null | undefined): number {

--- a/web/src/routes/parts/detail/AuthorizedSupplyTab.tsx
+++ b/web/src/routes/parts/detail/AuthorizedSupplyTab.tsx
@@ -12,6 +12,7 @@ import {
   bestUnitPriceAtQty,
   extendedPrice,
   lifecycleRiskTone,
+  riskToneClass,
   type SourcingPriceBreak,
 } from "@/lib/sourcing";
 import type { Column } from "@/components/DataTable";
@@ -302,7 +303,8 @@ function RiskBadge({
   if (!trimmed) return null;
   return (
     <span
-      className={`pill inline-flex items-center gap-1 ${lifecycleRiskTone(trimmed)}`}
+      className={`pill inline-flex items-center gap-1 ${riskToneClass(lifecycleRiskTone(trimmed))}`}
+      title={trimmed}
       aria-label={`${label}: ${trimmed}`}
     >
       {icon}

--- a/web/src/routes/projects/sourcing/BomDistributorsModal.tsx
+++ b/web/src/routes/projects/sourcing/BomDistributorsModal.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from "react";
 import { ExternalLink, Info, ShieldAlert, ShieldCheck, X } from "lucide-react";
 import { DataTable, type Column } from "@/components/DataTable";
 import { PoweredByTrustedParts } from "@/components/PoweredByTrustedParts";
-import { lifecycleRiskTone } from "@/lib/sourcing";
+import { lifecycleRiskTone, riskToneClass } from "@/lib/sourcing";
 import type {
   SourcingBomLine,
   SourcingBomOffer,
@@ -132,7 +132,7 @@ function RiskPill({
   const trimmed = value?.trim();
   if (!trimmed) return null;
   return (
-    <span className={`pill inline-flex items-center gap-1 ${lifecycleRiskTone(trimmed)}`} aria-label={`${label}: ${trimmed}`}>
+    <span className={`pill inline-flex items-center gap-1 ${riskToneClass(lifecycleRiskTone(trimmed))}`} title={trimmed} aria-label={`${label}: ${trimmed}`}>
       {icon}
       {trimmed}
     </span>

--- a/web/src/routes/projects/sourcing/ProjectSourcingPage.tsx
+++ b/web/src/routes/projects/sourcing/ProjectSourcingPage.tsx
@@ -6,10 +6,12 @@ import { toast } from "sonner";
 import EmptyState from "@/components/EmptyState";
 import { DataTable, type Column } from "@/components/DataTable";
 import { PoweredByTrustedParts } from "@/components/PoweredByTrustedParts";
+import { RiskLegendPopover } from "@/components/RiskLegendPopover";
 import { SourcingSourceLabel } from "@/components/SourcingSourceLabel";
 import { ApiError, api } from "@/lib/api";
 import { useWsKey } from "@/lib/queryKeys";
-import { lifecycleRiskTone } from "@/lib/sourcing";
+import { LIFECYCLE_LEGEND, SUPPLY_CHAIN_LEGEND } from "@/lib/riskLegends";
+import { lifecycleRiskTone, riskToneClass } from "@/lib/sourcing";
 import AlertFormModal from "@/routes/sourcing/alerts/AlertFormModal";
 import type { Project } from "@/types";
 import { BomDistributorsModal } from "./BomDistributorsModal";
@@ -233,7 +235,7 @@ function LifecycleRiskPill({ label = "Lifecycle risk", value }: { label?: string
   const trimmed = value?.trim();
   if (!trimmed) return null;
   return (
-    <span className={`pill ${lifecycleRiskTone(trimmed)}`} aria-label={`${label}: ${trimmed}`}>
+    <span className={`pill ${riskToneClass(lifecycleRiskTone(trimmed))}`} title={trimmed} aria-label={`${label}: ${trimmed}`}>
       {trimmed}
     </span>
   );
@@ -697,13 +699,25 @@ function BomRows({ rows, workspaceCurrency }: { rows: SourcingBomLine[]; workspa
     },
     {
       key: "lifecycle",
-      header: "Lifecycle",
+      header: (
+        <span className="inline-flex items-center gap-1">
+          Lifecycle
+          <RiskLegendPopover legend={LIFECYCLE_LEGEND} title="Lifecycle Risk Statuses" />
+        </span>
+      ),
+      headerLabel: "Lifecycle",
       accessor: row => row.best_offer?.lifecycle_risk?.trim() ?? "",
       render: row => <LifecycleRiskPill value={row.best_offer?.lifecycle_risk} />,
     },
     {
       key: "supply_chain",
-      header: "Supply chain",
+      header: (
+        <span className="inline-flex items-center gap-1">
+          Supply chain
+          <RiskLegendPopover legend={SUPPLY_CHAIN_LEGEND} title="Supply Chain Risk Statuses" />
+        </span>
+      ),
+      headerLabel: "Supply chain",
       accessor: row => row.best_offer?.supply_chain_risk?.trim() ?? "",
       render: row => (
         <LifecycleRiskPill label="Supply-chain risk" value={row.best_offer?.supply_chain_risk} />

--- a/web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.test.tsx
+++ b/web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.test.tsx
@@ -616,8 +616,8 @@ describe("ProjectSourcingPage", () => {
 
     await screen.findByText("BOM rows");
     const bomRowsTable = screen.getAllByRole("table")[1];
-    expect(within(bomRowsTable).getByRole("columnheader", { name: "Lifecycle" })).toBeDefined();
-    expect(within(bomRowsTable).getByRole("columnheader", { name: "Supply chain" })).toBeDefined();
+    expect(within(bomRowsTable).getByRole("columnheader", { name: /Lifecycle/ })).toBeDefined();
+    expect(within(bomRowsTable).getByRole("columnheader", { name: /Supply chain/ })).toBeDefined();
     expect(within(bomRowsTable).getByRole("columnheader", { name: "RoHS" })).toBeDefined();
 
     const lifecycle = screen.getByLabelText("Lifecycle risk: High");
@@ -634,6 +634,34 @@ describe("ProjectSourcingPage", () => {
     expect(within(riskCell as HTMLElement).queryByText("supply chain")).toBeNull();
     expect(within(riskCell as HTMLElement).queryByText("RoHS")).toBeNull();
     expect(screen.getByLabelText("TrustedParts did not find a compliant RoHS region for this BOM line.")).toBeDefined();
+  });
+
+  it("opens distinct 4-row risk legends from the Lifecycle and Supply chain headers", async () => {
+    const user = userEvent.setup();
+    mockReads();
+    vi.spyOn(api, "post").mockResolvedValue(sourcingResponse());
+
+    renderPage();
+
+    await screen.findByText("BOM rows");
+    const bomRowsTable = screen.getAllByRole("table")[1];
+    const lifecycleHeader = within(bomRowsTable).getByRole("columnheader", { name: /Lifecycle/ });
+    const supplyChainHeader = within(bomRowsTable).getByRole("columnheader", { name: /Supply chain/ });
+
+    expect(within(lifecycleHeader).getByRole("button", { name: "Show Lifecycle Risk Statuses" })).toBeDefined();
+
+    await user.click(within(lifecycleHeader).getByRole("button", { name: "Show Lifecycle Risk Statuses" }));
+    const lifecycleLegend = await screen.findByRole("dialog", { name: "Lifecycle Risk Statuses" });
+    expect(within(lifecycleLegend).getAllByRole("listitem")).toHaveLength(4);
+    expect(within(lifecycleLegend).getByText("This product is active.")).toBeDefined();
+    expect(within(lifecycleLegend).getByText("This product may be EOL (end of life) or NRND.")).toBeDefined();
+
+    await user.click(within(supplyChainHeader).getByRole("button", { name: "Show Supply Chain Risk Statuses" }));
+    const supplyChainLegend = await screen.findByRole("dialog", { name: "Supply Chain Risk Statuses" });
+    expect(within(supplyChainLegend).getAllByRole("listitem")).toHaveLength(4);
+    expect(within(supplyChainLegend).getByText("Available stock with short lead times.")).toBeDefined();
+    expect(within(supplyChainLegend).getByText("Limited stock or long lead times.")).toBeDefined();
+    expect(within(supplyChainLegend).queryByText("This product is active.")).toBeNull();
   });
 
   it("renders compliant RoHS data as a green pill", async () => {
@@ -680,7 +708,7 @@ describe("ProjectSourcingPage", () => {
 
     await screen.findByText("BOM rows");
     const bomRowsTable = screen.getAllByRole("table")[1];
-    expect(within(bomRowsTable).getByRole("columnheader", { name: "Lifecycle" })).toBeDefined();
+    expect(within(bomRowsTable).getByRole("columnheader", { name: /Lifecycle/ })).toBeDefined();
     const lifecycle = screen.getByLabelText("Lifecycle risk: Obsolete");
     expect(lifecycle.className).toContain("text-danger");
   });

--- a/web/src/routes/reports/SourcingRiskReport.tsx
+++ b/web/src/routes/reports/SourcingRiskReport.tsx
@@ -9,7 +9,7 @@ import { SourcingSourceLabel } from "@/components/SourcingSourceLabel";
 import { api, ApiError } from "@/lib/api";
 import { formatMoney } from "@/lib/format";
 import { useWsKey } from "@/lib/queryKeys";
-import { lifecycleRiskRank, lifecycleRiskTone } from "@/lib/sourcing";
+import { lifecycleRiskRank, lifecycleRiskTone, riskToneClass } from "@/lib/sourcing";
 
 type SourcingRiskFlag =
   | "single_source"
@@ -114,7 +114,7 @@ function LifecycleRiskPill({ value }: { value?: string | null }) {
   const trimmed = value?.trim();
   if (!trimmed) return null;
   return (
-    <span className={`pill ${lifecycleRiskTone(trimmed)}`} aria-label={`Lifecycle risk: ${trimmed}`}>
+    <span className={`pill ${riskToneClass(lifecycleRiskTone(trimmed))}`} title={trimmed} aria-label={`Lifecycle risk: ${trimmed}`}>
       {trimmed}
     </span>
   );


### PR DESCRIPTION
## Summary

- Adds a semantic `RiskTone` vocabulary with `low-warning`, plus shared tone classes for sourcing risk pills.
- Adds Lifecycle and Supply Chain four-row legend constants and a small dependency-free hover/click popover using the existing palette and lucide `Info` icon.
- Wires the legend triggers into the Project Sourcing BOM table headers and keeps raw risk text on per-pill `title` tooltips.
- Updates sourcing tests, Project Sourcing page tests, user docs, and changelog.

## Tests

- `cd web && npm run typecheck`
  - Passed: `tsc -b`
- `cd web && npm test -- "sourcing|ProjectSourcingPage"`
  - Failed before execution: Vitest 2.1.9 treats the quoted value as a file filter and reported `No test files found`.
- `cd web && npm test -- src/lib/__tests__/sourcing.test.ts src/routes/projects/sourcing/__tests__/ProjectSourcingPage.test.tsx`
  - Passed: 2 files, 48 tests.
- `cd web && npm test -- --testNamePattern "sourcing|ProjectSourcingPage"`
  - Passed: 2 files passed, 45 skipped; 40 tests passed, 361 skipped.
- `cd web && npm run lint`
  - Failed on pre-existing unrelated lint issues: `src/lib/bagCode.ts` `no-control-regex` errors plus unrelated warnings outside this PR scope.
- `cd web && npx eslint src/components/DataTable.tsx src/components/RiskLegendPopover.tsx src/lib/__tests__/sourcing.test.ts src/lib/riskLegends.ts src/lib/sourcing.ts src/routes/parts/detail/AuthorizedSupplyTab.tsx src/routes/projects/sourcing/BomDistributorsModal.tsx src/routes/projects/sourcing/ProjectSourcingPage.tsx src/routes/projects/sourcing/__tests__/ProjectSourcingPage.test.tsx src/routes/reports/SourcingRiskReport.tsx`
  - Passed with no output.
- `git diff --check`
  - Passed with no output.

## Tone Choice

Option A. `low-warning` uses `bg-success/30 text-success`, reusing the existing success palette at higher opacity than the Low tone. No Tailwind config or palette change.

## Merge Order

Merge order: #487 first, then #485, then #486; rebase later siblings after this lands because ProjectSourcingPage/test/CHANGELOG overlap.

Refs #487
