### PR TITLE
SA-11b: Extend threshold discriminated union to SourcingAlertPatch + SourcingAlertOut

### DIFF
--- a/backend/app/api/routes/sourcing.py
+++ b/backend/app/api/routes/sourcing.py
@@ -13,7 +13,7 @@ from app.api._helpers import assert_in_workspace
 from app.core.deps import CurrentUser, CurrentWorkspace, require_role
 from app.core.errors import ErrorCodes
 from app.core.ratelimit import limiter, workspace_key
-from app.core.responses import err, ok
+from app.core.responses import Envelope, err, ok
 from app.core.time import utcnow
 from app.domain.fx import rates as fx_rates
 from app.domain.fx._apply import apply_fx_to_offer
@@ -172,7 +172,7 @@ def list_sourcing_alerts(
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
     db: Session = Depends(get_db),
-):
+) -> Envelope[SourcingAlertListOut]:
     alerts, total = sourcing_service.list_alerts_page(
         db,
         workspace=ws,
@@ -204,7 +204,7 @@ def create_sourcing_alert(
     ws: CurrentWorkspace,
     user: CurrentUser,
     db: Session = Depends(get_db),
-):
+) -> Envelope[SourcingAlertOut]:
     alert = sourcing_service.create_alert(
         db,
         workspace=ws,
@@ -222,7 +222,7 @@ def get_sourcing_alert(
     alert_id: UUID,
     ws: CurrentWorkspace,
     db: Session = Depends(get_db),
-):
+) -> Envelope[SourcingAlertOut]:
     alert = sourcing_service.get_alert(db, workspace=ws, alert_id=alert_id)
     return ok(_alert_payload(alert))
 
@@ -236,7 +236,7 @@ def update_sourcing_alert(
     payload: SourcingAlertPatch,
     ws: CurrentWorkspace,
     db: Session = Depends(get_db),
-):
+) -> Envelope[SourcingAlertOut]:
     alert = sourcing_service.update_alert(
         db,
         workspace=ws,
@@ -254,7 +254,7 @@ def delete_sourcing_alert(
     alert_id: UUID,
     ws: CurrentWorkspace,
     db: Session = Depends(get_db),
-):
+) -> Envelope[SourcingAlertOut]:
     alert = sourcing_service.archive_alert(db, workspace=ws, alert_id=alert_id)
     return ok(_alert_payload(alert))
 

--- a/backend/app/domain/sourcing/schemas.py
+++ b/backend/app/domain/sourcing/schemas.py
@@ -343,20 +343,20 @@ _THRESHOLD_ADAPTER = TypeAdapter(SourcingAlertThreshold)
 
 def validate_alert_threshold(
     alert_type: SourcingAlertType | str,
-    threshold: SourcingAlertThreshold | dict[str, Any],
+    value: SourcingAlertThreshold | dict[str, Any],
 ) -> SourcingAlertThreshold:
-    if isinstance(threshold, BaseModel) and getattr(threshold, "alert_type", None) == alert_type:
-        return threshold
-    if isinstance(threshold, BaseModel):
-        threshold = threshold.model_dump(mode="python")
-    return _THRESHOLD_ADAPTER.validate_python({"alert_type": alert_type, **threshold})
+    if isinstance(value, BaseModel) and getattr(value, "alert_type", None) == alert_type:
+        return value
+    if isinstance(value, BaseModel):
+        value = value.model_dump(mode="python")
+    return _THRESHOLD_ADAPTER.validate_python({"alert_type": alert_type, **value})
 
 
 def dump_alert_threshold(
     alert_type: SourcingAlertType | str,
-    threshold: SourcingAlertThreshold | dict[str, Any],
+    value: SourcingAlertThreshold | dict[str, Any],
 ) -> dict[str, Any]:
-    return validate_alert_threshold(alert_type, threshold).model_dump(mode="json")
+    return validate_alert_threshold(alert_type, value).model_dump(mode="json")
 
 
 class SourcingAlertIn(BaseModel):
