### PR TITLE
AUD-014 route archive writes through API mutations

### DIFF
--- a/web/src/routes/builds/BuildDetail.test.tsx
+++ b/web/src/routes/builds/BuildDetail.test.tsx
@@ -1,0 +1,164 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import {
+  MutationCache,
+  QueryClient,
+  QueryClientProvider,
+} from "@tanstack/react-query";
+import { ApiError, api } from "@/lib/api";
+import { authBus } from "@/lib/queryKeys";
+import BuildDetail from "./BuildDetail";
+
+vi.mock("@/lib/api", () => {
+  class ApiError extends Error {
+    status: number;
+    body: unknown;
+    userMessage: string;
+
+    constructor(status: number, body: unknown, msg = "api error") {
+      super(msg);
+      this.status = status;
+      this.body = body;
+      this.userMessage = msg;
+    }
+  }
+
+  return {
+    ApiError,
+    api: {
+      get: vi.fn(),
+      post: vi.fn(),
+      patch: vi.fn(),
+      delete: vi.fn(),
+      upload: vi.fn(),
+    },
+  };
+});
+
+vi.mock("@/lib/auth", () => ({
+  useAuth: () => ({ workspaceId: "ws-1" }),
+}));
+
+vi.mock("@/components/AttachmentsPanel", () => ({
+  default: () => <div data-testid="attachments-panel" />,
+}));
+
+vi.mock("@/components/ActivityTimeline", () => ({
+  default: () => <div data-testid="activity-timeline" />,
+}));
+
+vi.mock("@/routes/projects/sourcing/SourceBomButton", () => ({
+  SourceBomButton: () => <button type="button">Source BOM</button>,
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+const buildDetail = {
+  build: {
+    id: "build-1",
+    project_id: "project-1",
+    name: "Build 1",
+    quantity: 1,
+    status: "planned",
+    archived_at: null,
+    completed_at: null,
+  },
+  shortage: [],
+};
+
+function mockReads() {
+  vi.mocked(api.get).mockImplementation((path: string) => {
+    if (path === "/builds/build-1") return Promise.resolve(buildDetail);
+    if (path === "/projects/project-1") return Promise.resolve({ id: "project-1", name: "Project 1" });
+    if (path === "/projects/project-1/entries") return Promise.resolve([]);
+    if (path === "/parts?limit=200") return Promise.resolve([]);
+    if (path === "/storage") return Promise.resolve([]);
+    return Promise.resolve(null);
+  });
+}
+
+function makeClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    mutationCache: new MutationCache({
+      onError: (err) => {
+        if (err instanceof ApiError && err.status === 401) {
+          authBus.emit("unauthorized");
+        }
+      },
+    }),
+  });
+}
+
+function renderBuildDetail() {
+  return render(
+    <QueryClientProvider client={makeClient()}>
+      <MemoryRouter initialEntries={["/builds/build-1"]}>
+        <Routes>
+          <Route path="/builds/:buildId" element={<BuildDetail />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  mockReads();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("BuildDetail archive mutation", () => {
+  it("test_double_click_archive_single_post", async () => {
+    vi.mocked(api.post).mockImplementation(
+      () => new Promise((resolve) => setTimeout(() => resolve(null), 30)),
+    );
+
+    renderBuildDetail();
+
+    const archive = await screen.findByRole("button", { name: "Archive" });
+    fireEvent.click(archive);
+
+    await waitFor(() => {
+      expect((archive as HTMLButtonElement).disabled).toBe(true);
+    });
+
+    fireEvent.click(archive);
+    fireEvent.click(archive);
+
+    await waitFor(() => {
+      expect(api.post).toHaveBeenCalledTimes(1);
+    });
+    expect(api.post).toHaveBeenCalledWith("/builds/build-1/archive");
+  });
+
+  it("routes archive 401s through the auth bus", async () => {
+    const heard = vi.fn();
+    const off = authBus.on((event) => heard(event));
+    vi.mocked(api.post).mockRejectedValue(
+      new ApiError(401, { data: null, status: { category: "unauthenticated", message: "expired" } }, "expired"),
+    );
+
+    renderBuildDetail();
+
+    fireEvent.click(await screen.findByRole("button", { name: "Archive" }));
+
+    await waitFor(() => {
+      expect(heard).toHaveBeenCalledWith("unauthorized");
+    });
+    expect(api.post).toHaveBeenCalledTimes(1);
+
+    off();
+  });
+});

--- a/web/src/routes/builds/BuildDetail.tsx
+++ b/web/src/routes/builds/BuildDetail.tsx
@@ -72,6 +72,21 @@ export default function BuildDetail() {
     },
   });
 
+  const archiveMutation = useApiMutation<unknown, { wasArchived: boolean }>({
+    mutationKey: ["build", buildId, "archive"],
+    mutationFn: ({ wasArchived }) =>
+      api.post(`/builds/${buildId}/${wasArchived ? "restore" : "archive"}`),
+    onSuccess: (_data, vars) => {
+      qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "build", buildId) });
+      qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "builds") });
+      toast.success(vars.wasArchived ? "Build restored." : "Build archived.");
+      if (!vars.wasArchived) nav("/builds");
+    },
+    onError: (e) => {
+      toast.error(e instanceof ApiError ? e.userMessage : "Archive failed");
+    },
+  });
+
 
   if (isError) return <div className="text-red-600 text-sm p-4">Failed to load build. {error instanceof ApiError ? error.userMessage : ""}</div>;
   if (!data) return <div className="text-muted">Loading…</div>;
