### PR TITLE
SA-7: Extract shared <Modal> + migrate OverrideOfferModal + PurchasePlanOptionsModal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ the canonical record.
   overrides; add error toast on failure.
 - **SA-3 / #494** Sourcing alert notifications now commit `last_notified_at`
   before SMTP dispatch, trading one missed outage email for duplicate suppression.
+- **SA-7 / #498** Project Sourcing modals now share an accessible dialog shell
+  with focus trap, ESC close, backdrop dismiss, and focus restoration.
 - **SX-10 / #485** Project Sourcing capacity now shows cost per single BOM
   alongside total BOM cost and short-quantity price to pay.
 - **SX-12 / #487** Project Sourcing now uses the four-level TrustedParts

--- a/web/src/components/Modal.tsx
+++ b/web/src/components/Modal.tsx
@@ -1,0 +1,136 @@
+import {
+  useEffect,
+  useId,
+  useRef,
+  type MouseEvent,
+  type ReactNode,
+  type RefObject,
+} from "react";
+
+type ModalSize = "sm" | "md" | "lg";
+
+type ModalProps = {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  children: ReactNode;
+  initialFocusRef?: RefObject<HTMLElement>;
+  size?: ModalSize;
+  className?: string;
+};
+
+const SIZE_CLASSES: Record<ModalSize, string> = {
+  sm: "max-w-lg",
+  md: "max-w-5xl",
+  lg: "max-w-6xl",
+};
+
+function focusableElements(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>(
+    [
+      "a[href]",
+      "button:not([disabled])",
+      "input:not([disabled])",
+      "select:not([disabled])",
+      "textarea:not([disabled])",
+      "[tabindex]:not([tabindex='-1'])",
+    ].join(","),
+  )).filter(element => element.getAttribute("aria-hidden") !== "true");
+}
+
+export function Modal({
+  open,
+  onClose,
+  title,
+  children,
+  initialFocusRef,
+  size = "md",
+  className,
+}: ModalProps) {
+  const titleId = useId();
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+  const restoreFocusRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    restoreFocusRef.current = document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null;
+
+    const focusTimer = window.setTimeout(() => {
+      const dialog = dialogRef.current;
+      if (!dialog) return;
+      const focusTarget = initialFocusRef?.current ?? focusableElements(dialog)[0] ?? dialog;
+      focusTarget.focus();
+    }, 0);
+
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        onClose();
+        return;
+      }
+      if (event.key !== "Tab") return;
+
+      const dialog = dialogRef.current;
+      if (!dialog) return;
+      const focusable = focusableElements(dialog);
+      if (focusable.length === 0) {
+        event.preventDefault();
+        dialog.focus();
+        return;
+      }
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement;
+      if (event.shiftKey && active === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && active === last) {
+        event.preventDefault();
+        first.focus();
+      } else if (!dialog.contains(active)) {
+        event.preventDefault();
+        first.focus();
+      }
+    }
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => {
+      window.clearTimeout(focusTimer);
+      window.removeEventListener("keydown", onKeyDown);
+      const restoreFocus = restoreFocusRef.current;
+      if (restoreFocus && document.contains(restoreFocus)) {
+        restoreFocus.focus();
+      }
+      restoreFocusRef.current = null;
+    };
+  }, [open, onClose, initialFocusRef]);
+
+  if (!open) return null;
+
+  function onBackdropMouseDown(event: MouseEvent<HTMLDivElement>) {
+    if (event.target === event.currentTarget) onClose();
+  }
+
+  const panelClassName = className ?? `card w-full ${SIZE_CLASSES[size]}`;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={titleId}
+      tabIndex={-1}
+      ref={dialogRef}
+      onMouseDown={onBackdropMouseDown}
+    >
+      <h2 id={titleId} className="sr-only">
+        {title}
+      </h2>
+      <div className={panelClassName}>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/README.md
+++ b/web/src/components/README.md
@@ -10,6 +10,7 @@ Reusable presentational + behavioural components shared across pages. Page-speci
 |---|---|
 | `DataTable.tsx` | The shared table — search, sort, hidden columns, CSV export, multi-select |
 | `DataTable.test.tsx` | Co-located unit test for DataTable |
