### PR TITLE
SA-18: Risk pill WCAG 1.4.1 - icon/text prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ the canonical record.
   per-run timeout that logs exit 124 on timeout while preserving cadence.
 - **SA-15 / #507** TrustedParts, Mouser, and DigiKey outbound calls now share
   bounded retry backoff for 429/503 and transient connect/read timeout failures.
+- **SA-18 / #510** Project Sourcing Lifecycle, Supply chain, and RoHS risk
+  pills now include hidden Lucide icon prefixes so severity is not conveyed by
+  colour alone.
 - **SA-8 / #499** Decompose ProjectSourcingPage into a feature folder.
 - **SA-6 / #497** Project Sourcing now runs the audited BOM sourcing POST only
   from an explicit Source click, preserving the display cache without

--- a/docs/frontend/components.md
+++ b/docs/frontend/components.md
@@ -242,6 +242,12 @@ classes, tariff and RoHS pills use the same semantic palette, and the
 specifications block is a native collapsed `<details>` panel. No new
 global utility or pill variant is introduced.
 
+Project Sourcing BOM risk pills follow the same palette and also prefix
+Lifecycle, Supply chain, and RoHS status text with `lucide-react` icons.
+The icons are `aria-hidden="true"` so assistive tech reads the existing
+status text/labels, while greyscale and low-vision users still get a
+non-colour severity cue (SA-18 / #510).
+
 ## MpnLookup
 
 `web/src/components/MpnLookup.tsx`. Affordance attached to MPN inputs that

--- a/web/src/routes/projects/sourcing/BomRows.tsx
+++ b/web/src/routes/projects/sourcing/BomRows.tsx
@@ -1,8 +1,10 @@
 import { useState } from "react";
+import { AlertCircle, AlertTriangle, CheckCircle2, Circle, OctagonAlert } from "lucide-react";
 import { DataTable, type Column } from "@/components/DataTable";
 import { RiskLegendPopover } from "@/components/RiskLegendPopover";
 import { SourcingSourceLabel } from "@/components/SourcingSourceLabel";
 import { LIFECYCLE_LEGEND, SUPPLY_CHAIN_LEGEND } from "@/lib/riskLegends";
+import { lifecycleRiskTone, type RiskTone } from "@/lib/sourcing";
 import { BomDistributorsModal } from "./BomDistributorsModal";
 import {
   formatLeadTime,
@@ -19,11 +21,30 @@ import {
 } from "./sourcingHelpers";
 import type { SourcingBomLine } from "./sourcingTypes";
 
+const RISK_TONE_ICONS = {
+  good: CheckCircle2,
+  "low-warning": AlertCircle,
+  warning: AlertTriangle,
+  danger: OctagonAlert,
+  neutral: Circle,
+} satisfies Record<RiskTone, typeof CheckCircle2>;
+
+function RiskToneIcon({ tone }: { tone: RiskTone }) {
+  const Icon = RISK_TONE_ICONS[tone];
+  return <Icon size={12} aria-hidden="true" />;
+}
+
 function LifecycleRiskPill({ label = "Lifecycle risk", value }: { label?: string; value?: string | null }) {
   const trimmed = value?.trim();
   if (!trimmed) return null;
+  const tone = lifecycleRiskTone(trimmed);
   return (
-    <span className={`pill ${lifecycleRiskClass(trimmed)}`} title={trimmed} aria-label={`${label}: ${trimmed}`}>
+    <span
+      className={`pill inline-flex items-center gap-1 ${lifecycleRiskClass(trimmed)}`}
+      title={trimmed}
+      aria-label={`${label}: ${trimmed}`}
+    >
+      <RiskToneIcon tone={tone} />
       {trimmed}
     </span>
   );
@@ -33,18 +54,20 @@ function RohsRiskPill({ tone }: { tone: "good" | "danger" | "neutral" }) {
   if (tone === "neutral") return <span className="text-muted">—</span>;
   return tone === "danger" ? (
     <span
-      className="pill bg-danger/10 text-danger"
+      className="pill inline-flex items-center gap-1 bg-danger/10 text-danger"
       title={riskTooltip("rohs_non_compliant")}
       aria-label={riskTooltip("rohs_non_compliant")}
     >
+      <RiskToneIcon tone="danger" />
       Non-compliant
     </span>
   ) : (
     <span
-      className="pill bg-success/10 text-success"
+      className="pill inline-flex items-center gap-1 bg-success/10 text-success"
       title="TrustedParts found compliant EU RoHS data for this BOM line."
       aria-label="TrustedParts found compliant EU RoHS data for this BOM line."
     >
+      <RiskToneIcon tone="good" />
       Compliant
     </span>
   );

--- a/web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.bomRows.test.tsx
+++ b/web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.bomRows.test.tsx
@@ -138,6 +138,9 @@ describe("ProjectSourcingPage", () => {
     expect(supplyChain.className).toContain("text-warning");
     expect(tariff.className).toContain("text-warning");
     expect(rohs.className).toContain("text-danger");
+    expect(lifecycle.querySelector("svg")?.getAttribute("aria-hidden")).toBe("true");
+    expect(supplyChain.querySelector("svg")?.getAttribute("aria-hidden")).toBe("true");
+    expect(rohs.querySelector("svg")?.getAttribute("aria-hidden")).toBe("true");
 
     const riskCell = within(bomRowsTable).getByRole("row", { name: /STM32/ }).querySelectorAll("td")[12];
     expect(within(riskCell as HTMLElement).queryByText("lifecycle")).toBeNull();

--- a/web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.riskColumns.test.tsx
+++ b/web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.riskColumns.test.tsx
@@ -42,6 +42,7 @@ describe("ProjectSourcingPage", () => {
     await sourceBom();
     const rohs = screen.getByText("Compliant");
     expect(rohs.className).toContain("text-success");
+    expect(rohs.querySelector("svg")?.getAttribute("aria-hidden")).toBe("true");
   });
 
   it("lifecycle column is visible by default and renders Obsolete as red", async () => {
@@ -66,6 +67,7 @@ describe("ProjectSourcingPage", () => {
     expect(within(bomRowsTable).getByRole("columnheader", { name: /Lifecycle/ })).toBeDefined();
     const lifecycle = screen.getByLabelText("Lifecycle risk: Obsolete");
     expect(lifecycle.className).toContain("text-danger");
+    expect(lifecycle.querySelector("svg")?.getAttribute("aria-hidden")).toBe("true");
   });
 
   it("renders Low lifecycle risk as a green pill in the BOM table", async () => {
@@ -88,6 +90,43 @@ describe("ProjectSourcingPage", () => {
     await sourceBom();
     const lifecycle = screen.getByLabelText("Lifecycle risk: Low risk");
     expect(lifecycle.className).toContain("text-success");
+  });
+
+  it("prefixes lifecycle risk tones with distinct hidden icons", async () => {
+    mockReads();
+    const base = sourcingResponse();
+    const tones = [
+      ["Active", "lucide-circle-check"],
+      ["Low-Med", "lucide-circle-alert"],
+      ["Medium", "lucide-triangle-alert"],
+      ["Obsolete", "lucide-octagon-alert"],
+      ["Review pending", "lucide-circle"],
+    ] as const;
+    vi.spyOn(api, "post").mockResolvedValue(sourcingResponse({
+      rows: tones.map(([risk], index) => ({
+        ...base.rows[0],
+        project_entry_id: `entry-tone-${index}`,
+        part_id: `part-tone-${index}`,
+        part_name: `Tone ${index}`,
+        mpn: `TONE-${index}`,
+        best_offer: {
+          ...base.rows[0].best_offer,
+          lifecycle_risk: risk,
+        },
+        risk_flags: [],
+      })),
+    }));
+
+    renderPage();
+
+    await sourceBom();
+    for (const [risk, iconClass] of tones) {
+      const pill = screen.getByLabelText(`Lifecycle risk: ${risk}`);
+      const icon = pill.querySelector("svg");
+      expect(icon?.getAttribute("aria-hidden")).toBe("true");
+      expect(icon?.getAttribute("class")).toContain(iconClass);
+      expect(pill.textContent).toBe(risk);
+    }
   });
 
   it("hides lead time by default but keeps per-row values available from the column menu", async () => {


### PR DESCRIPTION
## Summary
- Add Lucide icon prefixes to Project Sourcing Lifecycle, Supply chain, and RoHS risk pills without changing existing pill colors.
- Keep icons aria-hidden so screen readers hear the existing pill text/labels.
- Document the accessibility contract and add a changelog entry for SA-18 / #510.

## Tests
- cd web && npm run typecheck
- cd web && npm test -- src/routes/projects/sourcing/__tests__/ProjectSourcingPage.riskColumns.test.tsx src/routes/projects/sourcing/__tests__/ProjectSourcingPage.bomRows.test.tsx
- cd web && WORK_DIR="." LINT_CMD="npx eslint src --format=unix" BASELINE_FILE="../.eslint-baseline.txt" bash ../scripts/lint-delta.sh
- git diff --check

## Visual / Accessibility Note
- No browser screenshot captured; tests verify hidden icon prefixes and existing accessible text. Greyscale/manual visual parity expectation: colors are unchanged, with icons added as the non-colour severity cue.

## Merge Order
Independent; can merge before/after backend SA PRs, rebase for CHANGELOG conflicts.

Refs #510