### PR TITLE
SA-10: Structured sourcing error codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ the canonical record.
   thresholds before an alert can be persisted.
 - **SA-16 / #508** Sourcing cache keys now include full workspace/provider
   request shape and TrustedParts credential rotation purges matching cache rows.
+- **SA-10 / #502** Sourcing route-mapped failures now include stable
+  top-level `code` discriminators, and the frontend switches on those codes
+  for rate-limit, stale-plan, and currency-mismatch UX.
 - **SA-8 / #499** Decompose ProjectSourcingPage into a feature folder.
 - **SA-6 / #497** Project Sourcing now runs the audited BOM sourcing POST only
   from an explicit Source click, preserving the display cache without

--- a/backend/app/api/routes/sourcing.py
+++ b/backend/app/api/routes/sourcing.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Session
 
 from app.api._helpers import assert_in_workspace
 from app.core.deps import CurrentUser, CurrentWorkspace, require_role
+from app.core.errors import ErrorCodes
 from app.core.ratelimit import limiter, workspace_key
 from app.core.responses import err, ok
 from app.core.time import utcnow
@@ -741,31 +742,31 @@ def _error_response(
 def _default_error_code(status_code: int, category: str, message: str) -> str:
     normalized = message.strip().lower()
     if normalized == "sourcing not configured":
-        return "workspace_not_configured"
+        return ErrorCodes.SOURCING_WORKSPACE_NOT_CONFIGURED
     if normalized == "sourcing budget exhausted":
-        return "budget_exhausted"
+        return ErrorCodes.SOURCING_BUDGET_EXHAUSTED
     if normalized == "trustedparts rejected sourcing credentials":
-        return "provider_auth_failed"
+        return ErrorCodes.SOURCING_PROVIDER_AUTH_FAILED
     if normalized == "trustedparts rate limit reached":
-        return "provider_rate_limited"
+        return ErrorCodes.SOURCING_PROVIDER_RATE_LIMITED
     if normalized == "trustedparts request timed out":
-        return "provider_timeout"
+        return ErrorCodes.SOURCING_PROVIDER_TIMEOUT
     if normalized == "trustedparts sourcing request failed":
-        return "provider_unavailable"
+        return ErrorCodes.SOURCING_PROVIDER_UNAVAILABLE
     if normalized == "purchase plan not found":
-        return "purchase_plan_not_found"
+        return ErrorCodes.RESOURCE_NOT_FOUND
     if normalized == "plan expired":
-        return "plan_expired"
+        return ErrorCodes.SOURCING_PLAN_EXPIRED
     if normalized == "part has no mpn":
-        return "part_missing_mpn"
+        return ErrorCodes.SOURCING_PART_MISSING_MPN
     if status_code == 409 and ("refresh" in normalized or "stale" in normalized):
-        return "plan_stale"
+        return ErrorCodes.SOURCING_PLAN_STALE
     if status_code == 422 and "mixed currencies" in normalized:
-        return "currency_mismatch"
+        return ErrorCodes.SOURCING_CURRENCY_MISMATCH
     if status_code == 422 and "override" in normalized:
-        return "override_invalid"
+        return ErrorCodes.SOURCING_OVERRIDE_INVALID
     if status_code == 422:
-        return "invalid_sourcing_request"
+        return ErrorCodes.SOURCING_INVALID_REQUEST
     if category == "not_found":
-        return "not_found"
-    return "sourcing_error"
+        return ErrorCodes.RESOURCE_NOT_FOUND
+    return ErrorCodes.SOURCING_GENERIC

--- a/backend/app/api/routes/sourcing.py
+++ b/backend/app/api/routes/sourcing.py
@@ -721,12 +721,51 @@ def _error_response(
     status_code: int,
     category: str,
     message: str,
+    *,
+    code: str | None = None,
+    **extra,
 ) -> JSONResponse:
+    body = err(
+        category,
+        message,
+        request_id=getattr(request.state, "request_id", None),
+    )
+    body["code"] = code or _default_error_code(status_code, category, message)
+    body.update(extra)
     return JSONResponse(
         status_code=status_code,
-        content=err(
-            category,
-            message,
-            request_id=getattr(request.state, "request_id", None),
-        ),
+        content=body,
     )
+
+
+def _default_error_code(status_code: int, category: str, message: str) -> str:
+    normalized = message.strip().lower()
+    if normalized == "sourcing not configured":
+        return "workspace_not_configured"
+    if normalized == "sourcing budget exhausted":
+        return "budget_exhausted"
+    if normalized == "trustedparts rejected sourcing credentials":
+        return "provider_auth_failed"
+    if normalized == "trustedparts rate limit reached":
+        return "provider_rate_limited"
+    if normalized == "trustedparts request timed out":
+        return "provider_timeout"
+    if normalized == "trustedparts sourcing request failed":
+        return "provider_unavailable"
+    if normalized == "purchase plan not found":
+        return "purchase_plan_not_found"
+    if normalized == "plan expired":
+        return "plan_expired"
+    if normalized == "part has no mpn":
+        return "part_missing_mpn"
+    if status_code == 409 and ("refresh" in normalized or "stale" in normalized):
+        return "plan_stale"
+    if status_code == 422 and "mixed currencies" in normalized:
+        return "currency_mismatch"
+    if status_code == 422 and "override" in normalized:
+        return "override_invalid"
+    if status_code == 422:
+        return "invalid_sourcing_request"
+    if category == "not_found":
+        return "not_found"
+    return "sourcing_error"

--- a/backend/app/core/errors.py
+++ b/backend/app/core/errors.py
@@ -140,6 +140,24 @@ class ErrorCodes:
     RESOURCE_UNKNOWN_OBJECT_TYPE = "resource.unknown_object_type"
     RESOURCE_INSUFFICIENT_ROLE = "resource.insufficient_role"
 
+    # Global framework errors.
+    RATE_LIMITED = "rate_limited"
+
+    # Sourcing router.
+    SOURCING_WORKSPACE_NOT_CONFIGURED = "sourcing.workspace_not_configured"
+    SOURCING_BUDGET_EXHAUSTED = "sourcing.budget_exhausted"
+    SOURCING_PROVIDER_AUTH_FAILED = "sourcing.provider_auth_failed"
+    SOURCING_PROVIDER_RATE_LIMITED = "sourcing.provider_rate_limited"
+    SOURCING_PROVIDER_TIMEOUT = "sourcing.provider_timeout"
+    SOURCING_PROVIDER_UNAVAILABLE = "sourcing.provider_unavailable"
+    SOURCING_PLAN_EXPIRED = "sourcing.plan_expired"
+    SOURCING_PART_MISSING_MPN = "sourcing.part_missing_mpn"
+    SOURCING_PLAN_STALE = "sourcing.plan_stale"
+    SOURCING_CURRENCY_MISMATCH = "sourcing.currency_mismatch"
+    SOURCING_OVERRIDE_INVALID = "sourcing.override_invalid"
+    SOURCING_INVALID_REQUEST = "sourcing.invalid_request"
+    SOURCING_GENERIC = "sourcing.error"
+
     # Workspace dependency-injection edge cases (deps.py).
     # WORKSPACE_NONE: caller has no active membership in any workspace
     # at all — distinct from WORKSPACE_NOT_FOUND, which is "this id

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -223,6 +223,7 @@ def _rate_limit_handler(request: Request, exc: RateLimitExceeded):
     ``Retry-After`` header."""
     from fastapi.responses import JSONResponse
 
+    from app.core.errors import ErrorCodes
     from app.core.responses import err
 
     # The limit object carries the window size in seconds via get_expiry().
@@ -233,7 +234,7 @@ def _rate_limit_handler(request: Request, exc: RateLimitExceeded):
         pass
 
     body = err("rate_limited", f"rate limit exceeded: {exc.detail}")
-    body["code"] = "rate_limited"
+    body["code"] = ErrorCodes.RATE_LIMITED
     if retry_after is not None:
         body["retry_after_seconds"] = retry_after
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -233,6 +233,7 @@ def _rate_limit_handler(request: Request, exc: RateLimitExceeded):
         pass
 
     body = err("rate_limited", f"rate limit exceeded: {exc.detail}")
+    body["code"] = "rate_limited"
     if retry_after is not None:
         body["retry_after_seconds"] = retry_after
 

--- a/backend/tests/test_purchase_plan_convert_route.py
+++ b/backend/tests/test_purchase_plan_convert_route.py
@@ -351,6 +351,7 @@ def test_unrefreshed_plan_returns_409(authed_client):
     r = _convert(authed_client, r_plan.json()["data"]["id"])
 
     assert r.status_code == 409, r.text
+    assert r.json()["code"] == "plan_stale"
     assert "refresh" in r.json()["status"]["message"]
 
 
@@ -364,6 +365,7 @@ def test_stale_refresh_returns_409(authed_client, db):
     r = _convert(authed_client, plan["id"])
 
     assert r.status_code == 409, r.text
+    assert r.json()["code"] == "plan_stale"
     assert r.json()["status"]["message"] == "plan refresh is stale; refresh again before conversion"
 
 
@@ -395,6 +397,7 @@ def test_mixed_currency_in_group_returns_422(authed_client):
     r = _convert(authed_client, plan["id"])
 
     assert r.status_code == 422, r.text
+    assert r.json()["code"] == "currency_mismatch"
     assert "mixed currencies" in r.json()["status"]["message"]
 
 
@@ -407,6 +410,7 @@ def test_foreign_plan_returns_404(authed_client):
     r = _convert(client_b, plan["id"])
 
     assert r.status_code == 404, r.text
+    assert r.json()["code"] == "resource.not_found"
     assert r.json()["status"]["category"] == "not_found"
 
 
@@ -456,6 +460,7 @@ def test_workspace_isolation_two_plans_different_workspaces(authed_client):
     own = _convert(client_b, plan_b["id"])
 
     assert foreign.status_code == 404, foreign.text
+    assert foreign.json()["code"] == "resource.not_found"
     assert own.status_code == 200, own.text
     assert own.json()["data"]["orders"]
 

--- a/backend/tests/test_purchase_plan_convert_route.py
+++ b/backend/tests/test_purchase_plan_convert_route.py
@@ -351,7 +351,7 @@ def test_unrefreshed_plan_returns_409(authed_client):
     r = _convert(authed_client, r_plan.json()["data"]["id"])
 
     assert r.status_code == 409, r.text
-    assert r.json()["code"] == "plan_stale"
+    assert r.json()["code"] == "sourcing.plan_stale"
     assert "refresh" in r.json()["status"]["message"]
 
 
@@ -365,7 +365,7 @@ def test_stale_refresh_returns_409(authed_client, db):
     r = _convert(authed_client, plan["id"])
 
     assert r.status_code == 409, r.text
-    assert r.json()["code"] == "plan_stale"
+    assert r.json()["code"] == "sourcing.plan_stale"
     assert r.json()["status"]["message"] == "plan refresh is stale; refresh again before conversion"
 
 
@@ -397,7 +397,7 @@ def test_mixed_currency_in_group_returns_422(authed_client):
     r = _convert(authed_client, plan["id"])
 
     assert r.status_code == 422, r.text
-    assert r.json()["code"] == "currency_mismatch"
+    assert r.json()["code"] == "sourcing.currency_mismatch"
     assert "mixed currencies" in r.json()["status"]["message"]
 
 

--- a/backend/tests/test_purchase_plan_refresh_route.py
+++ b/backend/tests/test_purchase_plan_refresh_route.py
@@ -164,7 +164,7 @@ def test_expired_plan_returns_conflict(authed_client, db):
     r = _refresh(authed_client, initial["id"])
 
     assert r.status_code == 409, r.text
-    assert r.json()["code"] == "plan_expired"
+    assert r.json()["code"] == "sourcing.plan_expired"
     assert r.json()["status"] == {"category": "conflict", "message": "plan expired"}
 
 

--- a/backend/tests/test_purchase_plan_refresh_route.py
+++ b/backend/tests/test_purchase_plan_refresh_route.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import uuid
-from datetime import timedelta
+from datetime import datetime, timedelta
 from decimal import Decimal
 
 import pytest
@@ -21,6 +21,10 @@ from tests.test_purchase_plan_route import (
     _post_plan,
     _single_line_project,
 )
+
+
+def _parse_iso(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
 
 
 @pytest.fixture(autouse=True)
@@ -79,7 +83,7 @@ def test_refresh_replaces_lines_and_sets_status(authed_client, db):
     data = r.json()["data"]
     assert data["status"] == "refreshed"
     assert data["last_refreshed_at"] is not None
-    assert data["expires_at"] == original_expires_at
+    assert _parse_iso(data["expires_at"]) == _parse_iso(original_expires_at)
     assert len(data["lines"]) == 1
     assert data["lines"][0]["id"] != original_line_id
     assert data["lines"][0]["selected_distributor"] == "Mouser"
@@ -146,6 +150,7 @@ def test_foreign_plan_returns_404(authed_client):
     r = _refresh(client_b, initial["id"])
 
     assert r.status_code == 404, r.text
+    assert r.json()["code"] == "resource.not_found"
     assert r.json()["status"]["category"] == "not_found"
 
 
@@ -159,6 +164,7 @@ def test_expired_plan_returns_conflict(authed_client, db):
     r = _refresh(authed_client, initial["id"])
 
     assert r.status_code == 409, r.text
+    assert r.json()["code"] == "plan_expired"
     assert r.json()["status"] == {"category": "conflict", "message": "plan expired"}
 
 
@@ -173,6 +179,7 @@ def test_workspace_isolation_two_plans_different_workspaces(authed_client):
     own = _refresh(client_b, plan_b["id"])
 
     assert foreign.status_code == 404, foreign.text
+    assert foreign.json()["code"] == "resource.not_found"
     assert own.status_code == 200, own.text
     assert own.json()["data"]["id"] == plan_b["id"]
 

--- a/backend/tests/test_purchase_plan_route.py
+++ b/backend/tests/test_purchase_plan_route.py
@@ -231,7 +231,7 @@ def test_get_purchase_plan_requires_matching_project(authed_client):
     assert r.status_code == 404, r.text
     body = r.json()
     assert body["data"] is None
-    assert body["code"] == "purchase_plan_not_found"
+    assert body["code"] == "resource.not_found"
     assert body["status"]["category"] == "not_found"
 
 
@@ -305,7 +305,7 @@ def test_unconfigured_returns_409(authed_client, monkeypatch):
     r = _post_plan(authed_client, project_id)
 
     assert r.status_code == 409, r.text
-    assert r.json()["code"] == "workspace_not_configured"
+    assert r.json()["code"] == "sourcing.workspace_not_configured"
     assert r.json()["status"] == {
         "category": "conflict",
         "message": "sourcing not configured",
@@ -320,7 +320,7 @@ def test_budget_blocked_returns_503(authed_client):
     r = _post_plan(authed_client, project_id)
 
     assert r.status_code == 503, r.text
-    assert r.json()["code"] == "budget_exhausted"
+    assert r.json()["code"] == "sourcing.budget_exhausted"
     assert r.json()["status"] == {
         "category": "server_error",
         "message": "sourcing budget exhausted",

--- a/backend/tests/test_purchase_plan_route.py
+++ b/backend/tests/test_purchase_plan_route.py
@@ -231,6 +231,7 @@ def test_get_purchase_plan_requires_matching_project(authed_client):
     assert r.status_code == 404, r.text
     body = r.json()
     assert body["data"] is None
+    assert body["code"] == "purchase_plan_not_found"
     assert body["status"]["category"] == "not_found"
 
 
@@ -267,6 +268,7 @@ def test_foreign_project_returns_404(authed_client):
     r = _post_plan(authed_client, foreign_project_id)
 
     assert r.status_code == 404, r.text
+    assert r.json()["code"] == "resource.not_found"
     assert r.json()["status"]["category"] == "not_found"
 
 
@@ -303,6 +305,7 @@ def test_unconfigured_returns_409(authed_client, monkeypatch):
     r = _post_plan(authed_client, project_id)
 
     assert r.status_code == 409, r.text
+    assert r.json()["code"] == "workspace_not_configured"
     assert r.json()["status"] == {
         "category": "conflict",
         "message": "sourcing not configured",
@@ -317,6 +320,7 @@ def test_budget_blocked_returns_503(authed_client):
     r = _post_plan(authed_client, project_id)
 
     assert r.status_code == 503, r.text
+    assert r.json()["code"] == "budget_exhausted"
     assert r.json()["status"] == {
         "category": "server_error",
         "message": "sourcing budget exhausted",
@@ -334,6 +338,7 @@ def test_workspace_isolation_two_workspaces_same_project_id(authed_client, db):
     r = _post_plan(client_b, project_a)
 
     assert r.status_code == 404, r.text
+    assert r.json()["code"] == "resource.not_found"
     assert db.execute(select(PurchasePlan)).scalars().all() == []
 
 

--- a/backend/tests/test_sourcing_bom_route.py
+++ b/backend/tests/test_sourcing_bom_route.py
@@ -514,7 +514,7 @@ def test_unconfigured_returns_409(authed_client, monkeypatch):
     r = _post_sourcing(authed_client, project_id)
 
     assert r.status_code == 409, r.text
-    assert r.json()["code"] == "workspace_not_configured"
+    assert r.json()["code"] == "sourcing.workspace_not_configured"
     assert r.json()["status"] == {
         "category": "conflict",
         "message": "sourcing not configured",
@@ -529,7 +529,7 @@ def test_budget_blocked_returns_503(authed_client):
     r = _post_sourcing(authed_client, project_id)
 
     assert r.status_code == 503, r.text
-    assert r.json()["code"] == "budget_exhausted"
+    assert r.json()["code"] == "sourcing.budget_exhausted"
     assert r.json()["status"] == {
         "category": "server_error",
         "message": "sourcing budget exhausted",

--- a/backend/tests/test_sourcing_bom_route.py
+++ b/backend/tests/test_sourcing_bom_route.py
@@ -490,6 +490,7 @@ def test_foreign_project_returns_404(authed_client):
     r = _post_sourcing(authed_client, foreign_project_id)
 
     assert r.status_code == 404, r.text
+    assert r.json()["code"] == "resource.not_found"
     assert r.json()["status"]["category"] == "not_found"
 
 
@@ -513,6 +514,7 @@ def test_unconfigured_returns_409(authed_client, monkeypatch):
     r = _post_sourcing(authed_client, project_id)
 
     assert r.status_code == 409, r.text
+    assert r.json()["code"] == "workspace_not_configured"
     assert r.json()["status"] == {
         "category": "conflict",
         "message": "sourcing not configured",
@@ -527,6 +529,7 @@ def test_budget_blocked_returns_503(authed_client):
     r = _post_sourcing(authed_client, project_id)
 
     assert r.status_code == 503, r.text
+    assert r.json()["code"] == "budget_exhausted"
     assert r.json()["status"] == {
         "category": "server_error",
         "message": "sourcing budget exhausted",

--- a/backend/tests/test_sourcing_part_refresh_route.py
+++ b/backend/tests/test_sourcing_part_refresh_route.py
@@ -178,7 +178,7 @@ def test_part_without_mpn_returns_422(authed_client):
     assert r.status_code == 422, r.text
     body = r.json()
     assert body["data"] is None
-    assert body["code"] == "part_missing_mpn"
+    assert body["code"] == "sourcing.part_missing_mpn"
     assert body["status"] == {
         "category": "validation_error",
         "message": "part has no MPN",
@@ -224,7 +224,7 @@ def test_budget_block_returns_503(authed_client):
     r = authed_client.post(f"/api/parts/{part_id}/sourcing/refresh")
 
     assert r.status_code == 503, r.text
-    assert r.json()["code"] == "budget_exhausted"
+    assert r.json()["code"] == "sourcing.budget_exhausted"
     assert r.json()["status"] == {
         "category": "server_error",
         "message": "sourcing budget exhausted",

--- a/backend/tests/test_sourcing_part_refresh_route.py
+++ b/backend/tests/test_sourcing_part_refresh_route.py
@@ -178,6 +178,7 @@ def test_part_without_mpn_returns_422(authed_client):
     assert r.status_code == 422, r.text
     body = r.json()
     assert body["data"] is None
+    assert body["code"] == "part_missing_mpn"
     assert body["status"] == {
         "category": "validation_error",
         "message": "part has no MPN",
@@ -195,6 +196,7 @@ def test_foreign_part_returns_404(authed_client):
     assert r.status_code == 404, r.text
     body = r.json()
     assert body["data"] is None
+    assert body["code"] == "resource.not_found"
     assert body["status"]["category"] == "not_found"
 
 
@@ -222,6 +224,7 @@ def test_budget_block_returns_503(authed_client):
     r = authed_client.post(f"/api/parts/{part_id}/sourcing/refresh")
 
     assert r.status_code == 503, r.text
+    assert r.json()["code"] == "budget_exhausted"
     assert r.json()["status"] == {
         "category": "server_error",
         "message": "sourcing budget exhausted",

--- a/backend/tests/test_sourcing_part_route.py
+++ b/backend/tests/test_sourcing_part_route.py
@@ -323,7 +323,7 @@ def test_unconfigured_returns_409(authed_client, monkeypatch):
     r = authed_client.get(f"/api/parts/{part_id}/sourcing")
 
     assert r.status_code == 409, r.text
-    assert r.json()["code"] == "workspace_not_configured"
+    assert r.json()["code"] == "sourcing.workspace_not_configured"
     assert r.json()["status"] == {
         "category": "conflict",
         "message": "sourcing not configured",
@@ -338,7 +338,7 @@ def test_budget_blocked_returns_503(authed_client):
     r = authed_client.get(f"/api/parts/{part_id}/sourcing")
 
     assert r.status_code == 503, r.text
-    assert r.json()["code"] == "budget_exhausted"
+    assert r.json()["code"] == "sourcing.budget_exhausted"
     assert r.json()["status"] == {
         "category": "server_error",
         "message": "sourcing budget exhausted",

--- a/backend/tests/test_sourcing_part_route.py
+++ b/backend/tests/test_sourcing_part_route.py
@@ -309,6 +309,7 @@ def test_foreign_part_returns_404_envelope(authed_client):
     assert r.status_code == 404, r.text
     body = r.json()
     assert body["data"] is None
+    assert body["code"] == "resource.not_found"
     assert body["status"]["category"] == "not_found"
 
 
@@ -322,6 +323,7 @@ def test_unconfigured_returns_409(authed_client, monkeypatch):
     r = authed_client.get(f"/api/parts/{part_id}/sourcing")
 
     assert r.status_code == 409, r.text
+    assert r.json()["code"] == "workspace_not_configured"
     assert r.json()["status"] == {
         "category": "conflict",
         "message": "sourcing not configured",
@@ -336,6 +338,7 @@ def test_budget_blocked_returns_503(authed_client):
     r = authed_client.get(f"/api/parts/{part_id}/sourcing")
 
     assert r.status_code == 503, r.text
+    assert r.json()["code"] == "budget_exhausted"
     assert r.json()["status"] == {
         "category": "server_error",
         "message": "sourcing budget exhausted",

--- a/backend/tests/test_sourcing_search_route.py
+++ b/backend/tests/test_sourcing_search_route.py
@@ -194,7 +194,7 @@ def test_unconfigured_returns_409(authed_client, monkeypatch):
     r = authed_client.post("/api/sourcing/search", json={"mpns": ["BAT54C"]})
 
     assert r.status_code == 409, r.text
-    assert r.json()["code"] == "workspace_not_configured"
+    assert r.json()["code"] == "sourcing.workspace_not_configured"
     assert r.json()["status"] == {
         "category": "conflict",
         "message": "sourcing not configured",
@@ -209,7 +209,7 @@ def test_budget_blocked_returns_503(authed_client):
     r = authed_client.post("/api/sourcing/search", json={"mpns": ["BAT54C"]})
 
     assert r.status_code == 503, r.text
-    assert r.json()["code"] == "budget_exhausted"
+    assert r.json()["code"] == "sourcing.budget_exhausted"
     assert r.json()["status"] == {
         "category": "server_error",
         "message": "sourcing budget exhausted",

--- a/backend/tests/test_sourcing_search_route.py
+++ b/backend/tests/test_sourcing_search_route.py
@@ -194,6 +194,7 @@ def test_unconfigured_returns_409(authed_client, monkeypatch):
     r = authed_client.post("/api/sourcing/search", json={"mpns": ["BAT54C"]})
 
     assert r.status_code == 409, r.text
+    assert r.json()["code"] == "workspace_not_configured"
     assert r.json()["status"] == {
         "category": "conflict",
         "message": "sourcing not configured",
@@ -208,6 +209,7 @@ def test_budget_blocked_returns_503(authed_client):
     r = authed_client.post("/api/sourcing/search", json={"mpns": ["BAT54C"]})
 
     assert r.status_code == 503, r.text
+    assert r.json()["code"] == "budget_exhausted"
     assert r.json()["status"] == {
         "category": "server_error",
         "message": "sourcing budget exhausted",
@@ -226,6 +228,7 @@ def test_rate_limited_returns_429_after_60_per_minute(authed_client):
 
     assert r.status_code == 429, r.text
     assert r.json()["status"]["category"] == "rate_limited"
+    assert r.json()["code"] == "rate_limited"
 
 
 def test_cache_hit_reflected_in_response(authed_client):

--- a/docs/api/sourcing.md
+++ b/docs/api/sourcing.md
@@ -8,6 +8,40 @@ TrustedParts sourcing endpoints for workspace-scoped connection checks, short-li
 
 See [API conventions](./README.md) for envelope, errors, pagination. Connection checks are mounted under `/api/workspaces`; search is mounted under `/api/sourcing`; part reads are mounted under `/api/parts`. Current routes require a cookie session and current workspace.
 
+## Error Codes
+
+Sourcing route-mapped errors keep the standard envelope and add a stable
+top-level `code` discriminator:
+
+```json
+{
+  "data": null,
+  "status": { "category": "conflict", "message": "sourcing not configured" },
+  "code": "workspace_not_configured"
+}
+```
+
+Framework-level request validation errors still use the shared validation
+envelope. SlowAPI 429 responses add `code: "rate_limited"`.
+
+| Code | HTTP | Meaning |
+|---|---|---|
+| `resource.not_found` | 404 | Workspace-scoped project, part, or purchase-plan lookup failed. |
+| `workspace_not_configured` | 409 | Workspace has no usable TrustedParts sourcing API key. |
+| `purchase_plan_not_found` | 404 | Purchase plan exists outside the requested project/workspace relationship. |
+| `plan_expired` | 409 | Purchase plan is past its expiry and cannot be refreshed. |
+| `plan_stale` | 409 | Purchase plan must be refreshed before conversion. |
+| `part_missing_mpn` | 422 | Part sourcing refresh was requested for a part without an MPN. |
+| `override_invalid` | 422 | Purchase-plan conversion override does not match cached offers. |
+| `currency_mismatch` | 422 | A distributor group would mix selected currencies. |
+| `rate_limited` | 429 | Local workspace rate limit was exceeded. |
+| `budget_exhausted` | 503 | Local TrustedParts parts-count budget blocked live calls. |
+| `provider_auth_failed` | 502 | TrustedParts rejected sourcing credentials. |
+| `provider_rate_limited` | 502 | TrustedParts throttled the upstream request. |
+| `provider_timeout` | 502 | TrustedParts request timed out. |
+| `provider_unavailable` | 502 | TrustedParts returned another upstream/client failure. |
+| `invalid_sourcing_request` | 422 | Route-level sourcing validation failed. |
+
 ## Routes
 
 ### `GET /api/sourcing/alerts`

--- a/docs/api/sourcing.md
+++ b/docs/api/sourcing.md
@@ -17,7 +17,7 @@ top-level `code` discriminator:
 {
   "data": null,
   "status": { "category": "conflict", "message": "sourcing not configured" },
-  "code": "workspace_not_configured"
+  "code": "sourcing.workspace_not_configured"
 }
 ```
 
@@ -26,21 +26,20 @@ envelope. SlowAPI 429 responses add `code: "rate_limited"`.
 
 | Code | HTTP | Meaning |
 |---|---|---|
-| `resource.not_found` | 404 | Workspace-scoped project, part, or purchase-plan lookup failed. |
-| `workspace_not_configured` | 409 | Workspace has no usable TrustedParts sourcing API key. |
-| `purchase_plan_not_found` | 404 | Purchase plan exists outside the requested project/workspace relationship. |
-| `plan_expired` | 409 | Purchase plan is past its expiry and cannot be refreshed. |
-| `plan_stale` | 409 | Purchase plan must be refreshed before conversion. |
-| `part_missing_mpn` | 422 | Part sourcing refresh was requested for a part without an MPN. |
-| `override_invalid` | 422 | Purchase-plan conversion override does not match cached offers. |
-| `currency_mismatch` | 422 | A distributor group would mix selected currencies. |
+| `resource.not_found` | 404 | Workspace-scoped project, part, or purchase-plan lookup failed, including purchase plans outside the requested project relationship. |
+| `sourcing.workspace_not_configured` | 409 | Workspace has no usable TrustedParts sourcing API key. |
+| `sourcing.plan_expired` | 409 | Purchase plan is past its expiry and cannot be refreshed. |
+| `sourcing.plan_stale` | 409 | Purchase plan must be refreshed before conversion. |
+| `sourcing.part_missing_mpn` | 422 | Part sourcing refresh was requested for a part without an MPN. |
+| `sourcing.override_invalid` | 422 | Purchase-plan conversion override does not match cached offers. |
+| `sourcing.currency_mismatch` | 422 | A distributor group would mix selected currencies. |
 | `rate_limited` | 429 | Local workspace rate limit was exceeded. |
-| `budget_exhausted` | 503 | Local TrustedParts parts-count budget blocked live calls. |
-| `provider_auth_failed` | 502 | TrustedParts rejected sourcing credentials. |
-| `provider_rate_limited` | 502 | TrustedParts throttled the upstream request. |
-| `provider_timeout` | 502 | TrustedParts request timed out. |
-| `provider_unavailable` | 502 | TrustedParts returned another upstream/client failure. |
-| `invalid_sourcing_request` | 422 | Route-level sourcing validation failed. |
+| `sourcing.budget_exhausted` | 503 | Local TrustedParts parts-count budget blocked live calls. |
+| `sourcing.provider_auth_failed` | 502 | TrustedParts rejected sourcing credentials. |
+| `sourcing.provider_rate_limited` | 502 | TrustedParts throttled the upstream request. |
+| `sourcing.provider_timeout` | 502 | TrustedParts request timed out. |
+| `sourcing.provider_unavailable` | 502 | TrustedParts returned another upstream/client failure. |
+| `sourcing.invalid_request` | 422 | Route-level sourcing validation failed. |
 
 ## Routes
 

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -151,13 +151,13 @@ describe("ApiError.userMessage", () => {
       {
         data: null,
         status: { category: "not_found", message: "DB says nope" },
-        code: "purchase_plan_not_found",
+        code: "resource.not_found",
       },
       "DB says nope",
     );
     expect(err.message).toBe("DB says nope");
     expect(err.userMessage).toBe("Not found.");
-    expect(err.code).toBe("purchase_plan_not_found");
+    expect(err.code).toBe("resource.not_found");
   });
 
   it("leaves code undefined when the envelope has no structured code", () => {

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -148,11 +148,25 @@ describe("ApiError.userMessage", () => {
   it("populates userMessage from body.status.category", () => {
     const err = new ApiError(
       404,
-      { data: null, status: { category: "not_found", message: "DB says nope" } },
+      {
+        data: null,
+        status: { category: "not_found", message: "DB says nope" },
+        code: "purchase_plan_not_found",
+      },
       "DB says nope",
     );
     expect(err.message).toBe("DB says nope");
     expect(err.userMessage).toBe("Not found.");
+    expect(err.code).toBe("purchase_plan_not_found");
+  });
+
+  it("leaves code undefined when the envelope has no structured code", () => {
+    const err = new ApiError(
+      409,
+      { data: null, status: { category: "conflict", message: "dup" } },
+      "dup",
+    );
+    expect(err.code).toBeUndefined();
   });
 
   it("populates userMessage as generic fallback when body is null", () => {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -19,7 +19,12 @@
 import type { ZodType } from "zod";
 
 export type ApiOk<T> = { data: T; status: { category: string; message: string } };
-export type ApiErr = { data: null; status: { category: string; message: string }; errors?: { field: string; message: string }[] };
+export type ApiErr = {
+  data: null;
+  status: { category: string; message: string };
+  code?: string;
+  errors?: { field: string; message: string }[];
+};
 
 const BASE = "/api";
 
@@ -55,6 +60,10 @@ export class ApiError extends Error {
     this.status = status;
     this.body = body;
     this.userMessage = categoryToUserMessage(body?.status?.category);
+  }
+
+  get code(): string | undefined {
+    return typeof this.body?.code === "string" ? this.body.code : undefined;
   }
 }
 

--- a/web/src/routes/projects/sourcing/ProjectSourcingPage.tsx
+++ b/web/src/routes/projects/sourcing/ProjectSourcingPage.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useMemo, useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { Link, useNavigate, useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { PoweredByTrustedParts } from "@/components/PoweredByTrustedParts";
-import { api } from "@/lib/api";
+import { ApiError, api } from "@/lib/api";
 import { useWsKey } from "@/lib/queryKeys";
 import AlertFormModal from "@/routes/sourcing/alerts/AlertFormModal";
 import type { Project } from "@/types";
@@ -64,6 +64,7 @@ export default function ProjectSourcingPage() {
   }, [budgetDisabledUntil]);
 
   const status = errorStatus(sourcing.error);
+  const errorCode = sourcing.error instanceof ApiError ? sourcing.error.code : undefined;
   const sourceDisabled = sourcing.isPending || sourceBlocked;
   const hasRows = (sourcingData?.rows.length ?? 0) > 0;
   const primaryUrl = sourcingData?.links.primary;
@@ -142,6 +143,17 @@ export default function ProjectSourcingPage() {
       )}
       {sourcing.isError && status !== 409 && status !== 502 && status !== 503 && (
         <div className="card p-4 text-sm text-danger">Failed to source BOM.</div>
+      )}
+      {errorCode === "currency_mismatch" && (
+        <div className="rounded-md border border-warning/40 bg-warning/10 p-4 text-sm" role="status">
+          <div className="font-medium text-warning">Sourcing returned mixed currencies.</div>
+          <div className="mt-1 text-muted">
+            Review workspace sourcing currency settings before converting offers.
+          </div>
+          <Link className="mt-2 inline-block text-accent hover:underline" to="/settings/workspace">
+            Open workspace settings
+          </Link>
+        </div>
       )}
 
       {sourcingData && !hasRows && <EmptyBomState projectId={projectId} />}

--- a/web/src/routes/projects/sourcing/ProjectSourcingPage.tsx
+++ b/web/src/routes/projects/sourcing/ProjectSourcingPage.tsx
@@ -141,10 +141,14 @@ export default function ProjectSourcingPage() {
           </button>
         </div>
       )}
-      {sourcing.isError && status !== 409 && status !== 502 && status !== 503 && (
+      {sourcing.isError &&
+        status !== 409 &&
+        status !== 502 &&
+        status !== 503 &&
+        errorCode !== "sourcing.currency_mismatch" && (
         <div className="card p-4 text-sm text-danger">Failed to source BOM.</div>
       )}
-      {errorCode === "currency_mismatch" && (
+      {errorCode === "sourcing.currency_mismatch" && (
         <div className="rounded-md border border-warning/40 bg-warning/10 p-4 text-sm" role="status">
           <div className="font-medium text-warning">Sourcing returned mixed currencies.</div>
           <div className="mt-1 text-muted">

--- a/web/src/routes/projects/sourcing/PurchasePlanReviewPage.tsx
+++ b/web/src/routes/projects/sourcing/PurchasePlanReviewPage.tsx
@@ -121,12 +121,12 @@ function summaryCurrency(plan: PurchasePlan): string | null {
 function purchasePlanActionErrorMessage(error: unknown, fallback: string): string {
   if (!(error instanceof ApiError)) return fallback;
   switch (error.code) {
-    case "plan_stale":
+    case "sourcing.plan_stale":
       return "Prices are stale. Refresh prices before creating draft orders.";
-    case "currency_mismatch":
+    case "sourcing.currency_mismatch":
       return "Sourcing returned mixed currencies. Check workspace currency settings.";
     case "rate_limited":
-    case "provider_rate_limited":
+    case "sourcing.provider_rate_limited":
       return "Rate limit hit — wait a minute before trying again.";
     default:
       return error.userMessage || fallback;
@@ -273,7 +273,7 @@ export default function PurchasePlanReviewPage() {
       setRefreshAttention(false);
       toast.success("Prices refreshed");
     } catch (err) {
-      if (err instanceof ApiError && err.code === "plan_stale") setRefreshAttention(true);
+      if (err instanceof ApiError && err.code === "sourcing.plan_stale") setRefreshAttention(true);
       toast.error(purchasePlanActionErrorMessage(err, "Failed to refresh prices"));
     } finally {
       setBusyAction(null);
@@ -324,7 +324,7 @@ export default function PurchasePlanReviewPage() {
       queryClient.removeQueries({ queryKey: purchasePlanKey, exact: true });
       navigate("/orders");
     } catch (err) {
-      if (err instanceof ApiError && err.code === "plan_stale") setRefreshAttention(true);
+      if (err instanceof ApiError && err.code === "sourcing.plan_stale") setRefreshAttention(true);
       toast.error(purchasePlanActionErrorMessage(err, "Could not create draft orders"));
     } finally {
       setBusyAction(null);

--- a/web/src/routes/projects/sourcing/PurchasePlanReviewPage.tsx
+++ b/web/src/routes/projects/sourcing/PurchasePlanReviewPage.tsx
@@ -118,6 +118,20 @@ function groupLines(lines: PurchasePlanLine[]) {
 function summaryCurrency(plan: PurchasePlan): string | null {
   return plan.lines.find(line => line.selected_currency)?.selected_currency ?? plan.currency_code ?? null;
 }
+function purchasePlanActionErrorMessage(error: unknown, fallback: string): string {
+  if (!(error instanceof ApiError)) return fallback;
+  switch (error.code) {
+    case "plan_stale":
+      return "Prices are stale. Refresh prices before creating draft orders.";
+    case "currency_mismatch":
+      return "Sourcing returned mixed currencies. Check workspace currency settings.";
+    case "rate_limited":
+    case "provider_rate_limited":
+      return "Rate limit hit — wait a minute before trying again.";
+    default:
+      return error.userMessage || fallback;
+  }
+}
 export default function PurchasePlanReviewPage() {
   const { projectId, planId } = useParams<{ projectId: string; planId: string }>();
   const navigate = useNavigate();
@@ -136,6 +150,7 @@ export default function PurchasePlanReviewPage() {
   const plan = planQuery.data ?? null;
   const [project] = useState<Project | undefined>(locationState.project);
   const [busyAction, setBusyAction] = useState<"refresh" | "convert" | null>(null);
+  const [refreshAttention, setRefreshAttention] = useState(false);
   const [overrideLine, setOverrideLine] = useState<PurchasePlanLine | null>(null);
   const [overrides, setOverrides] = useState<Record<string, PurchasePlanOrderOverride>>({});
   const grouped = useMemo(() => groupLines(plan?.lines ?? []), [plan]);
@@ -255,10 +270,11 @@ export default function PurchasePlanReviewPage() {
     try {
       const next = await api.post<PurchasePlan>(`/sourcing/purchase-plans/${plan.id}/refresh`);
       queryClient.setQueryData(purchasePlanKey, next);
+      setRefreshAttention(false);
       toast.success("Prices refreshed");
     } catch (err) {
-      const message = err instanceof ApiError && err.userMessage ? err.userMessage : "Failed to refresh prices";
-      toast.error(message);
+      if (err instanceof ApiError && err.code === "plan_stale") setRefreshAttention(true);
+      toast.error(purchasePlanActionErrorMessage(err, "Failed to refresh prices"));
     } finally {
       setBusyAction(null);
     }
@@ -307,8 +323,9 @@ export default function PurchasePlanReviewPage() {
       toast.success(`Created ${result.orders.length} draft orders`);
       queryClient.removeQueries({ queryKey: purchasePlanKey, exact: true });
       navigate("/orders");
-    } catch {
-      toast.error("Could not create draft orders");
+    } catch (err) {
+      if (err instanceof ApiError && err.code === "plan_stale") setRefreshAttention(true);
+      toast.error(purchasePlanActionErrorMessage(err, "Could not create draft orders"));
     } finally {
       setBusyAction(null);
     }
@@ -385,7 +402,12 @@ export default function PurchasePlanReviewPage() {
         </section>
       )}
       <div className="sticky bottom-0 bg-panel border border-border rounded-md p-3 flex flex-wrap justify-end gap-2">
-        <button type="button" className="btn" onClick={refresh} disabled={busyAction !== null}>
+        <button
+          type="button"
+          className={refreshAttention ? "btn border-warning text-warning" : "btn"}
+          onClick={refresh}
+          disabled={busyAction !== null}
+        >
           <RefreshCw size={14} className={busyAction === "refresh" ? "animate-spin" : ""} />
           Refresh prices
         </button>

--- a/web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.filters.test.tsx
+++ b/web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.filters.test.tsx
@@ -106,7 +106,7 @@ describe("ProjectSourcingPage", () => {
   it("uses structured provider rate-limit codes for sourcing toast", async () => {
     mockReads();
     vi.spyOn(api, "post").mockRejectedValue(
-      apiError(502, "TrustedParts rate limit reached", "provider_rate_limited"),
+      apiError(502, "TrustedParts rate limit reached", "sourcing.provider_rate_limited"),
     );
 
     renderPage();
@@ -120,7 +120,7 @@ describe("ProjectSourcingPage", () => {
   it("links currency mismatch errors to workspace settings", async () => {
     mockReads();
     vi.spyOn(api, "post").mockRejectedValue(
-      apiError(422, "mixed currencies for distributor DigiKey", "currency_mismatch"),
+      apiError(422, "mixed currencies for distributor DigiKey", "sourcing.currency_mismatch"),
     );
 
     renderPage();

--- a/web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.filters.test.tsx
+++ b/web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.filters.test.tsx
@@ -103,6 +103,35 @@ describe("ProjectSourcingPage", () => {
     });
   });
 
+  it("uses structured provider rate-limit codes for sourcing toast", async () => {
+    mockReads();
+    vi.spyOn(api, "post").mockRejectedValue(
+      apiError(502, "TrustedParts rate limit reached", "provider_rate_limited"),
+    );
+
+    renderPage();
+    await clickSource();
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("Rate limit hit — wait a minute before sourcing again.");
+    });
+  });
+
+  it("links currency mismatch errors to workspace settings", async () => {
+    mockReads();
+    vi.spyOn(api, "post").mockRejectedValue(
+      apiError(422, "mixed currencies for distributor DigiKey", "currency_mismatch"),
+    );
+
+    renderPage();
+    await clickSource();
+
+    expect(await screen.findByText("Sourcing returned mixed currencies.")).toBeDefined();
+    const link = screen.getByRole("link", { name: "Open workspace settings" });
+    expect(link.getAttribute("href")).toBe("/settings/workspace");
+    expect(toast.error).toHaveBeenCalledWith("Sourcing returned mixed currencies. Check workspace currency settings.");
+  });
+
   it("distributors multi-select defaults to workspace.sourcing_preferred_distributors", async () => {
     mockReads({
       sourcing_preferred_distributors: ["Mouser", "Arrow"],

--- a/web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.testUtils.tsx
+++ b/web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.testUtils.tsx
@@ -161,7 +161,7 @@ export function sourcingResponse(overrides: Record<string, unknown> = {}) {
   };
 }
 
-export function apiError(status: number, message: string) {
+export function apiError(status: number, message: string, code?: string) {
   return new ApiError(
     status,
     {
@@ -170,6 +170,7 @@ export function apiError(status: number, message: string) {
         category: status === 409 ? "conflict" : "server_error",
         message,
       },
+      code,
     },
     message,
   );

--- a/web/src/routes/projects/sourcing/__tests__/PurchasePlanReviewPage.test.tsx
+++ b/web/src/routes/projects/sourcing/__tests__/PurchasePlanReviewPage.test.tsx
@@ -356,6 +356,29 @@ describe("PurchasePlanReviewPage", () => {
     });
   });
 
+  it("uses plan_stale code to highlight refresh after conversion failure", async () => {
+    const apiError = new ApiError(
+      409,
+      {
+        data: null,
+        status: { category: "conflict", message: "plan refresh is stale; refresh again before conversion" },
+        code: "plan_stale",
+      },
+      "plan refresh is stale; refresh again before conversion",
+    );
+    vi.spyOn(api, "post").mockRejectedValueOnce(apiError);
+    renderPage();
+
+    await userEvent.click(screen.getByRole("button", { name: /Create draft orders/ }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        "Prices are stale. Refresh prices before creating draft orders.",
+      );
+    });
+    expect(screen.getByRole("button", { name: /Refresh prices/ }).className).toContain("border-warning");
+  });
+
   it("Create draft orders is disabled when last_refreshed_at is null", () => {
     renderPage({ initialPlan: plan({ last_refreshed_at: null }) });
 

--- a/web/src/routes/projects/sourcing/__tests__/PurchasePlanReviewPage.test.tsx
+++ b/web/src/routes/projects/sourcing/__tests__/PurchasePlanReviewPage.test.tsx
@@ -356,13 +356,13 @@ describe("PurchasePlanReviewPage", () => {
     });
   });
 
-  it("uses plan_stale code to highlight refresh after conversion failure", async () => {
+  it("uses sourcing.plan_stale code to highlight refresh after conversion failure", async () => {
     const apiError = new ApiError(
       409,
       {
         data: null,
         status: { category: "conflict", message: "plan refresh is stale; refresh again before conversion" },
-        code: "plan_stale",
+        code: "sourcing.plan_stale",
       },
       "plan refresh is stale; refresh again before conversion",
     );

--- a/web/src/routes/projects/sourcing/sourcingHelpers.ts
+++ b/web/src/routes/projects/sourcing/sourcingHelpers.ts
@@ -116,11 +116,11 @@ export function sourcingErrorToastMessage(error: unknown): string {
   if (error instanceof ApiError) {
     switch (error.code) {
       case "rate_limited":
-      case "provider_rate_limited":
+      case "sourcing.provider_rate_limited":
         return "Rate limit hit — wait a minute before sourcing again.";
-      case "currency_mismatch":
+      case "sourcing.currency_mismatch":
         return "Sourcing returned mixed currencies. Check workspace currency settings.";
-      case "plan_stale":
+      case "sourcing.plan_stale":
         return "Prices are stale. Refresh prices before continuing.";
       default:
         break;

--- a/web/src/routes/projects/sourcing/sourcingHelpers.ts
+++ b/web/src/routes/projects/sourcing/sourcingHelpers.ts
@@ -113,8 +113,21 @@ export function errorStatus(error: unknown): number | null {
 }
 
 export function sourcingErrorToastMessage(error: unknown): string {
-  if (errorStatus(error) === 429) return "Rate limit hit — wait a minute before sourcing again.";
-  if (error instanceof ApiError) return error.userMessage;
+  if (error instanceof ApiError) {
+    switch (error.code) {
+      case "rate_limited":
+      case "provider_rate_limited":
+        return "Rate limit hit — wait a minute before sourcing again.";
+      case "currency_mismatch":
+        return "Sourcing returned mixed currencies. Check workspace currency settings.";
+      case "plan_stale":
+        return "Prices are stale. Refresh prices before continuing.";
+      default:
+        break;
+    }
+    if (error.status === 429) return "Rate limit hit — wait a minute before sourcing again.";
+    return error.userMessage;
+  }
   return "Failed to source BOM. Try again.";
 }
 


### PR DESCRIPTION
## Summary
- add stable top-level `code` discriminators to sourcing route-mapped error envelopes while preserving `{data,status}`
- expose `ApiError.code` in the frontend and switch sourcing UX on `rate_limited`, `provider_rate_limited`, `plan_stale`, and `currency_mismatch`
- document the sourcing error-code contract and assert codes in existing route tests

## Validation
- `cd backend && uv run --extra dev python -m pytest -q tests/test_sourcing_search_route.py tests/test_sourcing_bom_route.py tests/test_sourcing_part_route.py tests/test_sourcing_part_refresh_route.py tests/test_purchase_plan_route.py tests/test_purchase_plan_refresh_route.py tests/test_purchase_plan_convert_route.py` (98 passed)
- `cd backend && uv run --extra dev ruff check app/api/routes/sourcing.py tests/test_sourcing_search_route.py tests/test_sourcing_bom_route.py tests/test_sourcing_part_route.py tests/test_sourcing_part_refresh_route.py tests/test_purchase_plan_route.py tests/test_purchase_plan_refresh_route.py tests/test_purchase_plan_convert_route.py`
- `cd backend && WORK_DIR=. LINT_CMD="ruff check app --output-format=concise" BASELINE_FILE="../.ruff-baseline.txt" bash ../scripts/lint-delta.sh`
- `cd web && npm test -- --run src/lib/api.test.ts src/routes/projects/sourcing/__tests__/ProjectSourcingPage.filters.test.tsx src/routes/projects/sourcing/__tests__/PurchasePlanReviewPage.test.tsx` (50 passed)
- `cd web && npm run typecheck`
- `git diff --check`

## Merge Order
- Merge before SA-11/SA-12/SA-13 work (#503/#504/#505), because those issues should consume this error-code contract.
- Independent from #522/#523/#524/#525 at runtime, but sibling PRs all touch `CHANGELOG.md`; rebase whichever one lands later to resolve changelog-only conflicts.

Refs #502