@@ -120,11 +135,8 @@ export default function BuildDetail() {
     consumeMutation.mutate({ lines });
   }
 
-  async function doArchive() {
-    await api.post(`/builds/${buildId}/${build.archived_at ? "restore" : "archive"}`);
-    qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "build", buildId) });
-    qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "builds") });
-    if (!build.archived_at) nav("/builds");
+  function doArchive() {
+    archiveMutation.mutate({ wasArchived: !!build.archived_at });
   }
 
   function setRow(entryId: string, rowIdx: number, patch: Partial<ConsumeRow>) {
@@ -182,7 +194,9 @@ export default function BuildDetail() {
             {isEditable && (
               <button className="btn" onClick={fillSuggested}>Auto-fill</button>
             )}
-            <button className="btn" onClick={doArchive}>{build.archived_at ? "Restore" : "Archive"}</button>
+            <button className="btn" onClick={doArchive} disabled={archiveMutation.isPending}>
+              {build.archived_at ? "Restore" : "Archive"}
+            </button>
           </div>
         }
       />

--- a/web/src/routes/parts/detail/PartMembers.tsx
+++ b/web/src/routes/parts/detail/PartMembers.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useParams } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { api, ApiError } from "@/lib/api";
+import { useApiMutation } from "@/lib/mutations";
 import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
 import { useAuth } from "@/lib/auth";
 import QueryStateBoundary from "@/components/QueryStateBoundary";
@@ -24,20 +25,38 @@ export default function PartMembers() {
   const [pick, setPick] = useState("");
   const [err, setErr] = useState<string | null>(null);
 
-  async function add() {
-    if (!pick) return;
-    setErr(null);
-    try {
-      await api.post(`/parts/${partId}/members`, { member_part_id: pick });
+  const addMutation = useApiMutation<unknown, string>({
+    mutationKey: ["part", partId, "members", "add"],
+    mutationFn: (memberPartId) =>
+      api.post(`/parts/${partId}/members`, { member_part_id: memberPartId }),
+    onSuccess: () => {
       setPick("");
       qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "part", partId, "members") });
-    } catch (e) {
+    },
+    onError: (e) => {
       setErr(e instanceof ApiError ? e.userMessage : "Failed");
-    }
+    },
+  });
+
+  const removeMutation = useApiMutation<unknown, string>({
+    mutationKey: ["part", partId, "members", "remove"],
+    mutationFn: (memberPartId) => api.delete(`/parts/${partId}/members/${memberPartId}`),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "part", partId, "members") });
+    },
+    onError: (e) => {
+      setErr(e instanceof ApiError ? e.userMessage : "Failed");
+    },
+  });
+
+  function add() {
+    if (!pick) return;
+    setErr(null);
+    addMutation.mutate(pick);
   }
-  async function remove(mid: string) {
-    await api.delete(`/parts/${partId}/members/${mid}`);
-    qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "part", partId, "members") });
+  function remove(mid: string) {
+    setErr(null);
+    removeMutation.mutate(mid);
   }
 
   return (
@@ -58,7 +77,13 @@ export default function PartMembers() {
                 {p?.name ?? m.member_part_id}
                 {p?.mpn && <span className="text-muted ml-2">{p.mpn}</span>}
               </span>
-              <button className="btn-danger text-xs" onClick={() => remove(m.member_part_id)}>Remove</button>
+              <button
+                className="btn-danger text-xs"
+                onClick={() => remove(m.member_part_id)}
+                disabled={removeMutation.isPending}
+              >
+                Remove
+              </button>
             </li>
           );
         })}
