### PR TITLE
SA-MED: Sourcing backlog cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ the canonical record.
 
 ## 2026-05 — feedback brief fixes
 
+- **SA-MED / #512** Sourcing cleanup tightened service-layer workspace
+  guards, archived-project refresh filtering, raw Decimal wire prices, hashed
+  TrustedParts user-agent workspace identifiers, budget-counter locking, and
+  removed the deprecated `est_purchase_cost` sourcing capacity alias.
 - **SA-12 / #504** Sourcing alerts now return `{ items, total, limit, offset }`
   with 50-row default pagination and frontend next/previous controls.
 - **SA-13 / #505** Purchase-plan conversion is now capped at 10

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,7 @@
 3. Run `pytest` (backend) and `npm run build` (frontend) before marking the PR ready for review.
 4. Add screenshots for any visible UI changes.
 5. Link the issue: use `Closes #N` if this PR fully resolves it, or `Refs #N` if further work remains.
+6. Keep PRs narrowly scoped. If an umbrella/backlog issue requires bundling otherwise independent changes, state why in the PR body and list the merge-order or revert-risk notes reviewers need.
 
 ## Multi-step issues rule
 

--- a/backend/app/domain/reports/service.py
+++ b/backend/app/domain/reports/service.py
@@ -214,7 +214,7 @@ def bom_buyability_report(
                         if capacity.can_build_after_purchase < build_quantity
                         else 0
                     ),
-                    est_purchase_cost=capacity.est_purchase_cost,
+                    est_purchase_cost=capacity.purchase_to_pay_cost,
                     partial=sourced.partial,
                 )
             )

--- a/backend/app/domain/sourcing/budget.py
+++ b/backend/app/domain/sourcing/budget.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import time
 from dataclasses import dataclass
+from threading import Lock
 from typing import Callable, Literal
 from uuid import UUID
 
@@ -30,33 +31,44 @@ class BudgetTracker:
     def __init__(self, *, clock: Callable[[], float] | None = None) -> None:
         self._clock = clock or time.monotonic
         self._events: dict[tuple[UUID, int], list[tuple[float, int]]] = {}
+        self._lock = Lock()
 
     def record(self, workspace_id: UUID, parts_count: int) -> None:
         self._validate_parts_count(parts_count)
         now = self._clock()
-        for window_seconds in _WINDOWS:
-            self._events.setdefault((workspace_id, window_seconds), []).append((now, parts_count))
-        self._prune(workspace_id)
+        with self._lock:
+            for window_seconds in _WINDOWS:
+                self._events.setdefault((workspace_id, window_seconds), []).append(
+                    (now, parts_count)
+                )
+            self._prune(workspace_id)
 
     def check(self, workspace_id: UUID, parts_count: int) -> BudgetVerdict:
         self._validate_parts_count(parts_count)
-        self._prune(workspace_id)
+        with self._lock:
+            self._prune(workspace_id)
 
-        for window_seconds, limit in HARD_LIMITS:
-            if self._window_total(workspace_id, window_seconds) + parts_count > limit:
-                return BudgetVerdict(
-                    allow=False,
-                    mode="blocked",
-                    reason=f"hard limit exceeded for {self._window_label(window_seconds)} window",
-                )
+            for window_seconds, limit in HARD_LIMITS:
+                if self._window_total(workspace_id, window_seconds) + parts_count > limit:
+                    return BudgetVerdict(
+                        allow=False,
+                        mode="blocked",
+                        reason=(
+                            "hard limit exceeded for "
+                            f"{self._window_label(window_seconds)} window"
+                        ),
+                    )
 
-        for window_seconds, limit in SOFT_LIMITS:
-            if self._window_total(workspace_id, window_seconds) + parts_count > limit:
-                return BudgetVerdict(
-                    allow=True,
-                    mode="degraded",
-                    reason=f"soft limit exceeded for {self._window_label(window_seconds)} window",
-                )
+            for window_seconds, limit in SOFT_LIMITS:
+                if self._window_total(workspace_id, window_seconds) + parts_count > limit:
+                    return BudgetVerdict(
+                        allow=True,
+                        mode="degraded",
+                        reason=(
+                            "soft limit exceeded for "
+                            f"{self._window_label(window_seconds)} window"
+                        ),
+                    )
 
         return BudgetVerdict(
             allow=True,

--- a/backend/app/domain/sourcing/constants.py
+++ b/backend/app/domain/sourcing/constants.py
@@ -1,0 +1,4 @@
+"""Shared constants for TrustedParts sourcing computations."""
+
+INFINITE_LEAD_TIME_DAYS = 10**9
+

--- a/backend/app/domain/sourcing/coverage.py
+++ b/backend/app/domain/sourcing/coverage.py
@@ -8,6 +8,7 @@ from itertools import combinations
 from math import ceil
 from uuid import UUID
 
+from app.domain.sourcing.constants import INFINITE_LEAD_TIME_DAYS
 from app.domain.sourcing.optimizer import optimize
 from app.domain.sourcing.pricing import best_unit_price_at_qty
 from app.domain.sourcing.schemas import SourcingBomLineOut, SourcingBomOfferOut
@@ -561,7 +562,7 @@ def _best_offer_for_quantity(
         candidates,
         key=lambda offer: (
             _price_sort_value(_offer_unit_price(offer, quantity_for_offer(offer))),
-            offer.lead_time_days if offer.lead_time_days is not None else 10**9,
+            offer.lead_time_days if offer.lead_time_days is not None else INFINITE_LEAD_TIME_DAYS,
             offer.mpn.casefold(),
         ),
     )

--- a/backend/app/domain/sourcing/factory.py
+++ b/backend/app/domain/sourcing/factory.py
@@ -2,16 +2,21 @@
 
 from __future__ import annotations
 
-import hashlib
+import hmac
 from typing import Any
 
+from app.core.config import settings
 from app.core.secrets import decrypt
 from app.core.version import git_sha
 from app.domain.sourcing.client import TrustedPartsClient
 
 
 def _workspace_user_agent_fragment(workspace_id: Any) -> str:
-    digest = hashlib.sha256(str(workspace_id).encode("utf-8")).hexdigest()[:12]
+    digest = hmac.new(
+        settings().SESSION_SECRET.encode("utf-8"),
+        str(workspace_id).encode("utf-8"),
+        "sha256",
+    ).hexdigest()[:12]
     return f"workspace_sha={digest}"
 
 

--- a/backend/app/domain/sourcing/factory.py
+++ b/backend/app/domain/sourcing/factory.py
@@ -2,11 +2,17 @@
 
 from __future__ import annotations
 
+import hashlib
 from typing import Any
 
 from app.core.secrets import decrypt
 from app.core.version import git_sha
 from app.domain.sourcing.client import TrustedPartsClient
+
+
+def _workspace_user_agent_fragment(workspace_id: Any) -> str:
+    digest = hashlib.sha256(str(workspace_id).encode("utf-8")).hexdigest()[:12]
+    return f"workspace_sha={digest}"
 
 
 def make_sourcing_provider(workspace: Any) -> TrustedPartsClient | None:
@@ -24,5 +30,5 @@ def make_sourcing_provider(workspace: Any) -> TrustedPartsClient | None:
         country_code=workspace.sourcing_country_code,
         currency_code=workspace.sourcing_currency_code,
         language_code=workspace.sourcing_language_code,
-        user_agent=f"stockManager/{git_sha()} workspace={workspace.id}",
+        user_agent=f"stockManager/{git_sha()} {_workspace_user_agent_fragment(workspace.id)}",
     )

--- a/backend/app/domain/sourcing/optimizer.py
+++ b/backend/app/domain/sourcing/optimizer.py
@@ -7,6 +7,7 @@ from decimal import Decimal
 from typing import Literal
 from uuid import UUID
 
+from app.domain.sourcing.constants import INFINITE_LEAD_TIME_DAYS
 from app.domain.sourcing.pricing import best_unit_price_at_qty
 from app.domain.sourcing.schemas import SourcingBomLineOut, SourcingBomOfferOut
 
@@ -24,7 +25,6 @@ _VALID_STRATEGIES: set[str] = {
     "preferred_first",
 }
 _INFINITE_PRICE = Decimal("Infinity")
-_INFINITE_LEAD_TIME = 10**9
 
 
 @dataclass(frozen=True)