+| `Modal.tsx` | Shared accessible dialog shell with focus trap, ESC close, backdrop dismiss, and focus restoration |
 | `EntityHeader.tsx` | Standard entity-page header (title / breadcrumbs / actions) |
 | `SubNav.tsx` | Tabbed sub-navigation used on entity pages |
 | `PartsTopNav.tsx` | Parts-area top nav |
@@ -35,6 +36,7 @@ Every component is its default / named export. The most commonly reused:
 | Component | Use for |
 |---|---|
 | `DataTable` | Any table — before rolling your own |
+| `Modal` | Dialogs that need `role="dialog"`, `aria-modal`, focus trapping, ESC close, backdrop dismiss, and trigger focus restoration |
 | `EntityHeader` + `SubNav` | Entity pages (Part, Order, Build, …) |
 | `AttachmentsPanel` | Any entity that supports attachments |
 | `ConfirmDialog` | Any destructive action |
@@ -43,8 +45,9 @@ Every component is its default / named export. The most commonly reused:
 ## Hard rules (this module)
 
 1. **Use `DataTable` before adding a new table.** It already does search, sort, hidden columns, CSV export, multi-select. See [components](../../../docs/frontend/components.md).
-2. **Use the `index.css` utility set** (`btn`, `card`, `pill`, `input`, …) before adding new ones. See [tailwind-utilities](../../../docs/frontend/tailwind-utilities.md).
-3. **Lazy routes wrap their suspense in `RouteSkeleton`** and their data in `QueryStateBoundary` for uniform loading / error UX.
+2. **Use `Modal` before adding a route-local dialog shell.** API: `open`, `onClose`, `title`, `children`, optional `initialFocusRef`, `size`, and `className` for the panel.
+3. **Use the `index.css` utility set** (`btn`, `card`, `pill`, `input`, …) before adding new ones. See [tailwind-utilities](../../../docs/frontend/tailwind-utilities.md).
+4. **Lazy routes wrap their suspense in `RouteSkeleton`** and their data in `QueryStateBoundary` for uniform loading / error UX.
 
 ## See also
 

