### PR TITLE
chore: bump urllib3 to 2.7.0 for pip-audit

### DIFF
--- a/backend/requirements.lock
+++ b/backend/requirements.lock
@@ -604,9 +604,9 @@ tzdata==2026.2 ; sys_platform == 'win32' \
     --hash=sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10 \
     --hash=sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7
     # via psycopg
-urllib3==2.6.3 \
-    --hash=sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed \
-    --hash=sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4
+urllib3==2.7.0 \
+    --hash=sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c \
+    --hash=sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897
     # via sentry-sdk
 uvicorn==0.46.0 \
     --hash=sha256:bbebbcbed972d162afca128605223022bedd345b7bc7855ce66deb31487a9048 \

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1317,11 +1317,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bump locked `urllib3` from 2.6.3 to 2.7.0 in `backend/uv.lock` and `backend/requirements.lock`.
- Fix the shared `pip-audit` failure currently blocking PRs #528, #529, and #530: CVE-2026-44431 / CVE-2026-44432.

## Validation
- `uv lock --upgrade-package urllib3` -> updated urllib3 v2.6.3 to v2.7.0
- `uv export --format requirements-txt --hashes --no-dev --no-emit-project -o requirements.lock` -> regenerated hashed flat lock
- `uv lock --check` -> passed
- `uv export --format requirements-txt --hashes --no-dev --no-emit-project -o /tmp/requirements_fresh.lock && diff -u <(grep -v '^#' requirements.lock) <(grep -v '^#' /tmp/requirements_fresh.lock)` -> no diff
- `uvx pip-audit --requirement requirements.lock --skip-editable` -> No known vulnerabilities found

## Merge Order
- Merge before PRs #528, #529, and #530, then rebase those branches so their `pip-audit` checks pick up `urllib3==2.7.0`.
