### PR TITLE
SA-11: Discriminated-union threshold schemas on alert_type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ the canonical record.
 - **SA-18 / #510** Project Sourcing Lifecycle, Supply chain, and RoHS risk
   pills now include hidden Lucide icon prefixes so severity is not conveyed by
   colour alone.
+- **SA-11 / #503** Sourcing alert create requests now validate threshold shape
+  from the parent `alert_type`, returning 422 field errors for malformed
+  thresholds before an alert can be persisted.
 - **SA-8 / #499** Decompose ProjectSourcingPage into a feature folder.
 - **SA-6 / #497** Project Sourcing now runs the audited BOM sourcing POST only
   from an explicit Source click, preserving the display cache without

--- a/backend/app/domain/sourcing/alerts_evaluator.py
+++ b/backend/app/domain/sourcing/alerts_evaluator.py
@@ -9,6 +9,7 @@ from decimal import Decimal, InvalidOperation
 from typing import Any
 from uuid import UUID
 
+from pydantic import BaseModel, ValidationError
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
@@ -19,6 +20,13 @@ from app.domain.parts.models import Part
 from app.domain.projects.models import Project
 from app.domain.sourcing import service as sourcing_service
 from app.domain.sourcing.pricing import best_unit_price_at_qty
+from app.domain.sourcing.schemas import (
+    BomBuyableThreshold,
+    PriceChangedThreshold,
+    StockAboveThreshold,
+    StockBelowThreshold,
+    StringChangedThreshold,
+)
 from app.domain.stock import service as stock_service
 from app.domain.users.models import User
 from app.domain.workspaces.models import Workspace, WorkspaceMember
@@ -119,7 +127,7 @@ def _evaluate_stock_below(
         workspace_id=workspace.id,
         part_id=part.id,
     )
