### PR TITLE
SA-6: Convert POST /projects/:id/sourcing from queryFn -> useMutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ the canonical record.
 
 ## 2026-05 — feedback brief fixes
 
+- **SA-6 / #497** Project Sourcing now runs the audited BOM sourcing POST only
+  from an explicit Source click, preserving the display cache without
+  remount/focus/filter-change refetches.
 - **SA-1 / #492** Sourcing capacity now treats mixed-currency BOM totals as
   unknown instead of silently using the first currency.
 - **SA-2 / #493** Fix PurchasePlanReviewPage refresh silently wiping user

--- a/docs/api/sourcing.md
+++ b/docs/api/sourcing.md
@@ -279,6 +279,8 @@ Sources: `backend/app/domain/sourcing/service.py:1322-1386`,
 **Notes**
 
 - The route validates `project_id` with `assert_in_workspace()` before calling the sourcing service.
+- The React project sourcing page treats this audited POST as an explicit user-submit mutation, not a query. A successful response seeds a workspace-scoped TanStack display cache with `queryClient.setQueryData()`, so revisiting the page can render the previous result immediately; focus, remounts, and filter edits do not call this route again until the operator clicks Source.
+- Client source: `web/src/routes/projects/sourcing/ProjectSourcingPage.tsx:890-908`, `web/src/routes/projects/sourcing/ProjectSourcingPage.tsx:1067-1083`.
 - The service reuses `shortage_analysis()`, `dedupe_mpns()`, `chunk_mpns()`, and per-MPN `search()` cache rows; BOM chunks use `ttl_seconds=600`.
 - Decimal prices and extended costs serialize as strings.
 - `build_quantity` echoes the requested build quantity. `capacity.total_bom_cost`

--- a/web/src/routes/projects/sourcing/ProjectSourcingPage.tsx
+++ b/web/src/routes/projects/sourcing/ProjectSourcingPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { BellPlus, FolderKanban, RefreshCw } from "lucide-react";
 import { toast } from "sonner";
 import EmptyState from "@/components/EmptyState";
@@ -138,7 +138,6 @@ type SourcingRequest = {
   distributors?: string[];
 };
 
