### PR TITLE
[codex] audit logout session revocation

### DIFF
--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -13,6 +13,7 @@ from app.core.auth import (
     clear_login_failures,
     create_session_row,
     hash_password,
+    hash_session_token,
     record_login_failure,
     revoke_all_user_sessions,
     revoke_session,
@@ -27,7 +28,8 @@ from app.core.mail import send_verification_email
 from app.core.ratelimit import limiter
 from app.core.responses import Envelope, ok
 from app.core.time import utcnow
-from app.domain.users.models import PendingUser, User
+from app.domain.audit.service import log as _audit_log
+from app.domain.users.models import PendingUser, User, UserSession
 from app.domain.users.schemas import LoginIn, SignupIn, VerifyIn
 from app.domain.workspaces.models import Workspace, WorkspaceMember
 
@@ -63,6 +65,49 @@ def _hmac_token(plaintext: str) -> str:
     """
     key = settings().SESSION_SECRET.encode("utf-8")
     return _hmac.new(key, plaintext.encode("utf-8"), "sha256").hexdigest()
+
+
+def _workspace_for_logout_audit(db, request: Request, user: User) -> Workspace | None:
+    raw = request.headers.get("X-Workspace-Id") or request.cookies.get("stockmgr_workspace")
+    if raw:
+        try:
+            workspace_id = UUID(raw)
+        except ValueError:
+            workspace_id = None
+        if workspace_id:
+            membership = (
+                db.query(WorkspaceMember)
+                .filter(
+                    WorkspaceMember.user_id == user.id,
+                    WorkspaceMember.workspace_id == workspace_id,
+                    WorkspaceMember.status == "active",
+                )
+                .first()
+            )
+            if membership:
+                return db.get(Workspace, workspace_id)
+
+    membership = (
+        db.query(WorkspaceMember)
+        .filter(WorkspaceMember.user_id == user.id, WorkspaceMember.status == "active")
+        .order_by(WorkspaceMember.created_at.asc())
+        .first()
+    )
+    return db.get(Workspace, membership.workspace_id) if membership else None
+
+
+def _logout_audit_context(db, request: Request, token: str) -> tuple[User, Workspace] | None:
+    digest = hash_session_token(token)
+    session = db.get(UserSession, digest)
+    if session is None:
+        return None
+    user = db.get(User, session.user_id)
+    if user is None:
+        return None
+    workspace = _workspace_for_logout_audit(db, request, user)
+    if workspace is None:
+        return None
+    return user, workspace
 
 
 # ---------------------------------------------------------------------------
@@ -375,6 +420,18 @@ def logout(request: Request, response: Response, db: DbSession) -> Envelope[None
     cookie_name = settings().SESSION_COOKIE_NAME
     token = request.cookies.get(cookie_name)
     if token:
+        audit_context = _logout_audit_context(db, request, token)
+        if audit_context is not None:
+            user, workspace = audit_context
+            _audit_log(
+                db,
+                ws=workspace,
+                user=user,
+                action="user.logout",
+                target_type="user",
+                target_ids=[user.id],
+                request_id=getattr(request.state, "request_id", None),
+            )
         revoke_session(db, token)
     response.delete_cookie(cookie_name, path="/")
     log.info("logout")

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -180,6 +180,7 @@ def revoke_session(db: Session, token: str) -> None:
     row = db.query(UserSession).filter(UserSession.token_hash == digest).first()
     if row:
         db.delete(row)
+        db.commit()
 
 
 def revoke_all_user_sessions(db: Session, user_id) -> int:

--- a/backend/tests/test_auth_logout.py
+++ b/backend/tests/test_auth_logout.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import select
+
+from app.core.auth import hash_session_token, revoke_session
+from app.core.config import settings
+from app.domain.audit.models import AuditLog
+from app.domain.users.models import UserSession
+from tests._factories import signup_user
+
+
+def test_logout_commits_session_revocation(client, db, monkeypatch):
+    signup_user(client)
+    token = client.cookies.get(settings().SESSION_COOKIE_NAME)
+    assert token
+    digest = hash_session_token(token)
+    assert db.get(UserSession, digest) is not None
+
+    commit_count = 0
+    original_commit = db.commit
+
+    def commit_spy():
+        nonlocal commit_count
+        commit_count += 1
+        return original_commit()
+
+    monkeypatch.setattr(db, "commit", commit_spy)
+
+    revoke_session(db, token)
+
+    assert commit_count == 1
+    assert db.get(UserSession, digest) is None
+
+
+def test_logout_writes_audit_row(client, db):
+    signup = signup_user(client)
+    signed_up = signup.json()["data"]
+    user_id = UUID(signed_up["user"]["id"])
+    workspace_id = UUID(signed_up["workspace_id"])
+
+    request_id = "abc123"
+    response = client.post("/api/auth/logout", headers={"X-Request-Id": request_id})
+    assert response.status_code == 200, response.text
+
+    rows = db.scalars(select(AuditLog).where(AuditLog.action == "user.logout")).all()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.workspace_id == workspace_id
+    assert row.user_id == user_id
+    assert row.target_type == "user"
+    assert row.target_ids == [user_id]
+    assert row.request_id == request_id


### PR DESCRIPTION
## Summary

- Commit `revoke_session` after deleting a matching session row.
- Write a workspace-scoped `user.logout` audit row for valid logout sessions before revocation.
- Add focused logout regression tests for commit and audit behavior.

Closes #542

## Validation

- `uv run --extra dev python -m pytest tests/test_auth_logout.py -q` - 2 passed, 1 Alembic deprecation warning.
- `LINT_CMD="ruff check app --output-format=concise" BASELINE_FILE="../.ruff-baseline.txt" WORK_DIR="." bash ../scripts/lint-delta.sh` - no new violations.
- `uv run --extra dev ruff check app/core/auth.py tests/test_auth_logout.py --output-format=concise` - passed.
- `ruff check backend` was also attempted and reports the existing repository baseline violations; the baseline-aware gate above is the CI-equivalent check for new backend lint issues.

## Merge Order / Conflicts

- Based on `origin/main` at `094142f` (`SA-11b sourcing alert threshold unions (#537)`).
- Write scope is limited to `backend/app/api/routes/auth.py`, `backend/app/core/auth.py`, and `backend/tests/test_auth_logout.py`.
- Potential conflicts only with other branches editing auth logout/session handling or auth route imports.
