### PR TITLE
SA-1: Fix _total_currency else branch returning first instead of None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ the canonical record.
 
 ## 2026-05 — feedback brief fixes
 
+- **SA-1 / #492** Sourcing capacity now treats mixed-currency BOM totals as
+  unknown instead of silently using the first currency.
 - **SX-10 / #485** Project Sourcing capacity now shows cost per single BOM
   alongside total BOM cost and short-quantity price to pay.
 - **SX-12 / #487** Project Sourcing now uses the four-level TrustedParts

--- a/backend/app/domain/sourcing/coverage.py
+++ b/backend/app/domain/sourcing/coverage.py
@@ -156,6 +156,8 @@ def _sum_best_offer_cost(
     running = Decimal("0")
     priced = False
     total_currency = _total_currency(rows)
+    if total_currency is None and _has_mixed_offer_currencies(rows):
+        return None
     for row in rows:
         qty = quantity_for_row(row)
         if not isinstance(qty, int) or qty <= 0:
@@ -178,7 +180,8 @@ def _total_currency(rows: list[SourcingBomLineOut]) -> str | None:
         and row.best_offer.currency_displayed is not None
     ]
     if converted:
-        return converted[0]
+        first = converted[0]
+        return first if all(currency == first for currency in converted) else None
 
     currencies = [
         currency
@@ -189,7 +192,17 @@ def _total_currency(rows: list[SourcingBomLineOut]) -> str | None:
     if not currencies:
         return None
     first = currencies[0]
-    return first if all(currency == first for currency in currencies) else first
+    return first if all(currency == first for currency in currencies) else None
+
+
+def _has_mixed_offer_currencies(rows: list[SourcingBomLineOut]) -> bool:
+    currencies = {
+        currency
+        for row in rows
+        if row.best_offer is not None
+        and (currency := _offer_display_currency(row.best_offer)) is not None
+    }
+    return len(currencies) > 1
 
 
 def _best_offer_priced_for_total(

--- a/backend/tests/test_sourcing_capacity.py
+++ b/backend/tests/test_sourcing_capacity.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from decimal import Decimal
 from uuid import UUID
 
-from app.domain.sourcing.coverage import compute_build_capacity
+from app.domain.sourcing.coverage import _total_currency, compute_build_capacity
 from app.domain.sourcing.schemas import (
     BuildCapacityOut,
     SourcingBomLineOut,
@@ -346,6 +346,77 @@ def test_total_bom_cost_none_when_no_line_has_pricing():
     )
 
     assert capacity.total_bom_cost is None
+
+
+def test_total_currency_returns_none_when_mixed():
+    assert _total_currency(
+        [
+            _line(1, best_offer=_offer(currency="USD")),
+            _line(2, best_offer=_offer(currency="EUR")),
+        ]
+    ) is None
+    assert _total_currency(
+        [
+            _line(
+                1,
+                best_offer=_offer(
+                    currency="USD",
+                    unit_price_converted="1.00",
+                    currency_displayed="EUR",
+                ),
+            ),
+            _line(
+                2,
+                best_offer=_offer(
+                    currency="USD",
+                    unit_price_converted="1.00",
+                    currency_displayed="GBP",
+                ),
+            ),
+        ]
+    ) is None
+
+
+def test_total_currency_returns_first_when_all_same():
+    assert _total_currency(
+        [
+            _line(1, best_offer=_offer(currency="usd")),
+            _line(2, best_offer=_offer(currency="USD")),
+        ]
+    ) == "USD"
+
+
+def test_total_currency_handles_empty_and_none():
+    assert _total_currency([]) is None
+    assert _total_currency([_line(1)]) is None
+
+
+def test_compute_build_capacity_currency_is_none_when_offers_mix_currencies():
+    capacity = compute_build_capacity(
+        [
+            _line(1, required=2, best_offer=_offer(unit_price="1.50", currency="USD")),
+            _line(2, required=3, best_offer=_offer(unit_price="2.00", currency="EUR")),
+        ],
+        requested_build_quantity=1,
+    )
+
+    assert capacity.total_bom_cost is None
+    assert capacity.cost_per_single_bom is None
+    assert capacity.purchase_to_pay_cost is None
+
+
+def test_compute_build_capacity_keeps_total_when_offers_share_currency():
+    capacity = compute_build_capacity(
+        [
+            _line(1, required=2, best_offer=_offer(unit_price="1.50", currency="USD")),
+            _line(2, required=3, best_offer=_offer(unit_price="2.00", currency="USD")),
+        ],
+        requested_build_quantity=1,
+    )
+
+    assert capacity.total_bom_cost == Decimal("9.00")
+    assert capacity.cost_per_single_bom == Decimal("9.00")
+    assert capacity.purchase_to_pay_cost == Decimal("9.00")
 
 
 def test_purchase_to_pay_cost_sums_short_by_unit_price():


### PR DESCRIPTION
## Summary
- Fix `_total_currency` so mixed native or converted currencies return `None` instead of the first currency.
- Treat mixed native-currency capacity totals as unknown because the current capacity schema has no separate currency field to carry `None`.
- Add direct helper coverage plus build-capacity regression tests and a changelog entry.

## Validation
- `cd backend && uv run --extra dev python -m pytest -q tests/test_sourcing_capacity.py` -> 29 passed, 1 warning.
- `cd backend && uv run --extra dev ruff check app/domain/sourcing/coverage.py tests/test_sourcing_capacity.py` -> passed.
- `git diff --check` -> passed.

## Merge Order
- Merge before #495 because #495 also extends `backend/tests/test_sourcing_capacity.py`.
- Independent of frontend PRs #493/#497/#498 except for possible `CHANGELOG.md` conflicts.

Refs #492