-const SOURCING_BOM_STALE_TIME_MS = 5 * 60 * 1000;
 const SOURCING_BOM_GC_TIME_MS = 30 * 60 * 1000;
 
 function numberOrNull(value: string | number | null | undefined): number | null {
@@ -274,6 +273,12 @@ function RohsRiskPill({ tone }: { tone: "good" | "danger" | "neutral" }) {
 
 function errorStatus(error: unknown): number | null {
   return error instanceof ApiError ? error.status : null;
+}
+
+function sourcingErrorToastMessage(error: unknown): string {
+  if (errorStatus(error) === 429) return "Rate limit hit — wait a minute before sourcing again.";
+  if (error instanceof ApiError) return error.userMessage;
+  return "Failed to source BOM. Try again.";
 }
 
 function defaultFromActiveList(saved: string | null | undefined, active: string[]): string {
@@ -798,6 +803,7 @@ function BomRows({ rows, workspaceCurrency }: { rows: SourcingBomLine[]; workspa
 export default function ProjectSourcingPage() {
   const { projectId } = useParams<{ projectId: string }>();
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const [buildQuantity, setBuildQuantity] = useState(1);
   const [country, setCountry] = useState("");
   const [currency, setCurrency] = useState("");
@@ -881,35 +887,32 @@ export default function ProjectSourcingPage() {
     return body;
   }, [buildQuantity, country, currency, distributors, workspace?.sourcing_currency_code]);
 
-  const query = useQuery({
-    queryKey: useWsKey("sourcing", "project", projectId, requestBody),
-    queryFn: ({ signal }) =>
-      api.post<SourcingBomResponse, SourcingRequest>(`/projects/${projectId}/sourcing`, requestBody, { signal }),
-    enabled: !!projectId && buildQuantity >= 1 && defaultsApplied && activeListErrors.length === 0,
-    staleTime: SOURCING_BOM_STALE_TIME_MS,
+  const sourcingDisplayCacheKey = useWsKey("project-sourcing", projectId);
+  const cachedSourcing = useQuery<SourcingBomResponse | null>({
+    queryKey: sourcingDisplayCacheKey,
+    queryFn: async () => null,
+    enabled: false,
+    staleTime: Infinity,
     gcTime: SOURCING_BOM_GC_TIME_MS,
-    placeholderData: previousData => previousData,
-    refetchOnWindowFocus: false,
   });
+  const sourcing = useMutation<SourcingBomResponse, unknown, SourcingRequest>({
+    mutationFn: body =>
+      api.post<SourcingBomResponse, SourcingRequest>(`/projects/${projectId}/sourcing`, body),
+    onSuccess: result => {
+      queryClient.setQueryData(sourcingDisplayCacheKey, result);
+    },
+    onError: error => {
+      const status = errorStatus(error);
+      if (status === 503) setBudgetDisabledUntil(Date.now() + 5 * 60 * 1000);
+      toast.error(sourcingErrorToastMessage(error));
+    },
+  });
+  const sourcingData = sourcing.data ?? cachedSourcing.data ?? undefined;
   const purchasePlanBaseRequest = useMemo<Omit<PurchasePlanRequest, "strategy">>(() => {
     const body = { ...requestBody };
     if (body.currency == null) delete body.currency;
     return body as Omit<PurchasePlanRequest, "strategy">;
   }, [requestBody]);
-  const queryIsError = query.isError;
-  const queryError = query.error;
-  const refetchSourcing = query.refetch;
-
-  useEffect(() => {
-    if (!queryIsError) return;
-    const status = errorStatus(queryError);
-    if (status === 503) setBudgetDisabledUntil(Date.now() + 5 * 60 * 1000);
-    if (status === 502 || (queryError instanceof Error && queryError.name === "AbortError")) {
-      toast.error("TrustedParts unavailable. Retry?", {
-        action: { label: "Retry", onClick: () => refetchSourcing() },
-      });
-    }
-  }, [queryIsError, queryError, refetchSourcing]);
 
   useEffect(() => {
     if (budgetDisabledUntil == null) return;
@@ -918,16 +921,23 @@ export default function ProjectSourcingPage() {
     return () => window.clearTimeout(timeout);
   }, [budgetDisabledUntil]);
 
-  const status = errorStatus(query.error);
-  const sourceDisabled = query.isFetching ||
+  const status = errorStatus(sourcing.error);
+  const sourceBlocked =
     buildQuantity < 1 ||
+    !defaultsApplied ||
     activeListErrors.length > 0 ||
     (workspace ? !workspace.active_countries.includes(country) : false) ||
     (workspace ? !workspace.active_currencies.includes(currency) : false) ||
     distributors.some(distributor => workspace ? !workspace.active_distributors.includes(distributor) : false) ||
     (budgetDisabledUntil != null && Date.now() < budgetDisabledUntil);
-  const hasRows = (query.data?.rows.length ?? 0) > 0;
-  const primaryUrl = query.data?.links.primary;
+  const sourceDisabled = sourcing.isPending || sourceBlocked;
+  const hasRows = (sourcingData?.rows.length ?? 0) > 0;
+  const primaryUrl = sourcingData?.links.primary;
+
+  function runSourcing() {
+    if (!projectId || sourceDisabled) return;
+    sourcing.mutate(requestBody);
+  }
 
   async function generatePurchasePlan(planRequest: PurchasePlanRequest) {
     if (!projectId) return;
@@ -955,7 +965,7 @@ export default function ProjectSourcingPage() {
           <div className="text-sm text-muted">Projects · {project?.name ?? "Project"} · Sourcing</div>
           <div className="mt-1 flex flex-wrap items-center gap-2">
             <h1 className="text-xl font-semibold">Source BOM</h1>
-            {query.data?.partial && <span className="pill bg-warning/10 text-warning">Partial — some chunks served from cache</span>}
+            {sourcingData?.partial && <span className="pill bg-warning/10 text-warning">Partial — some chunks served from cache</span>}
           </div>
         </div>
         <PoweredByTrustedParts primaryUrl={primaryUrl} />
@@ -1058,47 +1068,47 @@ export default function ProjectSourcingPage() {
             type="button"
             className="btn-primary"
             disabled={sourceDisabled}
-            onClick={() => query.refetch()}
+            onClick={runSourcing}
           >
-            <RefreshCw size={14} className={query.isFetching ? "animate-spin" : ""} />
-            {query.isFetching ? "Sourcing…" : "Source"}
+            <RefreshCw size={14} className={sourcing.isPending ? "animate-spin" : ""} />
+            {sourcing.isPending ? "Sourcing…" : "Source"}
           </button>
         </div>
       </div>
 
-      {query.isLoading && <SourcingSkeleton />}
-      {query.isFetching && !query.isLoading && (
+      {sourcing.isPending && !sourcingData && <SourcingSkeleton />}
+      {sourcing.isPending && sourcingData && (
         <div className="text-xs text-muted" role="status">
           Refreshing prices in the background...
         </div>
       )}
-      {status === 503 && <BudgetState disabledUntil={budgetDisabledUntil} onRetry={() => query.refetch()} />}
+      {status === 503 && <BudgetState disabledUntil={budgetDisabledUntil} onRetry={runSourcing} />}
       {status === 502 && (
         <div className="card p-4" role="status">
-          <button type="button" className="btn" onClick={() => query.refetch()}>
+          <button type="button" className="btn" onClick={runSourcing}>
             Retry Source BOM
           </button>
         </div>
       )}
-      {query.isError && status !== 409 && status !== 502 && status !== 503 && (
+      {sourcing.isError && status !== 409 && status !== 502 && status !== 503 && (
         <div className="card p-4 text-sm text-danger">Failed to source BOM.</div>
       )}
 
-      {query.data && !hasRows && <EmptyBomState projectId={projectId} />}
+      {sourcingData && !hasRows && <EmptyBomState projectId={projectId} />}
       <SourcingDiagnosticsPanel
-        data={query.data}
+        data={sourcingData}
         projectId={projectId}
         status={status}
-        onRefresh={() => query.refetch()}
+        onRefresh={runSourcing}
       />
 
-      {query.data && hasRows && (
+      {sourcingData && hasRows && (
         <>
-          <CapacityBanner data={query.data} currency={requestBody.currency} />
-          <CoverageMatrix data={query.data} currency={requestBody.currency} />
-          <BomRows rows={query.data.rows} workspaceCurrency={requestBody.currency ?? workspace?.sourcing_currency_code ?? null} />
+          <CapacityBanner data={sourcingData} currency={requestBody.currency} />
+          <CoverageMatrix data={sourcingData} currency={requestBody.currency} />
+          <BomRows rows={sourcingData.rows} workspaceCurrency={requestBody.currency ?? workspace?.sourcing_currency_code ?? null} />
           <div className="text-xs text-muted">
-            {formatCount(query.data.rows.length)} line{query.data.rows.length === 1 ? "" : "s"} fetched from {query.data.powered_by}.
+            {formatCount(sourcingData.rows.length)} line{sourcingData.rows.length === 1 ? "" : "s"} fetched from {sourcingData.powered_by}.
           </div>
         </>
       )}

--- a/web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.test.tsx
+++ b/web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, render, screen, waitFor, within } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -224,6 +224,18 @@ function renderPage() {
   );
 }
 
+async function clickSource(user = userEvent.setup()) {
+  const button = await screen.findByRole("button", { name: "Source" }) as HTMLButtonElement;
+  await waitFor(() => expect(button.disabled).toBe(false));
+  await user.click(button);
+  return button;
+}
+
+async function sourceBom(user = userEvent.setup()) {
+  await clickSource(user);
+  expect(await screen.findByText("BOM rows")).toBeDefined();
+}
+
 beforeEach(() => {
   cleanup();
   localStorage.clear();
@@ -252,6 +264,67 @@ describe("ProjectSourcingPage", () => {
 
     const country = await screen.findByLabelText("Country") as HTMLSelectElement;
     await waitFor(() => expect(country.value).toBe("DE"));
+  });
+
+  it("does not fire POST on mount", async () => {
+    mockReads();
+    const post = vi.spyOn(api, "post").mockResolvedValue(sourcingResponse());
+
+    renderPage();
+
+    await screen.findByRole("button", { name: "Source" });
+    await waitFor(() => expect((screen.getByRole("button", { name: "Source" }) as HTMLButtonElement).disabled).toBe(false));
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it("fires exactly one POST on submit", async () => {
+    mockReads();
+    const post = vi.spyOn(api, "post").mockResolvedValue(sourcingResponse());
+
+    renderPage();
+    await clickSource();
+
+    await waitFor(() => expect(post).toHaveBeenCalledTimes(1));
+  });
+
+  it("does not refire POST on window focus", async () => {
+    mockReads();
+    const post = vi.spyOn(api, "post").mockResolvedValue(sourcingResponse());
+
+    renderPage();
+    await clickSource();
+    await waitFor(() => expect(post).toHaveBeenCalledTimes(1));
+
+    fireEvent.focus(window);
+
+    await waitFor(() => expect(post).toHaveBeenCalledTimes(1));
+  });
+
+  it("does not refire POST on requestBody keystroke before submit", async () => {
+    const user = userEvent.setup();
+    mockReads();
+    const post = vi.spyOn(api, "post").mockResolvedValue(sourcingResponse());
+
+    renderPage();
+
+    await screen.findByRole("button", { name: "Source" });
+    await waitFor(() => expect((screen.getByRole("button", { name: "Source" }) as HTMLButtonElement).disabled).toBe(false));
+    await user.clear(screen.getByLabelText("Build quantity"));
+    await user.type(screen.getByLabelText("Build quantity"), "12");
+
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it("shows error toast on 429", async () => {
+    mockReads();
+    vi.spyOn(api, "post").mockRejectedValue(apiError(429, "Too Many Requests"));
+
+    renderPage();
+    await clickSource();
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("Rate limit hit — wait a minute before sourcing again.");
+    });
   });
 
   it("distributors multi-select defaults to workspace.sourcing_preferred_distributors", async () => {
@@ -316,6 +389,7 @@ describe("ProjectSourcingPage", () => {
     vi.spyOn(api, "post").mockResolvedValue(sourcingResponse());
 
     renderPage();
+    await clickSource();
 
     expect(await screen.findByText("Can build now")).toBeDefined();
     expect(screen.getByText("After purchase")).toBeDefined();
@@ -330,6 +404,7 @@ describe("ProjectSourcingPage", () => {
     vi.spyOn(api, "post").mockResolvedValue(sourcingResponse());
 
     renderPage();
+    await clickSource();
 
     expect(await screen.findByText("Cost per 1 BOM:")).toBeDefined();
     expect(screen.getByText("15 USD")).toBeDefined();
@@ -341,6 +416,7 @@ describe("ProjectSourcingPage", () => {
     vi.spyOn(api, "post").mockResolvedValue(sourcingResponse());
 
     renderPage();
+    await clickSource();
 
     expect(await screen.findByText("Price to pay:")).toBeDefined();
     expect(screen.getAllByText("25 USD").length).toBeGreaterThan(0);
@@ -363,6 +439,7 @@ describe("ProjectSourcingPage", () => {
     }));
 
     renderPage();
+    await clickSource();
 
     expect(await screen.findByText("Total BOM cost:")).toBeDefined();
     expect(screen.getAllByText("no pricing available on any line").length).toBeGreaterThanOrEqual(2);
@@ -375,6 +452,7 @@ describe("ProjectSourcingPage", () => {
     vi.spyOn(api, "post").mockResolvedValue(sourcingResponse());
 
     renderPage();
+    await clickSource();
 
     const coverage = await screen.findByText("Coverage matrix");
     expect(coverage).toBeDefined();
@@ -384,12 +462,13 @@ describe("ProjectSourcingPage", () => {
     expect(within(table).getAllByText("Best two-distributor combo")).toHaveLength(2);
   });
 
-  it("cold load shows the sourced BOM skeleton without the background refresh hint", async () => {
+  it("first submit shows the sourced BOM skeleton without the background refresh hint", async () => {
     mockReads();
     const firstLoad = deferred<ReturnType<typeof sourcingResponse>>();
     vi.spyOn(api, "post").mockReturnValue(firstLoad.promise as never);
 
     renderPage();
+    await clickSource();
 
     expect(await screen.findByRole("status", { name: "Loading sourced BOM" })).toBeDefined();
     expect(screen.queryByText("Refreshing prices in the background...")).toBeNull();
@@ -407,8 +486,8 @@ describe("ProjectSourcingPage", () => {
 
     renderPage();
 
-    expect(await screen.findByText("BOM rows")).toBeDefined();
-    await user.click(screen.getByRole("button", { name: "Source" }));
+    await sourceBom(user);
+    await clickSource(user);
 
     expect(await screen.findByText("Refreshing prices in the background...")).toBeDefined();
     expect(screen.getAllByText("STM32").length).toBeGreaterThan(0);
@@ -417,7 +496,7 @@ describe("ProjectSourcingPage", () => {
     refetch.resolve(sourcingResponse());
   });
 
-  it("placeholderData renders previous result during a filter refetch", async () => {
+  it("display cache keeps previous result until a filter refresh is submitted", async () => {
     const user = userEvent.setup();
     mockReads();
     const filteredLoad = deferred<ReturnType<typeof sourcingResponse>>();
@@ -427,9 +506,11 @@ describe("ProjectSourcingPage", () => {
 
     renderPage();
 
-    expect(await screen.findByText("BOM rows")).toBeDefined();
+    await sourceBom(user);
     await user.click(screen.getByRole("checkbox", { name: "Mouser" }));
 
+    expect(post).toHaveBeenCalledTimes(1);
+    await clickSource(user);
     await waitFor(() => expect(post).toHaveBeenCalledTimes(2));
     expect(await screen.findByText("Refreshing prices in the background...")).toBeDefined();
     expect(screen.getAllByText("STM32").length).toBeGreaterThan(0);
@@ -463,6 +544,7 @@ describe("ProjectSourcingPage", () => {
     }));
 
     renderPage();
+    await clickSource();
 
     expect(await screen.findByText("Lowest total price")).toBeDefined();
     expect(screen.getByText("DigiKey + Mouser")).toBeDefined();
@@ -484,6 +566,7 @@ describe("ProjectSourcingPage", () => {
     }));
 
     renderPage();
+    await clickSource();
 
     expect(await screen.findByText("Price (covered lines)")).toBeDefined();
     expect(screen.getByText("1 uncovered line")).toBeDefined();
@@ -503,6 +586,7 @@ describe("ProjectSourcingPage", () => {
     }));
 
     renderPage();
+    await clickSource();
 
     expect(await screen.findByText("Price (covered lines)")).toBeDefined();
     expect(screen.getByText("No pricing available on covered lines.")).toBeDefined();
@@ -532,6 +616,7 @@ describe("ProjectSourcingPage", () => {
     }));
 
     renderPage();
+    await clickSource();
 
     expect(await screen.findByText("Fewest distributors")).toBeDefined();
     expect(screen.getAllByText("40 USD").length).toBeGreaterThan(0);
@@ -542,6 +627,7 @@ describe("ProjectSourcingPage", () => {
     vi.spyOn(api, "post").mockResolvedValue(sourcingResponse());
 
     renderPage();
+    await clickSource();
 
     expect(await screen.findByText("Lowest total price")).toBeDefined();
     expect(screen.getByText("Fewest distributors")).toBeDefined();
@@ -553,6 +639,7 @@ describe("ProjectSourcingPage", () => {
     vi.spyOn(api, "post").mockResolvedValue(sourcingResponse());
 
     renderPage();
+    await clickSource();
 
     expect(await screen.findByText("Single source")).toBeDefined();
     expect(screen.getByText("Long lead time")).toBeDefined();
@@ -583,7 +670,7 @@ describe("ProjectSourcingPage", () => {
 
     renderPage();
 
-    await screen.findByText("BOM rows");
+    await sourceBom(user);
     const bomRowsTable = screen.getAllByRole("table")[1];
     await user.click(within(bomRowsTable).getByRole("row", { name: /Open STM32/ }));
 
@@ -613,7 +700,7 @@ describe("ProjectSourcingPage", () => {
 
     renderPage();
 
-    await screen.findByText("BOM rows");
+    await sourceBom(user);
     const bomRowsTable = screen.getAllByRole("table")[1];
     await user.click(within(bomRowsTable).getByRole("row", { name: /STM32/ }));
 
@@ -652,7 +739,7 @@ describe("ProjectSourcingPage", () => {
 
     renderPage();
 
-    await screen.findByText("BOM rows");
+    await sourceBom();
     const bomRowsTable = screen.getAllByRole("table")[1];
     expect(within(bomRowsTable).getByRole("columnheader", { name: /Lifecycle/ })).toBeDefined();
     expect(within(bomRowsTable).getByRole("columnheader", { name: /Supply chain/ })).toBeDefined();
@@ -681,7 +768,7 @@ describe("ProjectSourcingPage", () => {
 
     renderPage();
 
-    await screen.findByText("BOM rows");
+    await sourceBom(user);
     const bomRowsTable = screen.getAllByRole("table")[1];
     const lifecycleHeader = within(bomRowsTable).getByRole("columnheader", { name: /Lifecycle/ });
     const supplyChainHeader = within(bomRowsTable).getByRole("columnheader", { name: /Supply chain/ });
@@ -722,7 +809,7 @@ describe("ProjectSourcingPage", () => {
 
     renderPage();
 
-    await screen.findByText("BOM rows");
+    await sourceBom();
     const rohs = screen.getByText("Compliant");
     expect(rohs.className).toContain("text-success");
   });
@@ -744,7 +831,7 @@ describe("ProjectSourcingPage", () => {
 
     renderPage();
 
-    await screen.findByText("BOM rows");
+    await sourceBom();
     const bomRowsTable = screen.getAllByRole("table")[1];
     expect(within(bomRowsTable).getByRole("columnheader", { name: /Lifecycle/ })).toBeDefined();
     const lifecycle = screen.getByLabelText("Lifecycle risk: Obsolete");
@@ -768,7 +855,7 @@ describe("ProjectSourcingPage", () => {
 
     renderPage();
 
-    await screen.findByText("BOM rows");
+    await sourceBom();
     const lifecycle = screen.getByLabelText("Lifecycle risk: Low risk");
     expect(lifecycle.className).toContain("text-success");
   });
@@ -798,7 +885,7 @@ describe("ProjectSourcingPage", () => {
 
     renderPage();
 
-    await screen.findByText("BOM rows");
+    await sourceBom(user);
     const bomRowsTable = screen.getAllByRole("table")[1];
     expect(within(bomRowsTable).queryByRole("columnheader", { name: "Lead time" })).toBeNull();
 
@@ -819,6 +906,7 @@ describe("ProjectSourcingPage", () => {
     vi.spyOn(api, "post").mockRejectedValue(apiError(409, "sourcing not configured"));
 
     renderPage();
+    await clickSource();
 
     expect(await screen.findByText("Sourcing not configured.")).toBeDefined();
     expect(screen.getByRole("status", { name: "Sourcing diagnostics" })).toBeDefined();
@@ -846,6 +934,7 @@ describe("ProjectSourcingPage", () => {
     }));
 
     renderPage();
+    await clickSource();
 
     expect(await screen.findByRole("status", { name: "Sourcing diagnostics" })).toBeDefined();
     expect(screen.getByText("BOM lines need manufacturer part numbers.")).toBeDefined();
@@ -872,6 +961,7 @@ describe("ProjectSourcingPage", () => {
     }));
 
     renderPage();
+    await clickSource(user);
 
     expect(await screen.findByText("Only cached no-offer results were available.")).toBeDefined();
     await user.click(screen.getByRole("button", { name: "Refresh prices" }));
@@ -897,6 +987,7 @@ describe("ProjectSourcingPage", () => {
     }));
 
     renderPage();
+    await clickSource();
 
     expect(await screen.findByText("Prices were found, but currency conversion is unavailable.")).toBeDefined();
     expect(screen.getByText("Retry later or choose the offer currency while exchange rates are unavailable.")).toBeDefined();
@@ -920,6 +1011,7 @@ describe("ProjectSourcingPage", () => {
     }));
 
     renderPage();
+    await clickSource();
 
     expect(await screen.findByText("No matching offers found.")).toBeDefined();
     expect(screen.getByText("TrustedParts returned no authorized offers for the selected country, currency, and distributors.")).toBeDefined();
@@ -930,6 +1022,7 @@ describe("ProjectSourcingPage", () => {
     vi.spyOn(api, "post").mockRejectedValue(apiError(503, "sourcing budget exhausted"));
 
     renderPage();
+    await clickSource();
 
     expect(await screen.findByText("TrustedParts request budget reached for this hour. Retry is paused for 5 minutes.")).toBeDefined();
     const retry = screen.getByRole("button", { name: "Retry Source BOM" }) as HTMLButtonElement;
@@ -941,6 +1034,7 @@ describe("ProjectSourcingPage", () => {
     vi.spyOn(api, "post").mockResolvedValue(sourcingResponse({ partial: true }));
 
     renderPage();
+    await clickSource();
 
     expect(await screen.findByText("Partial — some chunks served from cache")).toBeDefined();
   });
@@ -951,7 +1045,7 @@ describe("ProjectSourcingPage", () => {
 
     renderPage();
 
-    await screen.findByText("BOM rows");
+    await sourceBom();
     await waitFor(() => {
       expect(post).toHaveBeenCalledWith(
         `/projects/${projectId}/sourcing`,
@@ -961,7 +1055,6 @@ describe("ProjectSourcingPage", () => {
           currency: "EUR",
           distributors: ["DigiKey", "Mouser"],
         }),
-        expect.anything(),
       );
     });
   });
@@ -972,7 +1065,7 @@ describe("ProjectSourcingPage", () => {
 
     renderPage();
 
-    await screen.findByText("BOM rows");
+    await sourceBom();
     await waitFor(() => {
       expect(post).toHaveBeenCalledWith(
         `/projects/${projectId}/sourcing`,
@@ -980,7 +1073,6 @@ describe("ProjectSourcingPage", () => {
           build_quantity: 1,
           currency: null,
         }),
-        expect.anything(),
       );
     });
   });
@@ -1006,6 +1098,7 @@ describe("ProjectSourcingPage", () => {
     }));
 
     renderPage();
+    await clickSource();
 
     expect(await screen.findByText("1 EUR")).toBeDefined();
     expect(screen.queryByText("2 USD")).toBeNull();
@@ -1013,6 +1106,7 @@ describe("ProjectSourcingPage", () => {
   });
 
   it("Generate purchase plan posts default strategy from current sourcing filters", async () => {
+    const user = userEvent.setup();
     mockReads();
     const post = vi.spyOn(api, "post");
     post.mockResolvedValueOnce(sourcingResponse());
@@ -1031,9 +1125,9 @@ describe("ProjectSourcingPage", () => {
 
     renderPage();
 
-    await screen.findByText("BOM rows");
-    await userEvent.click(screen.getByRole("button", { name: "Generate purchase plan" }));
-    await userEvent.click(screen.getByRole("button", { name: "Generate" }));
+    await sourceBom(user);
+    await user.click(screen.getByRole("button", { name: "Generate purchase plan" }));
+    await user.click(screen.getByRole("button", { name: "Generate" }));
 
     expect(await screen.findByTestId("plan-route")).toBeDefined();
     await waitFor(() => {
@@ -1057,7 +1151,7 @@ describe("ProjectSourcingPage", () => {
 
     renderPage();
 
-    await screen.findByText("BOM rows");
+    await screen.findByLabelText("Build quantity");
     await user.clear(screen.getByLabelText("Build quantity"));
     await user.type(screen.getByLabelText("Build quantity"), "12");
     await user.click(screen.getByRole("button", { name: "Set BOM-buyable alert" }));
@@ -1087,19 +1181,15 @@ describe("ProjectSourcingPage", () => {
     expect(screen.getByText("Sourcing not configured")).toBeDefined();
   });
 
-  it("502 path shows toast and retry action", async () => {
+  it("502 path shows toast and retry button", async () => {
     mockReads();
     vi.spyOn(api, "post").mockRejectedValue(apiError(502, "TrustedParts request timed out"));
 
     renderPage();
+    await clickSource();
 
     await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith(
-        "TrustedParts unavailable. Retry?",
-        expect.objectContaining({
-          action: expect.objectContaining({ label: "Retry" }),
-        }),
-      );
+      expect(toast.error).toHaveBeenCalledWith("Something went wrong. Try again, or refresh.");
     });
     expect(screen.getByRole("button", { name: "Retry Source BOM" })).toBeDefined();
   });


### PR DESCRIPTION
## Summary
- Converted Project Sourcing's audited `POST /projects/:id/sourcing` path from a side-effecting TanStack query function to an explicit `useMutation`.
- Source/Retry actions are now the only client paths that submit the sourcing request; mount, focus, remount, and filter edits do not submit the POST.
- Added regression coverage for submit-only POST behavior, focus/filter non-refetch, 429 toast copy, and retained display-cache UX.
- Updated `docs/api/sourcing.md` and `CHANGELOG.md`.

## Cache strategy
- Preserved the SX-6 display cache with `queryClient.setQueryData` on mutation success.
- The cache key is workspace-scoped as `['ws', workspaceId, 'project-sourcing', projectId]`; a disabled read-only query observes that cached value without running a network query.
- Previously sourced data renders immediately on revisit, and a new upstream/audit/budget call happens only after the operator clicks Source.

## Validation
- `cd web && npm run typecheck`
  - Pass: `tsc -b`
- `cd web && npm test -- "ProjectSourcingPage"`
  - Pass: 1 file, 47 tests
- `cd web && npm run lint`
  - Baseline failing: existing unrelated eslint findings in `src/lib/bagCode.ts`, `src/components/scanner/ZxingScanner.tsx`, and several unused-var warnings.
- `cd web && WORK_DIR=. LINT_CMD="npx eslint src --format=unix" BASELINE_FILE=../.eslint-baseline.txt bash ../scripts/lint-delta.sh`
  - Pass: `lint-delta: no new violations (baseline: 8, current: 8, fixed since baseline: 0)`
- `git diff --check`
  - Pass
- Backend `pytest -k sourcing`
  - Not run: Docker is not installed in this environment (`docker: command not found`), and host route tests require a local Postgres setup.

## Merge order
Merge before #499; may conflict with #499 on ProjectSourcingPage and CHANGELOG

Refs #497
