### PR TITLE
SA-3: Persist last_notified_at before SMTP send (at-least-once -> at-most-once)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ the canonical record.
   unknown instead of silently using the first currency.
 - **SA-2 / #493** Fix PurchasePlanReviewPage refresh silently wiping user
   overrides; add error toast on failure.
+- **SA-3 / #494** Sourcing alert notifications now commit `last_notified_at`
+  before SMTP dispatch, trading one missed outage email for duplicate suppression.
 - **SX-10 / #485** Project Sourcing capacity now shows cost per single BOM
   alongside total BOM cost and short-quantity price to pay.
 - **SX-12 / #487** Project Sourcing now uses the four-level TrustedParts

--- a/backend/app/domain/sourcing/alerts_evaluator.py
+++ b/backend/app/domain/sourcing/alerts_evaluator.py
@@ -36,6 +36,13 @@ class AlertVerdict:
     new_state: dict[str, Any]
 
 
+@dataclass(frozen=True)
+class AlertEmail:
+    recipients: list[str]
+    subject: str
+    body: str
+
+
 EvaluatorFn = Callable[[Session, Workspace, SourcingAlert], AlertVerdict]
 
 
@@ -56,24 +63,37 @@ def evaluate_all_alerts(db: Session) -> int:
     evaluated = 0
     for alert, workspace in rows:
         evaluated += 1
+        alert_id: UUID | None = None
+        alert_type: str | None = None
+        workspace_id: UUID | None = None
         try:
+            alert_id = alert.id
+            alert_type = alert.alert_type
+            workspace_id = workspace.id
             evaluator = EVALUATORS[alert.alert_type]
             verdict = evaluator(db, workspace, alert)
             checked_at = utcnow()
             alert.last_checked_at = checked_at
             alert.last_evaluation_state = verdict.new_state
             sent = False
+            email: AlertEmail | None = None
             if verdict.triggered and _cooldown_elapsed(alert):
-                sent = _send_alert_email(db, workspace, alert, verdict)
-                if sent:
+                email = _prepare_alert_email(db, workspace, alert, verdict)
+                if email is not None:
                     alert.last_notified_at = checked_at
             db.commit()
+            if email is not None:
+                sent = _send_alert_email(
+                    workspace_id=workspace_id,
+                    alert_id=alert_id,
+                    email=email,
+                )
             log.info(
                 "sourcing_alert.evaluated workspace_id=%s alert_id=%s type=%s "
                 "triggered=%s notified=%s",
-                workspace.id,
-                alert.id,
-                alert.alert_type,
+                workspace_id,
+                alert_id,
+                alert_type,
                 verdict.triggered,
                 sent,
             )
@@ -81,9 +101,9 @@ def evaluate_all_alerts(db: Session) -> int:
             db.rollback()
             log.exception(
                 "sourcing_alert.evaluation_failed workspace_id=%s alert_id=%s type=%s",
-                getattr(workspace, "id", None),
-                getattr(alert, "id", None),
-                getattr(alert, "alert_type", None),
+                workspace_id,
+                alert_id,
+                alert_type,
             )
     return evaluated
 