@@ -291,7 +291,7 @@ def _fastest_key(candidate: _Candidate) -> tuple[int, Decimal, tuple[str, str, s
     lead_time = (
         candidate.offer.lead_time_days
         if candidate.offer.lead_time_days is not None
-        else _INFINITE_LEAD_TIME
+        else INFINITE_LEAD_TIME_DAYS
     )
     return lead_time, candidate.unit_price, _candidate_alpha_key(candidate)
 

--- a/backend/app/domain/sourcing/schemas.py
+++ b/backend/app/domain/sourcing/schemas.py
@@ -17,6 +17,8 @@ from pydantic import (
     field_validator,
 )
 
+from app.domain.sourcing.constants import INFINITE_LEAD_TIME_DAYS
+
 MAX_DISTRIBUTORS = 25
 
 
@@ -464,7 +466,11 @@ class SourcingBomOfferOut(BaseModel):
     fx_rate_date: date | None = None
     packaging: str | None = None
     moq: int | None = None
-    lead_time_days: int | None = None
+    lead_time_days: int | None = Field(
+        default=None,
+        ge=0,
+        lt=INFINITE_LEAD_TIME_DAYS,
+    )
     price_breaks: list[SourcingBomPriceBreakOut] = Field(default_factory=list)
     price_breaks_converted: list[SourcingBomPriceBreakOut] | None = None
     url: str | None = None

--- a/backend/app/domain/sourcing/schemas.py
+++ b/backend/app/domain/sourcing/schemas.py
@@ -20,6 +20,15 @@ from pydantic import (
 MAX_DISTRIBUTORS = 25
 
 
+def _decimal_from_wire(value: Any) -> Decimal | None:
+    if value is None or isinstance(value, Decimal):
+        return value
+    return Decimal(str(value))
+
+
+WireDecimal = Annotated[Decimal, BeforeValidator(_decimal_from_wire)]
+
+
 class SourcingQuery(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -31,7 +40,7 @@ class SourcingPriceBreak(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     quantity: int
-    unit_price: float
+    unit_price: WireDecimal
     formatted_amount: str | None = None
     text: str | None = None
 
@@ -60,7 +69,7 @@ class SourcingDistributor(BaseModel):
     moq: int | None = None
     lead_time_days: int | None = None
     stock: int | None = None
-    unit_price: float | None = None
+    unit_price: WireDecimal | None = None
     currency: str | None = None
     unit_price_converted: Decimal | None = None
     currency_displayed: str | None = None
@@ -519,11 +528,6 @@ class BuildCapacityOut(BaseModel):
             "Sum of short quantity times best-offer unit price across priced "
             "lines that are not blocking after authorized supply."
         ),
-    )
-    est_purchase_cost: Decimal | None = Field(
-        default=None,
-        deprecated=True,
-        description="Deprecated alias for purchase_to_pay_cost; remove after SX-8.",
     )
     blocking_lines_now: list[UUID]
     blocking_lines_after_purchase: list[UUID]

--- a/backend/app/domain/sourcing/service.py
+++ b/backend/app/domain/sourcing/service.py
@@ -84,6 +84,32 @@ class _LineUpdate:
     selected_url: str | None
 
 
+@dataclass(frozen=True)
+class _AlertValuesInput:
+    alert_type: SourcingAlertType | str
+    part_id: UUID | None
+    project_id: UUID | None
+    threshold: SourcingAlertThreshold | dict[str, Any]
+    country_code: str | None
+    currency_code: str | None
+    distributor_filter: list[str] | None
+    notify_user_ids: list[UUID] | list[str] | None
+    cooldown_seconds: int
+    enabled: bool
+
+
+@dataclass(frozen=True)
+class _BomSearchOptions:
+    country: str | None
+    currency: str | None
+    distributors: list[str] | None
+    in_stock_only: bool
+    use_cached_data: bool | None
+    ttl_seconds: int
+    requested_by: UUID | None
+    force_refresh: bool
+
+
 class SourcingNotConfigured(Exception):
     """Workspace has no usable TrustedParts sourcing configuration."""
 
@@ -114,16 +140,18 @@ def create_alert(
     values = _validated_alert_values(
         db,
         workspace=workspace,
-        alert_type=payload.alert_type,
-        part_id=payload.part_id,
-        project_id=payload.project_id,
-        threshold=payload.threshold,
-        country_code=payload.country_code,
-        currency_code=payload.currency_code,
-        distributor_filter=payload.distributor_filter,
-        notify_user_ids=payload.notify_user_ids,
-        cooldown_seconds=payload.cooldown_seconds,
-        enabled=payload.enabled,
+        values=_AlertValuesInput(
+            alert_type=payload.alert_type,
+            part_id=payload.part_id,
+            project_id=payload.project_id,
+            threshold=payload.threshold,
+            country_code=payload.country_code,
+            currency_code=payload.currency_code,
+            distributor_filter=payload.distributor_filter,
+            notify_user_ids=payload.notify_user_ids,
+            cooldown_seconds=payload.cooldown_seconds,
+            enabled=payload.enabled,
+        ),
     )
     alert = SourcingAlert(
         workspace_id=workspace.id,
@@ -259,16 +287,18 @@ def update_alert(
     values = _validated_alert_values(
         db,
         workspace=workspace,
-        alert_type=alert.alert_type,
-        part_id=data.get("part_id", alert.part_id),
-        project_id=data.get("project_id", alert.project_id),
-        threshold=data.get("threshold", alert.threshold),
-        country_code=data.get("country_code", alert.country_code),
-        currency_code=data.get("currency_code", alert.currency_code),
-        distributor_filter=data.get("distributor_filter", alert.distributor_filter),
-        notify_user_ids=data.get("notify_user_ids", alert.notify_user_ids),
-        cooldown_seconds=data.get("cooldown_seconds", alert.cooldown_seconds),
-        enabled=data.get("enabled", alert.enabled),
+        values=_AlertValuesInput(
+            alert_type=alert.alert_type,
+            part_id=data.get("part_id", alert.part_id),
+            project_id=data.get("project_id", alert.project_id),
+            threshold=data.get("threshold", alert.threshold),
+            country_code=data.get("country_code", alert.country_code),
+            currency_code=data.get("currency_code", alert.currency_code),
+            distributor_filter=data.get("distributor_filter", alert.distributor_filter),
+            notify_user_ids=data.get("notify_user_ids", alert.notify_user_ids),
+            cooldown_seconds=data.get("cooldown_seconds", alert.cooldown_seconds),
+            enabled=data.get("enabled", alert.enabled),
+        ),
     )
     for key, value in values.items():
         setattr(alert, key, value)
@@ -293,23 +323,14 @@ def _validated_alert_values(
     db: Session,
     *,
     workspace: Any,
-    alert_type: SourcingAlertType | str,
-    part_id: UUID | None,
-    project_id: UUID | None,
-    threshold: SourcingAlertThreshold | dict[str, Any],
-    country_code: str | None,
-    currency_code: str | None,
-    distributor_filter: list[str] | None,
-    notify_user_ids: list[UUID] | list[str] | None,
-    cooldown_seconds: int,
-    enabled: bool,
+    values: _AlertValuesInput,
 ) -> dict[str, Any]:
-    if threshold is None:
-        raise_http(422, "sourcing_alert.invalid_threshold", "threshold is required")
-    if cooldown_seconds is None:
-        raise_http(422, "sourcing_alert.invalid_cooldown", "cooldown_seconds is required")
-    if enabled is None:
-        raise_http(422, "sourcing_alert.invalid_enabled", "enabled is required")
+    alert_type = values.alert_type
+    part_id = values.part_id
+    project_id = values.project_id
+    country_code = values.country_code
+    currency_code = values.currency_code
+    distributor_filter = values.distributor_filter
     if alert_type not in SOURCING_ALERT_TYPE_VALUES:
         raise_http(422, "sourcing_alert.invalid_type", "invalid alert_type")
     if (part_id is None) == (project_id is None):
@@ -343,11 +364,11 @@ def _validated_alert_values(
     if project_id is not None:
         assert_in_workspace(db, Project, project_id, workspace.id, label="project")
 
-    validated_threshold = _validated_threshold(alert_type, threshold)
+    validated_threshold = _validated_threshold(alert_type, values.threshold)
     validated_notify_user_ids = _validated_notify_user_ids(
         db,
         workspace_id=workspace.id,
-        notify_user_ids=notify_user_ids,
+        notify_user_ids=values.notify_user_ids,
     )
     if alert_type not in _SOURCING_FILTER_ALERT_TYPES:
         country_code = None
@@ -363,8 +384,8 @@ def _validated_alert_values(
         "currency_code": currency_code,
         "distributor_filter": distributor_filter,
         "notify_user_ids": validated_notify_user_ids,
-        "cooldown_seconds": cooldown_seconds,
-        "enabled": enabled,
+        "cooldown_seconds": values.cooldown_seconds,
+        "enabled": values.enabled,
     }
 
 
@@ -429,6 +450,7 @@ def build_purchase_plan(
     price_tolerance_pct: Decimal = Decimal("5"),
     requested_by: UUID | None = None,
 ) -> PurchasePlan:
+    _assert_same_workspace(project, workspace, resource="project")
     bom = source_bom(
         db,
         workspace=workspace,
@@ -524,6 +546,7 @@ def convert_plan_to_orders(
     user_id: UUID | None,
     overrides: dict[UUID, PurchasePlanOrderOverrideIn] | None = None,
 ) -> list[Order]:
+    _assert_same_workspace(plan, workspace, resource="purchase plan")
     if plan.status != "refreshed":
         raise PurchasePlanStaleError(
             "plan must be refreshed before conversion; call /refresh first"
@@ -689,11 +712,16 @@ def refresh_purchase_plan(
     plan: PurchasePlan,
     requested_by: UUID | None = None,
 ) -> PurchasePlan:
+    _assert_same_workspace(plan, workspace, resource="purchase plan")
     project = db.execute(
-        select(Project).where(Project.id == plan.project_id, Project.workspace_id == workspace.id)
+        select(Project).where(
+            Project.id == plan.project_id,
+            Project.workspace_id == workspace.id,
+            Project.archived_at.is_(None),
+        )
     ).scalar_one_or_none()
     if project is None:
-        raise ValueError("purchase plan project not found")
+        raise_http(404, ErrorCodes.PROJECT_NOT_FOUND, "project not found")
 
     bom = source_bom(
         db,
@@ -858,6 +886,7 @@ def source_bom(
     requested_by: UUID | None = None,
     force_refresh: bool = False,
 ) -> SourcingBomOut:
+    _assert_same_workspace(project, workspace, resource="project")
     shortage = shortage_analysis(
         db,
         workspace_id=workspace.id,
@@ -872,28 +901,21 @@ def source_bom(
         if part_id in parts_by_id
     )
 
-    search_results: dict[str, SourcingSearchResult] = {}
-    fetched_at_values: list[datetime] = []
-    partial = False
-    for chunk in chunk_mpns(mpns):
-        verdict = BUDGET.check(workspace.id, parts_count=len(chunk))
-        partial = partial or verdict.mode == "degraded"
-        out = search(
-            db,
-            workspace=workspace,
-            mpns=chunk,
+    search_results, fetched_at_values, partial = _source_bom_search_results(
+        db,
+        workspace=workspace,
+        mpns=mpns,
+        options=_BomSearchOptions(
             country=country,
             currency=currency,
-            in_stock_only=in_stock_only,
             distributors=distributors,
+            in_stock_only=in_stock_only,
             use_cached_data=use_cached_data,
             ttl_seconds=ttl_seconds,
             requested_by=requested_by,
             force_refresh=force_refresh,
-        )
-        fetched_at_values.append(out.fetched_at)
-        for result in out.results:
-            search_results[result.mpn.casefold()] = result
+        ),
+    )
 
     preferred = _clean_distributors(workspace.sourcing_preferred_distributors)
     rows = [
@@ -927,6 +949,38 @@ def source_bom(
         links=TRUSTEDPARTS_LINKS,
         fx_status=fx_status,
     )
+
+
+def _source_bom_search_results(
+    db: Session,
+    *,
+    workspace: Any,
+    mpns: list[str],
+    options: _BomSearchOptions,
+) -> tuple[dict[str, SourcingSearchResult], list[datetime], bool]:
+    search_results: dict[str, SourcingSearchResult] = {}
+    fetched_at_values: list[datetime] = []
+    partial = False
+    for chunk in chunk_mpns(mpns):
+        verdict = BUDGET.check(workspace.id, parts_count=len(chunk))
+        partial = partial or verdict.mode == "degraded"
+        out = search(
+            db,
+            workspace=workspace,
+            mpns=chunk,
+            country=options.country,
+            currency=options.currency,
+            in_stock_only=options.in_stock_only,
+            distributors=options.distributors,
+            use_cached_data=options.use_cached_data,
+            ttl_seconds=options.ttl_seconds,
+            requested_by=options.requested_by,
+            force_refresh=options.force_refresh,
+        )
+        fetched_at_values.append(out.fetched_at)
+        for result in out.results:
+            search_results[result.mpn.casefold()] = result
+    return search_results, fetched_at_values, partial
 
 
 def _apply_fx_to_bom_rows(
@@ -973,6 +1027,7 @@ def _apply_fx_to_bom_rows(
             )
             statuses.append(status)
             row_unavailable = row_unavailable or status == "unavailable"
+        row.est_extended_cost = _offer_extended_cost(row.best_offer, row.short_by)
         row.fx_status = "unavailable" if row_unavailable else None
 
     if requested is None:
@@ -1249,12 +1304,7 @@ def _source_bom_line(
     search_results: dict[str, SourcingSearchResult],
     preferred_distributors: list[str] | None,
 ) -> SourcingBomLineOut:
-    part_id = UUID(str(row["part_id"]))
-    substitute_ids = [UUID(str(item)) for item in row.get("substitute_ids", [])]
-    candidate_ids = [part_id, *substitute_ids]
-    candidate_mpns = dedupe_mpns(
-        parts_by_id[item].mpn for item in candidate_ids if item in parts_by_id
-    )
+    part_id, substitute_ids, candidate_mpns = _bom_line_candidates(row, parts_by_id)
     short_by = int(row["short_by"])
     offers = _joined_offers(candidate_mpns, search_results, qty=max(short_by, 1))
     best_offer = _best_offer_at_qty(offers, short_by)
@@ -1275,11 +1325,7 @@ def _source_bom_line(
         authorized_stock=authorized_stock,
         offers=offers,
         best_offer=best_offer,
-        est_extended_cost=(
-            best_offer.unit_price * Decimal(short_by)
-            if best_offer is not None and best_offer.unit_price is not None
-            else None
-        ),
+        est_extended_cost=_offer_extended_cost(best_offer, short_by),
         lead_time_days=best_offer.lead_time_days if best_offer is not None else None,
         cache_hit=cache_hit,
         reason=reason,
@@ -1290,6 +1336,19 @@ def _source_bom_line(
             preferred_distributors=preferred_distributors,
         ),
     )
+
+
+def _bom_line_candidates(
+    row: dict[str, Any],
+    parts_by_id: dict[UUID, Part],
+) -> tuple[UUID, list[UUID], list[str]]:
+    part_id = UUID(str(row["part_id"]))
+    substitute_ids = [UUID(str(item)) for item in row.get("substitute_ids", [])]
+    candidate_ids = [part_id, *substitute_ids]
+    candidate_mpns = dedupe_mpns(
+        parts_by_id[item].mpn for item in candidate_ids if item in parts_by_id
+    )
+    return part_id, substitute_ids, candidate_mpns
 
 
 def _bom_line_cache_hit(
@@ -1368,12 +1427,35 @@ def _best_offer_at_qty(
 
     best: tuple[Decimal, SourcingBomOfferOut] | None = None
     for offer in offers:
-        price = offer.unit_price
+        price = _offer_unit_price_at_qty(offer, qty)
         if price is None:
             continue
         if best is None or price < best[0]:
             best = (price, offer)
     return best[1] if best is not None else None
+
+
+def _offer_extended_cost(
+    offer: SourcingBomOfferOut | None,
+    qty: int,
+) -> Decimal | None:
+    if offer is None or qty <= 0:
+        return None
+    unit_price = _offer_unit_price_at_qty(offer, qty)
+    if unit_price is None:
+        return None
+    return unit_price * Decimal(qty)
+
+
+def _offer_unit_price_at_qty(
+    offer: SourcingBomOfferOut,
+    qty: int,
+) -> Decimal | None:
+    price_breaks = offer.price_breaks_converted or offer.price_breaks
+    best = best_unit_price_at_qty(price_breaks, qty)
+    if best is not None:
+        return best[0]
+    return offer.unit_price_converted or offer.unit_price
 
 
 def _unit_price_for_distributor(distributor: Any, qty: int) -> Decimal | None:
@@ -1387,6 +1469,16 @@ def _unit_price_for_distributor(distributor: Any, qty: int) -> Decimal | None:
         ]
     best = best_unit_price_at_qty(price_breaks, qty)
     return best[0] if best is not None else None
+
+
+def _assert_same_workspace(obj: Any, workspace: Any, *, resource: str) -> None:
+    if getattr(obj, "workspace_id", None) != workspace.id:
+        raise_http(
+            404,
+            ErrorCodes.RESOURCE_NOT_FOUND,
+            f"{resource} not found",
+            resource=resource.replace(" ", "_"),
+        )
 
 
 def _price_breaks_for_distributor(distributor: Any) -> list[SourcingBomPriceBreakOut]:

--- a/backend/app/domain/sourcing/service.py
+++ b/backend/app/domain/sourcing/service.py
@@ -6,7 +6,7 @@ import json
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from decimal import Decimal
+from decimal import ROUND_HALF_UP, Decimal
 from typing import Any
 from uuid import UUID
 
@@ -63,6 +63,7 @@ TRUSTEDPARTS_LINKS = SourcingAttributionLinks(
     attribution="https://www.trustedparts.com/en/about",
 )
 TARGET_ROHS_REGION = "EU"
+MONEY_4DP = Decimal("0.0001")
 _SOURCING_FILTER_ALERT_TYPES = {
     "back_in_stock",
     "out_of_authorized_stock",
@@ -1027,7 +1028,8 @@ def _apply_fx_to_bom_rows(
             )
             statuses.append(status)
             row_unavailable = row_unavailable or status == "unavailable"
-        row.est_extended_cost = _offer_extended_cost(row.best_offer, row.short_by)
+        if requested is not None:
+            row.est_extended_cost = _offer_extended_cost(row.best_offer, row.short_by)
         row.fx_status = "unavailable" if row_unavailable else None
 
     if requested is None:
@@ -1439,12 +1441,14 @@ def _offer_extended_cost(
     offer: SourcingBomOfferOut | None,
     qty: int,
 ) -> Decimal | None:
-    if offer is None or qty <= 0:
+    if offer is None or qty < 0:
         return None
+    if qty == 0:
+        return Decimal("0")
     unit_price = _offer_unit_price_at_qty(offer, qty)
     if unit_price is None:
         return None
-    return unit_price * Decimal(qty)
+    return (unit_price * Decimal(qty)).quantize(MONEY_4DP, rounding=ROUND_HALF_UP)
 
 
 def _offer_unit_price_at_qty(

--- a/backend/tests/test_purchase_plan_refresh_route.py
+++ b/backend/tests/test_purchase_plan_refresh_route.py
@@ -10,6 +10,7 @@ from sqlalchemy import select
 
 import app.core.ratelimit as _ratelimit_mod
 from app.core.time import utcnow
+from app.domain.projects.models import Project
 from app.domain.sourcing.budget import BUDGET
 from app.domain.sourcing.models import PurchasePlan, PurchasePlanLine
 from app.main import app
@@ -182,6 +183,21 @@ def test_workspace_isolation_two_plans_different_workspaces(authed_client):
     assert foreign.json()["code"] == "resource.not_found"
     assert own.status_code == 200, own.text
     assert own.json()["data"]["id"] == plan_b["id"]
+
+
+def test_refresh_rejects_archived_project(authed_client, db):
+    initial = _create_plan(authed_client)
+    plan = db.get(PurchasePlan, uuid.UUID(initial["id"]))
+    assert plan is not None
+    project = db.get(Project, plan.project_id)
+    assert project is not None
+    project.archived_at = utcnow()
+    db.flush()
+
+    r = _refresh(authed_client, initial["id"])
+
+    assert r.status_code == 404, r.text
+    assert r.json()["code"] == "project.not_found"
 
 
 def test_decimals_as_strings_on_wire(authed_client):

--- a/backend/tests/test_sourcing_alerts_evaluator.py
+++ b/backend/tests/test_sourcing_alerts_evaluator.py
@@ -1241,6 +1241,56 @@ def test_evaluator_does_not_batch_across_workspaces(
     assert len(seen_workspace_ids) == 2
 
 
+def test_provider_exception_in_one_workspace_does_not_block_other_workspaces(
+    db: Session,
+    monkeypatch,
+) -> None:
+    workspace_a, user_a = _workspace(db)
+    workspace_b, user_b = _workspace(db)
+    part_a = _part(db, workspace_a, user_a, mpn="BROKEN-PROVIDER")
+    part_b = _part(db, workspace_b, user_b, mpn="HEALTHY-PROVIDER")
+    alert_a = _alert(
+        db,
+        workspace_a,
+        user_a,
+        part=part_a,
+        alert_type="back_in_stock",
+        threshold={},
+        last_state={"had_stock": False},
+    )
+    alert_b = _alert(
+        db,
+        workspace_b,
+        user_b,
+        part=part_b,
+        alert_type="back_in_stock",
+        threshold={},
+        last_state={"had_stock": False},
+    )
+    db.commit()
+    seen_workspace_ids: list[uuid.UUID] = []
+
+    def fake_search(*args: Any, **kwargs: Any) -> Any:
+        workspace_id = kwargs["workspace"].id
+        seen_workspace_ids.append(workspace_id)
+        if workspace_id == workspace_a.id:
+            raise RuntimeError("provider unavailable")
+        return _search_out(stock=1, mpn=kwargs["mpns"][0])
+
+    monkeypatch.setattr(alerts_evaluator.sourcing_service, "search", fake_search)
+    sent = _capture_mail(monkeypatch)
+
+    assert evaluate_all_alerts(db) == 2
+
+    assert set(seen_workspace_ids) == {workspace_a.id, workspace_b.id}
+    assert len(sent) == 1
+    db.refresh(alert_a)
+    db.refresh(alert_b)
+    assert alert_a.last_checked_at is None
+    assert alert_b.last_checked_at is not None
+    assert alert_b.last_notified_at is not None
+
+
 def test_evaluator_does_not_batch_distinct_queries(
     db: Session,
     monkeypatch,

--- a/backend/tests/test_sourcing_bom_integration.py
+++ b/backend/tests/test_sourcing_bom_integration.py
@@ -230,7 +230,7 @@ def _queried_mpns() -> list[str]:
 
 
 def _monetary_values(data: Any):
-    monetary_keys = {"unit_price", "est_extended_cost", "est_purchase_cost", "est_total_cost"}
+    monetary_keys = {"unit_price", "est_extended_cost", "est_total_cost"}
     if isinstance(data, dict):
         for key, value in data.items():
             if key in monetary_keys and value is not None:

--- a/backend/tests/test_sourcing_bom_route.py
+++ b/backend/tests/test_sourcing_bom_route.py
@@ -213,7 +213,7 @@ def test_basic_bom_returns_enriched_lines(authed_client):
     assert Decimal(data["capacity"]["total_bom_cost"]) == Decimal("2.00")
     assert Decimal(data["capacity"]["cost_per_single_bom"]) == Decimal("1.00")
     assert Decimal(data["capacity"]["purchase_to_pay_cost"]) == Decimal("2.00")
-    assert data["capacity"]["est_purchase_cost"] == data["capacity"]["purchase_to_pay_cost"]
+    assert "est_purchase_cost" not in data["capacity"]
     row = data["rows"][0]
     assert row["required"] == 20
     assert row["available"] == 0

--- a/backend/tests/test_sourcing_capacity.py
+++ b/backend/tests/test_sourcing_capacity.py
@@ -517,7 +517,7 @@ def test_cost_totals_skip_incompatible_display_currency_rows():
     assert capacity.purchase_to_pay_cost == Decimal("15.00")
 
 
-def test_decimal_serialisation_for_both_costs():
+def test_decimal_serialisation_for_capacity_costs():
     capacity = compute_build_capacity(
         [
             _line(
@@ -539,5 +539,4 @@ def test_decimal_serialisation_for_both_costs():
     assert isinstance(payload["cost_per_single_bom"], str)
     assert payload["purchase_to_pay_cost"] == "62.50"
     assert isinstance(payload["purchase_to_pay_cost"], str)
-    assert payload["est_purchase_cost"] == "62.50"
-    assert isinstance(payload["est_purchase_cost"], str)
+    assert "est_purchase_cost" not in payload

--- a/backend/tests/test_sourcing_client.py
+++ b/backend/tests/test_sourcing_client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from copy import deepcopy
 from datetime import datetime, timezone
+from decimal import Decimal
 
 import httpx
 import pytest
@@ -145,10 +146,10 @@ def test_happy_path_returns_offers(monkeypatch):
     assert distributor.packaging == "Cut Tape"
     assert distributor.moq == 1
     assert distributor.stock == 1200
-    assert distributor.unit_price == 2.5
+    assert distributor.unit_price == Decimal("2.5")
     assert distributor.currency == "EUR"
     assert distributor.price_breaks[1].quantity == 10
-    assert distributor.price_breaks[1].unit_price == 2.1
+    assert distributor.price_breaks[1].unit_price == Decimal("2.1")
     assert distributor.product_url == "https://example.com/product"
 
 

--- a/backend/tests/test_sourcing_coverage.py
+++ b/backend/tests/test_sourcing_coverage.py
@@ -97,6 +97,31 @@ def test_single_distributor_covers_all():
     assert matrix.fewest_distributors_total == Decimal("22.50")
 
 
+def test_lines_covered_counts_distinct_lines_not_offers():
+    matrix = compute_coverage(
+        [
+            _line(
+                1,
+                offers=[
+                    _offer("DigiKey", mpn="A-1"),
+                    _offer("DigiKey", mpn="A-1-ALT", unit_price="1.25"),
+                ],
+            ),
+            _line(
+                2,
+                offers=[
+                    _offer("DigiKey", mpn="B-1"),
+                    _offer("DigiKey", mpn="B-1-ALT", unit_price="1.25"),
+                ],
+            ),
+        ]
+    )
+
+    rows = {row.distributor: row for row in matrix.rows}
+    assert rows["DigiKey"].lines_covered == 2
+    assert rows["DigiKey"].coverage_pct == 1
+
+
 def test_two_distributors_needed_finds_optimal_pair():
     matrix = compute_coverage(
         [

--- a/backend/tests/test_sourcing_medium_backlog.py
+++ b/backend/tests/test_sourcing_medium_backlog.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from decimal import Decimal
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from app.domain.sourcing import service as sourcing_service
+from app.domain.sourcing.budget import BudgetTracker
+from app.domain.sourcing.schemas import (
+    SourcingBomLineOut,
+    SourcingBomOfferOut,
+    SourcingBomPriceBreakOut,
+    SourcingDistributor,
+    SourcingPriceBreak,
+)
+
+
+def _workspace(workspace_id):
+    return SimpleNamespace(id=workspace_id)
+
+
+def _workspace_object(workspace_id):
+    return SimpleNamespace(workspace_id=workspace_id)
+
+
+def test_service_helpers_reject_preloaded_objects_from_other_workspace():
+    workspace = _workspace(uuid4())
+    foreign = _workspace_object(uuid4())
+
+    with pytest.raises(HTTPException) as source_exc:
+        sourcing_service.source_bom(
+            None,
+            workspace=workspace,
+            project=foreign,
+            build_quantity=1,
+        )
+    assert source_exc.value.status_code == 404
+
+    with pytest.raises(HTTPException) as build_exc:
+        sourcing_service.build_purchase_plan(
+            None,
+            workspace=workspace,
+            project=foreign,
+            build_quantity=1,
+        )
+    assert build_exc.value.status_code == 404
+
+    with pytest.raises(HTTPException) as refresh_exc:
+        sourcing_service.refresh_purchase_plan(
+            None,
+            workspace=workspace,
+            plan=foreign,
+        )
+    assert refresh_exc.value.status_code == 404
+
+    with pytest.raises(HTTPException) as convert_exc:
+        sourcing_service.convert_plan_to_orders(
+            None,
+            workspace=workspace,
+            plan=foreign,
+            user_id=None,
+        )
+    assert convert_exc.value.status_code == 404
+
+
+def test_best_offer_uses_shortage_quantity_price_breaks():
+    bulk = SourcingBomOfferOut(
+        mpn="BULK",
+        distributor="Bulk",
+        stock=100,
+        unit_price=Decimal("1.00"),
+        price_breaks=[
+            SourcingBomPriceBreakOut(quantity=1, unit_price=Decimal("1.00")),
+            SourcingBomPriceBreakOut(quantity=10, unit_price=Decimal("0.80")),
+        ],
+    )
+    eaches = SourcingBomOfferOut(
+        mpn="BULK",
+        distributor="Eaches",
+        stock=100,
+        unit_price=Decimal("0.90"),
+        price_breaks=[
+            SourcingBomPriceBreakOut(quantity=1, unit_price=Decimal("0.90")),
+        ],
+    )
+
+    assert sourcing_service._best_offer_at_qty([bulk, eaches], 10) is bulk
+
+
+def test_bom_row_extended_cost_uses_converted_best_offer(monkeypatch):
+    offer = SourcingBomOfferOut(
+        mpn="FX",
+        distributor="DigiKey",
+        stock=100,
+        unit_price=Decimal("2.00"),
+        currency="USD",
+        price_breaks=[
+            SourcingBomPriceBreakOut(quantity=1, unit_price=Decimal("2.00")),
+        ],
+    )
+    row = SourcingBomLineOut(
+        project_entry_id=uuid4(),
+        part_id=uuid4(),
+        part_name="FX Line",
+        required=5,
+        available=0,
+        substitute_available=0,
+        short_by=5,
+        authorized_stock=100,
+        offers=[offer],
+        best_offer=offer,
+        est_extended_cost=Decimal("10.00"),
+    )
+    monkeypatch.setattr(
+        sourcing_service.fx_rates,
+        "get_or_fetch_today",
+        lambda _db, *, on_date: {"EUR": Decimal("1"), "USD": Decimal("2")},
+    )
+
+    assert (
+        sourcing_service._apply_fx_to_bom_rows(None, [row], requested_currency="EUR")
+        == "ok"
+    )
+
+    assert row.best_offer is not None
+    assert row.best_offer.unit_price_converted == Decimal("1.0000")
+    assert row.est_extended_cost == Decimal("5.0000")
+
+
+def test_wire_prices_parse_as_decimal_without_float_round_trip():
+    distributor = SourcingDistributor(
+        name="DigiKey",
+        unit_price=0.1,
+        price_breaks=[SourcingPriceBreak(quantity=1, unit_price=0.1)],
+    )
+
+    assert distributor.unit_price == Decimal("0.1")
+    assert distributor.price_breaks[0].unit_price == Decimal("0.1")
+
+
+def test_budget_tracker_records_concurrent_updates():
+    tracker = BudgetTracker()
+    workspace_id = uuid4()
+
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        list(pool.map(lambda _index: tracker.record(workspace_id, 1), range(40)))
+
+    assert tracker._window_total(workspace_id, 10) == 40
+

--- a/backend/tests/test_sourcing_medium_backlog.py
+++ b/backend/tests/test_sourcing_medium_backlog.py
@@ -10,6 +10,7 @@ from fastapi import HTTPException
 
 from app.domain.sourcing import service as sourcing_service
 from app.domain.sourcing.budget import BudgetTracker
+from app.domain.sourcing.constants import INFINITE_LEAD_TIME_DAYS
 from app.domain.sourcing.schemas import (
     SourcingBomLineOut,
     SourcingBomOfferOut,
@@ -131,6 +132,62 @@ def test_bom_row_extended_cost_uses_converted_best_offer(monkeypatch):
     assert row.est_extended_cost == Decimal("5.0000")
 
 
+def test_bom_row_extended_cost_is_not_recomputed_without_fx():
+    offer = SourcingBomOfferOut(
+        mpn="NOFX",
+        distributor="DigiKey",
+        stock=100,
+        unit_price=Decimal("2.00"),
+        currency="USD",
+        price_breaks=[
+            SourcingBomPriceBreakOut(quantity=1, unit_price=Decimal("2.00")),
+            SourcingBomPriceBreakOut(quantity=5, unit_price=Decimal("1.00")),
+        ],
+    )
+    row = SourcingBomLineOut(
+        project_entry_id=uuid4(),
+        part_id=uuid4(),
+        part_name="No FX Line",
+        required=5,
+        available=0,
+        substitute_available=0,
+        short_by=5,
+        authorized_stock=100,
+        offers=[offer],
+        best_offer=offer,
+        est_extended_cost=Decimal("10.00"),
+    )
+
+    assert sourcing_service._apply_fx_to_bom_rows(None, [row], requested_currency=None) is None
+    assert row.est_extended_cost == Decimal("10.00")
+
+
+def test_offer_extended_cost_preserves_zero_shortage_and_quantizes_products():
+    offer = SourcingBomOfferOut(
+        mpn="QTY",
+        distributor="DigiKey",
+        stock=100,
+        unit_price=Decimal("0.333333"),
+        currency="USD",
+        price_breaks=[
+            SourcingBomPriceBreakOut(quantity=1, unit_price=Decimal("0.333333")),
+        ],
+    )
+
+    assert sourcing_service._offer_extended_cost(offer, 0) == Decimal("0")
+    assert sourcing_service._offer_extended_cost(offer, 3) == Decimal("1.0000")
+
+
+def test_infinite_lead_time_sentinel_is_not_valid_wire_output():
+    with pytest.raises(ValueError):
+        SourcingBomOfferOut(
+            mpn="SENTINEL",
+            distributor="DigiKey",
+            stock=1,
+            lead_time_days=INFINITE_LEAD_TIME_DAYS,
+        )
+
+
 def test_wire_prices_parse_as_decimal_without_float_round_trip():
     distributor = SourcingDistributor(
         name="DigiKey",
@@ -150,4 +207,3 @@ def test_budget_tracker_records_concurrent_updates():
         list(pool.map(lambda _index: tracker.record(workspace_id, 1), range(40)))
 
     assert tracker._window_total(workspace_id, 10) == 40
-

--- a/backend/tests/test_sourcing_part_route.py
+++ b/backend/tests/test_sourcing_part_route.py
@@ -437,7 +437,7 @@ def test_sourcing_response_converts_when_distributor_returns_different_currency(
     data = r.json()["data"]
     distributor = data["offers"][0]["distributors"][0]
     assert data["fx_status"] is None
-    assert distributor["unit_price"] == 2.5
+    assert distributor["unit_price"] == "2.5"
     assert distributor["currency"] == "USD"
     assert Decimal(distributor["unit_price_converted"]) == Decimal("1.2500")
     assert distributor["currency_displayed"] == "EUR"
@@ -478,7 +478,7 @@ def test_sourcing_response_surfaces_fx_status_unavailable(authed_client, monkeyp
     data = r.json()["data"]
     distributor = data["offers"][0]["distributors"][0]
     assert data["fx_status"] == "unavailable"
-    assert distributor["unit_price"] == 1.23
+    assert distributor["unit_price"] == "1.23"
     assert distributor["currency"] == "USD"
     assert distributor["unit_price_converted"] is None
     assert distributor["fx_converted"] is None

--- a/backend/tests/test_sourcing_test_route.py
+++ b/backend/tests/test_sourcing_test_route.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import uuid
 
 import pytest
@@ -148,6 +149,9 @@ def test_good_creds_returns_ok_and_latency(authed_client, monkeypatch):
 
     assert r.status_code == 200, r.text
     body = r.json()
+    workspace_hash = hashlib.sha256(
+        str(_current_workspace_id(authed_client)).encode("utf-8")
+    ).hexdigest()[:12]
     assert body["data"]["ok"] is True
     assert body["data"]["message"] == "OK"
     assert body["data"]["latency_ms"] > 0
@@ -157,7 +161,7 @@ def test_good_creds_returns_ok_and_latency(authed_client, monkeypatch):
             "api_key": "api-key-456",
             "country_code": "CZ",
             "currency_code": "EUR",
-            "user_agent": f"stockManager/dev workspace={_current_workspace_id(authed_client)}",
+            "user_agent": f"stockManager/dev workspace_sha={workspace_hash}",
             "queries": [{"search_token": "TEST_PROBE_DO_NOT_BUY"}],
             "use_cached_data": False,
         }

--- a/backend/tests/test_sourcing_test_route.py
+++ b/backend/tests/test_sourcing_test_route.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import hashlib
+import hmac
 import uuid
 
 import pytest
@@ -8,6 +8,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy import select
 
 import app.core.ratelimit as _ratelimit_mod
+from app.core.config import settings
 from app.core.secrets import decrypt
 from app.domain.sourcing import SourcingAuthError
 from app.domain.sourcing.schemas import SourcingQuery
@@ -149,8 +150,10 @@ def test_good_creds_returns_ok_and_latency(authed_client, monkeypatch):
 
     assert r.status_code == 200, r.text
     body = r.json()
-    workspace_hash = hashlib.sha256(
-        str(_current_workspace_id(authed_client)).encode("utf-8")
+    workspace_hash = hmac.new(
+        settings().SESSION_SECRET.encode("utf-8"),
+        str(_current_workspace_id(authed_client)).encode("utf-8"),
+        "sha256",
     ).hexdigest()[:12]
     assert body["data"]["ok"] is True
     assert body["data"]["message"] == "OK"

--- a/docs/api/sourcing.md
+++ b/docs/api/sourcing.md
@@ -294,7 +294,6 @@ Path: `project_id` is a project UUID in the current workspace.
       "total_bom_cost": "2.00",
       "cost_per_single_bom": "1.00",
       "purchase_to_pay_cost": "2.00",
-      "est_purchase_cost": "2.00",
       "blocking_lines_now": [],
       "blocking_lines_after_purchase": []
     },
@@ -347,8 +346,7 @@ Sources: `backend/app/domain/sourcing/service.py:1322-1386`,
   rounded half-up to 2 decimal places, or `null` when no priced BOM cost is
   available. `capacity.purchase_to_pay_cost` sums
   `short_by * best_offer.unit_price` for priced rows that are not blocking after
-  authorized supply. `capacity.est_purchase_cost` is a deprecated alias of
-  `purchase_to_pay_cost` for one release.
+  authorized supply.
 - Capacity totals use converted/display prices when available and skip rows whose displayed currency does not match the selected total currency, so mixed native currencies are not added together.
 - `coverage.best_single_distributor`, `coverage.best_two_distributor_combo`, and the
   per-distributor matrix rows use legacy shortfall coverage: an offer covers a row

--- a/docs/domain/sourcing.md
+++ b/docs/domain/sourcing.md
@@ -94,7 +94,7 @@ Project BOM capacity reports two response-level cost numbers. `total_bom_cost`
 sums required quantity times best-offer unit price for every priced row and ignores
 on-hand stock. `purchase_to_pay_cost` sums short quantity times best-offer unit
 price for priced rows that are not blocking after authorized supply; the deprecated
-`est_purchase_cost` field is the same value for one release. Both totals use Decimal
+`purchase_to_pay_cost` field exposes the short-quantity price to pay. Totals use Decimal
 math, prefer converted/display prices from BOM FX conversion, and skip rows whose
 display currency does not match the selected total currency.
 

--- a/web/src/routes/parts/detail/PartSourcing.tsx
+++ b/web/src/routes/parts/detail/PartSourcing.tsx
@@ -3,6 +3,7 @@ import { useOutletContext } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { ExternalLink, RefreshCw } from "lucide-react";
+import { DataTable, type Column } from "@/components/DataTable";
 import { api, ApiError } from "@/lib/api";
 import { isCatalogKey } from "@/lib/providerCatalog";
 import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
@@ -65,6 +66,20 @@ export default function PartSourcing() {
     part.linked_provider && part.mpn
       ? PROVIDER_SEARCH_URL[part.linked_provider]?.(part.mpn)
       : null;
+  const columns: Column<CustomFieldRow>[] = [
+    {
+      key: "key",
+      header: "Field",
+      accessor: row => row.key,
+      render: row => <span className="text-muted whitespace-nowrap">{row.key}</span>,
+    },
+    {
+      key: "value",
+      header: "Value",
+      accessor: row => row.value,
+      render: row => <span className="tabular-nums">{row.value}</span>,
+    },
+  ];
 
   return (
     <div className="card p-4 space-y-3">
@@ -118,16 +133,14 @@ export default function PartSourcing() {
           No catalog data yet. Click Refresh to pull stock + pricing from {providerLabel ?? "the provider"}.
         </div>
       ) : (
-        <table className="text-sm w-full">
-          <tbody>
-            {rows.map(r => (
-              <tr key={r.id} className="align-top">
-                <td className="text-muted pr-4 py-1 whitespace-nowrap">{r.key}</td>
-                <td className="py-1 tabular-nums">{r.value}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+        <DataTable
+          rows={rows}
+          columns={columns}
+          rowKey={row => row.id}
+          tableId="part-sourcing-catalog"
+          exportFilename="part-sourcing"
+          searchPlaceholder="Search catalog data..."
+        />
       )}
     </div>
   );

--- a/web/src/routes/parts/detail/__tests__/PartSourcing.test.tsx
+++ b/web/src/routes/parts/detail/__tests__/PartSourcing.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter, Outlet, Route, Routes } from "react-router-dom";
+import { api } from "@/lib/api";
+import type { CustomFieldRow, Part } from "@/types";
+import PartSourcing from "../PartSourcing";
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({
+  useAuth: () => ({ workspaceId: "ws-1" }),
+}));
+
+const part: Part = {
+  id: "11111111-1111-4111-8111-111111111111",
+  part_type: "linked",
+  name: "STM32",
+  manufacturer: "STMicroelectronics",
+  mpn: "STM32F103C8T6",
+  internal_part_number: null,
+  description: null,
+  footprint: null,
+  notes_markdown: null,
+  low_stock_report_quantity: null,
+  attrition_percentage: 0,
+  attrition_min_quantity: 0,
+  default_storage_location_id: null,
+  default_storage_mandatory: false,
+  serialized: false,
+  linked_provider: "digikey",
+  linked_external_id: "dk-1",
+  last_refresh_at: "2026-05-08T12:00:00+00:00",
+  description_locally_edited: false,
+  archived_at: null,
+  on_hand: 0,
+  reserved: 0,
+  available: 0,
+  image_url: null,
+};
+
+const fields: CustomFieldRow[] = [
+  {
+    id: "22222222-2222-4222-8222-222222222222",
+    key: "In stock (qty)",
+    value: "42",
+    source: "provider",
+    original_value: null,
+  },
+  {
+    id: "33333333-3333-4333-8333-333333333333",
+    key: "Unit price (10+)",
+    value: "1.23 USD",
+    source: "provider",
+    original_value: null,
+  },
+  {
+    id: "44444444-4444-4444-8444-444444444444",
+    key: "Resistance",
+    value: "10k",
+    source: "provider",
+    original_value: null,
+  },
+];
+
+function renderPartSourcing() {
+  const client = new QueryClient({
+    defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+  });
+  render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={["/parts/11111111-1111-4111-8111-111111111111/sourcing"]}>
+        <Routes>
+          <Route path="/parts/:partId" element={<Outlet context={{ part }} />}>
+            <Route path="sourcing" element={<PartSourcing />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  cleanup();
+  localStorage.clear();
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+});
+
+describe("PartSourcing", () => {
+  it("renders catalog fields in the shared DataTable", async () => {
+    vi.spyOn(api, "get").mockResolvedValue(fields);
+
+    renderPartSourcing();
+
+    const table = await screen.findByRole("table");
+    expect(within(table).getByText("In stock (qty)")).toBeDefined();
+    expect(within(table).getByText("42")).toBeDefined();
+    expect(within(table).getByText("Unit price (10+)")).toBeDefined();
+    expect(within(table).queryByText("Resistance")).toBeNull();
+    expect(screen.getByPlaceholderText("Search catalog data...")).toBeDefined();
+    expect(screen.getByRole("button", { name: "Export CSV" })).toBeDefined();
+  });
+});

--- a/web/src/routes/projects/sourcing/CoverageMatrix.tsx
+++ b/web/src/routes/projects/sourcing/CoverageMatrix.tsx
@@ -18,6 +18,10 @@ function sameCombo(left: string[], right: string[]): boolean {
   return leftSorted.length === rightSorted.length && leftSorted.every((item, index) => item === rightSorted[index]);
 }
 
+function formatCoveragePct(pct: number): string {
+  return `${Math.floor(pct * 100)}%`;
+}
+
 function coverageForCombo(data: SourcingBomResponse, combo: string[]): { pct: number | null; shortLines: number | null } {
   if (combo.length === 0 || data.coverage.total_lines === 0) return { pct: null, shortLines: null };
   const comboSet = new Set(combo.map(item => item.toLocaleLowerCase()));
@@ -53,7 +57,7 @@ function CoverageVariantCard({
 }) {
   const { pct, shortLines } = coverageForCombo(data, variant.combo);
   const comboText = variant.combo.length > 0 ? normalizedCombo(variant.combo).join(" + ") : "—";
-  const coverageText = pct == null ? "—" : `${Math.round(pct * 100)}%`;
+  const coverageText = pct == null ? "—" : formatCoveragePct(pct);
   const hasPartialCoverage = shortLines != null && shortLines > 0;
   const priceLabel = hasPartialCoverage ? "Price (covered lines)" : "Price";
   const uncoveredText = hasPartialCoverage
@@ -129,7 +133,7 @@ export function CoverageMatrix({ data, currency }: { data: SourcingBomResponse; 
       key: "coverage",
       header: "Coverage",
       accessor: row => row.coverage_pct,
-      render: row => `${Math.round(row.coverage_pct * 100)}%`,
+      render: row => formatCoveragePct(row.coverage_pct),
       align: "right",
     },
     {

--- a/web/src/routes/projects/sourcing/OverrideOfferModal.tsx
+++ b/web/src/routes/projects/sourcing/OverrideOfferModal.tsx
@@ -67,13 +67,13 @@ function canSelectOffer(line: PurchasePlanLine, offer: PurchasePlanOffer): boole
 type OfferRow = {
   key: string;
   offer: PurchasePlanOffer;
+  isCurrent: boolean;
 };
 
 export default function OverrideOfferModal({ line, onSelect, onClose }: Props) {
   if (!line) return null;
 
   const rows: OfferRow[] = (line.available_offers ?? [])
-    .filter(offer => !isCurrentOffer(line, offer))
     .map((offer, index) => ({
       key: [
         offer.distributor ?? "unknown",
@@ -83,6 +83,7 @@ export default function OverrideOfferModal({ line, onSelect, onClose }: Props) {
         index,
       ].join("-"),
       offer,
+      isCurrent: isCurrentOffer(line, offer),
     }));
 
   const columns: Column<OfferRow>[] = [
@@ -90,7 +91,12 @@ export default function OverrideOfferModal({ line, onSelect, onClose }: Props) {
       key: "distributor",
       header: "Distributor",
       accessor: row => row.offer.distributor ?? "",
-      render: row => <div className="font-medium">{row.offer.distributor ?? "-"}</div>,
+      render: row => (
+        <div>
+          <div className="font-medium">{row.offer.distributor ?? "-"}</div>
+          {row.isCurrent ? <div className="text-xs text-muted">Current selection</div> : null}
+        </div>
+      ),
     },
     {
       key: "mpn",
@@ -155,10 +161,10 @@ export default function OverrideOfferModal({ line, onSelect, onClose }: Props) {
         <button
           type="button"
           className="btn"
-          disabled={!canSelectOffer(line, row.offer)}
+          disabled={row.isCurrent || !canSelectOffer(line, row.offer)}
           onClick={() => onSelect(line, row.offer)}
         >
-          Select
+          {row.isCurrent ? "Current" : "Select"}
         </button>
       ),
       align: "right",

--- a/web/src/routes/projects/sourcing/OverrideOfferModal.tsx
+++ b/web/src/routes/projects/sourcing/OverrideOfferModal.tsx
@@ -1,3 +1,4 @@
+import { DataTable, type Column } from "@/components/DataTable";
 import { Modal } from "@/components/Modal";
 import type { PurchasePlanLine, PurchasePlanOffer } from "./purchasePlanTypes";
 
@@ -63,10 +64,106 @@ function canSelectOffer(line: PurchasePlanLine, offer: PurchasePlanOffer): boole
   );
 }
 
+type OfferRow = {
+  key: string;
+  offer: PurchasePlanOffer;
+};
+
 export default function OverrideOfferModal({ line, onSelect, onClose }: Props) {
   if (!line) return null;
 
-  const offers = (line.available_offers ?? []).filter(offer => !isCurrentOffer(line, offer));
+  const rows: OfferRow[] = (line.available_offers ?? [])
+    .filter(offer => !isCurrentOffer(line, offer))
+    .map((offer, index) => ({
+      key: [
+        offer.distributor ?? "unknown",
+        offer.mpn ?? "mpn",
+        offer.url ?? "no-url",
+        String(offer.unit_price ?? "no-price"),
+        index,
+      ].join("-"),
+      offer,
+    }));
+
+  const columns: Column<OfferRow>[] = [
+    {
+      key: "distributor",
+      header: "Distributor",
+      accessor: row => row.offer.distributor ?? "",
+      render: row => <div className="font-medium">{row.offer.distributor ?? "-"}</div>,
+    },
+    {
+      key: "mpn",
+      header: "MPN",
+      accessor: row => row.offer.mpn ?? line.mpn_searched,
+      render: row => row.offer.mpn ?? line.mpn_searched,
+    },
+    {
+      key: "stock",
+      header: "Stock",
+      accessor: row => numericValue(row.offer.stock),
+      render: row => formatValue(row.offer.stock),
+      align: "right",
+    },
+    {
+      key: "unit_price",
+      header: "Unit price",
+      accessor: row => numericValue(row.offer.unit_price),
+      render: row => formatMoney(row.offer.unit_price, row.offer.currency),
+      align: "right",
+    },
+    {
+      key: "packaging",
+      header: "Packaging",
+      accessor: row => row.offer.packaging ?? "",
+      render: row => formatValue(row.offer.packaging),
+    },
+    {
+      key: "moq",
+      header: "MOQ",
+      accessor: row => numericValue(row.offer.moq),
+      render: row => formatValue(row.offer.moq),
+      align: "right",
+    },
+    {
+      key: "lead_time",
+      header: "Lead time",
+      accessor: row => row.offer.lead_time_days,
+      render: row => formatLeadTime(row.offer.lead_time_days),
+      align: "right",
+    },
+    {
+      key: "offer",
+      header: "Offer",
+      accessor: row => row.offer.url ?? "",
+      render: row => row.offer.url ? (
+        <a
+          className="text-accent hover:underline"
+          href={row.offer.url}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Open
+        </a>
+      ) : "-",
+    },
+    {
+      key: "action",
+      header: "Action",
+      headerLabel: "Action",
+      render: row => (
+        <button
+          type="button"
+          className="btn"
+          disabled={!canSelectOffer(line, row.offer)}
+          onClick={() => onSelect(line, row.offer)}
+        >
+          Select
+        </button>
+      ),
+      align: "right",
+    },
+  ];
 
   return (
     <Modal
@@ -90,71 +187,19 @@ export default function OverrideOfferModal({ line, onSelect, onClose }: Props) {
       </div>
 
       <div className="overflow-auto">
-        {offers.length === 0 ? (
+        {rows.length === 0 ? (
           <div className="p-4 text-sm text-muted">
             No cached alternate offers are available for this line.
           </div>
         ) : (
-          <table className="table text-sm">
-            <thead>
-              <tr>
-                <th>Distributor</th>
-                <th>MPN</th>
-                <th className="text-right">Stock</th>
-                <th className="text-right">Unit price</th>
-                <th>Packaging</th>
-                <th className="text-right">MOQ</th>
-                <th className="text-right">Lead time</th>
-                <th>Offer</th>
-                <th className="text-right">Action</th>
-              </tr>
-            </thead>
-            <tbody>
-              {offers.map((offer, index) => {
-                const key = `${offer.distributor ?? "unknown"}-${offer.mpn ?? "mpn"}-${index}`;
-                const isCurrent =
-                  offer.distributor === line.selected_distributor &&
-                  offer.unit_price === line.selected_unit_price &&
-                  offer.currency === line.selected_currency;
-                return (
-                  <tr key={key}>
-                    <td>
-                      <div className="font-medium">{offer.distributor ?? "-"}</div>
-                      {isCurrent && <div className="text-xs text-muted">Current selection</div>}
-                    </td>
-                    <td>{offer.mpn ?? line.mpn_searched}</td>
-                    <td className="text-right tabular-nums">{formatValue(offer.stock)}</td>
-                    <td className="text-right tabular-nums">{formatMoney(offer.unit_price, offer.currency)}</td>
-                    <td>{formatValue(offer.packaging)}</td>
-                    <td className="text-right tabular-nums">{formatValue(offer.moq)}</td>
-                    <td className="text-right tabular-nums">{formatLeadTime(offer.lead_time_days)}</td>
-                    <td>
-                      {offer.url ? (
-                        <a
-                          className="text-accent hover:underline"
-                          href={offer.url}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                        >
-                          Open
-                        </a>
-                      ) : "-"}
-                    </td>
-                    <td className="text-right">
-                      <button
-                        type="button"
-                        className="btn"
-                        disabled={!canSelectOffer(line, offer)}
-                        onClick={() => onSelect(line, offer)}
-                      >
-                        Select
-                      </button>
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
+          <DataTable
+            rows={rows}
+            columns={columns}
+            rowKey={row => row.key}
+            tableId="purchase-plan-override-offers"
+            exportFilename="override-offers"
+            searchPlaceholder="Search offers..."
+          />
         )}
       </div>
     </Modal>

--- a/web/src/routes/projects/sourcing/__tests__/OverrideOfferModal.test.tsx
+++ b/web/src/routes/projects/sourcing/__tests__/OverrideOfferModal.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import OverrideOfferModal from "../OverrideOfferModal";
@@ -35,15 +35,15 @@ function line(): PurchasePlanLine {
   };
 }
 
-function renderModal(onClose = vi.fn()) {
+function renderModal(onClose = vi.fn(), onSelect = vi.fn()) {
   render(
     <OverrideOfferModal
       line={line()}
-      onSelect={vi.fn()}
+      onSelect={onSelect}
       onClose={onClose}
     />,
   );
-  return { onClose };
+  return { onClose, onSelect };
 }
 
 beforeEach(() => {
@@ -75,5 +75,27 @@ describe("OverrideOfferModal", () => {
     fireEvent.mouseDown(screen.getByRole("dialog", { name: "Override offer" }));
 
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders alternate offers in the shared DataTable", () => {
+    renderModal();
+
+    const table = screen.getByRole("table");
+    expect(within(table).getByText("Mouser")).toBeDefined();
+    expect(within(table).getByText("1.80 USD")).toBeDefined();
+    expect(screen.getByPlaceholderText("Search offers...")).toBeDefined();
+    expect(screen.getByRole("button", { name: "Export CSV" })).toBeDefined();
+  });
+
+  it("keeps selecting an alternate offer wired through the table action", async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    renderModal(vi.fn(), onSelect);
+
+    await user.click(screen.getByRole("button", { name: "Select" }));
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect.mock.calls[0][0].id).toBe("line-1");
+    expect(onSelect.mock.calls[0][1].distributor).toBe("Mouser");
   });
 });

--- a/web/src/routes/projects/sourcing/__tests__/OverrideOfferModal.test.tsx
+++ b/web/src/routes/projects/sourcing/__tests__/OverrideOfferModal.test.tsx
@@ -98,4 +98,34 @@ describe("OverrideOfferModal", () => {
     expect(onSelect.mock.calls[0][0].id).toBe("line-1");
     expect(onSelect.mock.calls[0][1].distributor).toBe("Mouser");
   });
+
+  it("keeps the current offer visible with a disabled hint row", () => {
+    render(
+      <OverrideOfferModal
+        line={{
+          ...line(),
+          available_offers: [
+            {
+              mpn: "STM32F103C8T6",
+              distributor: "DigiKey",
+              stock: 100,
+              unit_price: "2.00",
+              currency: "USD",
+              packaging: "Cut Tape",
+              moq: 1,
+              lead_time_days: 3,
+              url: "https://example.com/digikey/stm32",
+            },
+          ],
+        }}
+        onSelect={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Current selection")).toBeDefined();
+    expect(
+      (screen.getByRole("button", { name: "Current" }) as HTMLButtonElement).disabled,
+    ).toBe(true);
+  });
 });

--- a/web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.coverage.test.tsx
+++ b/web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.coverage.test.tsx
@@ -125,6 +125,71 @@ describe("ProjectSourcingPage", () => {
     expect(screen.getAllByText("100%").length).toBeGreaterThan(0);
   });
 
+  it("floors displayed coverage percentages instead of rounding up to 100%", async () => {
+    mockReads();
+    vi.spyOn(api, "post").mockResolvedValue(sourcingResponse({
+      rows: [
+        {
+          ...sourcingResponse().rows[0],
+          project_entry_id: "entry-1",
+        },
+        {
+          ...sourcingResponse().rows[1],
+          project_entry_id: "entry-2",
+        },
+        {
+          ...sourcingResponse().rows[1],
+          project_entry_id: "entry-3",
+          part_id: "part-3",
+          part_name: "Oscillator",
+          mpn: "ABCD1234",
+        },
+        {
+          ...sourcingResponse().rows[1],
+          project_entry_id: "entry-4",
+          part_id: "part-4",
+          part_name: "Connector",
+          mpn: "CONN-4",
+        },
+        {
+          ...sourcingResponse().rows[1],
+          project_entry_id: "entry-5",
+          part_id: "part-5",
+          part_name: "Ferrite",
+          mpn: "FB-5",
+        },
+      ],
+      coverage: {
+        ...sourcingResponse().coverage,
+        total_lines: 5,
+        rows: [
+          {
+            distributor: "DigiKey",
+            lines_covered: 199,
+            lines_uncovered: ["entry-5"],
+            coverage_pct: 0.995,
+            est_total_cost: "20.00",
+            worst_lead_time_days: 3,
+          },
+        ],
+        best_single_distributor: "DigiKey",
+        best_two_distributor_combo: ["DigiKey"],
+        lowest_total_price_combo: ["DigiKey"],
+        lowest_total_price_total: "20.00",
+        fewest_distributors_combo: ["DigiKey"],
+        fewest_distributors_total: "20.00",
+      },
+    }));
+
+    renderPage();
+    await clickSource();
+
+    await screen.findByText("Coverage matrix");
+    const table = screen.getAllByRole("table")[0];
+    expect(within(table).getByText("99%")).toBeDefined();
+    expect(within(table).queryByText("100%")).toBeNull();
+  });
+
   it("Coverage card labels partial variant totals as covered-line prices", async () => {
     mockReads();
     vi.spyOn(api, "post").mockResolvedValue(sourcingResponse({

--- a/web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.filters.test.tsx
+++ b/web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.filters.test.tsx
@@ -237,7 +237,6 @@ describe("ProjectSourcingPage", () => {
         total_bom_cost: null,
         cost_per_single_bom: null,
         purchase_to_pay_cost: null,
-        est_purchase_cost: null,
         blocking_lines_now: ["entry-1"],
         blocking_lines_after_purchase: ["entry-1"],
       },

--- a/web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.testUtils.tsx
+++ b/web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.testUtils.tsx
@@ -145,7 +145,6 @@ export function sourcingResponse(overrides: Record<string, unknown> = {}) {
       total_bom_cost: "30.00",
       cost_per_single_bom: "15.00",
       purchase_to_pay_cost: "25.00",
-      est_purchase_cost: "25.00",
       blocking_lines_now: ["entry-2"],
       blocking_lines_after_purchase: ["entry-1"],
     },

--- a/web/src/routes/projects/sourcing/sourcingTypes.ts
+++ b/web/src/routes/projects/sourcing/sourcingTypes.ts
@@ -95,7 +95,6 @@ export type SourcingBomResponse = {
     total_bom_cost?: string | number | null;
     cost_per_single_bom?: string | number | null;
     purchase_to_pay_cost?: string | number | null;
-    est_purchase_cost?: string | number | null;
     blocking_lines_now: string[];
     blocking_lines_after_purchase: string[];
   };


### PR DESCRIPTION
## Summary

Refs #512

Frontend polish:
- Floor coverage percentage displays so 99.5% no longer renders as 100%.
- Migrate the override-offer modal to the shared DataTable while preserving row actions and the current-selection hint.
- Migrate the part sourcing catalog fields table to the shared DataTable.

Backend/API cleanup:
- Add service-layer workspace guards for preloaded project/plan helpers and reject refreshes for archived projects.
- Use shortage quantity for best-offer price-break selection and recompute BOM `est_extended_cost` from converted display prices only when a display currency is requested.
- Preserve zero-shortage extended cost as `Decimal(0)` and quantize recomputed extended costs to 4 decimals.
- Add a lock around the process-local sourcing budget tracker.
- Promote raw sourcing distributor/price-break wire prices to Decimal parsing.
- Hash the workspace identifier in the TrustedParts UserAgent with `SESSION_SECRET`-keyed HMAC.
- Extract the shared infinite lead-time sentinel and pin that it cannot escape through `SourcingBomOfferOut.lead_time_days`.
- Remove the deprecated BOM capacity `est_purchase_cost` API alias while preserving report response fields that intentionally expose `est_purchase_cost`.
- Add regression pins for distinct-line coverage, TrustedParts lead-time mapping, and provider-exception containment across workspaces.

Review feedback addressed:
- Gated non-FX BOM extended-cost recomputation.
- Restored zero-quantity cost semantics.
- Keyed the workspace UA hash.
- Quantized recomputed row costs.
- Added lead-time sentinel and current-selection UI pins.
- Added a CONTRIBUTING note for bundled umbrella/backlog PRs.

## Validation

Current review-fix validation on `317bc64`:
- `cd backend && uv run --extra dev ruff check app/domain/sourcing/service.py app/domain/sourcing/factory.py app/domain/sourcing/schemas.py tests/test_sourcing_medium_backlog.py tests/test_sourcing_test_route.py` - passed
- `cd backend && uv run --extra dev pytest tests/test_sourcing_medium_backlog.py -q` - 8 passed, 1 warning
- `cd backend && uv run --extra dev pytest tests/test_sourcing_test_route.py::test_good_creds_returns_ok_and_latency -q` - 1 passed, 1 warning
- `cd backend && WORK_DIR="." LINT_CMD="uv run --extra dev ruff check app --output-format=concise" BASELINE_FILE="../.ruff-baseline.txt" bash ../scripts/lint-delta.sh` - no new violations
- `cd web && npm run typecheck` - passed
- `cd web && npm test -- --run src/routes/projects/sourcing/__tests__/OverrideOfferModal.test.tsx src/routes/parts/detail/__tests__/PartSourcing.test.tsx src/routes/projects/sourcing/__tests__/ProjectSourcingPage.coverage.test.tsx` - 17 passed
- `cd web && npx eslint src/routes/projects/sourcing/OverrideOfferModal.tsx src/routes/projects/sourcing/__tests__/OverrideOfferModal.test.tsx` - passed
- `git diff --check` - passed

Earlier full-suite validation before the review-fix commit:
- `cd backend && uv run --extra dev pytest -q --tb=short` - 1279 passed, 2 skipped, 233 warnings

A full backend rerun after `317bc64` was attempted locally, but the local Postgres test database returned `No space left on device` after 1241 passing tests. The refreshed GitHub Actions backend job is the clean full-suite gate for this commit.

## Merge Order

Can merge independently of the currently open dependabot Docker PRs. If another sourcing PR appears before this lands, merge this one first or rebase the later PR, because this branch touches shared sourcing service/schema/docs and project-sourcing frontend tests.

## Skipped Checklist Items

None intentionally. This PR covers the promoted #512 checklist; follow-up should only be needed for review feedback or CI drift.