### PR TITLE
SX-11: Coverage variant Price = price of covered lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ the canonical record.
 - **SX-12 / #487** Project Sourcing now uses the four-level TrustedParts
   risk vocabulary, including a light-green Low-Med band and header popover
   legends for Lifecycle and Supply chain risk columns.
+- **SX-11 / #486** Project Sourcing coverage variant prices now represent the
+  purchasable covered lines for the returned distributor combo, including partial
+  coverage, and the UI labels partial totals as covered-line prices.
 - **SX-5 / #480** Project Sourcing keeps the legacy distributor coverage matrix
   shortfall-based while the fewest-distributors variant continues to apply MOQ
   selected quantities for feasibility and totals.

--- a/backend/app/domain/sourcing/coverage.py
+++ b/backend/app/domain/sourcing/coverage.py
@@ -354,7 +354,8 @@ def _lowest_total_price_variant(
     bom_rows: list[SourcingBomLineOut],
 ) -> tuple[list[str], Decimal | None]:
     outcome = optimize(bom_rows, strategy="lowest_total_price")
-    return outcome.distributors_used, outcome.est_total_cost
+    combo = tuple(distributor.casefold() for distributor in outcome.distributors_used)
+    return outcome.distributors_used, _combo_total_cost(combo, bom_rows)
 
 
 def _fewest_distributors_variant(
@@ -490,7 +491,7 @@ def _combo_total_cost(
         ]
         priced_costs = [cost for cost in costs if cost is not None]
         if not priced_costs:
-            return None
+            continue
         running += min(priced_costs)
         has_priced_line = True
     return running if has_priced_line else None

--- a/backend/tests/test_sourcing_coverage.py
+++ b/backend/tests/test_sourcing_coverage.py
@@ -21,7 +21,7 @@ def _offer(
     *,
     mpn: str = "MPN",
     stock: int = 10,
-    unit_price: str = "1.00",
+    unit_price: str | None = "1.00",
     moq: int | None = None,
     lead_time_days: int | None = 3,
     price_breaks: list[tuple[int, str]] | None = None,
@@ -30,12 +30,14 @@ def _offer(
         mpn=mpn,
         distributor=distributor,
         stock=stock,
-        unit_price=Decimal(unit_price),
+        unit_price=Decimal(unit_price) if unit_price is not None else None,
         moq=moq,
         lead_time_days=lead_time_days,
         price_breaks=[
             SourcingBomPriceBreakOut(quantity=quantity, unit_price=Decimal(price))
-            for quantity, price in (price_breaks or [(1, unit_price)])
+            for quantity, price in (
+                price_breaks or ([(1, unit_price)] if unit_price is not None else [])
+            )
         ],
     )
 
@@ -223,6 +225,53 @@ def test_lowest_total_price_combo_uses_optimizer_selections():
     assert matrix.fewest_distributors_total == Decimal("135.00")
 
 
+def test_lowest_total_price_total_sums_partial_covered_priced_lines():
+    matrix = compute_coverage(
+        [
+            _line(1, offers=[_offer("Alpha", unit_price="2.00")]),
+            _line(2, offers=[]),
+        ]
+    )
+
+    assert matrix.lowest_total_price_combo == ["Alpha"]
+    assert matrix.lowest_total_price_total == Decimal("10.00")
+
+
+def test_lowest_total_price_total_full_coverage_unchanged():
+    matrix = compute_coverage(
+        [
+            _line(1, offers=[_offer("Alpha", unit_price="2.00")]),
+            _line(2, offers=[_offer("Beta", unit_price="3.00")]),
+        ]
+    )
+
+    assert matrix.lowest_total_price_combo == ["Alpha", "Beta"]
+    assert matrix.lowest_total_price_total == Decimal("25.00")
+
+
+def test_variant_totals_return_none_when_no_covered_line_has_pricing():
+    matrix = compute_coverage(
+        [
+            _line(1, offers=[_offer("Unpriced", unit_price=None)]),
+            _line(2, offers=[]),
+        ]
+    )
+
+    assert matrix.lowest_total_price_combo == []
+    assert matrix.lowest_total_price_total is None
+    assert matrix.fewest_distributors_combo == ["Unpriced"]
+    assert matrix.fewest_distributors_total is None
+
+
+def test_variant_totals_return_none_for_zero_coverage():
+    matrix = compute_coverage([_line(1, offers=[])])
+
+    assert matrix.lowest_total_price_combo == []
+    assert matrix.lowest_total_price_total is None
+    assert matrix.fewest_distributors_combo == []
+    assert matrix.fewest_distributors_total is None
+
+
 def test_fewest_distributors_combo_returns_minimum_set():
     matrix = compute_coverage(
         [
@@ -271,6 +320,22 @@ def test_fewest_distributors_combo_tiebreak_by_total_cost():
 
     assert matrix.fewest_distributors_combo == ["Alpha", "Beta"]
     assert matrix.fewest_distributors_total == Decimal("10.00")
+
+
+def test_fewest_distributors_total_sums_partial_covered_priced_lines_with_moq():
+    matrix = compute_coverage(
+        [
+            _line(1, offers=[_offer("Alpha", unit_price="1.00")]),
+            _line(
+                2,
+                offers=[_offer("Alpha", stock=20, unit_price="2.00", moq=10)],
+            ),
+            _line(3, offers=[]),
+        ]
+    )
+
+    assert matrix.fewest_distributors_combo == ["Alpha"]
+    assert matrix.fewest_distributors_total == Decimal("25.00")
 
 
 def test_fewest_distributors_respects_moq_stock_and_totals_selected_qty():

--- a/docs/api/sourcing.md
+++ b/docs/api/sourcing.md
@@ -293,12 +293,15 @@ Sources: `backend/app/domain/sourcing/service.py:1322-1386`,
 - `coverage.best_single_distributor`, `coverage.best_two_distributor_combo`, and the
   per-distributor matrix rows use legacy shortfall coverage: an offer covers a row
   when distributor stock is at least `short_by`. `coverage.lowest_total_price_combo`
-  and `coverage.lowest_total_price_total` come from the optimizer's
-  `lowest_total_price` per-line selections. `coverage.fewest_distributors_combo`
-  and `coverage.fewest_distributors_total` choose the smallest distributor set that
-  reaches `target_coverage_pct`; this variant evaluates offer feasibility and totals
-  with the MOQ-aware selected quantity `max(short_by, moq)`. The implementation is
-  exhaustive up to 10 distributors and greedy beyond that threshold.
+  comes from the optimizer's `lowest_total_price` per-line selections.
+  `coverage.lowest_total_price_total` and `coverage.fewest_distributors_total`
+  sum only covered, purchasable lines that have pricing for the returned combo,
+  so partial coverage can still return a partial price. They are `null` only when
+  no covered, purchasable line has pricing. `coverage.fewest_distributors_combo`
+  chooses the smallest distributor set that reaches `target_coverage_pct`; this
+  variant evaluates offer feasibility and totals with the MOQ-aware selected
+  quantity `max(short_by, moq)`. The implementation is exhaustive up to 10
+  distributors and greedy beyond that threshold.
 - When `currency` is supplied, BOM offer prices whose native distributor currency differs are display-converted through the global ECB daily snapshot. Native `unit_price` and `currency` stay unchanged; converted display values are exposed as `unit_price_converted`, `currency_displayed`, `fx_converted`, `fx_rate_date`, and `price_breaks_converted`.
 - Each row exposes sourcing diagnostics: `reason` is `ok`, `no_mpn`, or `no_offers`; `cache_hit` is `true`/`false` for searched rows and `null` when no MPN was searched; row `fx_status` is `unavailable` when any offer on the row could not be converted. Top-level `fx_status` is `ok`, `partial`, or `unavailable` when a request currency was supplied and `null` when conversion was not requested.
 - BOM offer projections carry offer-level TrustedParts gap fields for downstream risk/report consumers, plus distributor availability text and quantity multiple for per-BOM-line distributor drill-downs.

--- a/docs/domain/sourcing.md
+++ b/docs/domain/sourcing.md
@@ -88,8 +88,12 @@ Sources: `backend/app/domain/sourcing/coverage.py:45-120`,
 
 Project BOM coverage returns two combination summaries above the per-distributor
 matrix: `lowest_total_price_combo` reuses the purchase-plan optimizer's
-`lowest_total_price` strategy, while `fewest_distributors_combo` finds the smallest
-distributor set that reaches the target coverage. The fewest-distributors search is
+`lowest_total_price` strategy for distributor selection, while
+`fewest_distributors_combo` finds the smallest distributor set that reaches the
+target coverage. Variant totals are the price of covered, purchasable BOM lines
+with pricing for that combination; partial coverage does not force the total to
+`null`. The total is `null` only when no covered, purchasable line has pricing.
+The fewest-distributors search is
 exhaustive through 10 distributors, then switches to a deterministic greedy set-cover
 heuristic that picks the distributor covering the most remaining lines and breaks ties
 by combo cost and distributor name.

--- a/web/src/routes/projects/sourcing/ProjectSourcingPage.tsx
+++ b/web/src/routes/projects/sourcing/ProjectSourcingPage.tsx
@@ -537,6 +537,12 @@ function CoverageVariantCard({
   const { pct, shortLines } = coverageForCombo(data, variant.combo);
   const comboText = variant.combo.length > 0 ? normalizedCombo(variant.combo).join(" + ") : "—";
   const coverageText = pct == null ? "—" : `${Math.round(pct * 100)}%`;
+  const hasPartialCoverage = shortLines != null && shortLines > 0;
+  const priceLabel = hasPartialCoverage ? "Price (covered lines)" : "Price";
+  const uncoveredText = hasPartialCoverage
+    ? `${shortLines.toLocaleString()} uncovered line${shortLines === 1 ? "" : "s"}`
+    : "";
+  const hasNoCoveredLinePricing = variant.total == null && variant.combo.length > 0;
   const shortText = shortLines && shortLines > 0
     ? ` (${shortLines.toLocaleString()} line${shortLines === 1 ? "" : "s"} short)`
     : "";
@@ -551,8 +557,14 @@ function CoverageVariantCard({
       <div className="text-lg font-semibold leading-snug">{comboText}</div>
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-sm">
         <div>
-          <div className="section-title">Price</div>
+          <div className="section-title">{priceLabel}</div>
           <div className="font-mono tabular-nums">{formatMoney(variant.total, currency)}</div>
+          {hasPartialCoverage && (
+            <div className="text-xs text-muted">{uncoveredText}</div>
+          )}
+          {hasNoCoveredLinePricing && (
+            <div className="text-xs text-muted">No pricing available on covered lines.</div>
+          )}
         </div>
         <div>
           <div className="section-title">Coverage</div>

--- a/web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.test.tsx
+++ b/web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.test.tsx
@@ -466,8 +466,46 @@ describe("ProjectSourcingPage", () => {
 
     expect(await screen.findByText("Lowest total price")).toBeDefined();
     expect(screen.getByText("DigiKey + Mouser")).toBeDefined();
+    expect(screen.getAllByText("Price").length).toBeGreaterThan(0);
     expect(screen.getAllByText("25 USD").length).toBeGreaterThan(0);
     expect(screen.getAllByText("100%").length).toBeGreaterThan(0);
+  });
+
+  it("Coverage card labels partial variant totals as covered-line prices", async () => {
+    mockReads();
+    vi.spyOn(api, "post").mockResolvedValue(sourcingResponse({
+      coverage: {
+        ...sourcingResponse().coverage,
+        lowest_total_price_combo: ["DigiKey"],
+        lowest_total_price_total: "20.00",
+        fewest_distributors_combo: ["DigiKey"],
+        fewest_distributors_total: "20.00",
+      },
+    }));
+
+    renderPage();
+
+    expect(await screen.findByText("Price (covered lines)")).toBeDefined();
+    expect(screen.getByText("1 uncovered line")).toBeDefined();
+    expect(screen.getAllByText("20 USD").length).toBeGreaterThan(0);
+  });
+
+  it("Coverage card explains null covered-line totals", async () => {
+    mockReads();
+    vi.spyOn(api, "post").mockResolvedValue(sourcingResponse({
+      coverage: {
+        ...sourcingResponse().coverage,
+        lowest_total_price_combo: ["DigiKey"],
+        lowest_total_price_total: null,
+        fewest_distributors_combo: ["DigiKey"],
+        fewest_distributors_total: null,
+      },
+    }));
+
+    renderPage();
+
+    expect(await screen.findByText("Price (covered lines)")).toBeDefined();
+    expect(screen.getByText("No pricing available on covered lines.")).toBeDefined();
   });
 
   it("Coverage card renders Fewest distributors variant", async () => {


### PR DESCRIPTION
## Summary

- Recompute coverage variant totals from the returned distributor combo so totals represent priced, purchasable covered BOM lines instead of going null when unrelated lines are unfilled.
- Keep legacy coverage rows, best single distributor, best two-distributor combo, and shortfall-based coverage semantics unchanged.
- Label partial coverage variant totals as `Price (covered lines)`, show the uncovered-line count, and explain null totals when covered lines have no pricing.
- Update sourcing API/domain docs and changelog for the partial covered-line total semantics.

## Tests

- `cd backend && uv run --extra dev python -m pytest -q tests/test_sourcing_coverage.py` -> 19 passed, 1 Alembic deprecation warning.
- `cd backend && uv run --extra dev ruff check app/domain/sourcing/coverage.py tests/test_sourcing_coverage.py` -> All checks passed.
- `cd web && npm ci` -> completed; npm reported Node 18 engine warnings for packages requiring Node 20+ and 6 moderate audit findings.
- `cd web && npm run typecheck` -> passed.
- `cd web && npm test -- "ProjectSourcingPage"` -> 1 file passed, 40 tests passed; React Router future-flag warnings.
- `cd web && npx eslint src/routes/projects/sourcing/ProjectSourcingPage.tsx src/routes/projects/sourcing/__tests__/ProjectSourcingPage.test.tsx` -> passed.
- `git diff --check` -> passed.

## None-as-incomplete consumers found

- `web/src/routes/projects/sourcing/ProjectSourcingPage.tsx` variant card formatting was the only runtime consumer found that displayed null variant totals as incomplete/no-price UI.
- `docs/api/sourcing.md` and `docs/domain/sourcing.md` documented the old semantics and were updated.
- Backend schema/dataclass fields remain nullable because `None` still means no covered, purchasable line has pricing.

## Merge order

Merge order: #487 first, then #485, then #486; rebase after earlier siblings land because ProjectSourcingPage/test/docs/CHANGELOG overlap.

Refs #486