@@ -71,7 +96,7 @@ export default function PartMembers() {
             <option key={p.id} value={p.id}>{p.name}{p.mpn ? ` — ${p.mpn}` : ""}</option>
           ))}
         </select>
-        <button className="btn-primary" onClick={add}>Add</button>
+        <button className="btn-primary" onClick={add} disabled={!pick || addMutation.isPending}>Add</button>
       </div>
       </QueryStateBoundary>
     </div>

--- a/web/src/routes/parts/detail/PartOther.tsx
+++ b/web/src/routes/parts/detail/PartOther.tsx
@@ -1,6 +1,8 @@
 import { useNavigate, useOutletContext, useParams } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 import { api } from "@/lib/api";
+import { useApiMutation } from "@/lib/mutations";
 import { useAuth } from "@/lib/auth";
 import { archivePartKeys } from "@/lib/queryKeys";
 import type { Part } from "@/types";
@@ -17,25 +19,35 @@ export default function PartOther() {
   // background data. We now scope invalidation to the active
   // workspace's prefix so we keep the workspace-keyed cache useful and
   // don't blow away unrelated data.
-  async function archive() {
-    await api.post(`/parts/${partId}/archive`);
-    for (const k of archivePartKeys(workspaceId, partId!))
-      qc.invalidateQueries({ queryKey: k });
-    nav("/parts");
+  const archiveMutation = useApiMutation<unknown, { wasArchived: boolean }>({
+    mutationKey: ["part", partId, "archive"],
+    mutationFn: ({ wasArchived }) =>
+      api.post(`/parts/${partId}/${wasArchived ? "restore" : "archive"}`),
+    onSuccess: (_data, vars) => {
+      for (const k of archivePartKeys(workspaceId, partId!))
+        qc.invalidateQueries({ queryKey: k });
+      toast.success(vars.wasArchived ? "Part restored." : "Part archived.");
+      if (!vars.wasArchived) nav("/parts");
+    },
+    onError: (e) => {
+      toast.error(e.userMessage);
+    },
+  });
+
+  function archive() {
+    archiveMutation.mutate({ wasArchived: false });
   }
-  async function restore() {
-    await api.post(`/parts/${partId}/restore`);
-    for (const k of archivePartKeys(workspaceId, partId!))
-      qc.invalidateQueries({ queryKey: k });
+  function restore() {
+    archiveMutation.mutate({ wasArchived: true });
   }
 
   return (
     <div className="card p-4 max-w-xl space-y-3">
       <h3 className="text-md font-semibold">Other operations</h3>
       {part.archived_at ? (
-        <button className="btn" onClick={restore}>Restore from archive</button>
+        <button className="btn" onClick={restore} disabled={archiveMutation.isPending}>Restore from archive</button>
       ) : (
-        <button className="btn-danger" onClick={archive}>Archive part</button>
+        <button className="btn-danger" onClick={archive} disabled={archiveMutation.isPending}>Archive part</button>
       )}
     </div>
   );

--- a/web/src/routes/parts/detail/PartSpecs.tsx
+++ b/web/src/routes/parts/detail/PartSpecs.tsx
@@ -70,7 +70,49 @@ export default function PartSpecs() {
     },
   });
 
+  const updateMutation = useApiMutation<unknown, { row: CustomFieldRow; value: string }>({
+    mutationKey: ["part", part.id, "spec-update"],
+    mutationFn: ({ row, value }) =>
+      api.post("/custom-fields", {
+        object_type: "part",
+        object_id: part.id,
+        key: row.key,
+        value,
+      }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey });
+    },
+    onError: (e) => {
+      toast.error(e instanceof ApiError ? e.userMessage : "Failed");
+    },
+  });
+
+  const removeMutation = useApiMutation<unknown, CustomFieldRow>({
+    mutationKey: ["part", part.id, "spec-remove"],
+    mutationFn: (row) => api.delete(`/custom-fields/${row.id}`),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey });
+      toast.success("Spec deleted.");
+    },
+    onError: (e) => {
+      toast.error(e instanceof ApiError ? e.userMessage : "Failed");
+    },
+  });
+
+  const restoreMutation = useApiMutation<unknown, CustomFieldRow>({
+    mutationKey: ["part", part.id, "spec-restore"],
+    mutationFn: (row) => api.delete(`/custom-fields/${row.id}/override`),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey });
+      toast.success("Restored upstream value.");
+    },
+    onError: (e) => {
+      toast.error(e instanceof ApiError ? e.userMessage : "Failed");
+    },
+  });
+
   const busy = addMutation.isPending;