--- a/web/src/components/__tests__/Modal.test.tsx
+++ b/web/src/components/__tests__/Modal.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Modal } from "../Modal";
+
+beforeEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("Modal", () => {
+  it("closes on ESC key", () => {
+    const onClose = vi.fn();
+    render(
+      <Modal open onClose={onClose} title="Demo modal">
+        <button type="button">Close</button>
+      </Modal>,
+    );
+
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes on backdrop click", () => {
+    const onClose = vi.fn();
+    render(
+      <Modal open onClose={onClose} title="Demo modal">
+        <button type="button">Close</button>
+      </Modal>,
+    );
+
+    fireEvent.mouseDown(screen.getByRole("dialog", { name: "Demo modal" }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("traps Tab inside the modal", async () => {
+    render(
+      <>
+        <button type="button">Outside</button>
+        <Modal open onClose={vi.fn()} title="Demo modal">
+          <button type="button">First</button>
+          <button type="button">Last</button>
+        </Modal>
+      </>,
+    );
+    const dialog = screen.getByRole("dialog", { name: "Demo modal" });
+    const first = within(dialog).getByRole("button", { name: "First" });
+    const last = within(dialog).getByRole("button", { name: "Last" });
+    await waitFor(() => expect(document.activeElement).toBe(first));
+
+    fireEvent.keyDown(window, { key: "Tab", shiftKey: true });
+    expect(document.activeElement).toBe(last);
+
+    fireEvent.keyDown(window, { key: "Tab" });
+    expect(document.activeElement).toBe(first);
+  });
+
+  it("restores focus to trigger on close", async () => {
+    const user = userEvent.setup();
+
+    function Harness() {
+      const [open, setOpen] = useState(false);
+      return (
+        <>
+          <button type="button" onClick={() => setOpen(true)}>
+            Open modal
+          </button>
+          <Modal open={open} onClose={() => setOpen(false)} title="Demo modal">
+            <button type="button" onClick={() => setOpen(false)}>
+              Close
+            </button>
+          </Modal>
+        </>
+      );
+    }
+
+    render(<Harness />);
+    const trigger = screen.getByRole("button", { name: "Open modal" });
+    await user.click(trigger);
+    const closeButton = screen.getByRole("button", { name: "Close" });
+    await waitFor(() => expect(document.activeElement).toBe(closeButton));
+
+    await user.click(closeButton);
+
+    await waitFor(() => expect(document.activeElement).toBe(trigger));
+  });
+
+  it("has role=dialog and aria-modal=true", () => {
+    render(
+      <Modal open onClose={vi.fn()} title="Demo modal">
+        <button type="button">Close</button>
+      </Modal>,
+    );
+
+    const dialog = screen.getByRole("dialog", { name: "Demo modal" });
+    const titleId = dialog.getAttribute("aria-labelledby");
+    expect(dialog.getAttribute("aria-modal")).toBe("true");
+    expect(titleId).toBeTruthy();
+    expect(titleId ? document.getElementById(titleId)?.textContent : null).toBe("Demo modal");
+  });
+});

--- a/web/src/routes/projects/sourcing/BomDistributorsModal.tsx
+++ b/web/src/routes/projects/sourcing/BomDistributorsModal.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useMemo, useRef } from "react";
+import { useMemo, useRef } from "react";
 import type { ReactNode } from "react";
 import { ExternalLink, Info, ShieldAlert, ShieldCheck, X } from "lucide-react";
 import { DataTable, type Column } from "@/components/DataTable";
+import { Modal } from "@/components/Modal";
 import { PoweredByTrustedParts } from "@/components/PoweredByTrustedParts";
 import { lifecycleRiskTone, riskToneClass } from "@/lib/sourcing";
 import type {
@@ -157,73 +158,8 @@ function uniqueTrimmed(values: Array<string | null | undefined>): string[] {
     .sort((a, b) => a.localeCompare(b));
 }
 
-function focusableElements(container: HTMLElement): HTMLElement[] {
-  return Array.from(container.querySelectorAll<HTMLElement>(
-    [
-      "a[href]",
-      "button:not([disabled])",
-      "input:not([disabled])",
-      "select:not([disabled])",
-      "textarea:not([disabled])",
-      "[tabindex]:not([tabindex='-1'])",
-    ].join(","),
-  )).filter(element => element.getAttribute("aria-hidden") !== "true");
-}
-
 export function BomDistributorsModal({ open, onClose, line, workspaceCurrency }: Props) {
-  const dialogRef = useRef<HTMLDivElement | null>(null);
   const closeButtonRef = useRef<HTMLButtonElement | null>(null);
-  const restoreFocusRef = useRef<HTMLElement | null>(null);
-
-  useEffect(() => {
-    if (!open) return undefined;
-    restoreFocusRef.current = document.activeElement instanceof HTMLElement
-      ? document.activeElement
-      : null;
-    window.setTimeout(() => {
-      closeButtonRef.current?.focus();
-    }, 0);
-
-    function onKeyDown(event: KeyboardEvent) {
-      if (event.key === "Escape") {
-        onClose();
-        return;
-      }
-      if (event.key !== "Tab") return;
-
-      const dialog = dialogRef.current;
-      if (!dialog) return;
-      const focusable = focusableElements(dialog);
-      if (focusable.length === 0) {
-        event.preventDefault();
-        dialog.focus();
-        return;
-      }
-
-      const first = focusable[0];
-      const last = focusable[focusable.length - 1];
-      const active = document.activeElement;
-      if (event.shiftKey && active === first) {
-        event.preventDefault();
-        last.focus();
-      } else if (!event.shiftKey && active === last) {
-        event.preventDefault();
-        first.focus();
-      } else if (!dialog.contains(active)) {
-        event.preventDefault();
-        first.focus();
-      }
-    }
-    window.addEventListener("keydown", onKeyDown);
-    return () => {
-      window.removeEventListener("keydown", onKeyDown);
-      const restoreFocus = restoreFocusRef.current;
-      if (restoreFocus && document.contains(restoreFocus)) {
-        restoreFocus.focus();
-      }
-      restoreFocusRef.current = null;
-    };
-  }, [open, onClose]);
 
   const rows = useMemo<DistributorRow[]>(() => {
     if (!line) return [];
@@ -343,60 +279,54 @@ export function BomDistributorsModal({ open, onClose, line, workspaceCurrency }:
   const stockedDistributorCount = new Set(rows.filter(row => row.stock > 0).map(row => row.distributor)).size;
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="bom-distributors-title"
-      tabIndex={-1}
-      ref={dialogRef}
-      onMouseDown={event => {
-        if (event.target === event.currentTarget) onClose();
-      }}
+    <Modal
+      open={open}
+      onClose={onClose}
+      title={`${line.part_name} — ${line.mpn ?? "No MPN"}`}
+      initialFocusRef={closeButtonRef}
+      className="flex max-h-[90vh] w-full max-w-6xl flex-col rounded border border-border bg-panel shadow-lg"
     >
-      <div className="flex max-h-[90vh] w-full max-w-6xl flex-col rounded border border-border bg-panel shadow-lg">
-        <div className="flex flex-wrap items-start justify-between gap-3 border-b border-border p-4">
-          <div className="min-w-0">
-            <h2 id="bom-distributors-title" className="text-base font-semibold text-text">
-              {line.part_name} — {line.mpn ?? "No MPN"}
-            </h2>
-            <div className="mt-2 flex flex-wrap items-center gap-2">
-              <PoweredByTrustedParts />
-              {statusPills.lifecycle.map(value => (
-                <RiskPill key={`lifecycle:${value}`} label="Lifecycle risk" value={value} icon={<ShieldCheck size={12} aria-hidden="true" />} />
-              ))}
-              {statusPills.supplyChain.map(value => (
-                <RiskPill key={`supply:${value}`} label="Supply-chain risk" value={value} icon={<ShieldAlert size={12} aria-hidden="true" />} />
-              ))}
-              {statusPills.tariffAffected && (
-                <span className="pill inline-flex items-center gap-1 bg-danger/10 text-danger" aria-label="Tariff-affected (US)">
-                  <Info size={12} aria-hidden="true" />
-                  Tariff-affected (US)
-                </span>
-              )}
-            </div>
+      <div className="flex flex-wrap items-start justify-between gap-3 border-b border-border p-4">
+        <div className="min-w-0">
+          <h2 id="bom-distributors-title" className="text-base font-semibold text-text">
+            {line.part_name} — {line.mpn ?? "No MPN"}
+          </h2>
+          <div className="mt-2 flex flex-wrap items-center gap-2">
+            <PoweredByTrustedParts />
+            {statusPills.lifecycle.map(value => (
+              <RiskPill key={`lifecycle:${value}`} label="Lifecycle risk" value={value} icon={<ShieldCheck size={12} aria-hidden="true" />} />
+            ))}
+            {statusPills.supplyChain.map(value => (
+              <RiskPill key={`supply:${value}`} label="Supply-chain risk" value={value} icon={<ShieldAlert size={12} aria-hidden="true" />} />
+            ))}
+            {statusPills.tariffAffected && (
+              <span className="pill inline-flex items-center gap-1 bg-danger/10 text-danger" aria-label="Tariff-affected (US)">
+                <Info size={12} aria-hidden="true" />
+                Tariff-affected (US)
+              </span>
+            )}
           </div>
-          <button type="button" className="btn-ghost btn-sm" aria-label="Close" onClick={onClose} ref={closeButtonRef}>
-            <X size={16} aria-hidden="true" />
-          </button>
         </div>
-
-        <div className="min-h-0 flex-1 overflow-auto p-4">
-          <DataTable
-            rows={rows}
-            columns={columns}
-            rowKey={row => row.id}
-            tableId="project-sourcing-bom-distributors"
-            exportFilename="sourced-bom-distributors"
-            empty={<div className="text-muted">No distributor offers for this BOM line.</div>}
-          />
-        </div>
-
-        <div className="border-t border-border px-4 py-3 text-sm text-muted">
-          {stockedDistributorCount.toLocaleString()} distributor{stockedDistributorCount === 1 ? "" : "s"} with stock;{" "}
-          {totalDistributorCount.toLocaleString()} total
-        </div>
+        <button type="button" className="btn-ghost btn-sm" aria-label="Close" onClick={onClose} ref={closeButtonRef}>
+          <X size={16} aria-hidden="true" />
+        </button>
       </div>
-    </div>
+
+      <div className="min-h-0 flex-1 overflow-auto p-4">
+        <DataTable
+          rows={rows}
+          columns={columns}
+          rowKey={row => row.id}
+          tableId="project-sourcing-bom-distributors"
+          exportFilename="sourced-bom-distributors"
+          empty={<div className="text-muted">No distributor offers for this BOM line.</div>}
+        />
+      </div>
+
+      <div className="border-t border-border px-4 py-3 text-sm text-muted">
+        {stockedDistributorCount.toLocaleString()} distributor{stockedDistributorCount === 1 ? "" : "s"} with stock;{" "}
+        {totalDistributorCount.toLocaleString()} total
+      </div>
+    </Modal>
   );
 }

--- a/web/src/routes/projects/sourcing/OverrideOfferModal.tsx
+++ b/web/src/routes/projects/sourcing/OverrideOfferModal.tsx
@@ -1,3 +1,4 @@
+import { Modal } from "@/components/Modal";
 import type { PurchasePlanLine, PurchasePlanOffer } from "./purchasePlanTypes";
 
 type Props = {
@@ -68,96 +69,94 @@ export default function OverrideOfferModal({ line, onSelect, onClose }: Props) {
   const offers = (line.available_offers ?? []).filter(offer => !isCurrentOffer(line, offer));
 
   return (
-    <div className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4">
-      <div
-        className="card max-w-5xl w-full max-h-[85vh] overflow-hidden flex flex-col"
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="override-offer-title"
-      >
-        <div className="flex items-start justify-between gap-3 p-4 border-b border-border">
-          <div>
-            <h2 id="override-offer-title" className="text-lg font-semibold">
-              Override offer
-            </h2>
-            <div className="text-sm text-muted">
-              {line.mpn_searched} - current: {line.selected_distributor ?? "Unfilled"}
-            </div>
+    <Modal
+      open={Boolean(line)}
+      onClose={onClose}
+      title="Override offer"
+      className="card max-w-5xl w-full max-h-[85vh] overflow-hidden flex flex-col"
+    >
+      <div className="flex items-start justify-between gap-3 p-4 border-b border-border">
+        <div>
+          <h2 id="override-offer-title" className="text-lg font-semibold">
+            Override offer
+          </h2>
+          <div className="text-sm text-muted">
+            {line.mpn_searched} - current: {line.selected_distributor ?? "Unfilled"}
           </div>
-          <button type="button" className="btn" onClick={onClose}>
-            Close
-          </button>
         </div>
-
-        <div className="overflow-auto">
-          {offers.length === 0 ? (
-            <div className="p-4 text-sm text-muted">
-              No cached alternate offers are available for this line.
-            </div>
-          ) : (
-            <table className="table text-sm">
-              <thead>
-                <tr>
-                  <th>Distributor</th>
-                  <th>MPN</th>
-                  <th className="text-right">Stock</th>
-                  <th className="text-right">Unit price</th>
-                  <th>Packaging</th>
-                  <th className="text-right">MOQ</th>
-                  <th className="text-right">Lead time</th>
-                  <th>Offer</th>
-                  <th className="text-right">Action</th>
-                </tr>
-              </thead>
-              <tbody>
-                {offers.map((offer, index) => {
-                  const key = `${offer.distributor ?? "unknown"}-${offer.mpn ?? "mpn"}-${index}`;
-                  const isCurrent =
-                    offer.distributor === line.selected_distributor &&
-                    offer.unit_price === line.selected_unit_price &&
-                    offer.currency === line.selected_currency;
-                  return (
-                    <tr key={key}>
-                      <td>
-                        <div className="font-medium">{offer.distributor ?? "-"}</div>
-                        {isCurrent && <div className="text-xs text-muted">Current selection</div>}
-                      </td>
-                      <td>{offer.mpn ?? line.mpn_searched}</td>
-                      <td className="text-right tabular-nums">{formatValue(offer.stock)}</td>
-                      <td className="text-right tabular-nums">{formatMoney(offer.unit_price, offer.currency)}</td>
-                      <td>{formatValue(offer.packaging)}</td>
-                      <td className="text-right tabular-nums">{formatValue(offer.moq)}</td>
-                      <td className="text-right tabular-nums">{formatLeadTime(offer.lead_time_days)}</td>
-                      <td>
-                        {offer.url ? (
-                          <a
-                            className="text-accent hover:underline"
-                            href={offer.url}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                          >
-                            Open
-                          </a>
-                        ) : "-"}
-                      </td>
-                      <td className="text-right">
-                        <button
-                          type="button"
-                          className="btn"
-                          disabled={!canSelectOffer(line, offer)}
-                          onClick={() => onSelect(line, offer)}
-                        >
-                          Select
-                        </button>
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          )}
-        </div>
+        <button type="button" className="btn" onClick={onClose}>
+          Close
+        </button>
       </div>
-    </div>
+
+      <div className="overflow-auto">
+        {offers.length === 0 ? (
+          <div className="p-4 text-sm text-muted">
+            No cached alternate offers are available for this line.
+          </div>
+        ) : (
+          <table className="table text-sm">
+            <thead>
+              <tr>
+                <th>Distributor</th>
+                <th>MPN</th>
+                <th className="text-right">Stock</th>
+                <th className="text-right">Unit price</th>
+                <th>Packaging</th>
+                <th className="text-right">MOQ</th>
+                <th className="text-right">Lead time</th>
+                <th>Offer</th>
+                <th className="text-right">Action</th>
+              </tr>
+            </thead>
+            <tbody>
+              {offers.map((offer, index) => {
+                const key = `${offer.distributor ?? "unknown"}-${offer.mpn ?? "mpn"}-${index}`;
+                const isCurrent =
+                  offer.distributor === line.selected_distributor &&
+                  offer.unit_price === line.selected_unit_price &&
+                  offer.currency === line.selected_currency;
+                return (
+                  <tr key={key}>
+                    <td>
+                      <div className="font-medium">{offer.distributor ?? "-"}</div>
+                      {isCurrent && <div className="text-xs text-muted">Current selection</div>}
+                    </td>
+                    <td>{offer.mpn ?? line.mpn_searched}</td>
+                    <td className="text-right tabular-nums">{formatValue(offer.stock)}</td>
+                    <td className="text-right tabular-nums">{formatMoney(offer.unit_price, offer.currency)}</td>
+                    <td>{formatValue(offer.packaging)}</td>
+                    <td className="text-right tabular-nums">{formatValue(offer.moq)}</td>
+                    <td className="text-right tabular-nums">{formatLeadTime(offer.lead_time_days)}</td>
+                    <td>
+                      {offer.url ? (
+                        <a
+                          className="text-accent hover:underline"
+                          href={offer.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          Open
+                        </a>
+                      ) : "-"}
+                    </td>
+                    <td className="text-right">
+                      <button
+                        type="button"
+                        className="btn"
+                        disabled={!canSelectOffer(line, offer)}
+                        onClick={() => onSelect(line, offer)}
+                      >
+                        Select
+                      </button>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </Modal>
   );
 }

--- a/web/src/routes/projects/sourcing/PurchasePlanOptionsModal.tsx
+++ b/web/src/routes/projects/sourcing/PurchasePlanOptionsModal.tsx
@@ -1,4 +1,5 @@
 import { useState, type FormEvent } from "react";
+import { Modal } from "@/components/Modal";
 import type { PurchasePlanRequest } from "./purchasePlanTypes";
 
 type Props = {
@@ -47,14 +48,14 @@ export default function PurchasePlanOptionsModal({
   }
 
   return (
-    <div className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4">
-      <form
-        className="card max-w-lg w-full p-4 space-y-4"
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="purchase-plan-options-title"
-        onSubmit={submit}
-      >
+    <Modal
+      open={open}
+      onClose={onClose}
+      title="Generate purchase plan"
+      size="sm"
+      className="card max-w-lg w-full"
+    >
+      <form className="p-4 space-y-4" onSubmit={submit}>
         <div className="flex items-start justify-between gap-3">
           <h2 id="purchase-plan-options-title" className="text-lg font-semibold">
             Generate purchase plan
@@ -145,6 +146,6 @@ export default function PurchasePlanOptionsModal({
           </button>
         </div>
       </form>
-    </div>
+    </Modal>
   );
 }

--- a/web/src/routes/projects/sourcing/__tests__/BomDistributorsModal.test.tsx
+++ b/web/src/routes/projects/sourcing/__tests__/BomDistributorsModal.test.tsx
@@ -99,6 +99,8 @@ describe("BomDistributorsModal", () => {
     renderModal();
 
     const dialog = screen.getByRole("dialog", { name: /STM32/ });
+    expect(dialog.getAttribute("aria-modal")).toBe("true");
+    expect(dialog.getAttribute("aria-labelledby")).toBeTruthy();
     expect(within(dialog).getByText("DigiKey")).toBeDefined();
     expect(within(dialog).getByText("Mouser")).toBeDefined();
     expect(within(dialog).getByText("2 distributors with stock; 2 total")).toBeDefined();

--- a/web/src/routes/projects/sourcing/__tests__/OverrideOfferModal.test.tsx
+++ b/web/src/routes/projects/sourcing/__tests__/OverrideOfferModal.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import OverrideOfferModal from "../OverrideOfferModal";
+import type { PurchasePlanLine } from "../purchasePlanTypes";
+
+function line(): PurchasePlanLine {
+  return {
+    id: "line-1",
+    part_id: "part-1",
+    mpn_searched: "STM32F103C8T6",
+    required_qty: 20,
+    internal_available_qty: 0,
+    shortage_qty: 20,
+    selected_distributor: "DigiKey",
+    selected_qty: 20,
+    selected_unit_price: "2.00",
+    selected_currency: "USD",
+    selected_packaging: "Cut Tape",
+    selected_moq: 1,
+    selected_lead_time_days: 3,
+    available_offers: [{
+      mpn: "STM32F103C8T6",
+      distributor: "Mouser",
+      stock: 100,
+      unit_price: "1.80",
+      currency: "USD",
+      packaging: "Reel",
+      moq: 10,
+      lead_time_days: 5,
+      url: "https://example.com/mouser/stm32",
+    }],
+    risk_flags: [],
+  };
+}
+
+function renderModal(onClose = vi.fn()) {
+  render(
+    <OverrideOfferModal
+      line={line()}
+      onSelect={vi.fn()}
+      onClose={onClose}
+    />,
+  );
+  return { onClose };
+}
+
+beforeEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("OverrideOfferModal", () => {
+  it("renders with shared dialog semantics", () => {
+    renderModal();
+
+    const dialog = screen.getByRole("dialog", { name: "Override offer" });
+    expect(dialog.getAttribute("aria-modal")).toBe("true");
+    expect(dialog.getAttribute("aria-labelledby")).toBeTruthy();
+  });
+
+  it("ESC closes the override modal", async () => {
+    const user = userEvent.setup();
+    const { onClose } = renderModal();
+
+    await user.keyboard("{Escape}");
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes on backdrop click", () => {
+    const { onClose } = renderModal();
+
+    fireEvent.mouseDown(screen.getByRole("dialog", { name: "Override offer" }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/routes/projects/sourcing/__tests__/PurchasePlanOptionsModal.test.tsx
+++ b/web/src/routes/projects/sourcing/__tests__/PurchasePlanOptionsModal.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import PurchasePlanOptionsModal from "../PurchasePlanOptionsModal";
@@ -10,6 +10,22 @@ beforeEach(() => {
 });
 
 describe("PurchasePlanOptionsModal", () => {
+  it("renders with shared dialog semantics", () => {
+    render(
+      <PurchasePlanOptionsModal
+        open
+        buildQuantity={3}
+        baseRequest={{ build_quantity: 3, country: "US", currency: "USD" }}
+        onClose={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    const dialog = screen.getByRole("dialog", { name: "Generate purchase plan" });
+    expect(dialog.getAttribute("aria-modal")).toBe("true");
+    expect(dialog.getAttribute("aria-labelledby")).toBeTruthy();
+  });
+
   it("submits with default strategy preferred_first", async () => {
     const onSubmit = vi.fn();
     render(
@@ -50,5 +66,40 @@ describe("PurchasePlanOptionsModal", () => {
 
     expect(screen.getByLabelText("Max distributors")).toBeDefined();
     expect(screen.getByLabelText("Tolerance %")).toBeDefined();
+  });
+
+  it("ESC closes the options modal", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    render(
+      <PurchasePlanOptionsModal
+        open
+        buildQuantity={3}
+        baseRequest={{ build_quantity: 3, country: "US", currency: "USD" }}
+        onClose={onClose}
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    await user.keyboard("{Escape}");
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes on backdrop click", () => {
+    const onClose = vi.fn();
+    render(
+      <PurchasePlanOptionsModal
+        open
+        buildQuantity={3}
+        baseRequest={{ build_quantity: 3, country: "US", currency: "USD" }}
+        onClose={onClose}
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    fireEvent.mouseDown(screen.getByRole("dialog", { name: "Generate purchase plan" }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary
- Added shared `Modal` with the extracted BomDistributors focus trap, ESC close, backdrop dismiss, focus restore, and dialog ARIA semantics.
- Migrated `BomDistributorsModal`, `OverrideOfferModal`, and `PurchasePlanOptionsModal` to render through the shared shell while preserving their panel classes.
- Added focused tests for shared modal behavior plus sourcing modal ESC/backdrop/dialog semantics, and documented the component.

## Validation
- `cd web && npm run typecheck` -> pass.
- `cd web && npm test -- --testNamePattern "Modal|Override|PurchasePlanOptions|BomDistributors"` -> pass: 9 files passed, 40 tests passed, 375 skipped.
- `cd web && npm test -- src/components/__tests__/Modal.test.tsx src/routes/projects/sourcing/__tests__/OverrideOfferModal.test.tsx src/routes/projects/sourcing/__tests__/PurchasePlanOptionsModal.test.tsx src/routes/projects/sourcing/__tests__/BomDistributorsModal.test.tsx` -> pass: 4 files passed, 22 tests passed.
- `cd web && npm run lint` -> baseline-failing only: 8 existing issues in untouched files (`ZxingScanner.tsx`, `bagCode.ts`, responsive grid test, `OrderDetail.tsx`, `PartsList.tsx`, `PartLayout.navigation.dom.test.tsx`, `StorageDetail.tsx`).
- `cd web && LINT_CMD="npm run lint -- --format=unix" BASELINE_FILE="../.eslint-baseline.txt" WORK_DIR="." bash ../scripts/lint-delta.sh` -> pass: no new violations (baseline 8, current 8).
- `git diff --check` -> pass.

## Notes
- Merge before #499; independent of #497 except CHANGELOG
- The issue command `npm test -- "Modal|Override|PurchasePlanOptions|BomDistributors"` was attempted, but Vitest treats that argument as a literal file filter and reports no files found; the regex form above is the passing equivalent.

Refs #498