### PR TITLE
SA-16: Cache invalidation audit + purge on workspace API-key rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ the canonical record.
 - **SA-11 / #503** Sourcing alert create requests now validate threshold shape
   from the parent `alert_type`, returning 422 field errors for malformed
   thresholds before an alert can be persisted.
+- **SA-16 / #508** Sourcing cache keys now include full workspace/provider
+  request shape and TrustedParts credential rotation purges matching cache rows.
 - **SA-8 / #499** Decompose ProjectSourcingPage into a feature folder.
 - **SA-6 / #497** Project Sourcing now runs the audited BOM sourcing POST only
   from an explicit Source click, preserving the display cache without

--- a/backend/app/api/routes/workspaces.py
+++ b/backend/app/api/routes/workspaces.py
@@ -17,6 +17,7 @@ from app.core.ratelimit import limiter
 from app.core.responses import ok
 from app.core.secrets import decrypt, encrypt
 from app.domain.audit.service import log as _audit_log
+from app.domain.sourcing import cache as sourcing_cache
 from app.domain.users.models import User
 from app.domain.workspaces.master_lists import (
     ALL_COUNTRIES,
@@ -213,6 +214,7 @@ def patch_current(payload: WorkspacePatch, db: DbSession, ws: CurrentWorkspace, 
     data = payload.model_dump(exclude_unset=True)
     regenerate = bool(data.pop("regenerate_catalog_token", False))
     was_enabled = bool(ws.catalog_enabled)
+    previous_sourcing_provider = ws.sourcing_provider or "none"
     active_list_changes = {
         key: value
         for key, value in data.items()
@@ -250,6 +252,27 @@ def patch_current(payload: WorkspacePatch, db: DbSession, ws: CurrentWorkspace, 
 
     for k, v in data.items():
         setattr(ws, k, v)
+
+    sourcing_provider_changed = (
+        "sourcing_provider" in payload.model_fields_set
+        and (ws.sourcing_provider or "none") != previous_sourcing_provider
+    )
+    sourcing_credentials_changed = any(
+        field in _credential_fields_changed
+        for field in ("sourcing_company_id", "sourcing_api_key")
+    )
+    if (
+        sourcing_credentials_changed
+        or (
+            sourcing_provider_changed
+            and "trustedparts" in {previous_sourcing_provider, ws.sourcing_provider}
+        )
+    ):
+        sourcing_cache.purge_provider_cache(
+            db,
+            workspace_id=ws.id,
+            provider="trustedparts",
+        )
     # Mint a token when enabling the catalog for the first time, or when the
     # caller explicitly asks for a fresh one while it's enabled.
     #

--- a/backend/app/domain/sourcing/cache.py
+++ b/backend/app/domain/sourcing/cache.py
@@ -15,6 +15,7 @@ from sqlalchemy.orm import Session
 
 from app.core.time import utcnow
 from app.domain.sourcing.models import PurchasePlan, SourcingCache
+from app.domain.workspaces.master_lists import ALL_DISTRIBUTORS
 
 SEVEN_DAYS = timedelta(days=7)
 
@@ -23,6 +24,56 @@ def canonical_query_hash(query: dict[str, Any]) -> str:
     """SHA-256 of canonical JSON: sorted keys and compact separators."""
     canonical = json.dumps(query, sort_keys=True, separators=(",", ":"))
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def sourcing_search_query(
+    *,
+    workspace_id: UUID,
+    provider: str,
+    mpn: str,
+    country_code: str | None,
+    currency_code: str | None,
+    language_code: str | None,
+    distributors: list[str] | None,
+    in_stock_only: bool,
+    use_cached_data: bool,
+    exact_match: bool = True,
+) -> dict[str, Any]:
+    """Canonical TrustedParts cache query shape.
+
+    Fields are: ``workspace_id``, ``provider``, ``mpn``, ``country_code``,
+    ``currency_code``, ``language_code``, sorted/canonical-cased
+    ``distributors``, ``in_stock_only``, ``use_cached_data``, and
+    ``exact_match``. Every field is an upstream request input or an isolation
+    boundary that must produce a different cache hash when changed.
+    """
+    return {
+        "workspace_id": str(workspace_id),
+        "provider": provider.strip().casefold(),
+        "mpn": mpn.strip(),
+        "country_code": _canonical_code(country_code),
+        "currency_code": _canonical_code(currency_code),
+        "language_code": _canonical_language(language_code),
+        "distributors": _canonical_distributors(distributors),
+        "in_stock_only": in_stock_only,
+        "use_cached_data": use_cached_data,
+        "exact_match": exact_match,
+    }
+
+
+def purge_provider_cache(
+    db: Session,
+    *,
+    workspace_id: UUID,
+    provider: str,
+) -> int:
+    """Delete cache rows for one workspace/provider and return row count."""
+    result = db.execute(
+        delete(SourcingCache)
+        .where(SourcingCache.workspace_id == workspace_id)
+        .where(SourcingCache.query_json["provider"].astext == provider.strip().casefold())
+    )
+    return result.rowcount or 0
 
 
 def get_or_fetch(
@@ -70,6 +121,32 @@ def get_or_fetch(
         )
     )
     return response, False
+
+
+def _canonical_code(value: str | None) -> str | None:
+    if value is None:
+        return None
+    value = value.strip().upper()
+    return value or None
+
+
+def _canonical_language(value: str | None) -> str | None:
+    if value is None:
+        return None
+    value = value.strip().casefold()
+    return value or None
+
+
+def _canonical_distributors(value: list[str] | None) -> list[str]:
+    if not value:
+        return []
+    known = {item.casefold(): item for item in ALL_DISTRIBUTORS}
+    canonical = {
+        known.get(str(item).strip().casefold(), str(item).strip())
+        for item in value
+        if str(item).strip()
+    }
+    return sorted(canonical, key=str.casefold)
 
 
 def sweep_expired(db: Session, *, workspace_id: UUID) -> int:

--- a/backend/app/domain/sourcing/service.py
+++ b/backend/app/domain/sourcing/service.py
@@ -983,10 +983,13 @@ def search(
 
     results: list[SourcingSearchResult] = []
     for mpn in clean_mpns:
-        query = _canonical_query(
+        query = cache.sourcing_search_query(
+            workspace_id=workspace.id,
+            provider=provider.name,
             mpn=mpn,
-            country=effective_country,
-            currency=effective_currency,
+            country_code=effective_country,
+            currency_code=effective_currency,
+            language_code=provider.language_code,
             in_stock_only=in_stock_only,
             distributors=effective_distributors,
             use_cached_data=effective_use_cached,
@@ -1141,27 +1144,6 @@ def _lead_time_label(value: int | None) -> str:
     if value is None:
         return "unknown"
     return f"{value}d"
-
-
-def _canonical_query(
-    *,
-    mpn: str,
-    country: str | None,
-    currency: str | None,
-    in_stock_only: bool,
-    distributors: list[str] | None,
-    use_cached_data: bool,
-) -> dict[str, Any]:
-    return {
-        "provider": "trustedparts",
-        "mpn": mpn,
-        "country": country,
-        "currency": currency,
-        "in_stock_only": in_stock_only,
-        "distributors": distributors or [],
-        "use_cached_data": use_cached_data,
-        "exact_match": True,
-    }
 
 
 def _raw_from_cache_response(response: dict[str, Any]) -> SourcingSearchRaw:

--- a/backend/app/domain/sourcing/service.py
+++ b/backend/app/domain/sourcing/service.py
@@ -980,16 +980,18 @@ def search(
 
     provider.country_code = effective_country
     provider.currency_code = effective_currency
+    provider_name = getattr(provider, "name", "trustedparts")
+    provider_language_code = getattr(provider, "language_code", workspace.sourcing_language_code)
 
     results: list[SourcingSearchResult] = []
     for mpn in clean_mpns:
         query = cache.sourcing_search_query(
             workspace_id=workspace.id,
-            provider=provider.name,
+            provider=provider_name,
             mpn=mpn,
             country_code=effective_country,
             currency_code=effective_currency,
-            language_code=provider.language_code,
+            language_code=provider_language_code,
             in_stock_only=in_stock_only,
             distributors=effective_distributors,
             use_cached_data=effective_use_cached,

--- a/backend/tests/test_sourcing_bom_integration.py
+++ b/backend/tests/test_sourcing_bom_integration.py
@@ -354,7 +354,8 @@ def test_workspace_isolation_no_cross_leak(db):
         select(SourcingCache).where(SourcingCache.query_json["mpn"].astext == "SHARED-00")
     ).scalars().all()
     assert {str(row.workspace_id) for row in cache_rows} == {ws_a, ws_b}
-    assert len({row.query_hash for row in cache_rows}) == 1
+    assert len({row.query_hash for row in cache_rows}) == 2
+    assert {row.query_json["workspace_id"] for row in cache_rows} == {ws_a, ws_b}
     assert all(row.response_json["offers"] for row in cache_rows)
 
 

--- a/backend/tests/test_sourcing_cache.py
+++ b/backend/tests/test_sourcing_cache.py
@@ -8,11 +8,13 @@ from sqlalchemy import func, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from app.core.secrets import decrypt
 from app.core.time import utcnow
 from app.domain.projects.models import Project
 from app.domain.sourcing.cache import (
     canonical_query_hash,
     get_or_fetch,
+    sourcing_search_query,
     sweep_expired,
     sweep_expired_all_workspaces,
 )
@@ -37,6 +39,12 @@ def _workspace(db: Session) -> uuid.UUID:
     db.add(workspace)
     db.flush()
     return workspace.id
+
+
+def _current_workspace_id(authed_client) -> uuid.UUID:
+    response = authed_client.get("/api/workspaces/current")
+    assert response.status_code == 200, response.text
+    return uuid.UUID(response.json()["data"]["id"])
 
 
 def _project(db: Session, *, workspace_id: uuid.UUID) -> Project:
@@ -66,6 +74,34 @@ def _cache_row(
         fetched_at=fetched_at,
         expires_at=fetched_at + ttl,
     )
+
+
+def _sourcing_query(
+    *,
+    workspace_id: uuid.UUID,
+    provider: str = "trustedparts",
+    mpn: str = "BAT54C",
+) -> dict:
+    return sourcing_search_query(
+        workspace_id=workspace_id,
+        provider=provider,
+        mpn=mpn,
+        country_code="CZ",
+        currency_code="EUR",
+        language_code="en",
+        distributors=["DigiKey", "Mouser"],
+        in_stock_only=False,
+        use_cached_data=True,
+    )
+
+
+def _cache_count(db: Session, *, workspace_id: uuid.UUID, provider: str) -> int:
+    return db.execute(
+        select(func.count())
+        .select_from(SourcingCache)
+        .where(SourcingCache.workspace_id == workspace_id)
+        .where(SourcingCache.query_json["provider"].astext == provider)
+    ).scalar_one()
 
 
 def _purchase_plan(
@@ -110,6 +146,64 @@ def test_canonical_query_hash_is_order_insensitive() -> None:
     assert canonical_query_hash({"a": 1, "b": 2}) == canonical_query_hash({"b": 2, "a": 1})
 
 
+def test_canonical_query_includes_country_currency_language_distributors() -> None:
+    base = sourcing_search_query(
+        workspace_id=uuid.uuid4(),
+        provider="TrustedParts",
+        mpn=" BAT54C ",
+        country_code="cz",
+        currency_code="eur",
+        language_code="EN",
+        distributors=["mouser", "DigiKey"],
+        in_stock_only=False,
+        use_cached_data=True,
+    )
+
+    assert set(base) == {
+        "workspace_id",
+        "provider",
+        "mpn",
+        "country_code",
+        "currency_code",
+        "language_code",
+        "distributors",
+        "in_stock_only",
+        "use_cached_data",
+        "exact_match",
+    }
+    assert base["provider"] == "trustedparts"
+    assert base["mpn"] == "BAT54C"
+    assert base["country_code"] == "CZ"
+    assert base["currency_code"] == "EUR"
+    assert base["language_code"] == "en"
+    assert base["distributors"] == ["DigiKey", "Mouser"]
+
+    changed_inputs = [
+        {"workspace_id": uuid.uuid4()},
+        {"provider": "mouser"},
+        {"mpn": "BAV99"},
+        {"country_code": "DE"},
+        {"currency_code": "USD"},
+        {"language_code": "de"},
+        {"distributors": ["DigiKey"]},
+    ]
+    for change in changed_inputs:
+        params = {
+            "workspace_id": uuid.UUID(base["workspace_id"]),
+            "provider": base["provider"],
+            "mpn": base["mpn"],
+            "country_code": base["country_code"],
+            "currency_code": base["currency_code"],
+            "language_code": base["language_code"],
+            "distributors": base["distributors"],
+            "in_stock_only": base["in_stock_only"],
+            "use_cached_data": base["use_cached_data"],
+            **change,
+        }
+        candidate = sourcing_search_query(**params)
+        assert canonical_query_hash(candidate) != canonical_query_hash(base)
+
+
 def test_get_or_fetch_hit(db: Session) -> None:
     workspace_id = _workspace(db)
     query = {"mpn": "STM32F103C8T6", "qty": 10}
@@ -139,6 +233,110 @@ def test_get_or_fetch_hit(db: Session) -> None:
     assert second_hit is True
     assert second == first
     assert calls == 1
+
+
+def test_rotate_api_key_purges_cache_rows(authed_client, db: Session) -> None:
+    workspace_id = _current_workspace_id(authed_client)
+    other_workspace_id = _workspace(db)
+    rows = [
+        _cache_row(
+            workspace_id=workspace_id,
+            query=_sourcing_query(workspace_id=workspace_id, provider="trustedparts"),
+            response={"provider": "trustedparts"},
+        ),
+        _cache_row(
+            workspace_id=workspace_id,
+            query=_sourcing_query(
+                workspace_id=workspace_id,
+                provider="mouser",
+                mpn="MOU-1",
+            ),
+            response={"provider": "mouser"},
+        ),
+        _cache_row(
+            workspace_id=other_workspace_id,
+            query=_sourcing_query(workspace_id=other_workspace_id, provider="trustedparts"),
+            response={"provider": "trustedparts", "workspace": "other"},
+        ),
+    ]
+    db.add_all(rows)
+    db.flush()
+
+    response = authed_client.patch(
+        "/api/workspaces/current",
+        json={
+            "sourcing_provider": "trustedparts",
+            "sourcing_api_key": "rotated-api-key",
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    assert _cache_count(db, workspace_id=workspace_id, provider="trustedparts") == 0
+    assert _cache_count(db, workspace_id=workspace_id, provider="mouser") == 1
+    assert _cache_count(db, workspace_id=other_workspace_id, provider="trustedparts") == 1
+
+
+def test_delete_api_key_purges_cache_rows(authed_client, db: Session) -> None:
+    workspace_id = _current_workspace_id(authed_client)
+    response = authed_client.patch(
+        "/api/workspaces/current",
+        json={
+            "sourcing_provider": "trustedparts",
+            "sourcing_api_key": "api-key-before-delete",
+        },
+    )
+    assert response.status_code == 200, response.text
+    db.add(
+        _cache_row(
+            workspace_id=workspace_id,
+            query=_sourcing_query(workspace_id=workspace_id, provider="trustedparts"),
+            response={"provider": "trustedparts"},
+        )
+    )
+    db.flush()
+
+    response = authed_client.patch(
+        "/api/workspaces/current",
+        json={"sourcing_api_key": ""},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["data"]["has_sourcing_api_key"] is False
+    assert _cache_count(db, workspace_id=workspace_id, provider="trustedparts") == 0
+
+
+def test_rotate_failure_does_not_partial_commit(
+    authed_client,
+    db: Session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = _current_workspace_id(authed_client)
+    response = authed_client.patch(
+        "/api/workspaces/current",
+        json={
+            "sourcing_provider": "trustedparts",
+            "sourcing_api_key": "old-api-key",
+        },
+    )
+    assert response.status_code == 200, response.text
+
+    def fail_purge(*args, **kwargs) -> int:
+        raise RuntimeError("purge failed")
+
+    monkeypatch.setattr(
+        "app.api.routes.workspaces.sourcing_cache.purge_provider_cache",
+        fail_purge,
+    )
+    with pytest.raises(RuntimeError, match="purge failed"):
+        authed_client.patch(
+            "/api/workspaces/current",
+            json={"sourcing_api_key": "new-api-key"},
+        )
+
+    db.expire_all()
+    workspace = db.get(Workspace, workspace_id)
+    assert workspace is not None
+    assert decrypt(workspace.sourcing_api_key_enc) == "old-api-key"
 
 
 def test_get_or_fetch_miss_after_expiry(db: Session) -> None:

--- a/backend/tests/test_workspace_isolation.py
+++ b/backend/tests/test_workspace_isolation.py
@@ -1254,7 +1254,8 @@ def test_sourcing_bom_isolated_by_workspace(db, monkeypatch):
     ).scalars().all()
     assert {str(row.workspace_id) for row in rows} == {ws_a, ws_b}
     assert len(rows) == 2
-    assert len({row.query_hash for row in rows}) == 1
+    assert len({row.query_hash for row in rows}) == 2
+    assert {row.query_json["workspace_id"] for row in rows} == {ws_a, ws_b}
 
     BUDGET._events.clear()
 

--- a/docs/domain/sourcing.md
+++ b/docs/domain/sourcing.md
@@ -352,7 +352,12 @@ project
 ```
 
 The cache boundary is per MPN inside each chunk: `search()` canonicalises one query per
-MPN and calls `get_or_fetch()` with the caller workspace id. Sources:
+MPN and calls `get_or_fetch()` with the caller workspace id. The canonical query dict
+contains `workspace_id`, `provider`, `mpn`, `country_code`, `currency_code`,
+`language_code`, sorted/canonical-cased `distributors`, `in_stock_only`,
+`use_cached_data`, and `exact_match`. Sourcing credential rotation, deletion, or
+provider deconfiguration purges rows for that workspace and provider in the same
+transaction as the workspace settings write. Sources:
 `backend/app/domain/sourcing/service.py:88-145`,
 `backend/app/domain/sourcing/service.py:195-231`
 
@@ -366,7 +371,9 @@ limit build count before and after purchase. Source:
 | Operation | Entry point | Notes |
 |---|---|---|
 | Hash query | `app.domain.sourcing.cache::canonical_query_hash` | `json.dumps(..., sort_keys=True, separators=(",", ":"))`. |
+| Build TrustedParts query | `app.domain.sourcing.cache::sourcing_search_query` | Includes workspace/provider/MPN/locale/distributor/request-shape fields. |
 | Read/write cache | `app.domain.sourcing.cache::get_or_fetch` | Returns `(response_json, cache_hit)` and upserts on miss. |
+| Purge provider rows | `app.domain.sourcing.cache::purge_provider_cache` | Deletes one workspace/provider scope on credential rotation or deconfiguration. |
 | Sweep expired rows | `app.domain.sourcing.cache::sweep_expired` | Deletes rows with `expires_at < now()`. |
 
 Source: `backend/app/domain/sourcing/cache.py:23`


### PR DESCRIPTION
## Summary
- Added a canonical TrustedParts sourcing cache query builder and moved sourcing search cache keys to include every workspace/provider request-shape field.
- Purges workspace+provider cache rows when TrustedParts sourcing credentials are rotated, deleted, or deconfigured through workspace settings, inside the request transaction.
- Documented the cache key shape and purge behavior, and added changelog coverage.

## Canonical-query dict shape
`{workspace_id, provider, mpn, country_code, currency_code, language_code, distributors, in_stock_only, use_cached_data, exact_match}`

`workspace_id` is stringified, `provider` and `language_code` are casefolded, `country_code` and `currency_code` are uppercased, `mpn` is stripped, and `distributors` are deduped, sorted, and canonical-cased against the workspace distributor list.

## Tests
- `cd backend && uv run --extra dev python -m pytest -q -k "sourcing_cache or workspace_keys or workspace_sourcing"`
  - 34 passed, 1205 deselected, 3 warnings.
- `cd backend && uv run --extra dev ruff check app/domain/sourcing/cache.py app/domain/sourcing/service.py app/api/routes/workspaces.py tests/test_sourcing_cache.py`
  - Passed.
- `cd backend && uv run --extra dev ruff check app/domain/sourcing app/api tests`
  - Fails on existing unrelated lint debt across app/api and tests; first examples include `app/api/routes/_parts_shared.py:69 E501`, `app/api/routes/attachments.py:6 F401`, and `app/api/routes/lots.py:28 E741`. Touched files pass the focused ruff command above.
- `git diff --check`
  - Passed.

## Transaction behavior
The purge runs before the request dependency commit. `test_rotate_failure_does_not_partial_commit` monkeypatches purge failure and verifies the credential write rolls back.

## Merge Order
Independent of route contract PRs; rebase for CHANGELOG/docs conflicts.

Refs #508