### PR TITLE
SA-8b: Split PurchasePlanReviewPage.tsx (zero-headroom at 400-LOC cap)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ the canonical record.
 
 ## 2026-05 — feedback brief fixes
 
+- **SA-8b / #535** Split PurchasePlanReviewPage to keep sourcing files under 300-LOC headroom cap.
 - **SA-MED / #512** Sourcing cleanup tightened service-layer workspace
   guards, archived-project refresh filtering, raw Decimal wire prices, hashed
   TrustedParts user-agent workspace identifiers, budget-counter locking, and

--- a/web/src/routes/projects/sourcing/PurchasePlanLinesTable.tsx
+++ b/web/src/routes/projects/sourcing/PurchasePlanLinesTable.tsx
@@ -1,0 +1,133 @@
+import { DataTable, type Column } from "@/components/DataTable";
+import { SourcingSourceLabel } from "@/components/SourcingSourceLabel";
+import {
+  extendedCost,
+  formatLeadTime,
+  formatMoney,
+  numberOrNull,
+} from "./purchasePlanHelpers";
+import type { PurchasePlanLine, PurchasePlanOrderOverride } from "./purchasePlanTypes";
+
+type Props = {
+  planId: string;
+  grouped: [string, PurchasePlanLine[]][];
+  unfilled: PurchasePlanLine[];
+  currency: string | null;
+  overrides: Record<string, PurchasePlanOrderOverride>;
+  onOverride: (line: PurchasePlanLine) => void;
+};
+
+export default function PurchasePlanLinesTable({
+  planId,
+  grouped,
+  unfilled,
+  currency,
+  overrides,
+  onOverride,
+}: Props) {
+  const columns: Column<PurchasePlanLine>[] = [
+    { key: "mpn", header: "MPN", accessor: line => line.mpn_searched },
+    { key: "required", header: "Required", accessor: line => line.required_qty, align: "right" },
+    { key: "internal", header: "Internal", accessor: line => line.internal_available_qty, align: "right" },
+    { key: "shortage", header: "Shortage", accessor: line => line.shortage_qty, align: "right" },
+    { key: "qty", header: "Selected qty", accessor: line => line.selected_qty ?? 0, align: "right" },
+    {
+      key: "unit",
+      header: "Unit price",
+      accessor: line => numberOrNull(line.selected_unit_price),
+      render: line => formatMoney(line.selected_unit_price, line.selected_currency),
+      align: "right",
+    },
+    {
+      key: "extended",
+      header: "Extended",
+      accessor: line => extendedCost(line),
+      render: line => formatMoney(extendedCost(line), line.selected_currency),
+      align: "right",
+    },
+    {
+      key: "lead",
+      header: "Lead time",
+      accessor: line => line.selected_lead_time_days,
+      render: line => formatLeadTime(line.selected_lead_time_days),
+      align: "right",
+    },
+    {
+      key: "risk",
+      header: "Risk",
+      accessor: line => line.risk_flags.join(" "),
+      render: line => (
+        <span className="flex flex-wrap gap-1">
+          {line.risk_flags.length === 0 ? (
+            <span className="text-muted">-</span>
+          ) : line.risk_flags.map(flag => (
+            <span key={flag} className="pill bg-warning/10 text-warning">
+              {flag.replaceAll("_", " ")}
+            </span>
+          ))}
+        </span>
+      ),
+    },
+    {
+      key: "link",
+      header: "Offer",
+      accessor: line => line.selected_url ?? "",
+      render: line => line.selected_url ? (
+        <a className="text-accent hover:underline" href={line.selected_url} target="_blank" rel="noopener noreferrer">
+          Open
+        </a>
+      ) : "-",
+    },
+    {
+      key: "override",
+      header: "Override",
+      accessor: () => "",
+      render: line => (
+        <button
+          type="button"
+          className={overrides[line.id] ? "btn-primary" : "btn"}
+          onClick={() => onOverride(line)}
+        >
+          Override
+        </button>
+      ),
+    },
+  ];
+
+  return (
+    <>
+      {grouped.map(([distributor, lines]) => {
+        const subtotal = lines.reduce((sum, line) => sum + (extendedCost(line) ?? 0), 0);
+        return (
+          <details key={distributor} className="rounded-md border border-border bg-panel p-4" open>
+            <summary className="cursor-pointer">
+              <span className="font-medium">{distributor}</span>
+              <span className="ml-2 text-sm text-muted">{lines.length} lines - {formatMoney(subtotal, currency)}</span>
+              <span className="ml-2"><SourcingSourceLabel source="trustedparts" /></span>
+            </summary>
+            <div className="mt-3">
+              <DataTable
+                rows={lines}
+                columns={columns}
+                rowKey={line => line.id}
+                tableId={`purchase-plan-${planId}-${distributor}`}
+                exportFilename={`purchase-plan-${distributor}`}
+              />
+            </div>
+          </details>
+        );
+      })}
+      {unfilled.length > 0 && (
+        <section className="rounded-md border border-danger/40 bg-panel p-4">
+          <h2 className="text-md font-semibold text-danger">Unfilled lines</h2>
+          <DataTable
+            rows={unfilled}
+            columns={columns}
+            rowKey={line => line.id}
+            tableId={`purchase-plan-${planId}-unfilled`}
+          />
+        </section>
+      )}
+    </>
+  );
+}

