### PR TITLE
SA-14: Alerts evaluator batches canonical sourcing queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ the canonical record.
 - **SA-13 / #505** Purchase-plan conversion is now capped at 10
   conversions/minute per workspace, and sourcing distributor filters reject
   requests with more than 25 values before provider fanout.
+- **SA-14 / #506** Sourcing alert evaluation now batches identical
+  workspace-scoped TrustedParts queries by canonical query hash.
 - **SA-17 / #509** Production cron sidecar jobs now have a 600-second
   per-run timeout that logs exit 124 on timeout while preserving cadence.
 - **SA-15 / #507** TrustedParts, Mouser, and DigiKey outbound calls now share

--- a/backend/app/domain/sourcing/alerts_evaluator.py
+++ b/backend/app/domain/sourcing/alerts_evaluator.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable
+from collections import defaultdict
+from collections.abc import Callable, Sequence
+from contextvars import ContextVar
 from dataclasses import dataclass
 from decimal import Decimal, InvalidOperation
 from typing import Any
@@ -18,6 +20,7 @@ from app.core.config import settings
 from app.core.time import utcnow
 from app.domain.parts.models import Part
 from app.domain.projects.models import Project
+from app.domain.sourcing import cache as sourcing_cache
 from app.domain.sourcing import service as sourcing_service
 from app.domain.sourcing.pricing import best_unit_price_at_qty
 from app.domain.sourcing.schemas import (
@@ -52,6 +55,36 @@ class AlertEmail:
 
 
 EvaluatorFn = Callable[[Session, Workspace, SourcingAlert], AlertVerdict]
+_SearchGroupKey = tuple[UUID, str]
+_SEARCH_ALERT_TYPES = {
+    "back_in_stock",
+    "out_of_authorized_stock",
+    "price_changed",
+    "lifecycle_risk_changed",
+    "supply_chain_risk_changed",
+    "tariff_status_changed",
+}
+
+
+@dataclass(frozen=True)
+class _SearchGroupAlert:
+    alert: SourcingAlert
+    workspace: Workspace
+    mpn: str
+
+
+@dataclass(frozen=True)
+class _SearchBatchContext:
+    alert_keys: dict[UUID, _SearchGroupKey]
+    results: dict[_SearchGroupKey, Any]
+    errors: dict[_SearchGroupKey, Exception]
+    alert_errors: dict[UUID, Exception]
+
+
+_SEARCH_BATCH_CONTEXT: ContextVar[_SearchBatchContext | None] = ContextVar(
+    "sourcing_alert_search_batch_context",
+    default=None,
+)
 
 
 def evaluate_all_alerts(db: Session) -> int:
@@ -60,14 +93,28 @@ def evaluate_all_alerts(db: Session) -> int:
     Returns the number of alert rows attempted. Each row commits
     independently so a bad alert cannot roll back earlier bookkeeping.
     """
-    rows = db.execute(
-        select(SourcingAlert, Workspace)
-        .join(Workspace, Workspace.id == SourcingAlert.workspace_id)
-        .where(SourcingAlert.enabled.is_(True))
-        .where(SourcingAlert.archived_at.is_(None))
-        .order_by(SourcingAlert.workspace_id, SourcingAlert.created_at, SourcingAlert.id)
-    ).all()
+    rows = [
+        (alert, workspace)
+        for alert, workspace in db.execute(
+            select(SourcingAlert, Workspace)
+            .join(Workspace, Workspace.id == SourcingAlert.workspace_id)
+            .where(SourcingAlert.enabled.is_(True))
+            .where(SourcingAlert.archived_at.is_(None))
+            .order_by(SourcingAlert.workspace_id, SourcingAlert.created_at, SourcingAlert.id)
+        ).all()
+    ]
+    search_batch = _prefetch_sourcing_searches(db, rows)
+    search_batch_token = _SEARCH_BATCH_CONTEXT.set(search_batch)
+    try:
+        return _evaluate_alert_rows(db, rows)
+    finally:
+        _SEARCH_BATCH_CONTEXT.reset(search_batch_token)
 
+
+def _evaluate_alert_rows(
+    db: Session,
+    rows: Sequence[tuple[SourcingAlert, Workspace]],
+) -> int:
     evaluated = 0
     for alert, workspace in rows:
         evaluated += 1
@@ -114,6 +161,118 @@ def evaluate_all_alerts(db: Session) -> int:
                 alert_type,
             )
     return evaluated
+
+
+def _prefetch_sourcing_searches(
+    db: Session,
+    rows: Sequence[tuple[SourcingAlert, Workspace]],
+) -> _SearchBatchContext:
+    groups: dict[_SearchGroupKey, list[_SearchGroupAlert]] = defaultdict(list)
+    alert_keys: dict[UUID, _SearchGroupKey] = {}
+    alert_errors: dict[UUID, Exception] = {}
+
+    for alert, workspace in rows:
+        if alert.alert_type not in _SEARCH_ALERT_TYPES:
+            continue
+        try:
+            part = _part_for_alert(db, workspace, alert)
+            if not part.mpn:
+                continue
+            query = _canonical_search_query_for_alert(workspace, alert, part)
+            _assert_query_is_workspace_scoped(query, workspace)
+            key = (workspace.id, sourcing_cache.canonical_query_hash(query))
+            groups[key].append(
+                _SearchGroupAlert(alert=alert, workspace=workspace, mpn=part.mpn)
+            )
+            alert_keys[alert.id] = key
+        except Exception as exc:
+            alert_errors[alert.id] = exc
+
+    results: dict[_SearchGroupKey, Any] = {}
+    errors: dict[_SearchGroupKey, Exception] = {}
+    for key, group in groups.items():
+        first = group[0]
+        try:
+            results[key] = sourcing_service.search(
+                db,
+                workspace=first.workspace,
+                mpns=[first.mpn],
+                country=first.alert.country_code,
+                currency=first.alert.currency_code,
+                distributors=_distributor_filter(first.alert),
+                use_cached_data=True,
+            )
+        except Exception as exc:
+            errors[key] = exc
+            db.rollback()
+
+    return _SearchBatchContext(
+        alert_keys=alert_keys,
+        results=results,
+        errors=errors,
+        alert_errors=alert_errors,
+    )
+
+
+def _canonical_search_query_for_alert(
+    workspace: Workspace,
+    alert: SourcingAlert,
+    part: Part,
+) -> dict[str, Any]:
+    alert_distributors = _distributor_filter(alert)
+    effective_distributors = (
+        sourcing_service._clean_distributors(alert_distributors)
+        if alert_distributors is not None
+        else sourcing_service._clean_distributors(workspace.sourcing_preferred_distributors)
+    )
+    return sourcing_cache.sourcing_search_query(
+        workspace_id=workspace.id,
+        provider=workspace.sourcing_provider or "trustedparts",
+        mpn=part.mpn or "",
+        country_code=sourcing_service._clean_code(alert.country_code)
+        or workspace.sourcing_country_code,
+        currency_code=sourcing_service._clean_code(alert.currency_code)
+        or workspace.sourcing_currency_code,
+        language_code=workspace.sourcing_language_code,
+        distributors=effective_distributors,
+        in_stock_only=False,
+        use_cached_data=True,
+    )
+
+
+def _assert_query_is_workspace_scoped(
+    query: dict[str, Any],
+    workspace: Workspace,
+) -> None:
+    if query.get("workspace_id") != str(workspace.id):
+        raise RuntimeError("canonical sourcing alert query is missing workspace_id")
+
+
+def _search_for_part(
+    db: Session,
+    workspace: Workspace,
+    alert: SourcingAlert,
+    part: Part,
+) -> Any:
+    context = _SEARCH_BATCH_CONTEXT.get()
+    if context is not None:
+        if alert.id in context.alert_errors:
+            raise context.alert_errors[alert.id]
+        key = context.alert_keys.get(alert.id)
+        if key is not None:
+            if key in context.errors:
+                raise context.errors[key]
+            return context.results[key]
+
+    return sourcing_service.search(
+        db,
+        workspace=workspace,
+        mpns=[part.mpn],
+        country=alert.country_code,
+        currency=alert.currency_code,
+        distributors=_distributor_filter(alert),
+        use_cached_data=True,
+    )
 
 
 def _evaluate_stock_below(
@@ -515,15 +674,7 @@ def _authorized_stock_for_part(
 ) -> int:
     if not part.mpn:
         return 0
-    result = sourcing_service.search(
-        db,
-        workspace=workspace,
-        mpns=[part.mpn],
-        country=alert.country_code,
-        currency=alert.currency_code,
-        distributors=_distributor_filter(alert),
-        use_cached_data=True,
-    )
+    result = _search_for_part(db, workspace, alert, part)
     return sum(
         max(0, int(distributor.stock or 0))
         for item in result.results
@@ -540,15 +691,7 @@ def _best_price_for_part(
 ) -> tuple[Decimal, str | None] | None:
     if not part.mpn:
         return None
-    result = sourcing_service.search(
-        db,
-        workspace=workspace,
-        mpns=[part.mpn],
-        country=alert.country_code,
-        currency=alert.currency_code,
-        distributors=_distributor_filter(alert),
-        use_cached_data=True,
-    )
+    result = _search_for_part(db, workspace, alert, part)
     best: tuple[Decimal, str | None] | None = None
     for item in result.results:
         for offer in item.offers:
@@ -583,15 +726,7 @@ def _first_matching_offer(
 ) -> Any | None:
     if not part.mpn:
         return None
-    result = sourcing_service.search(
-        db,
-        workspace=workspace,
-        mpns=[part.mpn],
-        country=alert.country_code,
-        currency=alert.currency_code,
-        distributors=_distributor_filter(alert),
-        use_cached_data=True,
-    )
+    result = _search_for_part(db, workspace, alert, part)
     expected = part.mpn.casefold()
     for item in result.results:
         item_mpn = getattr(item, "mpn", None)

--- a/backend/tests/test_sourcing_alerts_evaluator.py
+++ b/backend/tests/test_sourcing_alerts_evaluator.py
@@ -1046,13 +1046,16 @@ def test_evaluator_uses_cache_default_true_for_sourcing_alerts(
     monkeypatch,
 ) -> None:
     workspace, user = _workspace(db)
-    part = _part(db, workspace, user)
+    back_in_stock_part = _part(db, workspace, user, mpn="CACHE-BACK")
+    lifecycle_part = _part(db, workspace, user, mpn="CACHE-LIFE")
+    supply_chain_part = _part(db, workspace, user, mpn="CACHE-SUPPLY")
+    tariff_part = _part(db, workspace, user, mpn="CACHE-TARIFF")
     project = _project(db, workspace, user)
     _alert(
         db,
         workspace,
         user,
-        part=part,
+        part=back_in_stock_part,
         alert_type="back_in_stock",
         threshold={},
         last_state={"had_stock": False},
@@ -1061,7 +1064,7 @@ def test_evaluator_uses_cache_default_true_for_sourcing_alerts(
         db,
         workspace,
         user,
-        part=part,
+        part=lifecycle_part,
         alert_type="lifecycle_risk_changed",
         threshold={},
         last_state={"lifecycle_risk": "Active"},
@@ -1070,7 +1073,7 @@ def test_evaluator_uses_cache_default_true_for_sourcing_alerts(
         db,
         workspace,
         user,
-        part=part,
+        part=supply_chain_part,
         alert_type="supply_chain_risk_changed",
         threshold={},
         last_state={"supply_chain_risk": "Stable"},
@@ -1079,7 +1082,7 @@ def test_evaluator_uses_cache_default_true_for_sourcing_alerts(
         db,
         workspace,
         user,
-        part=part,
+        part=tariff_part,
         alert_type="tariff_status_changed",
         threshold={},
         last_state={"tariff": False},
@@ -1098,9 +1101,10 @@ def test_evaluator_uses_cache_default_true_for_sourcing_alerts(
 
     def fake_search(*args: Any, **kwargs: Any) -> Any:
         search_cached.append(kwargs.get("use_cached_data"))
+        mpn = kwargs["mpns"][0]
         return _search_out(
             stock=1,
-            mpn=part.mpn or "MPN",
+            mpn=mpn,
             lifecycle_risk="Obsolete",
             supply_chain_risk="Allocation",
             is_affected_by_tariff=True,
@@ -1120,6 +1124,212 @@ def test_evaluator_uses_cache_default_true_for_sourcing_alerts(
 
     assert search_cached == [True, True, True, True]
     assert bom_cached == [True]
+
+
+def test_evaluator_batches_alerts_with_same_canonical_query(
+    db: Session,
+    monkeypatch,
+) -> None:
+    workspace, user = _workspace(db)
+    part = _part(db, workspace, user, mpn="BATCH-MPN")
+    _alert(
+        db,
+        workspace,
+        user,
+        part=part,
+        alert_type="back_in_stock",
+        threshold={},
+        last_state={"had_stock": False},
+    )
+    _alert(
+        db,
+        workspace,
+        user,
+        part=part,
+        alert_type="out_of_authorized_stock",
+        threshold={},
+        last_state={"had_stock": True},
+    )
+    _alert(
+        db,
+        workspace,
+        user,
+        part=part,
+        alert_type="price_changed",
+        threshold={"delta_pct": 10},
+        last_state={"last_price": "1.00", "last_currency": "USD"},
+    )
+    _alert(
+        db,
+        workspace,
+        user,
+        part=part,
+        alert_type="lifecycle_risk_changed",
+        threshold={},
+        last_state={"lifecycle_risk": "Active"},
+    )
+    _alert(
+        db,
+        workspace,
+        user,
+        part=part,
+        alert_type="supply_chain_risk_changed",
+        threshold={},
+        last_state={"supply_chain_risk": "Stable"},
+    )
+    calls: list[dict[str, Any]] = []
+
+    def fake_search(*args: Any, **kwargs: Any) -> Any:
+        calls.append(kwargs)
+        return _search_out(
+            stock=10,
+            price="1.25",
+            mpn=kwargs["mpns"][0],
+            lifecycle_risk="Obsolete",
+            supply_chain_risk="Allocation",
+        )
+
+    monkeypatch.setattr(alerts_evaluator.sourcing_service, "search", fake_search)
+    _capture_mail(monkeypatch)
+
+    assert evaluate_all_alerts(db) == 5
+
+    assert len(calls) == 1
+    assert calls[0]["workspace"].id == workspace.id
+    assert calls[0]["mpns"] == ["BATCH-MPN"]
+    assert calls[0]["use_cached_data"] is True
+
+
+def test_evaluator_does_not_batch_across_workspaces(
+    db: Session,
+    monkeypatch,
+) -> None:
+    workspace_a, user_a = _workspace(db)
+    workspace_b, user_b = _workspace(db)
+    part_a = _part(db, workspace_a, user_a, mpn="SHARED-BATCH-MPN")
+    part_b = _part(db, workspace_b, user_b, mpn="SHARED-BATCH-MPN")
+    _alert(
+        db,
+        workspace_a,
+        user_a,
+        part=part_a,
+        alert_type="back_in_stock",
+        threshold={},
+        last_state={"had_stock": False},
+    )
+    _alert(
+        db,
+        workspace_b,
+        user_b,
+        part=part_b,
+        alert_type="back_in_stock",
+        threshold={},
+        last_state={"had_stock": False},
+    )
+    seen_workspace_ids: list[uuid.UUID] = []
+
+    def fake_search(*args: Any, **kwargs: Any) -> Any:
+        seen_workspace_ids.append(kwargs["workspace"].id)
+        return _search_out(stock=1, mpn=kwargs["mpns"][0])
+
+    monkeypatch.setattr(alerts_evaluator.sourcing_service, "search", fake_search)
+    _capture_mail(monkeypatch)
+
+    assert evaluate_all_alerts(db) == 2
+
+    assert set(seen_workspace_ids) == {workspace_a.id, workspace_b.id}
+    assert len(seen_workspace_ids) == 2
+
+
+def test_evaluator_does_not_batch_distinct_queries(
+    db: Session,
+    monkeypatch,
+) -> None:
+    workspace, user = _workspace(db)
+    parts = [
+        _part(db, workspace, user, mpn="DISTINCT-1"),
+        _part(db, workspace, user, mpn="DISTINCT-2"),
+        _part(db, workspace, user, mpn="DISTINCT-3"),
+    ]
+    for part in parts:
+        _alert(
+            db,
+            workspace,
+            user,
+            part=part,
+            alert_type="back_in_stock",
+            threshold={},
+            last_state={"had_stock": False},
+        )
+    seen_mpns: list[str] = []
+
+    def fake_search(*args: Any, **kwargs: Any) -> Any:
+        mpn = kwargs["mpns"][0]
+        seen_mpns.append(mpn)
+        return _search_out(stock=1, mpn=mpn)
+
+    monkeypatch.setattr(alerts_evaluator.sourcing_service, "search", fake_search)
+    _capture_mail(monkeypatch)
+
+    assert evaluate_all_alerts(db) == 3
+
+    assert seen_mpns == ["DISTINCT-1", "DISTINCT-2", "DISTINCT-3"]
+
+
+def test_evaluator_dispatches_to_each_alert_in_group(
+    db: Session,
+    monkeypatch,
+) -> None:
+    workspace, user = _workspace(db)
+    part = _part(db, workspace, user, mpn="DISPATCH-BATCH-MPN")
+    back_alert = _alert(
+        db,
+        workspace,
+        user,
+        part=part,
+        alert_type="back_in_stock",
+        threshold={},
+        last_state={"had_stock": False},
+    )
+    price_alert = _alert(
+        db,
+        workspace,
+        user,
+        part=part,
+        alert_type="price_changed",
+        threshold={"delta_pct": 10},
+        last_state={"last_price": "1.00", "last_currency": "USD"},
+    )
+    risk_alert = _alert(
+        db,
+        workspace,
+        user,
+        part=part,
+        alert_type="lifecycle_risk_changed",
+        threshold={},
+        last_state={"lifecycle_risk": "Active"},
+    )
+    calls: list[str] = []
+
+    def fake_search(*args: Any, **kwargs: Any) -> Any:
+        calls.append(kwargs["mpns"][0])
+        return _search_out(
+            stock=5,
+            price="1.25",
+            mpn=kwargs["mpns"][0],
+            lifecycle_risk="Obsolete",
+        )
+
+    monkeypatch.setattr(alerts_evaluator.sourcing_service, "search", fake_search)
+    sent = _capture_mail(monkeypatch)
+
+    assert evaluate_all_alerts(db) == 3
+
+    assert calls == ["DISPATCH-BATCH-MPN"]
+    assert len(sent) == 3
+    for alert in (back_alert, price_alert, risk_alert):
+        db.refresh(alert)
+        assert alert.last_notified_at is not None
 
 
 def test_workspace_isolation_two_alerts_same_mpn_different_workspaces(

--- a/docs/domain/sourcing.md
+++ b/docs/domain/sourcing.md
@@ -274,7 +274,11 @@ Sources: `backend/alembic/versions/0044_sourcing_alerts.py:20`,
 `evaluate_all_alerts(db)` scans enabled, non-archived rows across workspaces, dispatches
 by `alert_type`, persists `last_checked_at` and `last_evaluation_state`, and commits
 per alert row. Evaluator failures roll back only the current row and are logged so later
-alerts still run. Source: `backend/app/domain/sourcing/alerts_evaluator.py:49-108`
+alerts still run. Search-backed part alerts are grouped by `(workspace_id,
+canonical_query_hash)` before evaluation, so alerts with the same canonical TrustedParts
+query share one `sourcing.service.search(..., use_cached_data=True)` result while still
+evaluating and dispatching independently. Source:
+`backend/app/domain/sourcing/alerts_evaluator.py:90-275`
 
 Alert notification dispatch is intentionally at-most-once. When a triggered alert has
 recipients, the evaluator renders the email, writes `last_notified_at`, and commits


### PR DESCRIPTION
## Summary
- Batch search-backed sourcing alerts by `(workspace_id, canonical_query_hash)` before per-alert evaluation.
- Reuse `app.domain.sourcing.cache.sourcing_search_query()` and `canonical_query_hash()` for the grouping key.
- Fan the fetched search result back through existing alert verdict and notification code so each alert still persists/evaluates independently.
- Document the evaluator batching behavior and add the SA-14 changelog entry.

## Validation
- `docker compose -f docker-compose.dev.yml exec backend pytest -k "alerts"` - blocked: `/bin/bash: line 1: docker: command not found`.
- `docker compose -f docker-compose.dev.yml exec backend ruff check` - blocked: `/bin/bash: line 1: docker: command not found`.
- `cd backend && uv run --extra dev python -m pytest -q -k "alerts"` - passed: `85 passed, 1180 deselected, 10 warnings in 24.61s`.
- `cd backend && uv run --extra dev ruff check app/domain/sourcing/alerts_evaluator.py tests/test_sourcing_alerts_evaluator.py` - passed: `All checks passed!`
- `cd backend && WORK_DIR="." LINT_CMD="uv run --extra dev ruff check app --output-format=concise" BASELINE_FILE="../.ruff-baseline.txt" bash ../scripts/lint-delta.sh` - passed: `lint-delta: no new violations (baseline: 159, current: 139, fixed since baseline: 20)`.
- `git diff --check` - passed.

## Notes
- No route or schema files changed.
- Before/after 100-alert timing was not measured; the call-count tests pin the expected reduction from N identical canonical queries to one `service.search` call.
- Merge order: `CHANGELOG.md` may conflict with sibling SA PRs.

Refs #506