+  const rowMutationPending = updateMutation.isPending || removeMutation.isPending || restoreMutation.isPending;
 
   function add() {
     const k = newKey.trim();
@@ -87,40 +129,18 @@ export default function PartSpecs() {
     });
   }
 
-  async function update(row: CustomFieldRow, newValueText: string) {
+  function update(row: CustomFieldRow, newValueText: string) {
     if ((row.value ?? "") === newValueText) return;
-    try {
-      await api.post("/custom-fields", {
-        object_type: "part",
-        object_id: part.id,
-        key: row.key,
-        value: newValueText,
-      });
-      qc.invalidateQueries({ queryKey });
-    } catch (e) {
-      toast.error(e instanceof ApiError ? e.userMessage : "Failed");
-    }
+    updateMutation.mutate({ row, value: newValueText });
   }
 
   async function remove(row: CustomFieldRow) {
     if (!(await confirm({ message: `Delete spec "${row.key}"?`, severity: "danger" }))) return;
-    try {
-      await api.delete(`/custom-fields/${row.id}`);
-      qc.invalidateQueries({ queryKey });
-      toast.success("Spec deleted.");
-    } catch (e) {
-      toast.error(e instanceof ApiError ? e.userMessage : "Failed");
-    }
+    removeMutation.mutate(row);
   }
 
-  async function restore(row: CustomFieldRow) {
-    try {
-      await api.delete(`/custom-fields/${row.id}/override`);
-      qc.invalidateQueries({ queryKey });
-      toast.success("Restored upstream value.");
-    } catch (e) {
-      toast.error(e instanceof ApiError ? e.userMessage : "Failed");
-    }
+  function restore(row: CustomFieldRow) {
+    restoreMutation.mutate(row);
   }
 
   // Specs tab shows parametric values only — provider catalog rows
@@ -204,6 +224,7 @@ export default function PartSpecs() {
                         title="Restore upstream value"
                         aria-label={`Restore ${r.key}`}
                         onClick={() => restore(r)}
+                        disabled={rowMutationPending}
                       >
                         <RotateCcw size={14} />
                       </button>
@@ -213,6 +234,7 @@ export default function PartSpecs() {
                       className="btn-ghost btn-sm"
                       aria-label={`Delete ${r.key}`}
                       onClick={() => remove(r)}
+                      disabled={rowMutationPending}
                     >
                       <Trash2 size={14} className="text-danger" />
                     </button>

--- a/web/src/routes/projects/detail/ProjectOther.tsx
+++ b/web/src/routes/projects/detail/ProjectOther.tsx
@@ -1,6 +1,8 @@
 import { useNavigate, useOutletContext } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 import { api } from "@/lib/api";
+import { useApiMutation } from "@/lib/mutations";
 import { useAuth } from "@/lib/auth";
 import { archiveProjectKeys } from "@/lib/queryKeys";
 import type { Project } from "@/types";
@@ -10,23 +12,34 @@ export default function ProjectOther() {
   const qc = useQueryClient();
   const { workspaceId } = useAuth();
   const nav = useNavigate();
-  async function arch() {
-    await api.post(`/projects/${project.id}/archive`);
-    for (const k of archiveProjectKeys(workspaceId, project.id))
-      qc.invalidateQueries({ queryKey: k });
-    nav("/projects");
+
+  const archiveMutation = useApiMutation<unknown, { wasArchived: boolean }>({
+    mutationKey: ["project", project.id, "archive"],
+    mutationFn: ({ wasArchived }) =>
+      api.post(`/projects/${project.id}/${wasArchived ? "restore" : "archive"}`),
+    onSuccess: (_data, vars) => {
+      for (const k of archiveProjectKeys(workspaceId, project.id))
+        qc.invalidateQueries({ queryKey: k });
+      toast.success(vars.wasArchived ? "Project restored." : "Project archived.");
+      if (!vars.wasArchived) nav("/projects");
+    },
+    onError: (e) => {
+      toast.error(e.userMessage);
+    },
+  });
+
+  function arch() {
+    archiveMutation.mutate({ wasArchived: false });
   }
-  async function restore() {
-    await api.post(`/projects/${project.id}/restore`);
-    for (const k of archiveProjectKeys(workspaceId, project.id))
-      qc.invalidateQueries({ queryKey: k });
+  function restore() {
+    archiveMutation.mutate({ wasArchived: true });
   }
   return (
     <div className="card p-4 max-w-xl">
       {project.archived_at ? (
-        <button className="btn" onClick={restore}>Restore</button>
+        <button className="btn" onClick={restore} disabled={archiveMutation.isPending}>Restore</button>
       ) : (
-        <button className="btn-danger" onClick={arch}>Archive project</button>
+        <button className="btn-danger" onClick={arch} disabled={archiveMutation.isPending}>Archive project</button>
       )}
     </div>
   );

--- a/web/src/routes/storage/StorageDetail.tsx
+++ b/web/src/routes/storage/StorageDetail.tsx
@@ -1,7 +1,9 @@
-import { Link, Outlet, useParams, NavLink, useNavigate } from "react-router-dom";
+import { Link, Outlet, useParams, useNavigate } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { ScanLine } from "lucide-react";
+import { toast } from "sonner";
 import { api, ApiError } from "@/lib/api";
+import { useApiMutation } from "@/lib/mutations";
 import { useAuth } from "@/lib/auth";
 import { useWsKey, wsKeyOf, archiveStorageKeys } from "@/lib/queryKeys";
 import EntityHeader from "@/components/EntityHeader";
@@ -166,24 +168,34 @@ export function StorageOther() {
   const qc = useQueryClient();
   const { workspaceId } = useAuth();
   const { data } = useQuery({ queryKey: useWsKey("storage", storageId), queryFn: () => api.get<StorageLocation>(`/storage/${storageId}`), enabled: !!storageId });
+  const archiveMutation = useApiMutation<unknown, { wasArchived: boolean }>({
+    mutationKey: ["storage", storageId, "archive"],
+    mutationFn: ({ wasArchived }) =>
+      api.post(`/storage/${storageId}/${wasArchived ? "restore" : "archive"}`),
+    onSuccess: (_data, vars) => {
+      for (const k of archiveStorageKeys(workspaceId, storageId!))
+        qc.invalidateQueries({ queryKey: k });
+      toast.success(vars.wasArchived ? "Storage restored." : "Storage archived.");
+      if (!vars.wasArchived) nav("/storage");
+    },
+    onError: (e) => {
+      toast.error(e.userMessage);
+    },
+  });
+
   if (!data) return null;
-  async function arch() {
-    await api.post(`/storage/${storageId}/archive`);
-    for (const k of archiveStorageKeys(workspaceId, storageId!))
-      qc.invalidateQueries({ queryKey: k });
-    nav("/storage");
+  function arch() {
+    archiveMutation.mutate({ wasArchived: false });
   }
-  async function restore() {
-    await api.post(`/storage/${storageId}/restore`);
-    for (const k of archiveStorageKeys(workspaceId, storageId!))
-      qc.invalidateQueries({ queryKey: k });
+  function restore() {
+    archiveMutation.mutate({ wasArchived: true });
   }
   return (
     <div className="card p-4 max-w-xl">
       {data.archived_at ? (
-        <button className="btn" onClick={restore}>Restore</button>
+        <button className="btn" onClick={restore} disabled={archiveMutation.isPending}>Restore</button>
       ) : (
-        <button className="btn-danger" onClick={arch}>Archive</button>
+        <button className="btn-danger" onClick={arch} disabled={archiveMutation.isPending}>Archive</button>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- Wrap archive/restore and related parts detail remove/restore writes in `useApiMutation` with stable mutation keys.
- Disable the affected buttons while mutations are pending so duplicate clicks do not submit duplicate writes.
- Add a BuildDetail regression covering duplicate archive clicks and mutation-cache 401 auth-bus dispatch.

Closes #553

## Validation
- `npm --prefix web run test -- BuildDetail.test`
- `npm --prefix web run typecheck`
- `npm exec eslint -- src/routes/builds/BuildDetail.tsx src/routes/builds/BuildDetail.test.tsx src/routes/parts/detail/PartOther.tsx src/routes/projects/detail/ProjectOther.tsx src/routes/storage/StorageDetail.tsx src/routes/parts/detail/PartSpecs.tsx src/routes/parts/detail/PartMembers.tsx`
- `git -C /mnt/data/WORK/stockManager-aud-014 diff --check`

Full `npm --prefix web run lint` still fails on pre-existing unrelated issues in `web/src/lib/bagCode.ts` (`no-control-regex`) plus existing warnings outside this change.

## Merge Order / Conflicts
- Based on `origin/main` at `094142f`.
- No known merge-order dependency.
- Conflict risk is limited to the touched frontend route components if another AUD branch edits the same archive/remove handlers.