### PR TITLE
SA-2: Stop wiping overrides on PurchasePlanReviewPage refresh + add error toast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ the canonical record.
 
 - **SA-1 / #492** Sourcing capacity now treats mixed-currency BOM totals as
   unknown instead of silently using the first currency.
+- **SA-2 / #493** Fix PurchasePlanReviewPage refresh silently wiping user
+  overrides; add error toast on failure.
 - **SX-10 / #485** Project Sourcing capacity now shows cost per single BOM
   alongside total BOM cost and short-quantity price to pay.
 - **SX-12 / #487** Project Sourcing now uses the four-level TrustedParts

--- a/web/src/routes/projects/sourcing/PurchasePlanReviewPage.tsx
+++ b/web/src/routes/projects/sourcing/PurchasePlanReviewPage.tsx
@@ -5,7 +5,7 @@ import { toast } from "sonner";
 import { DataTable, type Column } from "@/components/DataTable";
 import { PoweredByTrustedParts } from "@/components/PoweredByTrustedParts";
 import { SourcingSourceLabel } from "@/components/SourcingSourceLabel";
-import { api } from "@/lib/api";
+import { ApiError, api } from "@/lib/api";
 import type { Project } from "@/types";
 import OverrideOfferModal from "./OverrideOfferModal";
 import type {
@@ -253,8 +253,10 @@ export default function PurchasePlanReviewPage() {
     try {
       const next = await api.post<PurchasePlan>(`/sourcing/purchase-plans/${plan.id}/refresh`);
       setPlan(next);
-      setOverrides({});
       toast.success("Prices refreshed");
+    } catch (err) {
+      const message = err instanceof ApiError && err.userMessage ? err.userMessage : "Failed to refresh prices";
+      toast.error(message);
     } finally {
       setBusyAction(null);
     }

--- a/web/src/routes/projects/sourcing/__tests__/PurchasePlanReviewPage.test.tsx
+++ b/web/src/routes/projects/sourcing/__tests__/PurchasePlanReviewPage.test.tsx
@@ -4,7 +4,7 @@ import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { toast } from "sonner";
-import { api } from "@/lib/api";
+import { ApiError, api } from "@/lib/api";
 import PurchasePlanReviewPage from "../PurchasePlanReviewPage";
 import type { PurchasePlan } from "../purchasePlanTypes";
 
@@ -213,6 +213,81 @@ describe("PurchasePlanReviewPage", () => {
     await waitFor(() => expect(screen.getByText("Arrow")).toBeDefined());
     expect(api.post).toHaveBeenCalledWith("/sourcing/purchase-plans/plan-12345678/refresh");
     expect(toast.success).toHaveBeenCalledWith("Prices refreshed");
+  });
+
+  it("preserves overrides across a successful refresh", async () => {
+    const refreshed = plan({
+      est_total_cost: "18.40",
+      lines: [
+        {
+          ...plan().lines[0],
+          selected_distributor: "DigiKey",
+          selected_qty: 16,
+          selected_unit_price: "1.15",
+        },
+        plan().lines[1],
+      ],
+      unfilled_count: 0,
+    });
+    const post = vi.spyOn(api, "post")
+      .mockResolvedValueOnce(refreshed)
+      .mockResolvedValueOnce({
+        orders: [{ id: "order-1", name: "Draft", supplier: "Arrow", status: "draft", entries: [] }],
+      });
+    renderPage();
+
+    await selectArrowOffer();
+    await userEvent.click(screen.getByRole("button", { name: /Refresh prices/ }));
+
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith("Prices refreshed"));
+
+    await userEvent.click(screen.getByRole("button", { name: /Create draft orders/ }));
+
+    await waitFor(() => expect(screen.getByTestId("location").textContent).toBe("/orders"));
+    expect(post).toHaveBeenNthCalledWith(2, "/sourcing/purchase-plans/plan-12345678/orders", {
+      overrides: {
+        "line-1": {
+          selected_distributor: "Arrow",
+          selected_qty: 16,
+          selected_unit_price: "2.05",
+          selected_currency: "USD",
+        },
+      },
+    });
+  });
+
+  it("shows error toast on refresh failure", async () => {
+    const apiError = new ApiError(
+      502,
+      { data: null, status: { category: "trustedparts_unavailable", message: "TrustedParts unavailable" } },
+      "Bad Gateway",
+    );
+    apiError.userMessage = "TrustedParts unavailable. Retry later.";
+    const post = vi.spyOn(api, "post")
+      .mockRejectedValueOnce(apiError)
+      .mockResolvedValueOnce({
+        orders: [{ id: "order-1", name: "Draft", supplier: "Arrow", status: "draft", entries: [] }],
+      });
+    renderPage();
+
+    await selectArrowOffer();
+    await userEvent.click(screen.getByRole("button", { name: /Refresh prices/ }));
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith("TrustedParts unavailable. Retry later."));
+
+    await userEvent.click(screen.getByRole("button", { name: /Create draft orders/ }));
+
+    await waitFor(() => expect(screen.getByTestId("location").textContent).toBe("/orders"));
+    expect(post).toHaveBeenNthCalledWith(2, "/sourcing/purchase-plans/plan-12345678/orders", {
+      overrides: {
+        "line-1": {
+          selected_distributor: "Arrow",
+          selected_qty: 16,
+          selected_unit_price: "2.05",
+          selected_currency: "USD",
+        },
+      },
+    });
   });
 
   it("Create draft orders is disabled when last_refreshed_at is null", () => {


### PR DESCRIPTION
## Summary
- Preserve purchase plan order overrides when Refresh prices succeeds.
- Show a refresh failure toast using `ApiError.userMessage`, with a generic fallback for non-API errors.
- Add PurchasePlanReviewPage tests covering successful refresh preservation and refresh failure toast/override retention.
- Add the requested CHANGELOG entry.

## Validation
- `cd web && npm run typecheck`: passed (`tsc -b`).
- `cd web && npm test -- "PurchasePlanReviewPage"`: passed (`1` test file, `11` tests).
- `cd web && npm run lint`: baseline-failing on pre-existing violations outside this issue (`ZxingScanner.tsx`, `bagCode.ts`, responsive grid/order/parts/storage warnings).
- `cd web && LINT_CMD="npm run lint -- --format=unix" BASELINE_FILE="../.eslint-baseline.txt" WORK_DIR="." bash ../scripts/lint-delta.sh`: passed (`lint-delta: no new violations (baseline: 8, current: 8, fixed since baseline: 0)`).
- `git diff --check`: passed.

## Merge order
Merge before #500; independent of #497/#498; expect CHANGELOG conflict if siblings merge first

Refs #493