### PR TITLE
SA-17: Cron sidecar per-job timeout 600 wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ the canonical record.
 
 ## 2026-05 — feedback brief fixes
 
+- **SA-17 / #509** Production cron sidecar jobs now have a 600-second
+  per-run timeout that logs exit 124 on timeout while preserving cadence.
 - **SA-8 / #499** Decompose ProjectSourcingPage into a feature folder.
 - **SA-6 / #497** Project Sourcing now runs the audited BOM sourcing POST only
   from an explicit Source click, preserving the display cache without

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -202,9 +202,9 @@ services:
       backend:
         condition: service_healthy
     # Runs the hourly TrustedParts cache retention sweep through the shared
-    # backend CLI. The sleep happens after each run finishes, so a long run
-    # delays the next start instead of overlapping it.
-    command: ["sh", "-c", "while true; do python -m app.cli.run_job sourcing-cache-sweep; sleep 3600; done"]
+    # backend CLI. Each run is capped at 600s; failures are logged and the
+    # loop sleeps on the same cadence before trying again.
+    command: ["sh", "-c", "while true; do timeout 600 python -m app.cli.run_job sourcing-cache-sweep; rc=$$?; if [ $$rc -eq 124 ]; then echo 'sourcing-cache-sweep timed out after 600s (exit=124)'; elif [ $$rc -ne 0 ]; then echo \"sourcing-cache-sweep failed (exit=$$rc)\"; fi; sleep 3600; done"]
     security_opt: ["no-new-privileges:true"]
     cap_drop: ["ALL"]
 
@@ -249,7 +249,8 @@ services:
         condition: service_healthy
     # Runs the 15-minute sourcing alert evaluator through the shared backend
     # CLI. Alert-level cooldowns enforce per-alert notification frequency.
-    command: ["sh", "-c", "while true; do python -m app.cli.run_job sourcing-alerts-evaluate; sleep 900; done"]
+    # Each run is capped at 600s; failures are logged and the loop continues.
+    command: ["sh", "-c", "while true; do timeout 600 python -m app.cli.run_job sourcing-alerts-evaluate; rc=$$?; if [ $$rc -eq 124 ]; then echo 'sourcing-alerts-evaluate timed out after 600s (exit=124)'; elif [ $$rc -ne 0 ]; then echo \"sourcing-alerts-evaluate failed (exit=$$rc)\"; fi; sleep 900; done"]
     security_opt: ["no-new-privileges:true"]
     cap_drop: ["ALL"]
 

--- a/docs/runbooks/on-call-quickstart.md
+++ b/docs/runbooks/on-call-quickstart.md
@@ -77,7 +77,15 @@ sudo -u deploy docker compose -f docker-compose.prod.yml --env-file .env.prod ps
 ```
 
 Expect: `db` healthy, `backend` healthy, `web` running, `backend-init`
-exited with code 0.
+exited with code 0. Cron sidecars should also be running:
+
+- `backend-cron` runs `sourcing-cache-sweep` every 3600 seconds.
+- `backend-cron-alerts` runs `sourcing-alerts-evaluate` every 900 seconds.
+
+Both cron sidecars wrap each job run in `timeout 600`. Log line `timed out
+after 600s (exit=124)` means the job hit the 10-minute cap and was
+terminated; other non-zero exits are logged as `failed (exit=<code>)`. The
+sidecar loop stays alive after either case and sleeps until the next tick.
 
 If `backend` is `Restarting`:
 ```bash


### PR DESCRIPTION
## Summary

- Wrap `backend-cron` and `backend-cron-alerts` run-job invocations in `timeout 600`.
- Log timeout exit `124` separately from other non-zero failures while keeping each loop alive.
- Document the 10-minute cap, exit 124 meaning, and sidecar cadence in the on-call quickstart.
- Add the SA-17 changelog entry.

## Compose stanza

Before:

```yaml
backend-cron: while true; do python -m app.cli.run_job sourcing-cache-sweep; sleep 3600; done
backend-cron-alerts: while true; do python -m app.cli.run_job sourcing-alerts-evaluate; sleep 900; done
```

After:

```yaml
backend-cron: while true; do timeout 600 python -m app.cli.run_job sourcing-cache-sweep; rc=$?; ...; sleep 3600; done
backend-cron-alerts: while true; do timeout 600 python -m app.cli.run_job sourcing-alerts-evaluate; rc=$?; ...; sleep 900; done
```

## Validation

```text
$ docker compose -f docker-compose.prod.yml config
/bin/bash: line 1: docker: command not found
```

Docker is not installed in this local execution environment, so the exact Compose config render could not be run here. As a fallback, the compose YAML was parsed with PyYAML and both extracted cron commands were checked with `sh -n` after Compose-style `$$` escaping was converted to runtime `$`:

```text
backend-cron:
  while true; do timeout 600 python -m app.cli.run_job sourcing-cache-sweep; rc=$$?; if [ $$rc -eq 124 ]; then echo 'sourcing-cache-sweep timed out after 600s (exit=124)'; elif [ $$rc -ne 0 ]; then echo "sourcing-cache-sweep failed (exit=$$rc)"; fi; sleep 3600; done
backend-cron-alerts:
  while true; do timeout 600 python -m app.cli.run_job sourcing-alerts-evaluate; rc=$$?; if [ $$rc -eq 124 ]; then echo 'sourcing-alerts-evaluate timed out after 600s (exit=124)'; elif [ $$rc -ne 0 ]; then echo "sourcing-alerts-evaluate failed (exit=$$rc)"; fi; sleep 900; done
backend-cron shell syntax: 0
backend-cron-alerts shell syntax: 0
```

```text
$ rg -n -A45 "^  backend-cron:" docker-compose.prod.yml && rg -n -A45 "^  backend-cron-alerts:" docker-compose.prod.yml
207-    command: ["sh", "-c", "while true; do timeout 600 python -m app.cli.run_job sourcing-cache-sweep; rc=$$?; if [ $$rc -eq 124 ]; then echo 'sourcing-cache-sweep timed out after 600s (exit=124)'; elif [ $$rc -ne 0 ]; then echo \"sourcing-cache-sweep failed (exit=$$rc)\"; fi; sleep 3600; done"]
253-    command: ["sh", "-c", "while true; do timeout 600 python -m app.cli.run_job sourcing-alerts-evaluate; rc=$$?; if [ $$rc -eq 124 ]; then echo 'sourcing-alerts-evaluate timed out after 600s (exit=124)'; elif [ $$rc -ne 0 ]; then echo \"sourcing-alerts-evaluate failed (exit=$$rc)\"; fi; sleep 900; done"]
```

```text
$ timeout 5 sleep 30; echo $?
124
```

```text
$ git diff --check
# no output
```

## Cadence

Cadence unchanged:

- `backend-cron` still sleeps `3600` seconds.
- `backend-cron-alerts` still sleeps `900` seconds.

## Merge Order

Independent; may merge before other SA-10..19 PRs, rebase only for CHANGELOG conflicts.

Refs #509
