### PR TITLE
SA-4: Test pin - est_purchase_cost non-None when capacity floors to zero

### DIFF
--- a/backend/tests/test_sourcing_capacity.py
+++ b/backend/tests/test_sourcing_capacity.py
@@ -19,7 +19,7 @@ def _uuid(index: int) -> UUID:
 def _offer(
     *,
     stock: int = 100,
-    unit_price: str = "1.00",
+    unit_price: str | Decimal = "1.00",
     distributor: str = "DigiKey",
     currency: str | None = None,
     unit_price_converted: str | None = None,
@@ -169,6 +169,34 @@ def test_est_purchase_cost_correct_at_build_quantity_1():
     assert capacity.can_build_after_purchase == 0
     assert capacity.purchase_to_pay_cost == Decimal("2.50")
     assert capacity.est_purchase_cost == Decimal("2.50")
+
+
+def test_est_purchase_cost_priced_when_capacity_floors_to_zero():
+    """Regression for CLAUDE.md hard rule: Sourcing est_purchase_cost still
+    prices when after-purchase capacity floors to zero.
+    """
+    capacity = compute_build_capacity(
+        [
+            _line(
+                1,
+                required=3,
+                available=2,
+                best_offer=_offer(
+                    stock=100,
+                    unit_price=Decimal("5.00"),
+                    currency="EUR",
+                ),
+            )
+        ],
+        requested_build_quantity=1,
+    )
+
+    assert capacity.can_build_now == 0
+    assert capacity.can_build_after_purchase == 0
+    assert capacity.est_purchase_cost is not None
+    assert capacity.est_purchase_cost > Decimal("0")
+    assert capacity.purchase_to_pay_cost == Decimal("5.00")
+    assert capacity.est_purchase_cost == Decimal("5.00")
 
 
 def test_est_purchase_cost_correct_at_build_quantity_2():


### PR DESCRIPTION
## Summary
- Adds `test_est_purchase_cost_priced_when_capacity_floors_to_zero` for the low-build integer capacity floor case.
- Pins that `est_purchase_cost` remains priced when requested quantity still has a real shortfall price.
- Backend test-only; no production code changes.

## Validation
- `uv run --extra dev python -m pytest -q tests/test_sourcing_capacity.py -k "capacity or floor"` -> 30 passed, 1 warning in 1.46s
- `uv run --extra dev ruff check tests/test_sourcing_capacity.py` -> All checks passed!
- `git diff --check` -> passed with no output
- Mutation check: temporarily removed the `compute_build_capacity` fallback; `uv run --extra dev python -m pytest -q tests/test_sourcing_capacity.py -k test_est_purchase_cost_priced_when_capacity_floors_to_zero` failed as expected with `AssertionError: assert None is not None` (1 failed, 29 deselected, 1 warning in 1.51s)

## Merge Order
After #513/#492; backend test-only; can merge before frontend structural PRs

Refs #495