### PR TITLE
SA-13: Rate-limit convert_purchase_plan_to_orders + list-length caps on distributors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ the canonical record.
 
 - **SA-12 / #504** Sourcing alerts now return `{ items, total, limit, offset }`
   with 50-row default pagination and frontend next/previous controls.
+- **SA-13 / #505** Purchase-plan conversion is now capped at 10
+  conversions/minute per workspace, and sourcing distributor filters reject
+  requests with more than 25 values before provider fanout.
 - **SA-17 / #509** Production cron sidecar jobs now have a 600-second
   per-run timeout that logs exit 124 on timeout while preserving cadence.
 - **SA-15 / #507** TrustedParts, Mouser, and DigiKey outbound calls now share

--- a/backend/app/api/routes/sourcing.py
+++ b/backend/app/api/routes/sourcing.py
@@ -29,6 +29,7 @@ from app.domain.sourcing import service as sourcing_service
 from app.domain.sourcing.factory import make_sourcing_provider
 from app.domain.sourcing.models import PurchasePlan
 from app.domain.sourcing.schemas import (
+    MAX_DISTRIBUTORS,
     PurchasePlanIn,
     PurchasePlanOrdersIn,
     SourcingAlertIn,
@@ -474,6 +475,7 @@ def refresh_purchase_plan(
     "/purchase-plans/{plan_id}/orders",
     dependencies=[Depends(require_role("member"))],
 )
+@limiter.limit("10/minute", key_func=workspace_key)
 def convert_purchase_plan_to_orders(
     request: Request,
     plan_id: UUID,
@@ -717,6 +719,8 @@ def _clean_query_distributors(value: list[str] | None) -> list[str] | None:
     cleaned: list[str] = []
     for item in value:
         cleaned.extend(part.strip() for part in item.split(",") if part.strip())
+    if len(cleaned) > MAX_DISTRIBUTORS:
+        raise ValueError(f"distributors list capped at {MAX_DISTRIBUTORS}")
     return cleaned or None
 
 
@@ -772,6 +776,8 @@ def _default_error_code(status_code: int, category: str, message: str) -> str:
         return ErrorCodes.SOURCING_CURRENCY_MISMATCH
     if status_code == 422 and "override" in normalized:
         return ErrorCodes.SOURCING_OVERRIDE_INVALID
+    if normalized == f"distributors list capped at {MAX_DISTRIBUTORS}":
+        return ErrorCodes.SOURCING_TOO_MANY_DISTRIBUTORS
     if status_code == 422:
         return ErrorCodes.SOURCING_INVALID_REQUEST
     if category == "not_found":

--- a/backend/app/core/errors.py
+++ b/backend/app/core/errors.py
@@ -155,6 +155,7 @@ class ErrorCodes:
     SOURCING_PLAN_STALE = "sourcing.plan_stale"
     SOURCING_CURRENCY_MISMATCH = "sourcing.currency_mismatch"
     SOURCING_OVERRIDE_INVALID = "sourcing.override_invalid"
+    SOURCING_TOO_MANY_DISTRIBUTORS = "sourcing.too_many_distributors"
     SOURCING_INVALID_REQUEST = "sourcing.invalid_request"
     SOURCING_GENERIC = "sourcing.error"
 

--- a/backend/app/domain/sourcing/schemas.py
+++ b/backend/app/domain/sourcing/schemas.py
@@ -17,6 +17,8 @@ from pydantic import (
     field_validator,
 )
 
+MAX_DISTRIBUTORS = 25
+
 
 class SourcingQuery(BaseModel):
     model_config = ConfigDict(extra="forbid")
@@ -126,7 +128,7 @@ class SourcingSearchIn(BaseModel):
     country: str | None = Field(default=None, min_length=2, max_length=2)
     currency: str | None = Field(default=None, min_length=3, max_length=3)
     in_stock_only: bool = False
-    distributors: list[str] | None = None
+    distributors: list[str] | None = Field(default=None, max_length=MAX_DISTRIBUTORS)
     use_cached_data: bool | None = None
 
     @field_validator("mpns")
@@ -191,7 +193,7 @@ class SourcingBomIn(BaseModel):
     build_quantity: int = Field(ge=1)
     country: str | None = Field(default=None, min_length=2, max_length=2)
     currency: str | None = Field(default=None, min_length=3, max_length=3)
-    distributors: list[str] | None = None
+    distributors: list[str] | None = Field(default=None, max_length=MAX_DISTRIBUTORS)
     in_stock_only: bool = False
     use_cached_data: bool | None = None
 
@@ -355,7 +357,7 @@ class SourcingAlertIn(BaseModel):
     threshold: SourcingAlertThresholdIn
     country_code: str | None = Field(default=None, min_length=2, max_length=2)
     currency_code: str | None = Field(default=None, min_length=3, max_length=3)
-    distributor_filter: list[str] | None = None
+    distributor_filter: list[str] | None = Field(default=None, max_length=MAX_DISTRIBUTORS)
     notify_user_ids: list[UUID] | None = None
     cooldown_seconds: int = Field(default=86400, ge=60)
     enabled: bool = True
@@ -385,7 +387,7 @@ class SourcingAlertPatch(BaseModel):
     threshold: dict[str, Any] | None = None
     country_code: str | None = Field(default=None, min_length=2, max_length=2)
     currency_code: str | None = Field(default=None, min_length=3, max_length=3)
-    distributor_filter: list[str] | None = None
+    distributor_filter: list[str] | None = Field(default=None, max_length=MAX_DISTRIBUTORS)
     notify_user_ids: list[UUID] | None = None
     cooldown_seconds: int | None = Field(default=None, ge=60)
     enabled: bool | None = None
@@ -569,7 +571,7 @@ class PurchasePlanIn(BaseModel):
     ] = "preferred_first"
     country: str | None = Field(default=None, min_length=2, max_length=2)
     currency: str | None = Field(default=None, min_length=3, max_length=3)
-    distributors: list[str] | None = None
+    distributors: list[str] | None = Field(default=None, max_length=MAX_DISTRIBUTORS)
     max_distributors: int | None = Field(default=None, ge=1)
     moq_overbuy_cap: int | None = Field(default=None, ge=1)
     price_tolerance_pct: Decimal = Field(default=Decimal("5"), ge=0)

--- a/backend/tests/test_purchase_plan_convert_route.py
+++ b/backend/tests/test_purchase_plan_convert_route.py
@@ -87,6 +87,21 @@ def _create_refreshed_plan(
     return _refresh(client, plan_response.json()["data"]["id"])
 
 
+def test_convert_orders_rate_limit_after_10_per_minute(authed_client):
+    _ratelimit_mod.limiter.enabled = True
+    missing_plan_id = uuid.uuid4()
+
+    for _index in range(10):
+        r = _convert(authed_client, str(missing_plan_id))
+        assert r.status_code == 404, r.text
+
+    r = _convert(authed_client, str(missing_plan_id))
+
+    assert r.status_code == 429, r.text
+    assert r.json()["status"]["category"] == "rate_limited"
+    assert r.json()["code"] == "rate_limited"
+
+
 def test_basic_conversion_creates_one_order_per_distributor(authed_client):
     plan = _create_refreshed_plan(
         authed_client,

--- a/backend/tests/test_sourcing_part_route.py
+++ b/backend/tests/test_sourcing_part_route.py
@@ -345,6 +345,24 @@ def test_budget_blocked_returns_503(authed_client):
     }
 
 
+def test_distributors_query_param_capped_at_25(authed_client):
+    _configure_sourcing(authed_client)
+    part_id = create_part(authed_client, name="BAT54", mpn="BAT54C")
+
+    r = authed_client.get(
+        f"/api/parts/{part_id}/sourcing",
+        params={"distributors": ",".join(f"D{index}" for index in range(26))},
+    )
+
+    assert r.status_code == 422, r.text
+    assert r.json()["code"] == "sourcing.too_many_distributors"
+    assert r.json()["status"] == {
+        "category": "validation_error",
+        "message": "distributors list capped at 25",
+    }
+    assert _FakeTrustedPartsClient.calls == []
+
+
 def test_rate_limit_after_60_per_minute(authed_client):
     _ratelimit_mod.limiter.enabled = True
     _configure_sourcing(authed_client)

--- a/backend/tests/test_sourcing_search_route.py
+++ b/backend/tests/test_sourcing_search_route.py
@@ -174,6 +174,22 @@ def test_too_few_or_too_many_mpns_422(authed_client):
     assert r.json()["status"]["category"] == "validation_error"
 
 
+def test_distributors_body_field_capped_at_25(authed_client):
+    r = authed_client.post(
+        "/api/sourcing/search",
+        json={
+            "mpns": ["BAT54C"],
+            "distributors": [f"D{index}" for index in range(26)],
+        },
+    )
+
+    assert r.status_code == 422, r.text
+    body = r.json()
+    assert body["status"]["category"] == "validation_error"
+    assert body["errors"][0]["field"] == "body.distributors"
+    assert _FakeTrustedPartsClient.calls == []
+
+
 def test_short_search_token_returns_422_without_provider_call(authed_client):
     _configure_sourcing(authed_client)
 

--- a/docs/api/sourcing.md
+++ b/docs/api/sourcing.md
@@ -33,6 +33,7 @@ envelope. SlowAPI 429 responses add `code: "rate_limited"`.
 | `sourcing.part_missing_mpn` | 422 | Part sourcing refresh was requested for a part without an MPN. |
 | `sourcing.override_invalid` | 422 | Purchase-plan conversion override does not match cached offers. |
 | `sourcing.currency_mismatch` | 422 | A distributor group would mix selected currencies. |
+| `sourcing.too_many_distributors` | 422 | A distributor filter contained more than 25 values. |
 | `rate_limited` | 429 | Local workspace rate limit was exceeded. |
 | `sourcing.budget_exhausted` | 503 | Local TrustedParts parts-count budget blocked live calls. |
 | `sourcing.provider_auth_failed` | 502 | TrustedParts rejected sourcing credentials. |
@@ -105,7 +106,7 @@ Create a workspace-scoped alert definition.
 | `threshold` | `object` | Yes | Validated per `alert_type` at request parsing; no nested `kind` field is required. |
 | `country_code` | `string` | No | Two-letter sourcing filter for `back_in_stock`, `out_of_authorized_stock`, and `price_changed`. Ignored for stock threshold alerts. |
 | `currency_code` | `string` | No | Three-letter sourcing filter for `price_changed`. Ignored for stock threshold alerts. |
-| `distributor_filter` | `string[]` | No | Sourcing filter for authorized-stock and price alerts. Ignored for stock threshold alerts. |
+| `distributor_filter` | `string[]` | No | Max 25 values; sourcing filter for authorized-stock and price alerts. Ignored for stock threshold alerts. |
 | `notify_user_ids` | `uuid[]` | No | `null` means default recipients. Non-null values must be active members of the workspace. |
 | `cooldown_seconds` | `integer` | No | Defaults to `86400`; minimum `60`. |
 | `enabled` | `boolean` | No | Defaults to `true`. |
@@ -233,7 +234,7 @@ Path: `project_id` is a project UUID in the current workspace.
 | `build_quantity` | `integer` | Yes | Must be at least `1`. |
 | `country` | `string` | No | Two-letter override; falls back to workspace sourcing default. |
 | `currency` | `string` | No | Three-letter override; falls back to workspace sourcing default. |
-| `distributors` | `string[]` | No | Falls back to `sourcing_preferred_distributors` when omitted. |
+| `distributors` | `string[]` | No | Max 25 values; falls back to `sourcing_preferred_distributors` when omitted. |
 | `in_stock_only` | `boolean` | No | Defaults to `false`. |
 | `use_cached_data` | `boolean` | No | Falls back to `sourcing_use_cached_for_dashboards`; forced true when the request is in degraded budget mode. |
 
@@ -384,7 +385,7 @@ Path: `project_id` is a project UUID in the current workspace.
 | `strategy` | `string` | No | One of `lowest_total_price`, `fewest_distributors`, `fastest_availability`, `preferred_first`; defaults to `preferred_first`. |
 | `country` | `string` | No | Two-letter override; persisted on the plan. |
 | `currency` | `string` | No | Three-letter override; persisted on the plan. |
-| `distributors` | `string[]` | No | Distributor filter / preferred order for optimizer decisions. |
+| `distributors` | `string[]` | No | Max 25 values; distributor filter / preferred order for optimizer decisions. |
 | `max_distributors` | `integer` | No | Positive cap used by `fewest_distributors`. |
 | `moq_overbuy_cap` | `integer` | No | Positive cap; offers requiring more than `shortage * cap` are ignored. |
 | `price_tolerance_pct` | `decimal` | No | Preferred-first tolerance; defaults to `5`. |
@@ -549,10 +550,12 @@ Path: `plan_id` is a purchase plan UUID in the current workspace. No request bod
 - `404 Not Found` — `plan_id` is missing or belongs to another workspace.
 - `409 Conflict` — the plan has not been refreshed or its refresh is older than 10 minutes.
 - `422 Unprocessable Entity` — one distributor group contains mixed currencies.
+- `429 Too Many Requests` — workspace rate limit: 10 conversions/minute.
 
 **Notes**
 
 - The route creates one `Order(status="draft")` per selected distributor and one `OrderEntry` per selected plan line.
+- The route is rate-limited per workspace at 10 conversions/minute. Production keeps the single-worker rate-limit invariant unchanged.
 - Conversion flips the plan to `converted` in the same transaction.
 - Permanent order comments are compliance-safe summaries. The raw `selected_url` from ephemeral plan lines is never copied into `orders.comments` or `order_entries.comments`.
 
@@ -569,7 +572,7 @@ Path: `part_id` is a part UUID in the current workspace.
 | `country` | `string` | No | Two-letter override; falls back to workspace sourcing default. |
 | `currency` | `string` | No | Three-letter override; falls back to workspace sourcing default. |
 | `in_stock_only` | `boolean` | No | Defaults to `false`. |
-| `distributors` | `string[]` | No | Repeatable query param; comma-separated values are also accepted. Falls back to `sourcing_preferred_distributors` when omitted. |
+| `distributors` | `string[]` | No | Max 25 values after comma-splitting; repeatable query param; comma-separated values are also accepted. Falls back to `sourcing_preferred_distributors` when omitted. |
 
 **Response** — `200 OK` (envelope: `{ data, status }`)
 
@@ -725,7 +728,7 @@ Search TrustedParts for 1-50 exact MPNs using the current workspace's encrypted 
 | `country` | `string` | No | Two-letter override; falls back to workspace sourcing default. |
 | `currency` | `string` | No | Three-letter override; falls back to workspace sourcing default. |
 | `in_stock_only` | `boolean` | No | Defaults to `false`. |
-| `distributors` | `string[]` | No | Falls back to `sourcing_preferred_distributors` when omitted. |
+| `distributors` | `string[]` | No | Max 25 values; falls back to `sourcing_preferred_distributors` when omitted. |
 | `use_cached_data` | `boolean` | No | Falls back to `sourcing_use_cached_for_dashboards`; forced true when the request is in degraded budget mode. |
 
 **Response** — `200 OK` (envelope: `{ data, status }`)


### PR DESCRIPTION
## Summary
- Add a workspace-keyed `10/minute` SlowAPI limit to `POST /api/sourcing/purchase-plans/{plan_id}/orders`.
- Cap sourcing distributor provider-name inputs at 25 values across body schemas and the part sourcing query parser.
- Return stable `sourcing.too_many_distributors` for oversized query distributor filters and document the limit.

## Validation
- `uv run --extra dev pytest tests/test_purchase_plan_convert_route.py tests/test_sourcing_part_route.py tests/test_sourcing_search_route.py -q` -> 41 passed, 4 warnings
- `uv run --extra dev pytest tests/test_purchase_plan_convert_route.py::test_convert_orders_rate_limit_after_10_per_minute tests/test_sourcing_part_route.py::test_distributors_query_param_capped_at_25 tests/test_sourcing_search_route.py::test_distributors_body_field_capped_at_25 -q` -> 3 passed, 2 warnings
- `uv run --extra dev ruff check app/api/routes/sourcing.py app/domain/sourcing/schemas.py app/core/errors.py tests/test_purchase_plan_convert_route.py tests/test_sourcing_part_route.py tests/test_sourcing_search_route.py` -> passed
- `LINT_CMD="uv run --extra dev ruff check app --output-format=concise" BASELINE_FILE="../.ruff-baseline.txt" WORK_DIR="." bash ../scripts/lint-delta.sh` -> no new violations
- `git diff --check` -> passed

## Notes
- Production `--workers 1` is unchanged.
- `docker compose -f docker-compose.dev.yml exec backend pytest -k "sourcing"` and the compose ruff command could not run locally because `docker` is not installed in this workspace.
- A local `pytest -k "sourcing"` run outside Docker reached 360+ passing tests but was blocked by existing test database schema reset drift (`users` table / `workspaces.sourcing_provider` missing). The touched test files pass cleanly.

## Merge Order
- Merge after PR #526 (already merged).
- Merge before #504 because #504 is expected to touch the same sourcing route/schema/docs surface.
- PRs #528 and #529 mostly conflict only in `CHANGELOG.md`; rebase whichever lands later.

Refs #505