@@ -355,11 +375,42 @@ def _cooldown_elapsed(alert: SourcingAlert) -> bool:
 
 
 def _send_alert_email(
+    *,
+    workspace_id: UUID,
+    alert_id: UUID,
+    email: AlertEmail,
+) -> bool:
+    sent_any = False
+    for recipient in email.recipients:
+        try:
+            mail.send(to=recipient, subject=email.subject, text_body=email.body)
+            sent_any = True
+        except Exception as exc:
+            log.warning(
+                "sourcing_alert.smtp_failed workspace_id=%s alert_id=%s to=%s "
+                "exception_type=%s error=%s",
+                workspace_id,
+                alert_id,
+                recipient,
+                type(exc).__name__,
+                exc,
+            )
+            log.debug(
+                "sourcing_alert.smtp_failed_debug workspace_id=%s alert_id=%s to=%s",
+                workspace_id,
+                alert_id,
+                recipient,
+                exc_info=True,
+            )
+    return sent_any
+
+
+def _prepare_alert_email(
     db: Session,
     workspace: Workspace,
     alert: SourcingAlert,
     verdict: AlertVerdict,
-) -> bool:
+) -> AlertEmail | None:
     recipients = _recipient_emails(db, workspace, alert)
     if not recipients:
         log.warning(
@@ -367,24 +418,11 @@ def _send_alert_email(
             workspace.id,
             alert.id,
         )
-        return False
+        return None
 
     subject = f"[stockManager] {verdict.summary}"
     body = _render_email_body(workspace, alert, verdict)
-    sent_any = False
-    for recipient in recipients:
-        try:
-            mail.send(to=recipient, subject=subject, text_body=body)
-            sent_any = True
-        except Exception as exc:
-            log.warning(
-                "sourcing_alert.smtp_failed workspace_id=%s alert_id=%s to=%s error=%s",
-                workspace.id,
-                alert.id,
-                recipient,
-                exc,
-            )
-    return sent_any
+    return AlertEmail(recipients=recipients, subject=subject, body=body)
 
 
 def _recipient_emails(

--- a/backend/tests/test_sourcing_alerts_evaluator.py
+++ b/backend/tests/test_sourcing_alerts_evaluator.py
@@ -836,6 +836,104 @@ def test_cooldown_elapsed_re_triggers(db: Session, monkeypatch) -> None:
     assert len(sent) == 1
 
 
+def test_smtp_failure_does_not_cause_resend_next_pass(
+    db: Session,
+    monkeypatch,
+    caplog,
+) -> None:
+    workspace, user = _workspace(db)
+    part = _part(db, workspace, user)
+    alert = _alert(
+        db,
+        workspace,
+        user,
+        part=part,
+        alert_type="stock_below",
+        threshold={"qty": 5},
+        cooldown_seconds=60,
+    )
+    monkeypatch.setitem(
+        alerts_evaluator.EVALUATORS,
+        "stock_below",
+        lambda _db, _ws, _alert: AlertVerdict(True, "Triggered", {}, {"qty": 1}),
+    )
+    attempts: list[dict[str, Any]] = []
+
+    def fail_send(**kwargs: Any) -> None:
+        attempts.append(kwargs)
+        raise RuntimeError("smtp down")
+
+    monkeypatch.setattr(alerts_evaluator.mail, "send", fail_send)
+
+    assert evaluate_all_alerts(db) == 1
+    db.refresh(alert)
+    first_notified_at = alert.last_notified_at
+
+    assert first_notified_at is not None
+    assert evaluate_all_alerts(db) == 1
+    db.refresh(alert)
+    assert alert.last_notified_at == first_notified_at
+    assert len(attempts) == 1
+    assert "sourcing_alert.smtp_failed" in caplog.text
+    assert "exception_type=RuntimeError" in caplog.text
+
+
+def test_db_commit_failure_propagates_before_smtp(db: Session, monkeypatch, caplog) -> None:
+    workspace, user = _workspace(db)
+    part = _part(db, workspace, user)
+    _alert(
+        db,
+        workspace,
+        user,
+        part=part,
+        alert_type="stock_below",
+        threshold={"qty": 5},
+    )
+    monkeypatch.setitem(
+        alerts_evaluator.EVALUATORS,
+        "stock_below",
+        lambda _db, _ws, _alert: AlertVerdict(True, "Triggered", {}, {"qty": 1}),
+    )
+    sent = _capture_mail(monkeypatch)
+
+    def fail_commit() -> None:
+        raise RuntimeError("commit failed")
+
+    monkeypatch.setattr(db, "commit", fail_commit)
+
+    assert evaluate_all_alerts(db) == 1
+
+    assert sent == []
+    assert "sourcing_alert.evaluation_failed" in caplog.text
+
+
+def test_happy_path_still_works(db: Session, monkeypatch) -> None:
+    workspace, user = _workspace(db)
+    part = _part(db, workspace, user)
+    alert = _alert(
+        db,
+        workspace,
+        user,
+        part=part,
+        alert_type="stock_below",
+        threshold={"qty": 5},
+    )
+    monkeypatch.setitem(
+        alerts_evaluator.EVALUATORS,
+        "stock_below",
+        lambda _db, _ws, _alert: AlertVerdict(True, "Triggered", {}, {"qty": 1}),
+    )
+    sent = _capture_mail(monkeypatch)
+
+    assert evaluate_all_alerts(db) == 1
+
+    db.refresh(alert)
+    assert len(sent) == 1
+    assert alert.last_checked_at is not None
+    assert alert.last_notified_at is not None
+    assert alert.last_evaluation_state == {"qty": 1}
+
+
 def test_smtp_failure_does_not_crash_loop(db: Session, monkeypatch, caplog) -> None:
     workspace, user = _workspace(db)
     part = _part(db, workspace, user)

--- a/docs/domain/sourcing.md
+++ b/docs/domain/sourcing.md
@@ -256,13 +256,21 @@ Sources: `backend/alembic/versions/0044_sourcing_alerts.py:20`,
 `evaluate_all_alerts(db)` scans enabled, non-archived rows across workspaces, dispatches
 by `alert_type`, persists `last_checked_at` and `last_evaluation_state`, and commits
 per alert row. Evaluator failures roll back only the current row and are logged so later
-alerts still run. Source: `backend/app/domain/sourcing/alerts_evaluator.py:42-88`
+alerts still run. Source: `backend/app/domain/sourcing/alerts_evaluator.py:49-108`
+
+Alert notification dispatch is intentionally at-most-once. When a triggered alert has
+recipients, the evaluator renders the email, writes `last_notified_at`, and commits
+before calling SMTP; an SMTP outage logs a WARN and the cooldown suppresses duplicate
+sends until the next eligible window. A DB commit failure happens before SMTP and leaves
+the alert retryable. Source: `backend/app/domain/sourcing/alerts_evaluator.py:80-90`,
+`backend/app/domain/sourcing/alerts_evaluator.py:377-425`
 
 All evaluator queries stay workspace-scoped. Part and project targets are loaded with
 `workspace_id == workspace.id`, recipient lookup joins `workspace_members` on the same
 workspace, and sourcing calls receive the current alert workspace. Sources:
-`backend/app/domain/sourcing/alerts_evaluator.py:331-349`,
-`backend/app/domain/sourcing/alerts_evaluator.py:377-402`
+`backend/app/domain/sourcing/alerts_evaluator.py:428-446`,
+`backend/app/domain/sourcing/alerts_evaluator.py:474-499`,
+`backend/app/domain/sourcing/alerts_evaluator.py:502-596`
 
 | `alert_type` | Trigger rule | Persisted state |
 |---|---|---|


### PR DESCRIPTION
## Summary
- Persist eligible sourcing alert `last_notified_at` in the same commit as evaluator state before any SMTP send occurs.
- Split alert email preparation from SMTP dispatch so SMTP failures log at WARN with `workspace_id`, `alert_id`, and exception type, plus DEBUG traceback, without rolling back the committed suppression marker.
- Document the at-most-once notification tradeoff and add a changelog note.

## Tests
- `cd backend && uv run --extra dev python -m pytest -q tests/test_sourcing_alerts_evaluator.py`
  - `35 passed, 1 warning in 2.04s`
- `cd backend && uv run --extra dev python -m pytest -q tests/test_sourcing_alerts_evaluator.py -k "test_smtp_failure_does_not_cause_resend_next_pass or test_db_commit_failure_propagates_before_smtp or test_happy_path_still_works"`
  - `3 passed, 32 deselected, 1 warning in 1.59s`
- `cd backend && uv run --extra dev ruff check app/domain/sourcing/alerts_evaluator.py tests/test_sourcing_alerts_evaluator.py`
  - `All checks passed!`
- `git diff --check`
  - No output.

## At-most-once Tradeoff
Alert notifications now prefer at-most-once delivery: once an eligible alert has recipients, the database records `last_notified_at` before SMTP dispatch. If SMTP is down, the operator may miss that one notification until the next eligible cooldown window, but the evaluator will not flood duplicate emails after a send succeeds and a later database commit fails.

## Merge Order
Can merge anytime after #492/#493; expect CHANGELOG conflict if siblings merge first

Refs #494
