### PR TITLE
SA-15: Outbound exponential backoff transport on TP/Mouser/DK 429/503

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ the canonical record.
 
 - **SA-17 / #509** Production cron sidecar jobs now have a 600-second
   per-run timeout that logs exit 124 on timeout while preserving cadence.
+- **SA-15 / #507** TrustedParts, Mouser, and DigiKey outbound calls now share
+  bounded retry backoff for 429/503 and transient connect/read timeout failures.
 - **SA-8 / #499** Decompose ProjectSourcingPage into a feature folder.
 - **SA-6 / #497** Project Sourcing now runs the audited BOM sourcing POST only
   from an explicit Source click, preserving the display cache without

--- a/backend/app/domain/parts/providers/digikey.py
+++ b/backend/app/domain/parts/providers/digikey.py
@@ -17,9 +17,8 @@ import time
 from typing import Any, Callable
 from urllib.parse import quote
 
-import httpx
-
 from app.domain.parts.providers.base import MpnLookupResult
+from app.domain.sourcing.providers import make_retrying_client
 
 _API_BASE = "https://api.digikey.com"
 _TOKEN_PATH = "/v1/oauth2/token"
@@ -43,7 +42,7 @@ _FOOTPRINT_KEYS = {
 
 def _post_token(client_id: str, client_secret: str) -> dict[str, Any]:
     """Network seam — tests monkeypatch this."""
-    with httpx.Client(timeout=_TIMEOUT_SEC) as client:
+    with make_retrying_client(provider_name="digikey", timeout=_TIMEOUT_SEC) as client:
         resp = client.post(
             f"{_API_BASE}{_TOKEN_PATH}",
             data={
@@ -77,7 +76,7 @@ def _get_product_details(
     """Network seam. Returns (status_code, json_body). Lets the caller
     distinguish 404 (no match) from 200 (found) without raising."""
     url = f"{_API_BASE}{_PRODUCT_DETAILS_PATH.format(mpn=quote(mpn, safe=''))}"
-    with httpx.Client(timeout=_TIMEOUT_SEC) as client:
+    with make_retrying_client(provider_name="digikey", timeout=_TIMEOUT_SEC) as client:
         resp = client.get(url, headers=_digikey_headers(token, client_id))
     try:
         body = resp.json()
@@ -96,7 +95,7 @@ def _post_keyword_search(
     url = f"{_API_BASE}{_KEYWORD_SEARCH_PATH}"
     payload = {"Keywords": keywords, "Limit": limit}
     headers = {**_digikey_headers(token, client_id), "Content-Type": "application/json"}
-    with httpx.Client(timeout=_TIMEOUT_SEC) as client:
+    with make_retrying_client(provider_name="digikey", timeout=_TIMEOUT_SEC) as client:
         resp = client.post(url, headers=headers, json=payload)
     try:
         body = resp.json()

--- a/backend/app/domain/parts/providers/mouser.py
+++ b/backend/app/domain/parts/providers/mouser.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 import re
 from typing import Any
 
-import httpx
-
 from app.domain.parts.providers.base import MpnLookupResult
+from app.domain.sourcing.providers import make_retrying_client
 
 _ENDPOINT = "https://api.mouser.com/api/v1/search/partnumber"
 _TIMEOUT_SEC = 8.0  # Cap upstream wall-clock to prevent worker stall (BE2-011).
@@ -14,7 +13,7 @@ _TIMEOUT_SEC = 8.0  # Cap upstream wall-clock to prevent worker stall (BE2-011).
 
 def _post_mouser(url: str, payload: dict[str, Any]) -> dict[str, Any]:
     """Network seam — tests monkeypatch this single function."""
-    with httpx.Client(timeout=_TIMEOUT_SEC) as client:
+    with make_retrying_client(provider_name="mouser", timeout=_TIMEOUT_SEC) as client:
         resp = client.post(url, json=payload, headers={"Accept": "application/json"})
         resp.raise_for_status()
         return resp.json()

--- a/backend/app/domain/sourcing/client.py
+++ b/backend/app/domain/sourcing/client.py
@@ -19,6 +19,7 @@ from app.domain.sourcing._generated.trustedparts_v2 import (
     ProductPricing,
     SearchApiLink,
 )
+from app.domain.sourcing.providers import make_retrying_client
 from app.domain.sourcing.schemas import (
     SourcingDistributor,
     SourcingLinks,
@@ -69,7 +70,10 @@ def _post_tp(
     headers: dict[str, str],
 ) -> tuple[int, dict[str, Any]]:
     """Network seam — monkeypatched in tests. Returns (status_code, body_dict)."""
-    with httpx.Client(timeout=TP_TIMEOUT_SECONDS) as client:
+    with make_retrying_client(
+        provider_name="trustedparts",
+        timeout=TP_TIMEOUT_SECONDS,
+    ) as client:
         response = client.post(
             url,
             json=json_body,

--- a/backend/app/domain/sourcing/providers/__init__.py
+++ b/backend/app/domain/sourcing/providers/__init__.py
@@ -1,0 +1,5 @@
+"""Shared outbound provider HTTP helpers."""
+
+from app.domain.sourcing.providers.factory import make_retrying_client
+
+__all__ = ["make_retrying_client"]

--- a/backend/app/domain/sourcing/providers/_retry_transport.py
+++ b/backend/app/domain/sourcing/providers/_retry_transport.py
@@ -1,0 +1,229 @@
+"""Bounded retry transports for outbound provider HTTP calls."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import random
+import time
+from collections.abc import Iterable
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+
+import httpx
+
+RETRYABLE_STATUSES = frozenset({429, 503})
+RETRYABLE_EXCEPTIONS = (httpx.ConnectError, httpx.ReadTimeout)
+
+logger = logging.getLogger(__name__)
+
+
+class RetryingHTTPTransport(httpx.HTTPTransport):
+    """Bounded exponential backoff on retryable upstream responses/errors."""
+
+    def __init__(
+        self,
+        *args,
+        max_retries: int = 3,
+        base_delay: float = 0.5,
+        max_delay: float = 8.0,
+        retryable_statuses: Iterable[int] = RETRYABLE_STATUSES,
+        provider_name: str | None = None,
+        inner: httpx.BaseTransport | None = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self._max_retries = max_retries
+        self._base = base_delay
+        self._cap = max_delay
+        self._retryable = frozenset(retryable_statuses)
+        self._provider_name = provider_name
+        self._inner = inner
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        response: httpx.Response | None = None
+        for attempt in range(self._max_retries + 1):
+            try:
+                response = self._handle_once(request)
+            except RETRYABLE_EXCEPTIONS as exc:
+                if attempt == self._max_retries:
+                    _log_exhausted(request, self._provider_name, attempt, exc=exc)
+                    raise
+                delay = self._compute_delay(attempt)
+                _log_retry(request, self._provider_name, attempt, delay, exc=exc)
+                time.sleep(delay)
+                continue
+
+            if response.status_code not in self._retryable:
+                return response
+            if attempt == self._max_retries:
+                _log_exhausted(request, self._provider_name, attempt, response=response)
+                return response
+
+            delay = _retry_after_seconds(response, self._cap)
+            if delay is None:
+                delay = self._compute_delay(attempt)
+            _log_retry(request, self._provider_name, attempt, delay, response=response)
+            response.close()
+            time.sleep(delay)
+
+        if response is None:  # pragma: no cover - defensive loop guard.
+            raise RuntimeError("retry transport exited without response")
+        return response
+
+    def close(self) -> None:
+        if self._inner is not None:
+            self._inner.close()
+        super().close()
+
+    def _handle_once(self, request: httpx.Request) -> httpx.Response:
+        if self._inner is not None:
+            return self._inner.handle_request(request)
+        return super().handle_request(request)
+
+    def _compute_delay(self, attempt: int) -> float:
+        exp = min(self._base * (2**attempt), self._cap)
+        return random.uniform(0, exp)
+
+
+class RetryingAsyncHTTPTransport(httpx.AsyncHTTPTransport):
+    """Async variant for future provider clients using httpx.AsyncClient."""
+
+    def __init__(
+        self,
+        *args,
+        max_retries: int = 3,
+        base_delay: float = 0.5,
+        max_delay: float = 8.0,
+        retryable_statuses: Iterable[int] = RETRYABLE_STATUSES,
+        provider_name: str | None = None,
+        inner: httpx.AsyncBaseTransport | None = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self._max_retries = max_retries
+        self._base = base_delay
+        self._cap = max_delay
+        self._retryable = frozenset(retryable_statuses)
+        self._provider_name = provider_name
+        self._inner = inner
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        response: httpx.Response | None = None
+        for attempt in range(self._max_retries + 1):
+            try:
+                response = await self._handle_once(request)
+            except RETRYABLE_EXCEPTIONS as exc:
+                if attempt == self._max_retries:
+                    _log_exhausted(request, self._provider_name, attempt, exc=exc)
+                    raise
+                delay = self._compute_delay(attempt)
+                _log_retry(request, self._provider_name, attempt, delay, exc=exc)
+                await asyncio.sleep(delay)
+                continue
+
+            if response.status_code not in self._retryable:
+                return response
+            if attempt == self._max_retries:
+                _log_exhausted(request, self._provider_name, attempt, response=response)
+                return response
+
+            delay = _retry_after_seconds(response, self._cap)
+            if delay is None:
+                delay = self._compute_delay(attempt)
+            _log_retry(request, self._provider_name, attempt, delay, response=response)
+            await response.aclose()
+            await asyncio.sleep(delay)
+
+        if response is None:  # pragma: no cover - defensive loop guard.
+            raise RuntimeError("retry transport exited without response")
+        return response
+
+    async def aclose(self) -> None:
+        if self._inner is not None:
+            await self._inner.aclose()
+        await super().aclose()
+
+    async def _handle_once(self, request: httpx.Request) -> httpx.Response:
+        if self._inner is not None:
+            return await self._inner.handle_async_request(request)
+        return await super().handle_async_request(request)
+
+    def _compute_delay(self, attempt: int) -> float:
+        exp = min(self._base * (2**attempt), self._cap)
+        return random.uniform(0, exp)
+
+
+def _retry_after_seconds(response: httpx.Response, max_delay: float) -> float | None:
+    raw = response.headers.get("Retry-After")
+    if raw is None:
+        return None
+    value = raw.strip()
+    if not value:
+        return None
+    try:
+        seconds = float(value)
+    except ValueError:
+        seconds = _retry_after_http_date_seconds(value)
+        if seconds is None:
+            return None
+    return min(max(0.0, seconds), max_delay)
+
+
+def _retry_after_http_date_seconds(value: str) -> float | None:
+    try:
+        when = parsedate_to_datetime(value)
+    except (TypeError, ValueError):
+        return None
+    if when.tzinfo is None:
+        when = when.replace(tzinfo=timezone.utc)
+    return (when - datetime.now(timezone.utc)).total_seconds()
+
+
+def _log_retry(
+    request: httpx.Request,
+    provider_name: str | None,
+    attempt: int,
+    delay: float,
+    *,
+    response: httpx.Response | None = None,
+    exc: Exception | None = None,
+) -> None:
+    logger.info(
+        "provider_retry provider=%s status=%s attempt=%s delay=%.3f url=%s error=%s",
+        provider_name or _provider_from_url(request.url),
+        response.status_code if response is not None else None,
+        attempt + 1,
+        delay,
+        request.url.host,
+        type(exc).__name__ if exc is not None else None,
+    )
+
+
+def _log_exhausted(
+    request: httpx.Request,
+    provider_name: str | None,
+    attempt: int,
+    *,
+    response: httpx.Response | None = None,
+    exc: Exception | None = None,
+) -> None:
+    logger.warning(
+        "provider_retry_exhausted provider=%s status=%s attempts=%s url=%s error=%s",
+        provider_name or _provider_from_url(request.url),
+        response.status_code if response is not None else None,
+        attempt + 1,
+        request.url.host,
+        type(exc).__name__ if exc is not None else None,
+    )
+
+
+def _provider_from_url(url: httpx.URL) -> str:
+    host = (url.host or "").lower()
+    if "trustedparts" in host:
+        return "trustedparts"
+    if "mouser" in host:
+        return "mouser"
+    if "digikey" in host:
+        return "digikey"
+    return host or "unknown"

--- a/backend/app/domain/sourcing/providers/factory.py
+++ b/backend/app/domain/sourcing/providers/factory.py
@@ -1,0 +1,27 @@
+"""HTTP client factory for outbound provider calls."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+import httpx
+
+from app.domain.sourcing.providers._retry_transport import RetryingHTTPTransport
+
+
+@contextmanager
+def make_retrying_client(
+    *,
+    provider_name: str,
+    timeout: float,
+    transport: httpx.BaseTransport | None = None,
+) -> Iterator[httpx.Client]:
+    """Build a provider HTTP client with the shared retry policy."""
+    retry_transport = RetryingHTTPTransport(
+        verify=True,
+        provider_name=provider_name,
+        inner=transport,
+    )
+    with httpx.Client(timeout=timeout, transport=retry_transport) as client:
+        yield client

--- a/backend/tests/test_sourcing_providers_retry.py
+++ b/backend/tests/test_sourcing_providers_retry.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable
+from datetime import datetime, timedelta, timezone
+from email.utils import format_datetime
+
+import httpx
+import pytest
+
+from app.domain.sourcing.providers._retry_transport import RetryingAsyncHTTPTransport
+
+
+async def _request_with_transport(
+    handler: Callable[[httpx.Request], httpx.Response],
+    *,
+    sleeps: list[float],
+    monkeypatch: pytest.MonkeyPatch,
+    max_retries: int = 3,
+) -> tuple[httpx.Response, int]:
+    attempts = 0
+
+    async def fake_sleep(delay: float) -> None:
+        sleeps.append(delay)
+
+    def wrapped(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        attempts += 1
+        return handler(request)
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+    transport = RetryingAsyncHTTPTransport(
+        provider_name="trustedparts",
+        inner=httpx.MockTransport(wrapped),
+        base_delay=0.5,
+        max_delay=8.0,
+        max_retries=max_retries,
+        verify=True,
+    )
+    async with httpx.AsyncClient(transport=transport) as client:
+        response = await client.get("https://api.trustedparts.com/v2/search")
+    return response, attempts
+
+
+def test_retries_on_429_then_succeeds(monkeypatch, caplog):
+    statuses = [429, 429, 200]
+    sleeps: list[float] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(statuses.pop(0), request=request)
+
+    caplog.set_level(logging.INFO)
+    response, attempts = asyncio.run(
+        _request_with_transport(handler, sleeps=sleeps, monkeypatch=monkeypatch)
+    )
+
+    assert response.status_code == 200
+    assert attempts == 3
+    assert len(sleeps) == 2
+    assert "provider_retry provider=trustedparts status=429 attempt=1" in caplog.text
+
+
+def test_retries_on_503_then_succeeds(monkeypatch):
+    statuses = [503, 200]
+    sleeps: list[float] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(statuses.pop(0), request=request)
+
+    response, attempts = asyncio.run(
+        _request_with_transport(handler, sleeps=sleeps, monkeypatch=monkeypatch)
+    )
+
+    assert response.status_code == 200
+    assert attempts == 2
+    assert len(sleeps) == 1
+
+
+def test_does_not_retry_on_400(monkeypatch):
+    sleeps: list[float] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(400, request=request)
+
+    response, attempts = asyncio.run(
+        _request_with_transport(handler, sleeps=sleeps, monkeypatch=monkeypatch)
+    )
+
+    assert response.status_code == 400
+    assert attempts == 1
+    assert sleeps == []
+
+
+def test_exhausts_retries_and_returns_last_response(monkeypatch, caplog):
+    sleeps: list[float] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(429, request=request)
+
+    caplog.set_level(logging.INFO)
+    response, attempts = asyncio.run(
+        _request_with_transport(handler, sleeps=sleeps, monkeypatch=monkeypatch)
+    )
+
+    assert response.status_code == 429
+    assert attempts == 4
+    assert len(sleeps) == 3
+    assert "provider_retry_exhausted provider=trustedparts status=429 attempts=4" in caplog.text
+
+
+def test_retries_on_connect_error(monkeypatch):
+    sleeps: list[float] = []
+    seen = {"raised": False}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if not seen["raised"]:
+            seen["raised"] = True
+            raise httpx.ConnectError("simulated connect failure", request=request)
+        return httpx.Response(200, request=request)
+
+    response, attempts = asyncio.run(
+        _request_with_transport(handler, sleeps=sleeps, monkeypatch=monkeypatch)
+    )
+
+    assert response.status_code == 200
+    assert attempts == 2
+    assert len(sleeps) == 1
+
+
+def test_honors_retry_after_header(monkeypatch):
+    sleeps: list[float] = []
+    statuses = [429, 200]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        status = statuses.pop(0)
+        headers = {"Retry-After": "2"} if status == 429 else {}
+        return httpx.Response(status, headers=headers, request=request)
+
+    response, attempts = asyncio.run(
+        _request_with_transport(handler, sleeps=sleeps, monkeypatch=monkeypatch)
+    )
+
+    assert response.status_code == 200
+    assert attempts == 2
+    assert sleeps == [2.0]
+
+
+def test_honors_retry_after_http_date_capped(monkeypatch):
+    sleeps: list[float] = []
+    retry_at = format_datetime(datetime.now(timezone.utc) + timedelta(seconds=60))
+    statuses = [503, 200]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        status = statuses.pop(0)
+        headers = {"Retry-After": retry_at} if status == 503 else {}
+        return httpx.Response(status, headers=headers, request=request)
+
+    response, attempts = asyncio.run(
+        _request_with_transport(handler, sleeps=sleeps, monkeypatch=monkeypatch)
+    )
+
+    assert response.status_code == 200
+    assert attempts == 2
+    assert sleeps == [8.0]
+
+
+@pytest.mark.parametrize("status", [401, 403, 404, 422, 500])
+def test_no_retry_for_non_retryable_status(monkeypatch, status):
+    sleeps: list[float] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(status, request=request)
+
+    response, attempts = asyncio.run(
+        _request_with_transport(handler, sleeps=sleeps, monkeypatch=monkeypatch)
+    )
+
+    assert response.status_code == status
+    assert attempts == 1
+    assert sleeps == []

--- a/docs/adr/0023-outbound-provider-backoff.md
+++ b/docs/adr/0023-outbound-provider-backoff.md
@@ -1,0 +1,60 @@
+# ADR-0023: Outbound provider backoff
+
+Audience: engineer
+
+- **Status**: Accepted
+- **Date**: 2026-05-11
+- **Supersedes**: —
+- **Superseded by**: —
+
+## Context
+
+TrustedParts sourcing and the Mouser/DigiKey catalog providers all call external
+HTTP APIs from request paths. Inbound slowapi limits do not protect those
+outbound calls from upstream rate limits or short outages. Before this decision,
+429/503 responses and transient connection failures propagated immediately to
+routes or provider lookup results.
+
+The project also has a hard TLS invariant: backend `httpx` clients must not set
+`verify=False` or loosen proxy/environment handling. The retry layer therefore
+has to sit on normal `httpx` transports with `verify=True`.
+
+## Decision
+
+All provider HTTP calls use a shared retrying transport. It retries only 429,
+503, `httpx.ConnectError`, and `httpx.ReadTimeout`, with at most three retries,
+base delay 0.5s, cap 8s, and full jitter. `Retry-After` seconds or HTTP-date
+headers override jitter, still capped at 8s.
+
+Current provider code is synchronous, so the shared factory returns a sync
+`httpx.Client` backed by `RetryingHTTPTransport`. The same module also provides
+`RetryingAsyncHTTPTransport` for future async provider clients.
+
+## Consequences
+
+- **Good**: Short provider-side rate limits and 503 blips are absorbed before
+  surfacing as user-visible failures.
+- **Trade-offs**: A request can spend additional time waiting for upstream
+  recovery, bounded by the existing provider timeout per attempt plus capped
+  retry sleeps.
+- **What it forbids**: Retrying ordinary client/auth errors, retrying 500, adding
+  a retry dependency, or changing `verify=True` to bypass TLS verification.
+
+## Alternatives considered
+
+- **Retry in each provider module** — rejected because it would duplicate policy
+  and make status/error handling drift across TrustedParts, Mouser, and DigiKey.
+- **Use a retry library** — rejected because the policy is small and issue #507
+  forbids new dependencies.
+- **Retry every 5xx** — rejected because the accepted contract is limited to 503;
+  ordinary 500s should still surface as upstream failures.
+
+## References
+
+- Source: `backend/app/domain/sourcing/providers/_retry_transport.py:15-229`
+- Source: `backend/app/domain/sourcing/providers/factory.py:13-27`
+- Source: `backend/app/domain/sourcing/client.py:67-81`
+- Source: `backend/app/domain/parts/providers/mouser.py:16-21`
+- Source: `backend/app/domain/parts/providers/digikey.py:45-106`
+- Related ADR: [ADR-0008](0008-no-tls-verify-false.md)
+- Issue: `https://github.com/matescb/stockManager/issues/507`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -31,3 +31,5 @@ New ADRs follow the template in [STYLE.md](../STYLE.md#adr-pages-docsadrnnnn-slu
 | 0019 | [Self-hosted Umami for product analytics, env-gated tracker](0019-umami-self-hosted-analytics.md) |
 | 0020 | [TrustedParts sourcing provider split](0020-trustedparts-sourcing-provider-split.md) |
 | 0021 | [Periodic jobs run in a backend-cron sidecar](0021-periodic-jobs-scheduler.md) |
+| 0022 | [TrustedParts schema version pinning](0022-trustedparts-schema-version-pinning.md) |
+| 0023 | [Outbound provider backoff](0023-outbound-provider-backoff.md) |

--- a/docs/domain/sourcing.md
+++ b/docs/domain/sourcing.md
@@ -27,6 +27,24 @@ required for new requests. HTTP 200 responses with `ErrorMessage` become upstrea
 `Messages[]` entries are logged at INFO with a `tp_message` tag and do not fail
 the search.
 
+## Provider Transport
+
+TrustedParts, Mouser, and DigiKey outbound calls use the shared retrying provider
+transport. It retries only 429, 503, `httpx.ConnectError`, and
+`httpx.ReadTimeout`; it does not retry 400/401/403/404/422/500. The retry budget
+is three retries with 0.5s base delay, 8s cap, and full jitter. `Retry-After`
+seconds and HTTP-date headers are honored, capped to the same 8s maximum.
+
+Retry attempts log at INFO and exhausted retry budgets log at WARNING. The
+factory keeps `verify=True` on the underlying transport.
+
+Sources: `backend/app/domain/sourcing/providers/_retry_transport.py:15-229`,
+`backend/app/domain/sourcing/providers/factory.py:13-27`,
+`backend/app/domain/sourcing/client.py:67-81`,
+`backend/app/domain/parts/providers/mouser.py:16-21`,
+`backend/app/domain/parts/providers/digikey.py:45-106`,
+[ADR-0023](../adr/0023-outbound-provider-backoff.md)
+
 ## TrustedParts Gap Fields (TPS-4)
 
 The adapter maps the Inventory API v2 fields that were previously dropped into public


### PR DESCRIPTION
## Summary

- Added shared bounded retry transports for outbound provider HTTP calls, covering sync provider code today and async clients for future provider work.
- Wired TrustedParts, Mouser, and DigiKey HTTP seams through the shared retrying client factory with `verify=True` preserved.
- Added retry coverage, sourcing docs, ADR-0023, and changelog entry.

## Validation

```text
cd backend && uv run --extra dev python -m pytest -q tests/test_sourcing_providers_retry.py
............                                                             [100%]
12 passed, 1 warning in 2.14s
```

Retry tests covered:
- `test_retries_on_429_then_succeeds`
- `test_retries_on_503_then_succeeds`
- `test_does_not_retry_on_400`
- `test_exhausts_retries_and_returns_last_response`
- `test_retries_on_connect_error`
- `test_honors_retry_after_header`
- `test_honors_retry_after_http_date_capped`
- `test_no_retry_for_non_retryable_status` for 401, 403, 404, 422, and 500

```text
cd backend && uv run --extra dev ruff check app/domain/sourcing/providers tests/test_sourcing_providers_retry.py
All checks passed!
```

```text
cd backend && uv run --extra dev ruff check app/domain/sourcing/providers app/domain/sourcing/client.py app/domain/parts/providers tests/test_sourcing_providers_retry.py
All checks passed!
```

```text
grep -rn "verify=False" backend/app/ && echo FAIL || echo OK
OK
```

```text
git diff --check
<no output>
```

## Retry Log Excerpt

Captured by `test_retries_on_429_then_succeeds` via `caplog`:

```text
provider_retry provider=trustedparts status=429 attempt=1 delay=... url=api.trustedparts.com error=None
```

## Merge Order

Independent of route contract PRs; rebase for CHANGELOG/docs conflicts.

Refs #507
