### PR TITLE
SA-19: SourcingCard uses active-list country and currency selects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ the canonical record.
   requests with more than 25 values before provider fanout.
 - **SA-14 / #506** Sourcing alert evaluation now batches identical
   workspace-scoped TrustedParts queries by canonical query hash.
+- **SA-19 / #511** Workspace sourcing country and currency defaults now use
+  active-list selects, with backend validation for non-active codes.
 - **SA-17 / #509** Production cron sidecar jobs now have a 600-second
   per-run timeout that logs exit 124 on timeout while preserving cadence.
 - **SA-15 / #507** TrustedParts, Mouser, and DigiKey outbound calls now share

--- a/backend/app/api/routes/workspaces.py
+++ b/backend/app/api/routes/workspaces.py
@@ -49,6 +49,72 @@ def _encrypt_patch_credential(value: str | None) -> str | None:
     return encrypt(value)
 
 
+def _normalize_sourcing_code(data: dict, key: str, current: str | None) -> str | None:
+    value = data.get(key, current)
+    if isinstance(value, str):
+        normalized = value.upper()
+        if key in data:
+            data[key] = normalized
+        return normalized
+    return value
+
+
+def _validate_sourcing_code(
+    code: str | None,
+    active_values: list[str] | None,
+    *,
+    error_code: str,
+    field: str,
+    active_field: str,
+) -> None:
+    if not code:
+        return
+    if code not in (active_values or []):
+        raise_http(
+            422,
+            error_code,
+            f"{field} must be active for this workspace",
+            field=field,
+            active_field=active_field,
+            value=code,
+        )
+
+
+def _validate_sourcing_defaults_against_active_lists(data: dict, ws: Workspace) -> None:
+    watched_fields = {
+        "sourcing_country_code",
+        "sourcing_currency_code",
+        "active_countries",
+        "active_currencies",
+    }
+    if not watched_fields.intersection(data):
+        return
+
+    country_code = _normalize_sourcing_code(data, "sourcing_country_code", ws.sourcing_country_code)
+    currency_code = _normalize_sourcing_code(
+        data,
+        "sourcing_currency_code",
+        ws.sourcing_currency_code,
+    )
+    active_countries = data.get("active_countries", ws.active_countries)
+    active_currencies = data.get("active_currencies", ws.active_currencies)
+
+    _validate_sourcing_code(
+        country_code,
+        active_countries,
+        error_code=ErrorCodes.SOURCING_INVALID_COUNTRY_CODE,
+        field="sourcing_country_code",
+        active_field="active_countries",
+    )
+    _validate_sourcing_code(
+        currency_code,
+        active_currencies,
+        error_code=ErrorCodes.SOURCING_INVALID_CURRENCY_CODE,
+        field="sourcing_currency_code",
+        active_field="active_currencies",
+    )
+
+
 @router.get("")
 def list_workspaces(user: CurrentUser, db: DbSession):
     memberships = (
@@ -215,6 +281,7 @@ def patch_current(payload: WorkspacePatch, db: DbSession, ws: CurrentWorkspace, 
     regenerate = bool(data.pop("regenerate_catalog_token", False))
     was_enabled = bool(ws.catalog_enabled)
     previous_sourcing_provider = ws.sourcing_provider or "none"
+    _validate_sourcing_defaults_against_active_lists(data, ws)
     active_list_changes = {
         key: value
         for key, value in data.items()

--- a/backend/app/core/errors.py
+++ b/backend/app/core/errors.py
@@ -157,6 +157,8 @@ class ErrorCodes:
     SOURCING_OVERRIDE_INVALID = "sourcing.override_invalid"
     SOURCING_TOO_MANY_DISTRIBUTORS = "sourcing.too_many_distributors"
     SOURCING_INVALID_REQUEST = "sourcing.invalid_request"
+    SOURCING_INVALID_COUNTRY_CODE = "invalid_country_code"
+    SOURCING_INVALID_CURRENCY_CODE = "invalid_currency_code"
     SOURCING_GENERIC = "sourcing.error"
 
     # Workspace dependency-injection edge cases (deps.py).

--- a/backend/tests/test_workspace_sourcing_settings.py
+++ b/backend/tests/test_workspace_sourcing_settings.py
@@ -205,3 +205,60 @@ def test_get_after_patch_masks_creds(authed_client):
     assert "sourcing_api_key_enc" not in body
     assert company_id not in r.text
     assert api_key not in r.text
+
+
+def test_save_sourcing_card_with_invalid_country_returns_422(authed_client):
+    r = authed_client.patch(
+        "/api/workspaces/current",
+        json={"sourcing_country_code": "ZZ"},
+    )
+
+    assert r.status_code == 422
+    body = r.json()
+    assert body["data"] is None
+    assert body["status"]["category"] == "validation_error"
+    assert body["code"] == "invalid_country_code"
+    assert body["field"] == "sourcing_country_code"
+    assert body["active_field"] == "active_countries"
+    assert body["value"] == "ZZ"
+
+
+def test_save_sourcing_card_with_inactive_currency_returns_422(authed_client):
+    r = authed_client.patch(
+        "/api/workspaces/current",
+        json={
+            "active_currencies": ["EUR"],
+            "sourcing_currency_code": "USD",
+        },
+    )
+
+    assert r.status_code == 422
+    body = r.json()
+    assert body["data"] is None
+    assert body["status"]["category"] == "validation_error"
+    assert body["code"] == "invalid_currency_code"
+    assert body["field"] == "sourcing_currency_code"
+    assert body["active_field"] == "active_currencies"
+    assert body["value"] == "USD"
+
+
+def test_save_sourcing_card_with_valid_codes_persists(authed_client, db):
+    r = authed_client.patch(
+        "/api/workspaces/current",
+        json={
+            "active_countries": ["CZ", "DE"],
+            "active_currencies": ["EUR", "USD"],
+            "sourcing_country_code": "cz",
+            "sourcing_currency_code": "eur",
+        },
+    )
+
+    assert r.status_code == 200, r.text
+    body = r.json()["data"]
+    assert body["sourcing_country_code"] == "CZ"
+    assert body["sourcing_currency_code"] == "EUR"
+
+    ws = db.get(Workspace, _current_workspace_id(authed_client))
+    assert ws is not None
+    assert ws.sourcing_country_code == "CZ"
+    assert ws.sourcing_currency_code == "EUR"

--- a/docs/api/workspaces.md
+++ b/docs/api/workspaces.md
@@ -127,6 +127,8 @@ Update workspace settings, rotate provider/scanner credentials, and (re)mint the
 | `parts_provider_api_secret` | string | Same encrypt-or-clear (`workspaces.py:179-182`). |
 | `scanner` | string | `"zxing"` / `"scandit"`. |
 | `scanner_license_key` | string | Encrypt-or-clear (`workspaces.py:183-186`). |
+| `sourcing_country_code` | string \| null | Optional TrustedParts country default. Non-null values are uppercased and must be present in `active_countries`; otherwise the route returns `422` with `code: "invalid_country_code"` (`workspaces.py:52-111`, `workspaces.py:284`). |
+| `sourcing_currency_code` | string \| null | Optional TrustedParts currency default. Non-null values are uppercased and must be present in `active_currencies`; otherwise the route returns `422` with `code: "invalid_currency_code"` (`workspaces.py:52-111`, `workspaces.py:284`). |
 | `sourcing_language_code` | string \| null | Optional TrustedParts spec translation language. Allowed values: `de`, `en`, `es`, `fr`, `it`, `pt`, `ja`, `zh-hans`, `zh-hant`; `null` omits `LanguageCode` so TP uses its default (`schemas.py:31-41`, `client.py:171-173`). |
 | `active_currencies` | string[] | Non-empty ISO-4217 uppercase codes; each matches `^[A-Z]{3}$` (`schemas.py:26`, `schemas.py:68`). |
 | `active_countries` | string[] | Non-empty ISO-3166 alpha-2 uppercase codes; each matches `^[A-Z]{2}$` (`schemas.py:27`, `schemas.py:69`). |

--- a/web/src/routes/settings/SourcingCard.tsx
+++ b/web/src/routes/settings/SourcingCard.tsx
@@ -26,6 +26,8 @@ export type SourcingWorkspace = {
   sourcing_currency_code: string | null;
   sourcing_language_code: Exclude<SourcingLanguageCode, ""> | null;
   sourcing_preferred_distributors: string[] | null;
+  active_countries: string[];
+  active_currencies: string[];
   sourcing_use_cached_for_dashboards: boolean;
   has_sourcing_company_id: boolean;
   has_sourcing_api_key: boolean;
@@ -139,12 +141,18 @@ export function SourcingCard({
     },
   });
 
+  const configured = hasApiKey;
+  const activeCountrySelected = Boolean(country && workspace.active_countries.includes(country));
+  const activeCurrencySelected = Boolean(currency && workspace.active_currencies.includes(currency));
+  const canSave = activeCountrySelected && activeCurrencySelected && !saveMutation.isPending;
+
   function submit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
+    if (!activeCountrySelected || !activeCurrencySelected) return;
     const body: SourcingPatch = {
       sourcing_provider: provider,
-      sourcing_country_code: country.trim() ? country.trim().toUpperCase() : null,
-      sourcing_currency_code: currency.trim() ? currency.trim().toUpperCase() : null,
+      sourcing_country_code: country || null,
+      sourcing_currency_code: currency || null,
       sourcing_language_code: language || null,
       sourcing_preferred_distributors: splitDistributors(distributors),
       sourcing_use_cached_for_dashboards: useCache,
@@ -153,8 +161,6 @@ export function SourcingCard({
     if (apiKeyTouched) body.sourcing_api_key = apiKey;
     saveMutation.mutate(body);
   }
-
-  const configured = hasApiKey;
 
   return (
     <form className="card p-4 mb-4 space-y-3 text-sm" onSubmit={submit}>
@@ -219,25 +225,35 @@ export function SourcingCard({
         </div>
         <div>
           <label className="label" htmlFor="sourcing-country">Country</label>
-          <input
+          <select
             id="sourcing-country"
             className="input uppercase"
-            maxLength={2}
             value={country}
-            onChange={(e) => setCountry(e.target.value.toUpperCase())}
-            placeholder="US"
-          />
+            onChange={(e) => setCountry(e.target.value)}
+          >
+            <option value="">Select country</option>
+            {workspace.active_countries.map((option) => (
+              <option key={option} value={option}>
+                {option}
+              </option>
+            ))}
+          </select>
         </div>
         <div>
           <label className="label" htmlFor="sourcing-currency">Currency</label>
-          <input
+          <select
             id="sourcing-currency"
             className="input uppercase"
-            maxLength={3}
             value={currency}
-            onChange={(e) => setCurrency(e.target.value.toUpperCase())}
-            placeholder="USD"
-          />
+            onChange={(e) => setCurrency(e.target.value)}
+          >
+            <option value="">Select currency</option>
+            {workspace.active_currencies.map((option) => (
+              <option key={option} value={option}>
+                {option}
+              </option>
+            ))}
+          </select>
         </div>
         <div>
           <label className="label" htmlFor="sourcing-language">Language</label>
@@ -285,7 +301,7 @@ export function SourcingCard({
       )}
 
       <div className="flex flex-wrap gap-2">
-        <button className="btn-primary" type="submit" disabled={saveMutation.isPending}>
+        <button className="btn-primary" type="submit" disabled={!canSave}>
           Save
         </button>
         <button

--- a/web/src/routes/settings/__dom__/SourcingCard.dom.test.tsx
+++ b/web/src/routes/settings/__dom__/SourcingCard.dom.test.tsx
@@ -20,6 +20,8 @@ const baseWorkspace: SourcingWorkspace = {
   sourcing_currency_code: null,
   sourcing_language_code: null,
   sourcing_preferred_distributors: null,
+  active_countries: ["CZ", "DE", "US"],
+  active_currencies: ["EUR", "USD"],
   sourcing_use_cached_for_dashboards: true,
   has_sourcing_company_id: false,
   has_sourcing_api_key: false,
@@ -62,6 +64,21 @@ describe("SourcingCard", () => {
     expect(screen.queryByText("Configured ✓")).toBeNull();
   });
 
+  it("renders country select with active countries", () => {
+    renderCard();
+
+    expect(screen.getByRole("combobox", { name: "Country" })).toBeDefined();
+    expect(screen.getByRole("option", { name: "CZ" })).toBeDefined();
+    expect(screen.getByRole("option", { name: "DE" })).toBeDefined();
+    expect(screen.queryByRole("textbox", { name: "Country" })).toBeNull();
+  });
+
+  it("disables save when country is empty", () => {
+    renderCard({ ...baseWorkspace, sourcing_currency_code: "EUR" });
+
+    expect(screen.getByRole("button", { name: "Save" })).toHaveProperty("disabled", true);
+  });
+
   it("submits PATCH with the expected body shape on Save", async () => {
     const user = userEvent.setup();
     const patchSpy = vi.spyOn(api, "patch").mockResolvedValue({
@@ -71,6 +88,8 @@ describe("SourcingCard", () => {
       sourcing_currency_code: "EUR",
       sourcing_language_code: "de",
       sourcing_preferred_distributors: ["DigiKey", "Mouser"],
+      active_countries: ["CZ", "DE", "US"],
+      active_currencies: ["EUR", "USD"],
       sourcing_use_cached_for_dashboards: false,
       has_sourcing_company_id: true,
       has_sourcing_api_key: true,
@@ -80,8 +99,8 @@ describe("SourcingCard", () => {
     await user.selectOptions(screen.getByLabelText("Provider"), "trustedparts");
     await user.type(screen.getByLabelText("CompanyId (deprecated)"), "company-123");
     await user.type(screen.getByLabelText("API Key"), "api-456");
-    await user.type(screen.getByLabelText("Country"), "cz");
-    await user.type(screen.getByLabelText("Currency"), "eur");
+    await user.selectOptions(screen.getByLabelText("Country"), "CZ");
+    await user.selectOptions(screen.getByLabelText("Currency"), "EUR");
     await user.selectOptions(screen.getByLabelText("Language"), "de");
     await user.type(screen.getByLabelText("Preferred distributors"), "DigiKey, Mouser");
     await user.click(screen.getByLabelText("Use cached data for dashboards"));
@@ -103,10 +122,39 @@ describe("SourcingCard", () => {
     expect(screen.getByText("Configured ✓")).toBeDefined();
   });
 
+  it("submits with selected country code", async () => {
+    const user = userEvent.setup();
+    const patchSpy = vi.spyOn(api, "patch").mockResolvedValue({
+      ...baseWorkspace,
+      sourcing_country_code: "US",
+      sourcing_currency_code: "USD",
+    });
+    renderCard();
+
+    await user.selectOptions(screen.getByLabelText("Country"), "US");
+    await user.selectOptions(screen.getByLabelText("Currency"), "USD");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(patchSpy).toHaveBeenCalledWith(
+        "/workspaces/current",
+        expect.objectContaining({
+          sourcing_country_code: "US",
+          sourcing_currency_code: "USD",
+        }),
+      );
+    });
+  });
+
   it("maps the default language option to null on Save", async () => {
     const user = userEvent.setup();
     const patchSpy = vi.spyOn(api, "patch").mockResolvedValue(baseWorkspace);
-    renderCard({ ...baseWorkspace, sourcing_language_code: "fr" });
+    renderCard({
+      ...baseWorkspace,
+      sourcing_country_code: "CZ",
+      sourcing_currency_code: "EUR",
+      sourcing_language_code: "fr",
+    });
 
     await user.selectOptions(screen.getByLabelText("Language"), "");
     await user.click(screen.getByRole("button", { name: "Save" }));
@@ -163,6 +211,8 @@ describe("SourcingCard", () => {
 
     await user.type(screen.getByLabelText("CompanyId (deprecated)"), "secret-company-id");
     await user.type(screen.getByLabelText("API Key"), "secret-api-key");
+    await user.selectOptions(screen.getByLabelText("Country"), "CZ");
+    await user.selectOptions(screen.getByLabelText("Currency"), "EUR");
     await user.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => {


### PR DESCRIPTION
## Summary
- Replaced SourcingCard country/currency free-text fields with native selects populated from the workspace active country/currency lists.
- Added PATCH /api/workspaces/current validation that normalizes sourcing defaults to uppercase and rejects non-active country/currency codes with structured 422 codes.
- Added focused backend/frontend tests plus workspace API docs and changelog notes.

## Validation
- `docker compose -f docker-compose.dev.yml exec backend pytest -k "workspace_sourcing or sourcing_settings"` - blocked: `docker` is not installed in this environment.
- `cd backend && uv run --extra dev python -m pytest -q tests/test_workspace_sourcing_settings.py` - 19 passed, 3 warnings.
- `cd web && npm run typecheck` - passed.
- `cd web && npm test -- SourcingCard` - 1 file passed, 9 tests passed.
- `cd web && npm run lint` - blocked by existing unrelated lint errors in `src/lib/bagCode.ts` (`no-control-regex`) plus existing warnings.
- `cd web && npx eslint src/routes/settings/SourcingCard.tsx src/routes/settings/__dom__/SourcingCard.dom.test.tsx` - passed.
- `cd backend && ruff check app/api/routes/workspaces.py app/core/errors.py` - passed.
- `cd backend && ruff check app` - blocked by existing unrelated app-wide ruff violations.

## Example 422
```json
{
  "data": null,
  "status": {
    "category": "validation_error",
    "message": "sourcing_country_code must be active for this workspace"
  },
  "code": "invalid_country_code",
  "field": "sourcing_country_code",
  "active_field": "active_countries",
  "value": "ZZ"
}
```

## Screenshots
Before/after browser screenshots were not captured because the Docker dev stack is unavailable here. Before: country/currency were free-text inputs. After: country/currency are native selects bound to the active lists and covered by jsdom tests.

## Merge Order
`CHANGELOG.md` may conflict with sibling SA PRs; preserve all SA entries when resolving.

Refs #511