@@ -395,7 +395,7 @@ class SourcingAlertPatch(BaseModel):
     alert_type: SourcingAlertType | None = None
     part_id: UUID | None = None
     project_id: UUID | None = None
-    threshold: dict[str, Any] | None = None
+    threshold: SourcingAlertThresholdIn | None = None
     country_code: str | None = Field(default=None, min_length=2, max_length=2)
     currency_code: str | None = Field(default=None, min_length=3, max_length=3)
     distributor_filter: list[str] | None = Field(default=None, max_length=MAX_DISTRIBUTORS)
@@ -427,7 +427,7 @@ class SourcingAlertOut(BaseModel):
     alert_type: SourcingAlertType
     part_id: UUID | None = None
     project_id: UUID | None = None
-    threshold: dict[str, Any]
+    threshold: SourcingAlertThreshold
     country_code: str | None = None
     currency_code: str | None = None
     distributor_filter: list[str] | None = None
@@ -440,6 +440,11 @@ class SourcingAlertOut(BaseModel):
     created_by: UUID | None = None
     created_at: datetime
     updated_at: datetime
+
+    @field_validator("threshold", mode="before")
+    @classmethod
+    def _threshold_with_alert_type(cls, value: Any, info: ValidationInfo) -> Any:
+        return _threshold_with_parent_alert_type(value, info)
 
 
 class SourcingAlertListOut(BaseModel):

--- a/backend/app/domain/sourcing/service.py
+++ b/backend/app/domain/sourcing/service.py
@@ -2,15 +2,13 @@
 
 from __future__ import annotations
 
-import json
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from decimal import ROUND_HALF_UP, Decimal
-from typing import Any
+from typing import Any, cast
 from uuid import UUID
 