--- a/web/src/routes/projects/sourcing/PurchasePlanReviewPage.tsx
+++ b/web/src/routes/projects/sourcing/PurchasePlanReviewPage.tsx
@@ -3,13 +3,24 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 import { RefreshCw, ShoppingCart } from "lucide-react";
 import { toast } from "sonner";
-import { DataTable, type Column } from "@/components/DataTable";
 import { PoweredByTrustedParts } from "@/components/PoweredByTrustedParts";
-import { SourcingSourceLabel } from "@/components/SourcingSourceLabel";
 import { ApiError, api } from "@/lib/api";
 import { useWsKey } from "@/lib/queryKeys";
 import type { Project } from "@/types";
 import OverrideOfferModal from "./OverrideOfferModal";
+import PurchasePlanLinesTable from "./PurchasePlanLinesTable";
+import {
+  formatLeadTime,
+  formatMoney,
+  groupLines,
+  isRefreshFresh,
+  purchasePlanActionErrorMessage,
+  recomputePlanFromLines,
+  refreshedLabel,
+  selectedQtyForOffer,
+  summaryCurrency,
+  unitPriceForOffer,
+} from "./purchasePlanHelpers";
 import type {
   ConvertOrdersRequest,
   ConvertOrdersResponse,
@@ -19,119 +30,7 @@ import type {
   PurchasePlanOrderOverride,
 } from "./purchasePlanTypes";
 type LocationState = { plan?: PurchasePlan; project?: Project };
-const STALE_MS = 10 * 60 * 1000;
-function numberOrNull(value: string | number | null | undefined): number | null {
-  if (value == null || value === "") return null;
-  const parsed = typeof value === "number" ? value : Number(value);
-  return Number.isFinite(parsed) ? parsed : null;
-}
-function formatMoney(value: string | number | null | undefined, currency?: string | null): string {
-  const numeric = numberOrNull(value);
-  if (numeric == null) return "-";
-  const formatted = numeric.toLocaleString(undefined, {
-    maximumFractionDigits: 2,
-    minimumFractionDigits: numeric % 1 === 0 ? 0 : 2,
-  });
-  return currency ? `${formatted} ${currency}` : formatted;
-}
-function formatLeadTime(days: number | null | undefined): string {
-  return days == null ? "-" : days === 1 ? "1 day" : `${days.toLocaleString()} days`;
-}
-function refreshedLabel(plan: PurchasePlan): string {
-  if (!plan.last_refreshed_at) return "Not refreshed yet";
-  const ageMs = Date.now() - new Date(plan.last_refreshed_at).getTime();
-  const minutes = Math.max(0, Math.floor(ageMs / 60000));
-  return `Refreshed ${minutes} min ago`;
-}
-function isRefreshFresh(plan: PurchasePlan): boolean {
-  return !!plan.last_refreshed_at && Date.now() - new Date(plan.last_refreshed_at).getTime() <= STALE_MS;
-}
-function extendedCost(line: PurchasePlanLine): number | null {
-  const unit = numberOrNull(line.selected_unit_price);
-  if (unit == null || line.selected_qty == null) return null;
-  return unit * line.selected_qty;
-}
-function selectedQtyForOffer(line: PurchasePlanLine, offer: PurchasePlanOffer): number {
-  return Math.max(Math.max(0, line.shortage_qty), Math.max(0, numberOrNull(offer.moq) ?? 0), 1);
-}
-function unitPriceForOffer(offer: PurchasePlanOffer, qty: number): string | number | null {
-  const breaks = (offer.price_breaks ?? [])
-    .map(priceBreak => ({
-      quantity: numberOrNull(priceBreak.quantity),
-      unitPrice: priceBreak.unit_price,
-    }))
-    .filter((priceBreak): priceBreak is { quantity: number; unitPrice: string | number } =>
-      priceBreak.quantity != null &&
-      priceBreak.quantity >= 1 &&
-      priceBreak.unitPrice != null &&
-      priceBreak.unitPrice !== "",
-    )
-    .sort((a, b) => a.quantity - b.quantity);
-  if (breaks.length === 0) return offer.unit_price ?? null;
-  let selected = breaks[0];
-  for (const candidate of breaks) {
-    if (candidate.quantity > qty) break;
-    selected = candidate;
-  }
-  return selected.unitPrice;
-}
-function recomputePlanFromLines(plan: PurchasePlan, lines: PurchasePlanLine[]): PurchasePlan {
-  const distributors = new Set<string>();
-  let estTotal = 0;
-  let hasCost = false;
-  let worstLeadTime: number | null = null;
-  let unfilledCount = 0;
-  for (const line of lines) {
-    if (line.selected_distributor) {
-      distributors.add(line.selected_distributor);
-    } else {
-      unfilledCount += 1;
-    }
-    const cost = extendedCost(line);
-    if (cost != null) {
-      estTotal += cost;
-      hasCost = true;
-    }
-    if (line.selected_lead_time_days != null) {
-      worstLeadTime = Math.max(worstLeadTime ?? 0, line.selected_lead_time_days);
-    }
-  }
-  return {
-    ...plan,
-    lines,
-    distributors_used: [...distributors].sort((a, b) => a.localeCompare(b)),
-    est_total_cost: hasCost ? estTotal : plan.est_total_cost,
-    worst_lead_time_days: worstLeadTime,
-    unfilled_count: unfilledCount,
-  };
-}
-function groupLines(lines: PurchasePlanLine[]) {
-  const groups = new Map<string, PurchasePlanLine[]>();
-  for (const line of lines) {
-    if (!line.selected_distributor) continue;
-    const current = groups.get(line.selected_distributor) ?? [];
-    current.push(line);
-    groups.set(line.selected_distributor, current);
-  }
-  return [...groups.entries()].sort(([a], [b]) => a.localeCompare(b));
-}
-function summaryCurrency(plan: PurchasePlan): string | null {
-  return plan.lines.find(line => line.selected_currency)?.selected_currency ?? plan.currency_code ?? null;
-}
-function purchasePlanActionErrorMessage(error: unknown, fallback: string): string {
-  if (!(error instanceof ApiError)) return fallback;
-  switch (error.code) {
-    case "sourcing.plan_stale":
-      return "Prices are stale. Refresh prices before creating draft orders.";
-    case "sourcing.currency_mismatch":
-      return "Sourcing returned mixed currencies. Check workspace currency settings.";
-    case "rate_limited":
-    case "sourcing.provider_rate_limited":
-      return "Rate limit hit — wait a minute before trying again.";
-    default:
-      return error.userMessage || fallback;
-  }
-}
+
 export default function PurchasePlanReviewPage() {
   const { projectId, planId } = useParams<{ projectId: string; planId: string }>();
   const navigate = useNavigate();
@@ -196,74 +95,6 @@ export default function PurchasePlanReviewPage() {
   }
   const fresh = isRefreshFresh(plan);
   const currency = summaryCurrency(plan);
-  const columns: Column<PurchasePlanLine>[] = [
-    { key: "mpn", header: "MPN", accessor: line => line.mpn_searched },
-    { key: "required", header: "Required", accessor: line => line.required_qty, align: "right" },
-    { key: "internal", header: "Internal", accessor: line => line.internal_available_qty, align: "right" },
-    { key: "shortage", header: "Shortage", accessor: line => line.shortage_qty, align: "right" },
-    { key: "qty", header: "Selected qty", accessor: line => line.selected_qty ?? 0, align: "right" },
-    {
-      key: "unit",
-      header: "Unit price",
-      accessor: line => numberOrNull(line.selected_unit_price),
-      render: line => formatMoney(line.selected_unit_price, line.selected_currency),
-      align: "right",
-    },
-    {
-      key: "extended",
-      header: "Extended",
-      accessor: line => extendedCost(line),
-      render: line => formatMoney(extendedCost(line), line.selected_currency),
-      align: "right",
-    },
-    {
-      key: "lead",
-      header: "Lead time",
-      accessor: line => line.selected_lead_time_days,
-      render: line => formatLeadTime(line.selected_lead_time_days),
-      align: "right",
-    },
-    {
-      key: "risk",
-      header: "Risk",
-      accessor: line => line.risk_flags.join(" "),
-      render: line => (
-        <span className="flex flex-wrap gap-1">
-          {line.risk_flags.length === 0 ? (
-            <span className="text-muted">-</span>
-          ) : line.risk_flags.map(flag => (
-            <span key={flag} className="pill bg-warning/10 text-warning">
-              {flag.replaceAll("_", " ")}
-            </span>
-          ))}
-        </span>
-      ),
-    },
-    {
-      key: "link",
-      header: "Offer",
-      accessor: line => line.selected_url ?? "",
-      render: line => line.selected_url ? (
-        <a className="text-accent hover:underline" href={line.selected_url} target="_blank" rel="noopener noreferrer">
-          Open
-        </a>
-      ) : "-",
-    },
-    {
-      key: "override",
-      header: "Override",
-      accessor: () => "",
-      render: line => (
-        <button
-          type="button"
-          className={overrides[line.id] ? "btn-primary" : "btn"}
-          onClick={() => setOverrideLine(line)}
-        >
-          Override
-        </button>
-      ),
-    },
-  ];
   async function refresh() {
     if (!plan) return;
     setBusyAction("refresh");
@@ -369,38 +200,14 @@ export default function PurchasePlanReviewPage() {
           <div className="text-2xl font-semibold">{plan.unfilled_count}</div>
         </div>
       </div>
-      {grouped.map(([distributor, lines]) => {
-        const subtotal = lines.reduce((sum, line) => sum + (extendedCost(line) ?? 0), 0);
-        return (
-          <details key={distributor} className="rounded-md border border-border bg-panel p-4" open>
-            <summary className="cursor-pointer">
-              <span className="font-medium">{distributor}</span>
-              <span className="ml-2 text-sm text-muted">{lines.length} lines - {formatMoney(subtotal, currency)}</span>
-              <span className="ml-2"><SourcingSourceLabel source="trustedparts" /></span>
-            </summary>
-            <div className="mt-3">
-              <DataTable
-                rows={lines}
-                columns={columns}
-                rowKey={line => line.id}
-                tableId={`purchase-plan-${plan.id}-${distributor}`}
-                exportFilename={`purchase-plan-${distributor}`}
-              />
-            </div>
-          </details>
-        );
-      })}
-      {unfilled.length > 0 && (
-        <section className="rounded-md border border-danger/40 bg-panel p-4">
-          <h2 className="text-md font-semibold text-danger">Unfilled lines</h2>
-          <DataTable
-            rows={unfilled}
-            columns={columns}
-            rowKey={line => line.id}
-            tableId={`purchase-plan-${plan.id}-unfilled`}
-          />
-        </section>
-      )}
+      <PurchasePlanLinesTable
+        planId={plan.id}
+        grouped={grouped}
+        unfilled={unfilled}
+        currency={currency}
+        overrides={overrides}
+        onOverride={setOverrideLine}
+      />
       <div className="sticky bottom-0 bg-panel border border-border rounded-md p-3 flex flex-wrap justify-end gap-2">
         <button
           type="button"

--- a/web/src/routes/projects/sourcing/README.md
+++ b/web/src/routes/projects/sourcing/README.md
@@ -13,4 +13,5 @@ frontend conventions live in `docs/frontend/`; architecture rules live in
 - `BomRows.tsx` owns the sourced BOM table and distributor drill-down entry.
 - `SourcingStates.tsx` owns loading, empty, diagnostics, and retry states.
 - `sourcingTypes.ts` and `sourcingHelpers.ts` hold shared route-local types and pure helpers.
+- `PurchasePlanLinesTable.tsx` and `purchasePlanHelpers.ts` keep purchase-plan tables and pure helpers out of the review route.
 - Modal and purchase-plan files remain adjacent because they share sourcing DTOs.

--- a/web/src/routes/projects/sourcing/purchasePlanHelpers.ts
+++ b/web/src/routes/projects/sourcing/purchasePlanHelpers.ts
@@ -1,0 +1,128 @@
+import { ApiError } from "@/lib/api";
+import type { PurchasePlan, PurchasePlanLine, PurchasePlanOffer } from "./purchasePlanTypes";
+
+export const STALE_MS = 10 * 60 * 1000;
+
+export function numberOrNull(value: string | number | null | undefined): number | null {
+  if (value == null || value === "") return null;
+  const parsed = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export function formatMoney(value: string | number | null | undefined, currency?: string | null): string {
+  const numeric = numberOrNull(value);
+  if (numeric == null) return "-";
+  const formatted = numeric.toLocaleString(undefined, {
+    maximumFractionDigits: 2,
+    minimumFractionDigits: numeric % 1 === 0 ? 0 : 2,
+  });
+  return currency ? `${formatted} ${currency}` : formatted;
+}
+
+export function formatLeadTime(days: number | null | undefined): string {
+  return days == null ? "-" : days === 1 ? "1 day" : `${days.toLocaleString()} days`;
+}
+
+export function refreshedLabel(plan: PurchasePlan): string {
+  if (!plan.last_refreshed_at) return "Not refreshed yet";
+  const ageMs = Date.now() - new Date(plan.last_refreshed_at).getTime();
+  const minutes = Math.max(0, Math.floor(ageMs / 60000));
+  return `Refreshed ${minutes} min ago`;
+}
+
+export function isRefreshFresh(plan: PurchasePlan): boolean {
+  return !!plan.last_refreshed_at && Date.now() - new Date(plan.last_refreshed_at).getTime() <= STALE_MS;
+}
+
+export function extendedCost(line: PurchasePlanLine): number | null {
+  const unit = numberOrNull(line.selected_unit_price);
+  if (unit == null || line.selected_qty == null) return null;
+  return unit * line.selected_qty;
+}
+
+export function selectedQtyForOffer(line: PurchasePlanLine, offer: PurchasePlanOffer): number {
+  return Math.max(Math.max(0, line.shortage_qty), Math.max(0, numberOrNull(offer.moq) ?? 0), 1);
+}
+
+export function unitPriceForOffer(offer: PurchasePlanOffer, qty: number): string | number | null {
+  const breaks = (offer.price_breaks ?? [])
+    .map(priceBreak => ({
+      quantity: numberOrNull(priceBreak.quantity),
+      unitPrice: priceBreak.unit_price,
+    }))
+    .filter((priceBreak): priceBreak is { quantity: number; unitPrice: string | number } =>
+      priceBreak.quantity != null &&
+      priceBreak.quantity >= 1 &&
+      priceBreak.unitPrice != null &&
+      priceBreak.unitPrice !== "",
+    )
+    .sort((a, b) => a.quantity - b.quantity);
+  if (breaks.length === 0) return offer.unit_price ?? null;
+  let selected = breaks[0];
+  for (const candidate of breaks) {
+    if (candidate.quantity > qty) break;
+    selected = candidate;
+  }
+  return selected.unitPrice;
+}
+
+export function recomputePlanFromLines(plan: PurchasePlan, lines: PurchasePlanLine[]): PurchasePlan {
+  const distributors = new Set<string>();
+  let estTotal = 0;
+  let hasCost = false;
+  let worstLeadTime: number | null = null;
+  let unfilledCount = 0;
+  for (const line of lines) {
+    if (line.selected_distributor) {
+      distributors.add(line.selected_distributor);
+    } else {
+      unfilledCount += 1;
+    }
+    const cost = extendedCost(line);
+    if (cost != null) {
+      estTotal += cost;
+      hasCost = true;
+    }
+    if (line.selected_lead_time_days != null) {
+      worstLeadTime = Math.max(worstLeadTime ?? 0, line.selected_lead_time_days);
+    }
+  }
+  return {
+    ...plan,
+    lines,
+    distributors_used: [...distributors].sort((a, b) => a.localeCompare(b)),
+    est_total_cost: hasCost ? estTotal : plan.est_total_cost,
+    worst_lead_time_days: worstLeadTime,
+    unfilled_count: unfilledCount,
+  };
+}
+
+export function groupLines(lines: PurchasePlanLine[]) {
+  const groups = new Map<string, PurchasePlanLine[]>();
+  for (const line of lines) {
+    if (!line.selected_distributor) continue;
+    const current = groups.get(line.selected_distributor) ?? [];
+    current.push(line);
+    groups.set(line.selected_distributor, current);
+  }
+  return [...groups.entries()].sort(([a], [b]) => a.localeCompare(b));
+}
+
+export function summaryCurrency(plan: PurchasePlan): string | null {
+  return plan.lines.find(line => line.selected_currency)?.selected_currency ?? plan.currency_code ?? null;
+}
+
+export function purchasePlanActionErrorMessage(error: unknown, fallback: string): string {
+  if (!(error instanceof ApiError)) return fallback;
+  switch (error.code) {
+    case "sourcing.plan_stale":
+      return "Prices are stale. Refresh prices before creating draft orders.";
+    case "sourcing.currency_mismatch":
+      return "Sourcing returned mixed currencies. Check workspace currency settings.";
+    case "rate_limited":
+    case "sourcing.provider_rate_limited":
+      return "Rate limit hit — wait a minute before trying again.";
+    default:
+      return error.userMessage || fallback;
+  }
+}


### PR DESCRIPTION
## Summary
- Moved pure purchase-plan helpers out of `PurchasePlanReviewPage.tsx` into `purchasePlanHelpers.ts`.
- Moved the purchase-plan line table columns/rendering into `PurchasePlanLinesTable.tsx`.
- Added the requested sourcing README bullet and changelog line.

## Rendered Output
No rendered-output diff intended. The JSX/class names/table ids/export filenames, helper bodies, and column definitions were moved without behavior changes; the existing `PurchasePlanReviewPage` test suite passes unchanged.

## LOC Audit
Before highlights from `origin/main`:
- `PurchasePlanReviewPage.tsx`: 422 LOC
- `BomDistributorsModal.tsx`: 332 LOC, pre-existing and outside this issue's write scope

After, touched purchase-plan files:
```text
  128 web/src/routes/projects/sourcing/purchasePlanHelpers.ts
  133 web/src/routes/projects/sourcing/PurchasePlanLinesTable.tsx
  229 web/src/routes/projects/sourcing/PurchasePlanReviewPage.tsx
```

After, non-test sourcing audit:
```text
   43 web/src/routes/projects/sourcing/useProjectSourcing.ts
   52 web/src/routes/projects/sourcing/SourceBomButton.tsx
   78 web/src/routes/projects/sourcing/CapacityBanner.tsx
  101 web/src/routes/projects/sourcing/purchasePlanTypes.ts
  110 web/src/routes/projects/sourcing/useSourcingFilters.ts
  117 web/src/routes/projects/sourcing/sourcingTypes.ts
  125 web/src/routes/projects/sourcing/SourcingStates.tsx
  128 web/src/routes/projects/sourcing/purchasePlanHelpers.ts
  133 web/src/routes/projects/sourcing/PurchasePlanLinesTable.tsx
  144 web/src/routes/projects/sourcing/sourcingHelpers.ts
  151 web/src/routes/projects/sourcing/PurchasePlanOptionsModal.tsx
  152 web/src/routes/projects/sourcing/SourcingControls.tsx
  181 web/src/routes/projects/sourcing/CoverageMatrix.tsx
  193 web/src/routes/projects/sourcing/ProjectSourcingPage.tsx
  210 web/src/routes/projects/sourcing/BomRows.tsx
  213 web/src/routes/projects/sourcing/OverrideOfferModal.tsx
  229 web/src/routes/projects/sourcing/PurchasePlanReviewPage.tsx
  332 web/src/routes/projects/sourcing/BomDistributorsModal.tsx
 2692 total
```

Required command output after the split:
```text
    43 web/src/routes/projects/sourcing/useProjectSourcing.ts
    52 web/src/routes/projects/sourcing/SourceBomButton.tsx
    78 web/src/routes/projects/sourcing/CapacityBanner.tsx
   101 web/src/routes/projects/sourcing/purchasePlanTypes.ts
   105 web/src/routes/projects/sourcing/__tests__/PurchasePlanOptionsModal.test.tsx
   110 web/src/routes/projects/sourcing/useSourcingFilters.ts
   117 web/src/routes/projects/sourcing/sourcingTypes.ts
   125 web/src/routes/projects/sourcing/SourcingStates.tsx
   128 web/src/routes/projects/sourcing/purchasePlanHelpers.ts
   131 web/src/routes/projects/sourcing/__tests__/OverrideOfferModal.test.tsx
   133 web/src/routes/projects/sourcing/PurchasePlanLinesTable.tsx
   142 web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.actions.test.tsx
   144 web/src/routes/projects/sourcing/sourcingHelpers.ts
   151 web/src/routes/projects/sourcing/PurchasePlanOptionsModal.tsx
   152 web/src/routes/projects/sourcing/SourcingControls.tsx
   173 web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.riskColumns.test.tsx
   180 web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.bomRows.test.tsx
   181 web/src/routes/projects/sourcing/CoverageMatrix.tsx
   193 web/src/routes/projects/sourcing/ProjectSourcingPage.tsx
   198 web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.diagnostics.test.tsx
   205 web/src/routes/projects/sourcing/__tests__/BomDistributorsModal.test.tsx
   210 web/src/routes/projects/sourcing/BomRows.tsx
   213 web/src/routes/projects/sourcing/OverrideOfferModal.tsx
   229 web/src/routes/projects/sourcing/PurchasePlanReviewPage.tsx
   231 web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.testUtils.tsx
   254 web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.filters.test.tsx
   274 web/src/routes/projects/sourcing/__tests__/ProjectSourcingPage.coverage.test.tsx
   332 web/src/routes/projects/sourcing/BomDistributorsModal.tsx
   468 web/src/routes/projects/sourcing/__tests__/PurchasePlanReviewPage.test.tsx
  5053 total
```

## Validation
- `npm run typecheck`: pass
- `npm test -- "PurchasePlanReview"`: pass, 1 file / 15 tests
- `npx eslint src/routes/projects/sourcing/PurchasePlanReviewPage.tsx src/routes/projects/sourcing/PurchasePlanLinesTable.tsx src/routes/projects/sourcing/purchasePlanHelpers.ts`: pass
- `npm run build`: pass; Vite emitted existing env-placeholder and chunk-size warnings
- `npm run lint`: fails on unrelated existing files outside this PR, notably `src/lib/bagCode.ts:91` and `src/lib/bagCode.ts:164` `no-control-regex`, plus existing warnings in scanner/routes files

## Merge Order
Based on `origin/main` at `aa12e44`. Independent of #534 backend alert work; no backend alert schema/service files were touched.

Refs #535