-    threshold = _threshold_int(alert, "qty")
+    threshold = _threshold_model(alert, StockBelowThreshold).qty
     previous_qty = _previous_int(alert.last_evaluation_state, "qty")
     triggered = previous_qty is not None and previous_qty >= threshold and qty < threshold
     return AlertVerdict(
@@ -147,7 +155,7 @@ def _evaluate_stock_above(
         workspace_id=workspace.id,
         part_id=part.id,
     )
-    threshold = _threshold_int(alert, "qty")
+    threshold = _threshold_model(alert, StockAboveThreshold).qty
     previous_qty = _previous_int(alert.last_evaluation_state, "qty")
     triggered = previous_qty is not None and previous_qty <= threshold and qty > threshold
     return AlertVerdict(
@@ -235,7 +243,7 @@ def _evaluate_price_changed(
     previous = alert.last_evaluation_state or {}
     previous_price = _decimal_or_none(previous.get("last_price"))
     previous_currency = previous.get("last_currency")
-    delta_pct = _threshold_decimal(alert, "delta_pct")
+    delta_pct = _threshold_model(alert, PriceChangedThreshold).delta_pct
     triggered = False
     observed_delta: Decimal | None = None
     if (
@@ -272,7 +280,7 @@ def _evaluate_bom_buyable(
     alert: SourcingAlert,
 ) -> AlertVerdict:
     project = _project_for_alert(db, workspace, alert)
-    build_quantity = _threshold_int(alert, "build_quantity")
+    build_quantity = _threshold_model(alert, BomBuyableThreshold).build_quantity
     bom = sourcing_service.source_bom(
         db,
         workspace=workspace,
@@ -624,14 +632,15 @@ def _string_changed_verdict(
 
 
 def _string_threshold_matches(alert: SourcingAlert, current: str | None) -> bool:
-    must_contain = (alert.threshold or {}).get("must_contain")
+    threshold = _threshold_model(alert, StringChangedThreshold)
+    must_contain = threshold.must_contain
     if must_contain in (None, ""):
         return True
     if current is None:
         return False
     needle = str(must_contain)
     haystack = str(current)
-    if not bool((alert.threshold or {}).get("case_sensitive", False)):
+    if not threshold.case_sensitive:
         needle = needle.casefold()
         haystack = haystack.casefold()
     return needle in haystack
@@ -658,18 +667,11 @@ def _distributor_filter(alert: SourcingAlert) -> list[str] | None:
     return [str(item).strip() for item in alert.distributor_filter if str(item).strip()]
 
 
-def _threshold_int(alert: SourcingAlert, key: str) -> int:
+def _threshold_model[T: BaseModel](alert: SourcingAlert, schema: type[T]) -> T:
     try:
-        return int(alert.threshold[key])
-    except (KeyError, TypeError, ValueError) as exc:
-        raise ValueError(f"alert {alert.id} threshold.{key} must be an integer") from exc
-
-
-def _threshold_decimal(alert: SourcingAlert, key: str) -> Decimal:
-    try:
-        return Decimal(str(alert.threshold[key]))
-    except (KeyError, InvalidOperation) as exc:
-        raise ValueError(f"alert {alert.id} threshold.{key} must be numeric") from exc
+        return schema.model_validate(alert.threshold or {})
+    except ValidationError as exc:
+        raise ValueError(f"alert {alert.id} has invalid {schema.__name__}") from exc
 
 
 def _previous_int(state: dict[str, Any] | None, key: str) -> int | None:

--- a/backend/app/domain/sourcing/schemas.py
+++ b/backend/app/domain/sourcing/schemas.py
@@ -4,10 +4,18 @@ from __future__ import annotations
 
 from datetime import date, datetime
 from decimal import Decimal
-from typing import Any, Literal
+from typing import Annotated, Any, Literal, get_args
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import (
+    BaseModel,
+    BeforeValidator,
+    ConfigDict,
+    Field,
+    TypeAdapter,
+    ValidationInfo,
+    field_validator,
+)
 
 
 class SourcingQuery(BaseModel):
@@ -214,37 +222,49 @@ SourcingAlertType = Literal[
     "supply_chain_risk_changed",
     "tariff_status_changed",
 ]
+SOURCING_ALERT_TYPE_VALUES = frozenset(get_args(SourcingAlertType))
 
 
 class StockBelowThreshold(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
+    alert_type: Literal["stock_below"] = Field(default="stock_below", exclude=True)
     qty: int = Field(ge=0)
 
 
 class StockAboveThreshold(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
+    alert_type: Literal["stock_above"] = Field(default="stock_above", exclude=True)
     qty: int = Field(ge=0)
 
 
 class BackInStockThreshold(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
+    alert_type: Literal["back_in_stock"] = Field(default="back_in_stock", exclude=True)
+
 
 class OutOfAuthorizedStockThreshold(BaseModel):
     model_config = ConfigDict(extra="forbid")
+
+    alert_type: Literal["out_of_authorized_stock"] = Field(
+        default="out_of_authorized_stock",
+        exclude=True,
+    )
 
 
 class PriceChangedThreshold(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
+    alert_type: Literal["price_changed"] = Field(default="price_changed", exclude=True)
     delta_pct: Decimal = Field(gt=0, le=100)
 
 
 class BomBuyableThreshold(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
+    alert_type: Literal["bom_buyable"] = Field(default="bom_buyable", exclude=True)
     build_quantity: int = Field(ge=1)
 
 
@@ -258,6 +278,73 @@ class StringChangedThreshold(BaseModel):
 class TariffStatusChangedThreshold(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
+    alert_type: Literal["tariff_status_changed"] = Field(
+        default="tariff_status_changed",
+        exclude=True,
+    )
+
+
+class LifecycleRiskChangedThreshold(StringChangedThreshold):
+    alert_type: Literal["lifecycle_risk_changed"] = Field(
+        default="lifecycle_risk_changed",
+        exclude=True,
+    )
+
+
+class SupplyChainRiskChangedThreshold(StringChangedThreshold):
+    alert_type: Literal["supply_chain_risk_changed"] = Field(
+        default="supply_chain_risk_changed",
+        exclude=True,
+    )
+
+
+SourcingAlertThreshold = Annotated[
+    StockBelowThreshold
+    | StockAboveThreshold
+    | BackInStockThreshold
+    | OutOfAuthorizedStockThreshold
+    | PriceChangedThreshold
+    | BomBuyableThreshold
+    | LifecycleRiskChangedThreshold
+    | SupplyChainRiskChangedThreshold
+    | TariffStatusChangedThreshold,
+    Field(discriminator="alert_type"),
+]
+
+
+def _threshold_with_parent_alert_type(value: Any, info: ValidationInfo) -> Any:
+    if isinstance(value, dict) and "alert_type" not in value and isinstance(info.data, dict):
+        alert_type = info.data.get("alert_type")
+        if alert_type is not None:
+            return {"alert_type": alert_type, **value}
+    return value
+
+
+SourcingAlertThresholdIn = Annotated[
+    SourcingAlertThreshold,
+    BeforeValidator(_threshold_with_parent_alert_type),
+]
+
+_THRESHOLD_ADAPTER = TypeAdapter(SourcingAlertThreshold)
+
+
+def validate_alert_threshold(
+    alert_type: SourcingAlertType | str,
+    threshold: SourcingAlertThreshold | dict[str, Any],
+) -> SourcingAlertThreshold:
+    if isinstance(threshold, BaseModel) and getattr(threshold, "alert_type", None) == alert_type:
+        return threshold
+    if isinstance(threshold, BaseModel):
+        threshold = threshold.model_dump(mode="python")
+    return _THRESHOLD_ADAPTER.validate_python({"alert_type": alert_type, **threshold})
+
+
+def dump_alert_threshold(
+    alert_type: SourcingAlertType | str,
+    threshold: SourcingAlertThreshold | dict[str, Any],
+) -> dict[str, Any]:
+    return validate_alert_threshold(alert_type, threshold).model_dump(mode="json")
+
 
 class SourcingAlertIn(BaseModel):
     model_config = ConfigDict(extra="forbid")
@@ -265,7 +352,7 @@ class SourcingAlertIn(BaseModel):
     alert_type: SourcingAlertType
     part_id: UUID | None = None
     project_id: UUID | None = None
-    threshold: dict[str, Any]
+    threshold: SourcingAlertThresholdIn
     country_code: str | None = Field(default=None, min_length=2, max_length=2)
     currency_code: str | None = Field(default=None, min_length=3, max_length=3)
     distributor_filter: list[str] | None = None
@@ -319,11 +406,21 @@ class SourcingAlertPatch(BaseModel):
         return stripped or None
 
 
-class SourcingAlertOut(SourcingAlertIn):
+class SourcingAlertOut(BaseModel):
     model_config = ConfigDict(extra="forbid", from_attributes=True)
 
     id: UUID
     workspace_id: UUID
+    alert_type: SourcingAlertType
+    part_id: UUID | None = None
+    project_id: UUID | None = None
+    threshold: dict[str, Any]
+    country_code: str | None = None
+    currency_code: str | None = None
+    distributor_filter: list[str] | None = None
+    notify_user_ids: list[UUID] | None = None
+    cooldown_seconds: int
+    enabled: bool
     last_checked_at: datetime | None = None
     last_notified_at: datetime | None = None
     archived_at: datetime | None = None

--- a/backend/app/domain/sourcing/service.py
+++ b/backend/app/domain/sourcing/service.py
@@ -10,7 +10,7 @@ from decimal import Decimal
 from typing import Any
 from uuid import UUID
 
-from pydantic import BaseModel, ValidationError
+from pydantic import ValidationError
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
@@ -31,17 +31,15 @@ from app.domain.sourcing.models import PurchasePlan, PurchasePlanLine, SourcingA
 from app.domain.sourcing.optimizer import Strategy, optimize
 from app.domain.sourcing.pricing import best_unit_price_at_qty
 from app.domain.sourcing.schemas import (
-    BackInStockThreshold,
-    BomBuyableThreshold,
+    SOURCING_ALERT_TYPE_VALUES,
     BuildCapacityOut,
     DistributorCoverageMatrixOut,
-    OutOfAuthorizedStockThreshold,
-    PriceChangedThreshold,
     PurchasePlanOrderOverrideIn,
     PurchasePlanOrdersOut,
     PurchasePlanOut,
     SourcingAlertIn,
     SourcingAlertPatch,
+    SourcingAlertThreshold,
     SourcingAlertType,
     SourcingAttributionLinks,
     SourcingBomLineOut,
@@ -52,10 +50,7 @@ from app.domain.sourcing.schemas import (
     SourcingSearchOut,
     SourcingSearchRaw,
     SourcingSearchResult,
-    StockAboveThreshold,
-    StockBelowThreshold,
-    StringChangedThreshold,
-    TariffStatusChangedThreshold,
+    dump_alert_threshold,
 )
 from app.domain.workspaces.models import WorkspaceMember
 
@@ -76,19 +71,6 @@ _SOURCING_FILTER_ALERT_TYPES = {
     "supply_chain_risk_changed",
     "tariff_status_changed",
 }
-_THRESHOLD_SCHEMAS: dict[SourcingAlertType, type[BaseModel]] = {
-    "stock_below": StockBelowThreshold,
-    "stock_above": StockAboveThreshold,
-    "back_in_stock": BackInStockThreshold,
-    "out_of_authorized_stock": OutOfAuthorizedStockThreshold,
-    "price_changed": PriceChangedThreshold,
-    "bom_buyable": BomBuyableThreshold,
-    "lifecycle_risk_changed": StringChangedThreshold,
-    "supply_chain_risk_changed": StringChangedThreshold,
-    "tariff_status_changed": TariffStatusChangedThreshold,
-}
-
-
 @dataclass(frozen=True)
 class _LineUpdate:
     line: PurchasePlanLine
@@ -265,7 +247,7 @@ def _validated_alert_values(
     alert_type: SourcingAlertType | str,
     part_id: UUID | None,
     project_id: UUID | None,
-    threshold: dict[str, Any],
+    threshold: SourcingAlertThreshold | dict[str, Any],
     country_code: str | None,
     currency_code: str | None,
     distributor_filter: list[str] | None,
@@ -279,7 +261,7 @@ def _validated_alert_values(
         raise_http(422, "sourcing_alert.invalid_cooldown", "cooldown_seconds is required")
     if enabled is None:
         raise_http(422, "sourcing_alert.invalid_enabled", "enabled is required")
-    if alert_type not in _THRESHOLD_SCHEMAS:
+    if alert_type not in SOURCING_ALERT_TYPE_VALUES:
         raise_http(422, "sourcing_alert.invalid_type", "invalid alert_type")
     if (part_id is None) == (project_id is None):
         raise_http(
@@ -339,11 +321,10 @@ def _validated_alert_values(
 
 def _validated_threshold(
     alert_type: SourcingAlertType | str,
-    threshold: dict[str, Any],
+    threshold: SourcingAlertThreshold | dict[str, Any],
 ) -> dict[str, Any]:
-    schema = _THRESHOLD_SCHEMAS[alert_type]
     try:
-        parsed = schema.model_validate(threshold)
+        return dump_alert_threshold(alert_type, threshold)
     except ValidationError as exc:
         raise_http(
             422,
@@ -351,7 +332,6 @@ def _validated_threshold(
             "invalid threshold for alert_type",
             errors=json.loads(exc.json()),
         )
-    return parsed.model_dump(mode="json")
 
 
 def _validated_notify_user_ids(

--- a/backend/tests/test_sourcing_alerts_evaluator.py
+++ b/backend/tests/test_sourcing_alerts_evaluator.py
@@ -196,6 +196,28 @@ def test_stock_below_triggers_when_qty_drops(db: Session, monkeypatch) -> None:
     assert alert.last_evaluation_state == {"qty": 4}
 
 
+def test_evaluator_consumes_typed_threshold(db: Session, monkeypatch) -> None:
+    workspace, user = _workspace(db)
+    part = _part(db, workspace, user)
+    _stock(db, workspace, part, 4, user)
+    alert = _alert(
+        db,
+        workspace,
+        user,
+        part=part,
+        alert_type="stock_below",
+        threshold={"qty": 5},
+        last_state={"qty": 5},
+    )
+    sent = _capture_mail(monkeypatch)
+
+    assert evaluate_all_alerts(db) == 1
+
+    db.refresh(alert)
+    assert alert.last_evaluation_state == {"qty": 4}
+    assert "threshold_qty: 5" in sent[0]["text_body"]
+
+
 def test_stock_above_triggers_when_qty_rises(db: Session, monkeypatch) -> None:
     workspace, user = _workspace(db)
     part = _part(db, workspace, user)

--- a/backend/tests/test_sourcing_alerts_route.py
+++ b/backend/tests/test_sourcing_alerts_route.py
@@ -161,7 +161,7 @@ def test_create_tariff_status_changed_alert_empty_threshold(authed_client):
         ("tariff_status_changed", {"must_contain": "yes"}),
     ],
 )
-def test_create_with_invalid_threshold_returns_422(
+def test_create_alert_with_wrong_threshold_shape_returns_422(
     authed_client,
     alert_type: str,
     threshold: dict,
@@ -179,7 +179,56 @@ def test_create_with_invalid_threshold_returns_422(
     r = authed_client.post("/api/sourcing/alerts", json=payload)
 
     assert r.status_code == 422, r.text
-    assert r.json()["status"]["category"] == "validation_error"
+    body = r.json()
+    assert body["status"]["category"] == "validation_error"
+    fields = {error["field"] for error in body["errors"]}
+    assert any(field.startswith("body.threshold.") for field in fields)
+
+
+@pytest.mark.parametrize(
+    ("alert_type", "threshold", "expected_threshold"),
+    [
+        ("stock_below", {"qty": 5}, {"qty": 5}),
+        ("stock_above", {"qty": 5}, {"qty": 5}),
+        ("back_in_stock", {}, {}),
+        ("out_of_authorized_stock", {}, {}),
+        ("price_changed", {"delta_pct": 5}, {"delta_pct": "5"}),
+        ("bom_buyable", {"build_quantity": 2}, {"build_quantity": 2}),
+        (
+            "lifecycle_risk_changed",
+            {"must_contain": "EOL", "case_sensitive": True},
+            {"must_contain": "EOL", "case_sensitive": True},
+        ),
+        (
+            "supply_chain_risk_changed",
+            {"must_contain": "NRND", "case_sensitive": False},
+            {"must_contain": "NRND", "case_sensitive": False},
+        ),
+        ("tariff_status_changed", {}, {}),
+    ],
+)
+def test_create_alert_with_valid_threshold_persists(
+    authed_client,
+    alert_type: str,
+    threshold: dict,
+    expected_threshold: dict,
+):
+    project_id, part_id = _single_line_project(authed_client)
+    payload = {
+        "alert_type": alert_type,
+        "threshold": threshold,
+    }
+    if alert_type == "bom_buyable":
+        payload["project_id"] = project_id
+    else:
+        payload["part_id"] = part_id
+
+    r = authed_client.post("/api/sourcing/alerts", json=payload)
+
+    assert r.status_code == 200, r.text
+    data = r.json()["data"]
+    assert data["alert_type"] == alert_type
+    assert data["threshold"] == expected_threshold
 
 
 @pytest.mark.parametrize(

--- a/docs/api/sourcing.md
+++ b/docs/api/sourcing.md
@@ -19,7 +19,7 @@ List current workspace sourcing alerts.
 | Field | Type | Required | Notes |
 |---|---|---|---|
 | `enabled` | `boolean` | No | Filters enabled or disabled alerts. |
-| `alert_type` | `string` | No | One of the six MVP alert types in the threshold table below. |
+| `alert_type` | `string` | No | One of the alert types in the threshold table below. |
 | `part_id` | `uuid` | No | Filters part-scoped alerts. |
 | `project_id` | `uuid` | No | Filters project-scoped alerts. |
 | `include_archived` | `boolean` | No | Defaults to `false`; archived rows are soft-deleted alerts. |
@@ -63,7 +63,7 @@ Create a workspace-scoped alert definition.
 | `alert_type` | `string` | Yes | See threshold table below. Immutable after create. |
 | `part_id` | `uuid` | Conditional | Required for all non-`bom_buyable` alerts. Mutually exclusive with `project_id`. |
 | `project_id` | `uuid` | Conditional | Required for `bom_buyable`. Mutually exclusive with `part_id`. |
-| `threshold` | `object` | Yes | Validated per `alert_type` in the service layer. |
+| `threshold` | `object` | Yes | Validated per `alert_type` at request parsing; no nested `kind` field is required. |
 | `country_code` | `string` | No | Two-letter sourcing filter for `back_in_stock`, `out_of_authorized_stock`, and `price_changed`. Ignored for stock threshold alerts. |
 | `currency_code` | `string` | No | Three-letter sourcing filter for `price_changed`. Ignored for stock threshold alerts. |
 | `distributor_filter` | `string[]` | No | Sourcing filter for authorized-stock and price alerts. Ignored for stock threshold alerts. |
@@ -81,6 +81,9 @@ Create a workspace-scoped alert definition.
 | `out_of_authorized_stock` | part | `{}`. |
 | `price_changed` | part | `{ "delta_pct": 5 }`, decimal `0 < delta_pct <= 100`. V1 is relative-change only; absolute target-price thresholds are out of scope for TP-502. |
 | `bom_buyable` | project | `{ "build_quantity": 10 }`, integer `build_quantity >= 1`. |
+| `lifecycle_risk_changed` | part | `{}` or `{ "must_contain": "EOL", "case_sensitive": false }`. |
+| `supply_chain_risk_changed` | part | `{}` or `{ "must_contain": "NRND", "case_sensitive": false }`. |
+| `tariff_status_changed` | part | `{}`. |
 
 **Response** — `200 OK` (envelope: `{ data, status }`)
 
@@ -92,10 +95,25 @@ Shape matches one item from `GET /api/sourcing/alerts`.
 - `422 Unprocessable Entity` — invalid threshold, invalid target scope, both/neither `part_id` and `project_id`, immutable fields, or malformed body.
 - `429 Too Many Requests` — workspace rate limit: 30 creates/minute.
 
+Malformed thresholds return a validation envelope with a field path under `body.threshold`:
+
+```json
+{
+  "data": null,
+  "status": { "category": "validation_error", "message": "validation failed" },
+  "errors": [
+    {
+      "field": "body.threshold.stock_below.qty",
+      "message": "Field required"
+    }
+  ]
+}
+```
+
 **Notes**
 
 - `bom_buyable` rejects sourcing filters; stock threshold alerts silently drop sourcing filters because they evaluate internal stock only.
-- Empty threshold objects are intentionally valid for transition alerts, so validation is mapped per type instead of using a nested discriminator.
+- Empty threshold objects are intentionally valid for transition alerts; the parent `alert_type` selects the threshold schema.
 - Source: `backend/app/api/routes/sourcing.py:181-199`.
 - Service: `backend/app/domain/sourcing/service.py:114-142`.
 


### PR DESCRIPTION
## Summary

- Adds typed sourcing alert threshold models wired as a Pydantic v2 discriminated union, selected from the parent `alert_type` without requiring clients to send `threshold.kind` or a nested discriminator.
- Moves create-time malformed threshold handling to FastAPI request validation, while keeping service validation for PATCH because PATCH does not carry the immutable `alert_type`.
- Updates the alert evaluator to parse stored JSON thresholds into typed models and use attribute access instead of threshold dict key/get access.
- Documents all alert threshold shapes and notes the create-time 422 behavior.

Refs #503

## Validation

- `cd backend && uv sync --extra dev`
- `cd backend && uv run ruff check app/domain/sourcing/schemas.py app/domain/sourcing/alerts_evaluator.py app/domain/sourcing/service.py tests/test_sourcing_alerts_route.py tests/test_sourcing_alerts_evaluator.py` -> `All checks passed!`
- `cd backend && uv run python -m pytest tests/test_sourcing_alerts_route.py tests/test_sourcing_alerts_evaluator.py tests/test_sourcing_alert_models.py` -> `85 passed, 10 warnings in 15.48s`

Additional attempts:

- `docker compose -f docker-compose.dev.yml exec backend pytest -k "alerts or schemas"` could not run in this environment because `docker` is not installed.
- `cd backend && uv run python -m pytest -k "alerts or schemas"` selected `test_migration_isolation.py` via the `schemas` expression and later failed during route setup with `relation "users" does not exist`; the alert-focused files above pass in a fresh process.
- `cd backend && uv run mypy app/domain/sourcing` is not practical in this repo state: mypy is not part of the backend dev dependencies/config, and the invocation reports 56 import/stub errors for project dependencies such as `pydantic`, `fastapi`, and `sqlalchemy`.

## Example 422

Posting `{"alert_type":"stock_below","part_id":"...","threshold":{"delta_pct":5}}` now returns a request validation envelope like:

```json
{
  "data": null,
  "status": { "category": "validation_error", "message": "validation failed" },
  "errors": [
    {
      "field": "body.threshold.stock_below.qty",
      "message": "Field required"
    }
  ]
}
```

## Merge Order Note

This touches `CHANGELOG.md` and `docs/api/sourcing.md`, which are likely to conflict with nearby SA PRs including #525 and #526. Prefer merging/rebasing this after whichever sibling PR lands first, resolving docs/changelog conflicts mechanically.