-from pydantic import ValidationError
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
@@ -285,6 +283,9 @@ def update_alert(
 
     alert = get_alert(db, workspace=workspace, alert_id=alert_id)
     data = payload.model_dump(exclude_unset=True)
+    threshold: SourcingAlertThreshold | dict[str, Any] = cast(dict[str, Any], alert.threshold)
+    if "threshold" in payload.model_fields_set and payload.threshold is not None:
+        threshold = payload.threshold
     values = _validated_alert_values(
         db,
         workspace=workspace,
@@ -292,7 +293,7 @@ def update_alert(
             alert_type=alert.alert_type,
             part_id=data.get("part_id", alert.part_id),
             project_id=data.get("project_id", alert.project_id),
-            threshold=data.get("threshold", alert.threshold),
+            threshold=threshold,
             country_code=data.get("country_code", alert.country_code),
             currency_code=data.get("currency_code", alert.currency_code),
             distributor_filter=data.get("distributor_filter", alert.distributor_filter),
@@ -365,7 +366,7 @@ def _validated_alert_values(
     if project_id is not None:
         assert_in_workspace(db, Project, project_id, workspace.id, label="project")
 
-    validated_threshold = _validated_threshold(alert_type, values.threshold)
+    validated_threshold = dump_alert_threshold(alert_type, values.threshold)
     validated_notify_user_ids = _validated_notify_user_ids(
         db,
         workspace_id=workspace.id,
@@ -388,21 +389,6 @@ def _validated_alert_values(
         "cooldown_seconds": values.cooldown_seconds,
         "enabled": values.enabled,
     }
-
-
-def _validated_threshold(
-    alert_type: SourcingAlertType | str,
-    threshold: SourcingAlertThreshold | dict[str, Any],
-) -> dict[str, Any]:
-    try:
-        return dump_alert_threshold(alert_type, threshold)
-    except ValidationError as exc:
-        raise_http(
-            422,
-            "sourcing_alert.invalid_threshold",
-            "invalid threshold for alert_type",
-            errors=json.loads(exc.json()),
-        )
 
 
 def _validated_notify_user_ids(

--- a/backend/tests/test_sourcing_alerts_route.py
+++ b/backend/tests/test_sourcing_alerts_route.py
@@ -88,6 +88,101 @@ def _single_line_project(client: TestClient, *, name: str = "Alerts BOM") -> tup
     return project_id, part_id
 
 
+WRONG_THRESHOLD_CASES = [
+    ("stock_below", {"qty": -5}),
+    ("stock_above", {"qty": -5}),
+    ("back_in_stock", {"qty": 1}),
+    ("out_of_authorized_stock", {"qty": 1}),
+    ("price_changed", {"delta_pct": 150}),
+    ("bom_buyable", {"build_quantity": 0}),
+    ("lifecycle_risk_changed", {"to_states": ["Obsolete"]}),
+    ("supply_chain_risk_changed", {"must_contain": "NRND", "unexpected": True}),
+    ("tariff_status_changed", {"must_contain": "yes"}),
+]
+
+VALID_THRESHOLD_CASES = [
+    ("stock_below", {"qty": 5}, {"qty": 5}),
+    ("stock_above", {"qty": 5}, {"qty": 5}),
+    ("back_in_stock", {}, {}),
+    ("out_of_authorized_stock", {}, {}),
+    ("price_changed", {"delta_pct": 5}, {"delta_pct": "5"}),
+    ("bom_buyable", {"build_quantity": 2}, {"build_quantity": 2}),
+    (
+        "lifecycle_risk_changed",
+        {"must_contain": "EOL", "case_sensitive": True},
+        {"must_contain": "EOL", "case_sensitive": True},
+    ),
+    (
+        "supply_chain_risk_changed",
+        {"must_contain": "NRND", "case_sensitive": False},
+        {"must_contain": "NRND", "case_sensitive": False},
+    ),
+    ("tariff_status_changed", {}, {}),
+]
+
+PATCH_THRESHOLD_CASES = [
+    ("stock_below", {"qty": 7}, {"qty": 7}),
+    ("stock_above", {"qty": 70}, {"qty": 70}),
+    ("back_in_stock", {}, {}),
+    ("out_of_authorized_stock", {}, {}),
+    ("price_changed", {"delta_pct": 7}, {"delta_pct": "7"}),
+    ("bom_buyable", {"build_quantity": 3}, {"build_quantity": 3}),
+    (
+        "lifecycle_risk_changed",
+        {"must_contain": "EOL", "case_sensitive": False},
+        {"must_contain": "EOL", "case_sensitive": False},
+    ),
+    (
+        "supply_chain_risk_changed",
+        {"must_contain": "NRND", "case_sensitive": True},
+        {"must_contain": "NRND", "case_sensitive": True},
+    ),
+    ("tariff_status_changed", {}, {}),
+]
+
+VALID_THRESHOLDS_BY_TYPE = {
+    alert_type: threshold for alert_type, threshold, _expected in VALID_THRESHOLD_CASES
+}
+
+
+def _targeted_alert_payload(
+    alert_type: str,
+    *,
+    project_id: str,
+    part_id: str,
+    threshold: dict,
+) -> dict:
+    payload = {
+        "alert_type": alert_type,
+        "threshold": threshold,
+    }
+    if alert_type == "bom_buyable":
+        payload["project_id"] = project_id
+    else:
+        payload["part_id"] = part_id
+    return payload
+
+
+def _create_alert_for_type(
+    client: TestClient,
+    alert_type: str,
+    *,
+    project_id: str,
+    part_id: str,
+) -> dict:
+    r = client.post(
+        "/api/sourcing/alerts",
+        json=_targeted_alert_payload(
+            alert_type,
+            project_id=project_id,
+            part_id=part_id,
+            threshold=VALID_THRESHOLDS_BY_TYPE[alert_type],
+        ),
+    )
+    assert r.status_code == 200, r.text
+    return r.json()["data"]
+
+
 def test_create_stock_below_alert(authed_client):
     part_id = create_part(authed_client, name="Alert resistor")
 
@@ -159,17 +254,7 @@ def test_create_tariff_status_changed_alert_empty_threshold(authed_client):
 
 @pytest.mark.parametrize(
     ("alert_type", "threshold"),
-    [
-        ("stock_below", {"qty": -5}),
-        ("stock_above", {"qty": -5}),
-        ("back_in_stock", {"qty": 1}),
-        ("out_of_authorized_stock", {"qty": 1}),
-        ("price_changed", {"delta_pct": 150}),
-        ("bom_buyable", {"build_quantity": 0}),
-        ("lifecycle_risk_changed", {"to_states": ["Obsolete"]}),
-        ("supply_chain_risk_changed", {"must_contain": "NRND", "unexpected": True}),
-        ("tariff_status_changed", {"must_contain": "yes"}),
-    ],
+    WRONG_THRESHOLD_CASES,
 )
 def test_create_alert_with_wrong_threshold_shape_returns_422(
     authed_client,
@@ -197,25 +282,7 @@ def test_create_alert_with_wrong_threshold_shape_returns_422(
 
 @pytest.mark.parametrize(
     ("alert_type", "threshold", "expected_threshold"),
-    [
-        ("stock_below", {"qty": 5}, {"qty": 5}),
-        ("stock_above", {"qty": 5}, {"qty": 5}),
-        ("back_in_stock", {}, {}),
-        ("out_of_authorized_stock", {}, {}),
-        ("price_changed", {"delta_pct": 5}, {"delta_pct": "5"}),
-        ("bom_buyable", {"build_quantity": 2}, {"build_quantity": 2}),
-        (
-            "lifecycle_risk_changed",
-            {"must_contain": "EOL", "case_sensitive": True},
-            {"must_contain": "EOL", "case_sensitive": True},
-        ),
-        (
-            "supply_chain_risk_changed",
-            {"must_contain": "NRND", "case_sensitive": False},
-            {"must_contain": "NRND", "case_sensitive": False},
-        ),
-        ("tariff_status_changed", {}, {}),
-    ],
+    VALID_THRESHOLD_CASES,
 )
 def test_create_alert_with_valid_threshold_persists(
     authed_client,
@@ -239,6 +306,132 @@ def test_create_alert_with_valid_threshold_persists(
     data = r.json()["data"]
     assert data["alert_type"] == alert_type
     assert data["threshold"] == expected_threshold
+
+
+@pytest.mark.parametrize(
+    ("alert_type", "threshold"),
+    WRONG_THRESHOLD_CASES,
+)
+def test_patch_alert_with_wrong_threshold_shape_returns_422(
+    authed_client,
+    alert_type: str,
+    threshold: dict,
+):
+    project_id, part_id = _single_line_project(authed_client)
+    alert = _create_alert_for_type(
+        authed_client,
+        alert_type,
+        project_id=project_id,
+        part_id=part_id,
+    )
+
+    r = authed_client.patch(
+        f"/api/sourcing/alerts/{alert['id']}",
+        json={"threshold": {"alert_type": alert_type, **threshold}},
+    )
+
+    assert r.status_code == 422, r.text
+    body = r.json()
+    assert body["status"]["category"] == "validation_error"
+    fields = {error["field"] for error in body["errors"]}
+    assert any(field.startswith("body.threshold.") for field in fields)
+
+
+def test_patch_alert_with_null_threshold_is_noop(authed_client, db):
+    part_id = create_part(authed_client, name="Null patch target")
+    alert = _create_stock_alert(authed_client, part_id, threshold={"qty": 12})
+    row = db.execute(
+        select(SourcingAlert).where(SourcingAlert.id == uuid.UUID(alert["id"]))
+    ).scalar_one()
+    stored_threshold = dict(row.threshold)
+
+    r = authed_client.patch(
+        f"/api/sourcing/alerts/{alert['id']}",
+        json={"threshold": None},
+    )
+
+    assert r.status_code == 200, r.text
+    data = r.json()["data"]
+    assert data["threshold"] == {"qty": 12}
+    db.refresh(row)
+    assert row.threshold == stored_threshold
+
+
+@pytest.mark.parametrize(
+    ("alert_type", "threshold", "expected_threshold"),
+    PATCH_THRESHOLD_CASES,
+)
+def test_patch_alert_with_valid_threshold_persists(
+    authed_client,
+    alert_type: str,
+    threshold: dict,
+    expected_threshold: dict,
+):
+    project_id, part_id = _single_line_project(authed_client)
+    alert = _create_alert_for_type(
+        authed_client,
+        alert_type,
+        project_id=project_id,
+        part_id=part_id,
+    )
+
+    r = authed_client.patch(
+        f"/api/sourcing/alerts/{alert['id']}",
+        json={"threshold": {"alert_type": alert_type, **threshold}},
+    )
+
+    assert r.status_code == 200, r.text
+    data = r.json()["data"]
+    assert data["alert_type"] == alert_type
+    assert data["threshold"] == expected_threshold
+
+
+def test_output_threshold_serializes_as_typed_model(authed_client):
+    part_id = create_part(authed_client, name="Typed output target")
+    alert = _create_stock_alert(authed_client, part_id, threshold={"qty": 12})
+
+    get_response = authed_client.get(f"/api/sourcing/alerts/{alert['id']}")
+    list_response = authed_client.get("/api/sourcing/alerts")
+
+    assert get_response.status_code == 200, get_response.text
+    assert list_response.status_code == 200, list_response.text
+    assert get_response.json()["data"]["threshold"] == {"qty": 12}
+    listed = list_response.json()["data"]["items"]
+    listed_alert = next(item for item in listed if item["id"] == alert["id"])
+    assert listed_alert["threshold"] == {"qty": 12}
+
+
+def test_output_threshold_excludes_inner_alert_type(authed_client):
+    part_id = create_part(authed_client, name="Output discriminator target")
+    r = authed_client.post(
+        "/api/sourcing/alerts",
+        json={
+            "alert_type": "stock_below",
+            "part_id": part_id,
+            "threshold": {"alert_type": "stock_below", "qty": 9},
+        },
+    )
+
+    assert r.status_code == 200, r.text
+    alert = r.json()["data"]
+    assert alert["threshold"] == {"qty": 9}
+    assert "alert_type" not in alert["threshold"]
+
+    get_response = authed_client.get(f"/api/sourcing/alerts/{alert['id']}")
+
+    assert get_response.status_code == 200, get_response.text
+    threshold = get_response.json()["data"]["threshold"]
+    assert threshold == {"qty": 9}
+    assert "alert_type" not in threshold
+
+
+def test_output_threshold_openapi_schema_uses_discriminated_union():
+    threshold_schema = app.openapi()["components"]["schemas"]["SourcingAlertOut"][
+        "properties"
+    ]["threshold"]
+
+    assert threshold_schema["discriminator"]["propertyName"] == "alert_type"
+    assert len(threshold_schema["oneOf"]) == len(VALID_THRESHOLD_CASES)
 
 
 @pytest.mark.parametrize(

--- a/docs/api/sourcing.md
+++ b/docs/api/sourcing.md
@@ -89,6 +89,7 @@ List current workspace sourcing alerts.
 - The service filters every query by `workspace_id`; archived rows are excluded unless requested.
 - `total` is counted after filters and before `limit`/`offset`.
 - `include_archived=true` is list-only. GET-by-id, PATCH, and DELETE treat archived rows as not found.
+- `threshold` is advertised in OpenAPI as a discriminated union keyed by `alert_type`, while responses omit the inner discriminator and keep the existing payload shape.
 - Source: `backend/app/api/routes/sourcing.py:156-193`.
 - Service: `backend/app/domain/sourcing/service.py:138-195`.
 
@@ -184,7 +185,9 @@ Patch mutable alert fields.
 
 **Request**
 
-Path: `alert_id` is a sourcing alert UUID in the current workspace. Body accepts the same fields as create except `alert_type`; sending `alert_type` returns `422`.
+Path: `alert_id` is a sourcing alert UUID in the current workspace. Body accepts the same mutable fields as create except `alert_type`; sending top-level `alert_type` returns `422`.
+
+`threshold: null` is accepted as a no-op and leaves the stored threshold unchanged. When a PATCH changes `threshold`, the threshold object is validated at request parsing as the same discriminated union used by create; include the threshold discriminator inside the object, for example `{ "threshold": { "alert_type": "stock_below", "qty": 20 } }`. The response still omits the inner `alert_type` and returns `{ "threshold": { "qty": 20 } }`.
 
 **Response** — `200 OK` (envelope: `{ data, status }`)
 
@@ -193,7 +196,7 @@ Shape matches one item from `GET /api/sourcing/alerts` `data.items`.
 **Errors**
 
 - `404 Not Found` — `alert_id` is missing, archived, or foreign to the workspace; target part/project or notify user is missing or foreign.
-- `422 Unprocessable Entity` — invalid threshold, invalid target scope, `alert_type` in the patch body, or malformed body.
+- `422 Unprocessable Entity` — invalid threshold shape under `body.threshold`, invalid target scope, top-level `alert_type` in the patch body, or malformed body.
 
 **Notes**
 


### PR DESCRIPTION
## Summary

- Types `SourcingAlertPatch.threshold` as the optional alert threshold discriminated union and keeps `threshold: null` as a no-op.
- Types `SourcingAlertOut.threshold` as the outbound threshold union, with alert route envelope annotations so OpenAPI exposes `SourcingAlertOut` and its union schema.
- Removes the service-layer `_validated_threshold` wrapper; persistence still uses `dump_alert_threshold` for DB JSON storage.
- Adds PATCH threshold validation/persistence/no-op tests, output serialization tests, OpenAPI schema coverage, and sourcing API docs.

## Validation

Docker is not available in this environment (`docker: command not found`), so I ran the backend `uv` equivalents from `backend/`.

- `uv run pytest -k "alerts" -q`
  - `110 passed, 1196 deselected, 20 warnings in 22.79s`
- `uv run ruff check app/domain/sourcing/schemas.py app/domain/sourcing/service.py app/api/routes/sourcing.py tests/test_sourcing_alerts_route.py`
  - `All checks passed!`
- `.venv/bin/mypy app/domain/sourcing`
  - Fails on existing typing baseline: `164 errors in 12 files`.
  - Representative existing blockers include SQLAlchemy `Column[...]` vs runtime value errors in `app/domain/sourcing/service.py`, `app/domain/sourcing/alerts_evaluator.py`, `app/domain/stock/service.py`, and `_THRESHOLD_ADAPTER` needing an annotation at `app/domain/sourcing/schemas.py:341` under this local mypy version.
- GitHub Actions on this PR: backend-tests, web-build, playwright-e2e, policy, audit, and schema checks all passed; deploy skipped as expected.

## Example PATCH 422

```json
{
  "data": null,
  "status": {
    "category": "validation_error",
    "message": "validation failed"
  },
  "errors": [
    {
      "field": "body.threshold.stock_below.qty",
      "message": "Input should be greater than or equal to 0"
    }
  ]
}
```

## OpenAPI Spot Check

`SourcingAlertOut.threshold` now advertises the discriminated union:

```json
{
  "oneOf": [
    { "$ref": "#/components/schemas/StockBelowThreshold-Output" },
    { "$ref": "#/components/schemas/StockAboveThreshold-Output" },
    { "$ref": "#/components/schemas/BackInStockThreshold-Output" },
    { "$ref": "#/components/schemas/OutOfAuthorizedStockThreshold-Output" },
    { "$ref": "#/components/schemas/PriceChangedThreshold-Output" },
    { "$ref": "#/components/schemas/BomBuyableThreshold-Output" },
    { "$ref": "#/components/schemas/LifecycleRiskChangedThreshold-Output" },
    { "$ref": "#/components/schemas/SupplyChainRiskChangedThreshold-Output" },
    { "$ref": "#/components/schemas/TariffStatusChangedThreshold-Output" }
  ],
  "title": "Threshold",
  "discriminator": {
    "propertyName": "alert_type"
  }
}
```

## Merge Order

- Based on current `main` at `aa12e44` (`SA-MED: Sourcing backlog cleanup (#533)`).
- No dependency on issue #535; merge before or after #535 as long as #535 does not overwrite the backend sourcing alert schema/route changes.
- Independent of the currently open dependabot Docker PRs.

Refs #534