### PR TITLE
SA-10b: Migrate convert route's legacy _error_response calls to raise_http

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ the canonical record.
 
 ## 2026-05 — feedback brief fixes
 
+- **SA-10b / #539** Convert-orders route now uses explicit `raise_http` +
+  `ErrorCodes.*` instead of the legacy `_error_response` mapper.
 - **SA-8b / #535** Split PurchasePlanReviewPage to keep sourcing files under 300-LOC headroom cap.
 - **SA-MED / #512** Sourcing cleanup tightened service-layer workspace
   guards, archived-project refresh filtering, raw Decimal wire prices, hashed

--- a/backend/app/api/routes/sourcing.py
+++ b/backend/app/api/routes/sourcing.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import Session
 
 from app.api._helpers import assert_in_workspace
 from app.core.deps import CurrentUser, CurrentWorkspace, require_role
-from app.core.errors import ErrorCodes
+from app.core.errors import ErrorCodes, raise_http
 from app.core.ratelimit import limiter, workspace_key
 from app.core.responses import Envelope, err, ok
 from app.core.time import utcnow
@@ -494,11 +494,11 @@ def convert_purchase_plan_to_orders(
             overrides=(payload.overrides if payload is not None else None),
         )
     except sourcing_service.PurchasePlanStaleError as exc:
-        return _error_response(request, 409, "conflict", str(exc))
+        raise_http(409, ErrorCodes.SOURCING_PLAN_STALE, message=str(exc))
     except sourcing_service.PurchasePlanOverrideError as exc:
-        return _error_response(request, 422, "validation_error", str(exc))
+        raise_http(422, ErrorCodes.SOURCING_OVERRIDE_INVALID, message=str(exc))
     except sourcing_service.PurchasePlanCurrencyError as exc:
-        return _error_response(request, 422, "validation_error", str(exc))
+        raise_http(422, ErrorCodes.SOURCING_CURRENCY_MISMATCH, message=str(exc))
 
     return ok(
         sourcing_service.purchase_plan_orders_to_out(

--- a/backend/tests/test_purchase_plan_convert_route.py
+++ b/backend/tests/test_purchase_plan_convert_route.py
@@ -213,6 +213,7 @@ def test_invalid_conversion_override_persists_no_orders(authed_client, db):
     )
 
     assert r.status_code == 422, r.text
+    assert r.json()["code"] == "sourcing.override_invalid"
     assert "cached offers" in r.json()["status"]["message"]
     assert db.execute(select(func.count()).select_from(Order)).scalar_one() == 0
     assert db.execute(select(func.count()).select_from(OrderEntry)).scalar_one() == 0
@@ -296,6 +297,7 @@ def test_override_mixed_currency_guard_persists_no_orders(authed_client, db):
     )
 
     assert r.status_code == 422, r.text
+    assert r.json()["code"] == "sourcing.currency_mismatch"
     assert "mixed currencies" in r.json()["status"]["message"]
     assert db.execute(select(func.count()).select_from(Order)).scalar_one() == 0
     assert db.execute(select(func.count()).select_from(OrderEntry)).scalar_one() == 0


### PR DESCRIPTION
## Summary
- Replaced the three `convert_purchase_plan_to_orders` legacy `_error_response` exception handlers with explicit `raise_http` calls and stable `ErrorCodes.*` values.
- Tightened the existing convert-route tests to assert `sourcing.override_invalid` and `sourcing.currency_mismatch` alongside the existing stale-plan assertions.
- Added the SA-10b CHANGELOG entry.

## Validation
- `docker compose -f docker-compose.dev.yml exec -T backend pytest -k "purchase_plan or sourcing_routes"` could not run on this host: `/bin/bash: line 1: docker: command not found`.
- `uv run --all-extras pytest tests/test_purchase_plan_convert_route.py -q` passed: `18 passed, 1 warning in 9.74s`.
- `uv run --all-extras pytest -k "purchase_plan or sourcing_routes"` did not pass as a broad local selector: `57 passed, 1248 deselected, 1 error`; the error was `psycopg.errors.UndefinedTable: relation "users" does not exist` after the selector included `test_migration_isolation.py` for a purchase-plan migration.
- `uv run --all-extras ruff check app/api/routes/sourcing.py tests/test_purchase_plan_convert_route.py` passed: `All checks passed!`.
- `grep -nE '_error_response\("(conflict|validation_error)"' backend/app/api/routes/sourcing.py && echo "FAIL - legacy patterns remain" || echo "OK"` passed: `OK`.
- Convert-route-only grep passed: `OK - convert route has no _error_response calls`.

## Merge Order / Conflicts
- Based on `origin/main` at `094142f`.
- Expected conflict risk is low; touched only `CHANGELOG.md`, `backend/app/api/routes/sourcing.py`, and `backend/tests/test_purchase_plan_convert_route.py`.
- If another sourcing cleanup PR lands first, re-check the import line and the convert-route exception block.

Refs #501
Closes #539