### PR TITLE
SA-9: PurchasePlanReviewPage - store plan via TanStack Query keyed by planId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ the canonical record.
 - **SA-6 / #497** Project Sourcing now runs the audited BOM sourcing POST only
   from an explicit Source click, preserving the display cache without
   remount/focus/filter-change refetches.
+- **SA-9 / #500** Purchase plan review now stores plan snapshots in a
+  TanStack Query cache keyed by plan id, with direct-link reload hydration.
 - **SA-1 / #492** Sourcing capacity now treats mixed-currency BOM totals as
   unknown instead of silently using the first currency.
 - **SA-2 / #493** Fix PurchasePlanReviewPage refresh silently wiping user

--- a/backend/app/api/routes/sourcing.py
+++ b/backend/app/api/routes/sourcing.py
@@ -382,6 +382,25 @@ def create_project_purchase_plan(
     return ok(sourcing_service.purchase_plan_to_out(plan).model_dump(mode="json"))
 
 
+@projects_router.get(
+    "/{project_id}/purchase-plans/{plan_id}",
+    dependencies=[Depends(require_role("member"))],
+)
+def get_project_purchase_plan(
+    request: Request,
+    project_id: UUID,
+    plan_id: UUID,
+    ws: CurrentWorkspace,
+    db: Session = Depends(get_db),
+):
+    project = assert_in_workspace(db, Project, project_id, ws.id, label="project")
+    plan = assert_in_workspace(db, PurchasePlan, plan_id, ws.id, label="purchase plan")
+    if plan.project_id != project.id:
+        return _error_response(request, 404, "not_found", "purchase plan not found")
+
+    return ok(sourcing_service.purchase_plan_to_out(plan).model_dump(mode="json"))
+
+
 @search_router.post(
     "/purchase-plans/{plan_id}/refresh",
     dependencies=[Depends(require_role("member"))],

--- a/backend/tests/test_purchase_plan_route.py
+++ b/backend/tests/test_purchase_plan_route.py
@@ -202,6 +202,38 @@ def test_basic_plan_creation_with_default_strategy(authed_client, db):
     assert plan.expires_at <= plan.created_at + timedelta(days=7)
 
 
+def test_get_purchase_plan_returns_persisted_plan(authed_client):
+    _configure_sourcing(authed_client, preferred=["DigiKey"])
+    project_id = _single_line_project(authed_client, mpn="GET-PLAN", quantity=4)
+    created = _post_plan(authed_client, project_id, build_quantity=2)
+    assert created.status_code == 200, created.text
+    plan_id = created.json()["data"]["id"]
+
+    r = authed_client.get(f"/api/projects/{project_id}/purchase-plans/{plan_id}")
+
+    assert r.status_code == 200, r.text
+    data = r.json()["data"]
+    assert data["id"] == plan_id
+    assert data["project_id"] == project_id
+    assert len(data["lines"]) == 1
+
+
+def test_get_purchase_plan_requires_matching_project(authed_client):
+    _configure_sourcing(authed_client, preferred=["DigiKey"])
+    project_id = _single_line_project(authed_client, mpn="GET-PLAN-MATCH", quantity=4)
+    other_project_id = _single_line_project(authed_client, mpn="GET-PLAN-OTHER", quantity=1)
+    created = _post_plan(authed_client, project_id)
+    assert created.status_code == 200, created.text
+    plan_id = created.json()["data"]["id"]
+
+    r = authed_client.get(f"/api/projects/{other_project_id}/purchase-plans/{plan_id}")
+
+    assert r.status_code == 404, r.text
+    body = r.json()
+    assert body["data"] is None
+    assert body["status"]["category"] == "not_found"
+
+
 @pytest.mark.parametrize(
     "strategy",
     [

--- a/backend/tests/test_workspace_isolation.py
+++ b/backend/tests/test_workspace_isolation.py
@@ -600,6 +600,16 @@ def test_purchase_plan_refresh_returns_404_for_foreign_workspace(monkeypatch):
     _assert_not_found_envelope(r)
 
 
+def test_purchase_plan_get_returns_404_for_foreign_workspace(monkeypatch):
+    a, b = _two_workspaces()
+    plan_a = _create_purchase_plan(a, monkeypatch, mpn="FOREIGN-GET")
+    project_b = _single_line_project(b, mpn="LOCAL-GET", quantity=1)
+
+    r = b.get(f"/api/projects/{project_b}/purchase-plans/{plan_a}")
+
+    _assert_not_found_envelope(r)
+
+
 def test_purchase_plan_convert_to_orders_returns_404_for_foreign_workspace(monkeypatch):
     a, b = _two_workspaces()
     plan_a = _create_refreshed_purchase_plan(a, monkeypatch, mpn="FOREIGN-ORDERS")

--- a/docs/api/sourcing.md
+++ b/docs/api/sourcing.md
@@ -382,6 +382,32 @@ Path: `project_id` is a project UUID in the current workspace.
 - `expires_at` is capped to `created_at + 7 days`; refresh and conversion are later Phase-4 endpoints.
 - Decimal monetary fields serialize as strings.
 
+### `GET /api/projects/{project_id}/purchase-plans/{plan_id}`
+
+Read a persisted purchase plan snapshot for the current workspace.
+
+**Request**
+
+Path: `project_id` is a project UUID in the current workspace; `plan_id` is a
+purchase plan UUID owned by that project and workspace.
+
+**Response** — `200 OK` (envelope: `{ data, status }`)
+
+Shape matches `POST /api/projects/{project_id}/purchase-plan`.
+
+**Errors**
+
+- `404 Not Found` — `project_id` or `plan_id` is missing, belongs to another
+  workspace, or the plan belongs to a different project.
+- `422 Unprocessable Entity` — malformed UUID.
+
+**Notes**
+
+- The route validates both the project and purchase plan with
+  `assert_in_workspace()` before serializing the plan.
+- The frontend purchase-plan review route uses this endpoint to hydrate
+  TanStack Query on direct links and browser reloads.
+
 ### `POST /api/sourcing/purchase-plans/{plan_id}/refresh`
 
 Re-run a purchase plan with fresh TrustedParts offers and replace its plan lines.

--- a/docs/frontend/tanstack-patterns.md
+++ b/docs/frontend/tanstack-patterns.md
@@ -159,6 +159,15 @@ Initial loads still render their skeleton. Background refetches render the
 existing data plus a small `isFetching && !isLoading` status hint
 (`web/src/routes/projects/sourcing/ProjectSourcingPage.tsx:895-900`).
 
+## Purchase Plan Review State
+
+`PurchasePlanReviewPage` treats TanStack Query as the source of truth for
+the persisted purchase plan response, keyed by the active workspace and
+`planId` (`useWsKey("purchase-plan", planId)`). Local React state on that
+page is reserved for ephemeral UI state such as offer overrides and the
+currently open override modal; refresh writes the new server plan into the
+query cache without clearing those overrides.
+
 ## QueryClient defaults
 
 `web/src/main.tsx:45-49`:

--- a/web/src/routes/projects/sourcing/PurchasePlanReviewPage.tsx
+++ b/web/src/routes/projects/sourcing/PurchasePlanReviewPage.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 import { RefreshCw, ShoppingCart } from "lucide-react";
 import { toast } from "sonner";
@@ -6,6 +7,7 @@ import { DataTable, type Column } from "@/components/DataTable";
 import { PoweredByTrustedParts } from "@/components/PoweredByTrustedParts";
 import { SourcingSourceLabel } from "@/components/SourcingSourceLabel";
 import { ApiError, api } from "@/lib/api";
+import { useWsKey } from "@/lib/queryKeys";
 import type { Project } from "@/types";
 import OverrideOfferModal from "./OverrideOfferModal";
 import type {
@@ -148,7 +150,17 @@ export default function PurchasePlanReviewPage() {
   const navigate = useNavigate();
   const { state } = useLocation();
   const locationState = (state ?? {}) as LocationState;
-  const [plan, setPlan] = useState<PurchasePlan | null>(locationState.plan ?? null);
+  const queryClient = useQueryClient();
+  const purchasePlanKey = useWsKey("purchase-plan", planId);
+  const initialPlan = locationState.plan?.id === planId ? locationState.plan : undefined;
+  const planQuery = useQuery({
+    queryKey: purchasePlanKey,
+    queryFn: () => api.get<PurchasePlan>(`/projects/${projectId}/purchase-plans/${planId}`),
+    enabled: !!projectId && !!planId,
+    initialData: initialPlan,
+    staleTime: 5 * 60 * 1000,
+  });
+  const plan = planQuery.data ?? null;
   const [project] = useState<Project | undefined>(locationState.project);
   const [busyAction, setBusyAction] = useState<"refresh" | "convert" | null>(null);
   const [overrideLine, setOverrideLine] = useState<PurchasePlanLine | null>(null);
@@ -165,6 +177,27 @@ export default function PurchasePlanReviewPage() {
   );
 
   if (!projectId || !planId) return null;
+  if (planQuery.isLoading) {
+    return (
+      <div className="card p-4">
+        <div className="font-medium">Loading purchase plan...</div>
+      </div>
+    );
+  }
+  if (planQuery.isError) {
+    const message = planQuery.error instanceof ApiError && planQuery.error.userMessage
+      ? planQuery.error.userMessage
+      : "Could not load purchase plan";
+    return (
+      <div className="card border-danger/40 p-4">
+        <div className="font-medium text-danger">Could not load purchase plan</div>
+        <div className="mt-1 text-sm text-muted">{message}</div>
+        <button type="button" className="btn mt-3" onClick={() => navigate(`/projects/${projectId}/sourcing`)}>
+          Back to sourcing
+        </button>
+      </div>
+    );
+  }
   if (!plan) {
     return (
       <div className="card p-4">
@@ -252,7 +285,7 @@ export default function PurchasePlanReviewPage() {
     setBusyAction("refresh");
     try {
       const next = await api.post<PurchasePlan>(`/sourcing/purchase-plans/${plan.id}/refresh`);
-      setPlan(next);
+      queryClient.setQueryData(purchasePlanKey, next);
       toast.success("Prices refreshed");
     } catch (err) {
       const message = err instanceof ApiError && err.userMessage ? err.userMessage : "Failed to refresh prices";
@@ -276,7 +309,7 @@ export default function PurchasePlanReviewPage() {
       selected_currency: offer.currency,
     };
 
-    setPlan(current => {
+    queryClient.setQueryData<PurchasePlan>(purchasePlanKey, current => {
       if (!current) return current;
       const nextLines = current.lines.map(currentLine =>
         currentLine.id === line.id
@@ -308,6 +341,7 @@ export default function PurchasePlanReviewPage() {
         { overrides },
       );
       toast.success(`Created ${result.orders.length} draft orders`);
+      queryClient.removeQueries({ queryKey: purchasePlanKey, exact: true });
       navigate("/orders");
     } catch {
       toast.error("Could not create draft orders");

--- a/web/src/routes/projects/sourcing/__tests__/PurchasePlanReviewPage.test.tsx
+++ b/web/src/routes/projects/sourcing/__tests__/PurchasePlanReviewPage.test.tsx
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
@@ -13,6 +14,10 @@ vi.mock("sonner", () => ({
     success: vi.fn(),
     error: vi.fn(),
   },
+}));
+
+vi.mock("@/lib/auth", () => ({
+  useAuth: () => ({ workspaceId: "ws-1" }),
 }));
 
 function plan(overrides: Partial<PurchasePlan> = {}): PurchasePlan {
@@ -125,16 +130,39 @@ function LocationProbe() {
   return <div data-testid="location">{location.pathname}</div>;
 }
 
-function renderPage(initialPlan: PurchasePlan = plan()) {
-  render(
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+}
+
+function renderPage({
+  initialPlan = plan(),
+  client = makeQueryClient(),
+}: {
+  initialPlan?: PurchasePlan | null;
+  client?: QueryClient;
+} = {}) {
+  const view = render(
+    <QueryClientProvider client={client}>
+      <PurchasePlanRoutes initialPlan={initialPlan} />
+    </QueryClientProvider>,
+  );
+  return { ...view, client };
+}
+
+function PurchasePlanRoutes({ initialPlan }: { initialPlan?: PurchasePlan | null }) {
+  return (
     <MemoryRouter
       initialEntries={[
         {
           pathname: "/projects/project-123/purchase-plans/plan-12345678",
-          state: {
-            plan: initialPlan,
-            project: { id: "project-123", name: "Amplifier" },
-          },
+          state: initialPlan != null
+            ? {
+                plan: initialPlan,
+                project: { id: "project-123", name: "Amplifier" },
+              }
+            : undefined,
         },
       ]}
     >
@@ -145,7 +173,7 @@ function renderPage(initialPlan: PurchasePlan = plan()) {
         />
         <Route path="/orders" element={<LocationProbe />} />
       </Routes>
-    </MemoryRouter>,
+    </MemoryRouter>
   );
 }
 
@@ -165,6 +193,44 @@ beforeEach(() => {
 });
 
 describe("PurchasePlanReviewPage", () => {
+  it("deep-link to /purchase-plans/:id renders the plan", async () => {
+    vi.spyOn(api, "get").mockResolvedValueOnce(plan());
+
+    renderPage({ initialPlan: null });
+
+    expect(await screen.findByRole("heading", { name: /Purchase plan #\s*plan-123/ })).toBeDefined();
+    expect(api.get).toHaveBeenCalledWith("/projects/project-123/purchase-plans/plan-12345678");
+  });
+
+  it("reload preserves the plan view from the fresh query cache", async () => {
+    const get = vi.spyOn(api, "get").mockResolvedValueOnce(plan());
+    const client = makeQueryClient();
+
+    const first = renderPage({ initialPlan: null, client });
+    expect(await screen.findByRole("heading", { name: /Purchase plan #\s*plan-123/ })).toBeDefined();
+    first.unmount();
+
+    renderPage({ initialPlan: null, client });
+
+    expect(await screen.findByRole("heading", { name: /Purchase plan #\s*plan-123/ })).toBeDefined();
+    expect(get).toHaveBeenCalledTimes(1);
+  });
+
+  it("error state renders banner", async () => {
+    const apiError = new ApiError(
+      500,
+      { data: null, status: { category: "server_error", message: "plan exploded" } },
+      "Internal Server Error",
+    );
+    apiError.userMessage = "Purchase plan unavailable.";
+    vi.spyOn(api, "get").mockRejectedValueOnce(apiError);
+
+    renderPage({ initialPlan: null });
+
+    expect(await screen.findByText("Could not load purchase plan")).toBeDefined();
+    expect(screen.getByText("Purchase plan unavailable.")).toBeDefined();
+  });
+
   it("renders summary cards from server response", () => {
     renderPage();
 
@@ -291,7 +357,7 @@ describe("PurchasePlanReviewPage", () => {
   });
 
   it("Create draft orders is disabled when last_refreshed_at is null", () => {
-    renderPage(plan({ last_refreshed_at: null }));
+    renderPage({ initialPlan: plan({ last_refreshed_at: null }) });
 
     const button = screen.getByRole("button", { name: /Create draft orders/ });
     expect((button as HTMLButtonElement).disabled).toBe(true);
@@ -299,7 +365,7 @@ describe("PurchasePlanReviewPage", () => {
 
   it("Create draft orders is disabled when last_refreshed_at is > 10 min old", () => {
     const stale = new Date(Date.now() - 11 * 60 * 1000).toISOString();
-    renderPage(plan({ last_refreshed_at: stale }));
+    renderPage({ initialPlan: plan({ last_refreshed_at: stale }) });
 
     const button = screen.getByRole("button", { name: /Create draft orders/ });
     expect((button as HTMLButtonElement).disabled).toBe(true);
@@ -310,13 +376,14 @@ describe("PurchasePlanReviewPage", () => {
     vi.spyOn(api, "post").mockResolvedValueOnce({
       orders: [{ id: "order-1", name: "Draft", supplier: "DigiKey", status: "draft", entries: [] }],
     });
-    renderPage();
+    const { client } = renderPage();
 
     await userEvent.click(screen.getByRole("button", { name: /Create draft orders/ }));
 
     await waitFor(() => expect(screen.getByTestId("location").textContent).toBe("/orders"));
     expect(api.post).toHaveBeenCalledWith("/sourcing/purchase-plans/plan-12345678/orders", { overrides: {} });
     expect(toast.success).toHaveBeenCalledWith("Created 1 draft orders");
+    expect(client.getQueryData(["ws", "ws-1", "purchase-plan", "plan-12345678"])).toBeUndefined();
   });
 
   it("selects an alternate cached offer and sends it as a conversion override", async () => {


### PR DESCRIPTION
Refs #500

## Summary
- Store PurchasePlanReviewPage plan data in a workspace-scoped TanStack Query keyed by planId, with route-state initial hydration.
- Refresh writes the returned plan into the query cache while preserving local override state.
- Successful conversion removes the plan cache so back/deep-link loads rehydrate from the server.
- Add the missing purchase-plan GET route with matching-project and cross-workspace 404 envelope tests, and document the state/API behavior.

## Validation
- `npm run typecheck` - passed
- `npm test -- "PurchasePlanReviewPage"` - passed (14 tests)
- `uv run --extra dev python -m pytest -q tests/test_purchase_plan_route.py::test_get_purchase_plan_returns_persisted_plan tests/test_purchase_plan_route.py::test_get_purchase_plan_requires_matching_project tests/test_workspace_isolation.py::test_purchase_plan_get_returns_404_for_foreign_workspace` - passed (3 tests)
- `uv run --extra dev ruff check app/api/routes/sourcing.py tests/test_purchase_plan_route.py tests/test_workspace_isolation.py` - passed
- frontend lint-delta - passed, no new violations
- backend lint-delta - passed, no new violations
- `git diff --check` - passed

## Merge Order
After #514/#493; after #518/#498 already merged; before any future PurchasePlanReviewPage split/refactor. Rebase #499 if #520 merges first.
