### PR TITLE
SA-12: GET /sourcing/alerts pagination — {items, total} + limit/offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ the canonical record.
 
 ## 2026-05 — feedback brief fixes
 
+- **SA-12 / #504** Sourcing alerts now return `{ items, total, limit, offset }`
+  with 50-row default pagination and frontend next/previous controls.
 - **SA-17 / #509** Production cron sidecar jobs now have a 600-second
   per-run timeout that logs exit 124 on timeout while preserving cadence.
 - **SA-15 / #507** TrustedParts, Mouser, and DigiKey outbound calls now share

--- a/backend/app/api/routes/sourcing.py
+++ b/backend/app/api/routes/sourcing.py
@@ -32,6 +32,7 @@ from app.domain.sourcing.schemas import (
     PurchasePlanIn,
     PurchasePlanOrdersIn,
     SourcingAlertIn,
+    SourcingAlertListOut,
     SourcingAlertOut,
     SourcingAlertPatch,
     SourcingAlertType,
@@ -167,11 +168,11 @@ def list_sourcing_alerts(
     part_id: UUID | None = None,
     project_id: UUID | None = None,
     include_archived: bool = False,
-    limit: int = Query(100, ge=1, le=500),
+    limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
     db: Session = Depends(get_db),
 ):
-    alerts = sourcing_service.list_alerts(
+    alerts, total = sourcing_service.list_alerts_page(
         db,
         workspace=ws,
         enabled=enabled,
@@ -182,7 +183,13 @@ def list_sourcing_alerts(
         limit=limit,
         offset=offset,
     )
-    return ok([_alert_payload(alert) for alert in alerts])
+    payload = SourcingAlertListOut(
+        items=[SourcingAlertOut.model_validate(alert) for alert in alerts],
+        total=total,
+        limit=limit,
+        offset=offset,
+    )
+    return ok(payload.model_dump(mode="json"))
 
 
 @search_router.post(

--- a/backend/app/domain/sourcing/schemas.py
+++ b/backend/app/domain/sourcing/schemas.py
@@ -429,6 +429,15 @@ class SourcingAlertOut(BaseModel):
     updated_at: datetime
 
 
+class SourcingAlertListOut(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    items: list[SourcingAlertOut]
+    total: int
+    limit: int
+    offset: int
+
+
 class SourcingBomOfferOut(BaseModel):
     model_config = ConfigDict(extra="forbid")
 

--- a/backend/app/domain/sourcing/service.py
+++ b/backend/app/domain/sourcing/service.py
@@ -11,7 +11,7 @@ from typing import Any
 from uuid import UUID
 
 from pydantic import ValidationError
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from app.api._helpers import assert_in_workspace
@@ -135,7 +135,7 @@ def create_alert(
     return alert
 
 
-def list_alerts(
+def _alerts_query(
     db: Session,
     *,
     workspace: Any,
@@ -144,9 +144,7 @@ def list_alerts(
     part_id: UUID | None = None,
     project_id: UUID | None = None,
     include_archived: bool = False,
-    limit: int = 100,
-    offset: int = 0,
-) -> list[SourcingAlert]:
+):
     if part_id is not None:
         assert_in_workspace(db, Part, part_id, workspace.id, label="part")
     if project_id is not None:
@@ -163,9 +161,60 @@ def list_alerts(
         stmt = stmt.where(SourcingAlert.part_id == part_id)
     if project_id is not None:
         stmt = stmt.where(SourcingAlert.project_id == project_id)
+    return stmt
+
+
+def list_alerts_page(
+    db: Session,
+    *,
+    workspace: Any,
+    enabled: bool | None = None,
+    alert_type: str | None = None,
+    part_id: UUID | None = None,
+    project_id: UUID | None = None,
+    include_archived: bool = False,
+    limit: int = 50,
+    offset: int = 0,
+) -> tuple[list[SourcingAlert], int]:
+    stmt = _alerts_query(
+        db,
+        workspace=workspace,
+        enabled=enabled,
+        alert_type=alert_type,
+        part_id=part_id,
+        project_id=project_id,
+        include_archived=include_archived,
+    )
+    total = db.execute(select(func.count()).select_from(stmt.subquery())).scalar_one()
     stmt = stmt.order_by(SourcingAlert.created_at.desc(), SourcingAlert.id)
     stmt = stmt.limit(limit).offset(offset)
-    return list(db.execute(stmt).scalars())
+    return list(db.execute(stmt).scalars()), total
+
+
+def list_alerts(
+    db: Session,
+    *,
+    workspace: Any,
+    enabled: bool | None = None,
+    alert_type: str | None = None,
+    part_id: UUID | None = None,
+    project_id: UUID | None = None,
+    include_archived: bool = False,
+    limit: int = 50,
+    offset: int = 0,
+) -> list[SourcingAlert]:
+    alerts, _total = list_alerts_page(
+        db,
+        workspace=workspace,
+        enabled=enabled,
+        alert_type=alert_type,
+        part_id=part_id,
+        project_id=project_id,
+        include_archived=include_archived,
+        limit=limit,
+        offset=offset,
+    )
+    return alerts
 
 
 def get_alert(

--- a/backend/tests/test_sourcing_alerts_route.py
+++ b/backend/tests/test_sourcing_alerts_route.py
@@ -68,6 +68,16 @@ def _create_project_alert(
     return r.json()["data"]
 
 
+def _list_alerts(client: TestClient, query: str = "") -> dict:
+    r = client.get(f"/api/sourcing/alerts{query}")
+    assert r.status_code == 200, r.text
+    return r.json()["data"]
+
+
+def _list_alert_items(client: TestClient, query: str = "") -> list[dict]:
+    return _list_alerts(client, query)["items"]
+
+
 def _single_line_project(client: TestClient, *, name: str = "Alerts BOM") -> tuple[str, str]:
     part_id = create_part(client, name=f"{name} part", mpn=f"ALERT-{uuid.uuid4().hex[:6]}")
     project_id = create_project_with_bom(
@@ -355,23 +365,19 @@ def test_list_filters(authed_client):
     )
     authed_client.delete(f"/api/sourcing/alerts/{archived_alert['id']}")
 
-    disabled = authed_client.get("/api/sourcing/alerts?enabled=false").json()["data"]
+    disabled = _list_alert_items(authed_client, "?enabled=false")
     assert {alert["id"] for alert in disabled} == {disabled_alert["id"]}
 
-    stock_above = authed_client.get("/api/sourcing/alerts?alert_type=stock_above").json()["data"]
+    stock_above = _list_alert_items(authed_client, "?alert_type=stock_above")
     assert {alert["id"] for alert in stock_above} == {disabled_alert["id"]}
 
-    part_filtered = authed_client.get(f"/api/sourcing/alerts?part_id={part_b}").json()["data"]
+    part_filtered = _list_alert_items(authed_client, f"?part_id={part_b}")
     assert {alert["id"] for alert in part_filtered} == {part_b_alert["id"]}
 
-    project_filtered = authed_client.get(
-        f"/api/sourcing/alerts?project_id={project_a}"
-    ).json()["data"]
+    project_filtered = _list_alert_items(authed_client, f"?project_id={project_a}")
     assert {alert["id"] for alert in project_filtered} == {project_a_alert["id"]}
 
-    include_archived = authed_client.get(
-        "/api/sourcing/alerts?include_archived=true"
-    ).json()["data"]
+    include_archived = _list_alert_items(authed_client, "?include_archived=true")
     assert archived_alert["id"] in {alert["id"] for alert in include_archived}
     assert enabled_alert["id"] in {alert["id"] for alert in include_archived}
     assert project_b_alert["id"] in {alert["id"] for alert in include_archived}
@@ -408,7 +414,7 @@ def test_archived_excluded_from_default_list(authed_client):
     alert = _create_stock_alert(authed_client, part_id)
     authed_client.delete(f"/api/sourcing/alerts/{alert['id']}")
 
-    data = authed_client.get("/api/sourcing/alerts").json()["data"]
+    data = _list_alert_items(authed_client)
 
     assert alert["id"] not in {item["id"] for item in data}
 
@@ -449,20 +455,58 @@ def test_delete_archived_returns_404(authed_client):
     assert r.json()["status"]["category"] == "not_found"
 
 
-def test_list_alerts_paginates(authed_client):
+def test_list_alerts_default_returns_first_50_with_total(authed_client):
+    part_id = create_part(authed_client, name="Default paged alert target")
+    alerts = [
+        _create_stock_alert(authed_client, part_id, threshold={"qty": qty})
+        for qty in range(55)
+    ]
+
+    data = _list_alerts(authed_client)
+
+    assert data["total"] == 55
+    assert data["limit"] == 50
+    assert data["offset"] == 0
+    assert len(data["items"]) == 50
+    assert {item["id"] for item in data["items"]}.issubset({alert["id"] for alert in alerts})
+
+
+def test_list_alerts_offset_pagination_works(authed_client):
     part_id = create_part(authed_client, name="Paged alert target")
     alerts = [
         _create_stock_alert(authed_client, part_id, threshold={"qty": qty})
         for qty in range(3)
     ]
 
-    first = authed_client.get("/api/sourcing/alerts?limit=1").json()["data"]
-    second = authed_client.get("/api/sourcing/alerts?limit=1&offset=1").json()["data"]
+    first = _list_alerts(authed_client, "?limit=1")
+    second = _list_alerts(authed_client, "?limit=1&offset=1")
 
-    assert len(first) == 1
-    assert len(second) == 1
-    assert first[0]["id"] != second[0]["id"]
-    assert {first[0]["id"], second[0]["id"]}.issubset({alert["id"] for alert in alerts})
+    assert first["total"] == 3
+    assert first["limit"] == 1
+    assert first["offset"] == 0
+    assert second["total"] == 3
+    assert second["limit"] == 1
+    assert second["offset"] == 1
+    assert len(first["items"]) == 1
+    assert len(second["items"]) == 1
+    assert first["items"][0]["id"] != second["items"][0]["id"]
+    assert {first["items"][0]["id"], second["items"][0]["id"]}.issubset(
+        {alert["id"] for alert in alerts}
+    )
+
+
+def test_list_alerts_limit_max_200(authed_client):
+    part_id = create_part(authed_client, name="Max paged alert target")
+    for qty in range(205):
+        _create_stock_alert(authed_client, part_id, threshold={"qty": qty})
+
+    data = _list_alerts(authed_client, "?limit=200")
+    over_limit = authed_client.get("/api/sourcing/alerts?limit=201")
+
+    assert data["total"] == 205
+    assert data["limit"] == 200
+    assert len(data["items"]) == 200
+    assert over_limit.status_code == 422
 
 
 def test_rate_limit_30_per_minute(authed_client, limiter_enabled):
@@ -491,7 +535,7 @@ def test_workspace_isolation_two_workspaces_same_part_alerts():
     alert_a = _create_stock_alert(client_a, part_a, threshold={"qty": 3})
     alert_b = _create_stock_alert(client_b, part_b, threshold={"qty": 3})
 
-    data_b = client_b.get("/api/sourcing/alerts").json()["data"]
+    data_b = _list_alert_items(client_b)
 
     assert alert_b["id"] in {alert["id"] for alert in data_b}
     assert alert_a["id"] not in {alert["id"] for alert in data_b}

--- a/backend/tests/test_workspace_isolation.py
+++ b/backend/tests/test_workspace_isolation.py
@@ -640,7 +640,7 @@ def test_sourcing_alerts_isolated_by_workspace():
         },
     ).json()["data"]
 
-    listed_b = b.get("/api/sourcing/alerts").json()["data"]
+    listed_b = b.get("/api/sourcing/alerts").json()["data"]["items"]
 
     assert alert_b["id"] in {alert["id"] for alert in listed_b}
     assert alert_a["id"] not in {alert["id"] for alert in listed_b}

--- a/docs/api/sourcing.md
+++ b/docs/api/sourcing.md
@@ -56,24 +56,29 @@ List current workspace sourcing alerts.
 | `part_id` | `uuid` | No | Filters part-scoped alerts. |
 | `project_id` | `uuid` | No | Filters project-scoped alerts. |
 | `include_archived` | `boolean` | No | Defaults to `false`; archived rows are soft-deleted alerts. |
-| `limit` | `integer` | No | Defaults to `100`; min `1`, max `500`. |
+| `limit` | `integer` | No | Defaults to `50`; min `1`, max `200`. |
 | `offset` | `integer` | No | Defaults to `0`; deterministic order is newest first. |
 
 **Response** — `200 OK` (envelope: `{ data, status }`)
 
 ```json
 {
-  "data": [
-    {
-      "id": "9b7f7d43-6b5c-4f7d-bc0e-44c6d73f0992",
-      "alert_type": "stock_below",
-      "part_id": "012f2f63-3b2c-45c4-a841-682ec681f508",
-      "project_id": null,
-      "threshold": { "qty": 10 },
-      "enabled": true,
-      "archived_at": null
-    }
-  ],
+  "data": {
+    "items": [
+      {
+        "id": "9b7f7d43-6b5c-4f7d-bc0e-44c6d73f0992",
+        "alert_type": "stock_below",
+        "part_id": "012f2f63-3b2c-45c4-a841-682ec681f508",
+        "project_id": null,
+        "threshold": { "qty": 10 },
+        "enabled": true,
+        "archived_at": null
+      }
+    ],
+    "total": 42,
+    "limit": 50,
+    "offset": 0
+  },
   "status": { "category": "ok", "message": "OK" }
 }
 ```
@@ -81,9 +86,10 @@ List current workspace sourcing alerts.
 **Notes**
 
 - The service filters every query by `workspace_id`; archived rows are excluded unless requested.
+- `total` is counted after filters and before `limit`/`offset`.
 - `include_archived=true` is list-only. GET-by-id, PATCH, and DELETE treat archived rows as not found.
-- Source: `backend/app/api/routes/sourcing.py:156-178`.
-- Service: `backend/app/domain/sourcing/service.py:145-172`.
+- Source: `backend/app/api/routes/sourcing.py:156-193`.
+- Service: `backend/app/domain/sourcing/service.py:138-195`.
 
 ### `POST /api/sourcing/alerts`
 
@@ -120,7 +126,7 @@ Create a workspace-scoped alert definition.
 
 **Response** — `200 OK` (envelope: `{ data, status }`)
 
-Shape matches one item from `GET /api/sourcing/alerts`.
+Shape matches one item from `GET /api/sourcing/alerts` `data.items`.
 
 **Errors**
 
@@ -160,7 +166,7 @@ Path: `alert_id` is a sourcing alert UUID in the current workspace.
 
 **Response** — `200 OK` (envelope: `{ data, status }`)
 
-Shape matches one item from `GET /api/sourcing/alerts`.
+Shape matches one item from `GET /api/sourcing/alerts` `data.items`.
 
 **Errors**
 
@@ -181,7 +187,7 @@ Path: `alert_id` is a sourcing alert UUID in the current workspace. Body accepts
 
 **Response** — `200 OK` (envelope: `{ data, status }`)
 
-Shape matches one item from `GET /api/sourcing/alerts`.
+Shape matches one item from `GET /api/sourcing/alerts` `data.items`.
 
 **Errors**
 

--- a/web/src/lib/sourcingAlerts.ts
+++ b/web/src/lib/sourcingAlerts.ts
@@ -63,6 +63,18 @@ export type SourcingAlertFilters = {
   project_id?: string | null;
 };
 
+export type SourcingAlertListOut = {
+  items: SourcingAlert[];
+  total: number;
+  limit: number;
+  offset: number;
+};
+
+export type SourcingAlertPagination = {
+  limit?: number;
+  offset?: number;
+};
+
 export type WorkspaceSourcingSettings = {
   sourcing_country_code?: string | null;
   sourcing_currency_code?: string | null;
@@ -117,7 +129,11 @@ export function isSourcingFilteredAlert(type: SourcingAlertType): boolean {
     || type === "tariff_status_changed";
 }
 
-export function listSourcingAlerts(filters: SourcingAlertFilters = {}, opts?: ApiOptions) {
+export function listSourcingAlerts(
+  filters: SourcingAlertFilters = {},
+  pagination: SourcingAlertPagination = {},
+  opts?: ApiOptions,
+) {
   const params = new URLSearchParams();
   if (filters.alert_type) params.set("alert_type", filters.alert_type);
   if (filters.enabled !== undefined && filters.enabled !== null) {
@@ -126,8 +142,10 @@ export function listSourcingAlerts(filters: SourcingAlertFilters = {}, opts?: Ap
   if (filters.include_archived) params.set("include_archived", "true");
   if (filters.part_id) params.set("part_id", filters.part_id);
   if (filters.project_id) params.set("project_id", filters.project_id);
+  params.set("limit", String(pagination.limit ?? 50));
+  params.set("offset", String(pagination.offset ?? 0));
   const suffix = params.toString();
-  return api.get<SourcingAlert[]>(`/sourcing/alerts${suffix ? `?${suffix}` : ""}`, opts);
+  return api.get<SourcingAlertListOut>(`/sourcing/alerts${suffix ? `?${suffix}` : ""}`, opts);
 }
 
 export function createSourcingAlert(payload: SourcingAlertInput) {

--- a/web/src/routes/sourcing/alerts/AlertsPage.tsx
+++ b/web/src/routes/sourcing/alerts/AlertsPage.tsx
@@ -23,6 +23,7 @@ import type { Part, Project } from "@/types";
 import AlertFormModal from "./AlertFormModal";
 
 type EnabledFilter = "all" | "enabled" | "disabled";
+const PAGE_SIZE = 50;
 
 function formatThreshold(alert: SourcingAlert): string {
   switch (alert.alert_type) {
@@ -63,15 +64,16 @@ export default function AlertsPage() {
   const [includeArchived, setIncludeArchived] = useState(false);
   const [formAlert, setFormAlert] = useState<SourcingAlert | null>(null);
   const [formOpen, setFormOpen] = useState(false);
+  const [offset, setOffset] = useState(0);
 
   const enabled = enabledFilter === "all" ? null : enabledFilter === "enabled";
   const query = useQuery({
-    queryKey: useWsKey("sourcing-alerts", typeFilter, enabledFilter, includeArchived),
+    queryKey: useWsKey("sourcing-alerts", typeFilter, enabledFilter, includeArchived, PAGE_SIZE, offset),
     queryFn: ({ signal }) => listSourcingAlerts({
       alert_type: typeFilter,
       enabled,
       include_archived: includeArchived,
-    }, { signal }),
+    }, { limit: PAGE_SIZE, offset }, { signal }),
   });
   const partsQuery = useQuery({
     queryKey: useWsKey("parts", "alert-scope-map"),
@@ -83,7 +85,12 @@ export default function AlertsPage() {
   });
   const partMap = useMemo(() => mapById(partsQuery.data), [partsQuery.data]);
   const projectMap = useMemo(() => mapById(projectsQuery.data), [projectsQuery.data]);
-  const rows = query.data ?? [];
+  const rows = query.data?.items ?? [];
+  const total = query.data?.total ?? 0;
+  const showingStart = total === 0 ? 0 : offset + 1;
+  const showingEnd = Math.min(offset + rows.length, total);
+  const canGoPrevious = offset > 0;
+  const canGoNext = offset + PAGE_SIZE < total;
 
   const archiveMutation = useApiMutation<SourcingAlert, SourcingAlert>({
     mutationKey: wsKeyOf(workspaceId, "sourcing-alerts", "archive"),
@@ -200,7 +207,14 @@ export default function AlertsPage() {
         <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
           <label className="label">
             Alert type
-            <select className="input" value={typeFilter} onChange={event => setTypeFilter(event.currentTarget.value as SourcingAlertType | "")}>
+            <select
+              className="input"
+              value={typeFilter}
+              onChange={event => {
+                setTypeFilter(event.currentTarget.value as SourcingAlertType | "");
+                setOffset(0);
+              }}
+            >
               <option value="">All types</option>
               <option value="stock_below">Stock below</option>
               <option value="stock_above">Stock above</option>
@@ -212,7 +226,14 @@ export default function AlertsPage() {
           </label>
           <label className="label">
             Enabled
-            <select className="input" value={enabledFilter} onChange={event => setEnabledFilter(event.currentTarget.value as EnabledFilter)}>
+            <select
+              className="input"
+              value={enabledFilter}
+              onChange={event => {
+                setEnabledFilter(event.currentTarget.value as EnabledFilter);
+                setOffset(0);
+              }}
+            >
               <option value="all">All</option>
               <option value="enabled">Enabled only</option>
               <option value="disabled">Disabled only</option>
@@ -222,7 +243,10 @@ export default function AlertsPage() {
             <input
               type="checkbox"
               checked={includeArchived}
-              onChange={event => setIncludeArchived(event.currentTarget.checked)}
+              onChange={event => {
+                setIncludeArchived(event.currentTarget.checked);
+                setOffset(0);
+              }}
             />
             Include archived
           </label>
@@ -239,6 +263,30 @@ export default function AlertsPage() {
         exportFilename="sourcing-alerts"
         empty={query.isLoading ? "Loading alerts..." : "No sourcing alerts."}
       />
+
+      <div className="flex flex-wrap items-center justify-between gap-2 text-sm text-muted">
+        <span>
+          Showing {showingStart}-{showingEnd} of {total}
+        </span>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            className="btn btn-sm"
+            disabled={!canGoPrevious || query.isFetching}
+            onClick={() => setOffset(value => Math.max(0, value - PAGE_SIZE))}
+          >
+            Prev
+          </button>
+          <button
+            type="button"
+            className="btn btn-sm"
+            disabled={!canGoNext || query.isFetching}
+            onClick={() => setOffset(value => value + PAGE_SIZE)}
+          >
+            Next
+          </button>
+        </div>
+      </div>
 
       <AlertFormModal
         open={formOpen}

--- a/web/src/routes/sourcing/alerts/__tests__/SourcingAlertsPage.test.tsx
+++ b/web/src/routes/sourcing/alerts/__tests__/SourcingAlertsPage.test.tsx
@@ -93,24 +93,37 @@ function mockReads() {
     if (String(path).startsWith("/projects?")) return projects() as never;
     if (String(path).startsWith("/sourcing/alerts")) {
       if (String(path).includes("alert_type=bom_buyable")) {
-        return [alert({
-          id: "alert-2",
-          alert_type: "bom_buyable",
-          part_id: null,
-          project_id: projectId,
-          threshold: { build_quantity: 5 },
-        })] as never;
+        return {
+          items: [alert({
+            id: "alert-2",
+            alert_type: "bom_buyable",
+            part_id: null,
+            project_id: projectId,
+            threshold: { build_quantity: 5 },
+          })],
+          total: 1,
+          limit: 50,
+          offset: 0,
+        } as never;
       }
-      return [
-        alert(),
-        alert({
-          id: "alert-2",
-          alert_type: "bom_buyable",
-          part_id: null,
-          project_id: projectId,
-          threshold: { build_quantity: 5 },
-        }),
-      ] as never;
+      const offset = String(path).includes("offset=50") ? 50 : 0;
+      return {
+        items: offset === 50
+          ? [alert({ id: "alert-51", threshold: { qty: 51 } })]
+          : [
+            alert(),
+            alert({
+              id: "alert-2",
+              alert_type: "bom_buyable",
+              part_id: null,
+              project_id: projectId,
+              threshold: { build_quantity: 5 },
+            }),
+          ],
+        total: 51,
+        limit: 50,
+        offset,
+      } as never;
     }
     throw new Error(`unexpected GET ${path}`);
   });
@@ -149,6 +162,29 @@ describe("AlertsPage", () => {
     expect(screen.getByText("Below 10")).toBeDefined();
   });
 
+  it("test_renders_paginated_total_label", async () => {
+    mockReads();
+
+    renderPage();
+
+    expect(await screen.findByText("Showing 1-2 of 51")).toBeDefined();
+  });
+
+  it("test_next_page_fetches_offset_50", async () => {
+    const user = userEvent.setup();
+    mockReads();
+
+    renderPage();
+
+    await screen.findByText("Showing 1-2 of 51");
+    await user.click(screen.getByRole("button", { name: "Next" }));
+
+    await waitFor(() => {
+      expect(api.get).toHaveBeenCalledWith("/sourcing/alerts?limit=50&offset=50", expect.any(Object));
+    });
+    expect(await screen.findByText("Showing 51-51 of 51")).toBeDefined();
+  });
+
   it("filter by alert_type narrows visible rows", async () => {
     const user = userEvent.setup();
     mockReads();
@@ -159,7 +195,10 @@ describe("AlertsPage", () => {
     await user.selectOptions(screen.getByLabelText("Alert type"), "bom_buyable");
 
     await waitFor(() => {
-      expect(api.get).toHaveBeenCalledWith("/sourcing/alerts?alert_type=bom_buyable", expect.any(Object));
+      expect(api.get).toHaveBeenCalledWith(
+        "/sourcing/alerts?alert_type=bom_buyable&limit=50&offset=0",
+        expect.any(Object),
+      );
     });
     const table = screen.getByRole("table");
     expect(within(table).getByText("BOM buyable")).toBeDefined();


### PR DESCRIPTION
Refs #504

## Summary

- Changes `GET /api/sourcing/alerts` to return the existing API envelope with paginated `data: { items, total, limit, offset }`.
- Adds backend `SourcingAlertListOut`, counted workspace-scoped alert pagination, and route tests for default 50, offset pagination, and max 200 validation.
- Updates the Sourcing Alerts frontend fetcher/page to request `limit=50&offset=...`, render the total label, and provide Prev/Next controls.
- Updates sourcing API docs and changelog.

## Example response

```json
{
  "data": {
    "items": [
      {
        "id": "9b7f7d43-6b5c-4f7d-bc0e-44c6d73f0992",
        "alert_type": "stock_below",
        "part_id": "012f2f63-3b2c-45c4-a841-682ec681f508",
        "project_id": null,
        "threshold": { "qty": 10 },
        "enabled": true,
        "archived_at": null
      }
    ],
    "total": 42,
    "limit": 50,
    "offset": 0
  },
  "status": { "category": "ok", "message": "OK" }
}
```

## Validation

- `docker compose -f docker-compose.dev.yml exec backend pytest -k "alerts"` could not run in this environment: `docker: command not found`.
- `cd backend && uv run python -m pytest -q -k "alerts"`: passed, `83 passed, 1180 deselected, 11 warnings in 21.70s`.
- `cd backend && uv run python -m pytest -q tests/test_sourcing_alerts_route.py -k "test_list_alerts_default_returns_first_50_with_total or test_list_alerts_offset_pagination_works or test_list_alerts_limit_max_200"`: passed, `3 passed, 37 deselected, 2 warnings in 9.91s`.
- `cd backend && uv run ruff check app/api/routes/sourcing.py app/domain/sourcing/schemas.py app/domain/sourcing/service.py tests/test_sourcing_alerts_route.py tests/test_workspace_isolation.py`: passed.
- `cd web && npm run typecheck`: passed.
- `cd web && npm test -- "SourcingAlerts"`: passed, `1 passed (5 tests)`.
- `cd web && npx eslint src/lib/sourcingAlerts.ts src/routes/sourcing/alerts/AlertsPage.tsx src/routes/sourcing/alerts/__tests__/SourcingAlertsPage.test.tsx`: passed.
- `cd web && npm run lint`: failed on pre-existing unrelated findings in `src/lib/bagCode.ts`, `src/components/scanner/ZxingScanner.tsx`, `src/routes/__tests__/responsive-grids.test.ts`, `src/routes/orders/OrderDetail.tsx`, `src/routes/parts/PartsList.tsx`, `src/routes/parts/detail/__dom__/PartLayout.navigation.dom.test.tsx`, and `src/routes/storage/StorageDetail.tsx`.
- Guardrail grep for `inventory.qty`, `verify=False`, `trust_env=False`, and `ssl=False` under changed scope did not find introduced backend app violations; the only `inventory.qty` hit was existing stock README prose.

## Screenshots

Not captured here because the local Docker app stack is unavailable in this environment (`docker: command not found`). The frontend behavior is covered by `SourcingAlertsPage.test.tsx` for the total label and next-page offset fetch.

## Merge order

- #531 (`urllib3` pip-audit fix) should merge first, then this branch should rebase.
- #530 (#505 SA-13 route/schema caps) should merge before #504 if possible because both touch `backend/app/api/routes/sourcing.py`, `backend/app/domain/sourcing/schemas.py`, `docs/api/sourcing.md`, and `CHANGELOG.md`.
- #528/#529 mostly conflict only in CHANGELOG/docs; rebase whichever lands later.
