### PR TITLE
[codex] Block provider-reserved custom field keys

### DIFF
--- a/backend/app/api/routes/custom_fields.py
+++ b/backend/app/api/routes/custom_fields.py
@@ -11,6 +11,7 @@ from app.core.errors import ErrorCodes, raise_http
 from app.core.responses import ok
 from app.domain.custom_fields.models import CustomField
 from app.domain.custom_fields.schemas import CustomFieldIn
+from app.domain.parts.provider_fields import is_provider_reserved_custom_field_key
 
 router = APIRouter()
 
@@ -40,7 +41,12 @@ def list_for(object_type: str, object_id: UUID, db: DbSession, ws: CurrentWorksp
 
 
 @router.post("", status_code=status.HTTP_201_CREATED)
-def create_or_update(payload: CustomFieldIn, db: DbSession, ws: CurrentWorkspace, user: CurrentUser):
+def create_or_update(
+    payload: CustomFieldIn,
+    db: DbSession,
+    ws: CurrentWorkspace,
+    user: CurrentUser,
+):
     """Upsert. Provider/override transitions:
 
     * existing.source='provider' and the value changes →
@@ -56,6 +62,14 @@ def create_or_update(payload: CustomFieldIn, db: DbSession, ws: CurrentWorkspace
     domain/parts/services/provider.py. Without this guard a caller could
     POST {source: "provider"} and forge a provider-origin row.
     """
+    if is_provider_reserved_custom_field_key(payload.key):
+        raise_http(
+            400,
+            code=ErrorCodes.CUSTOM_FIELD_RESERVED_KEY,
+            message=f"{payload.key!r} is reserved for provider-managed data",
+            key=payload.key,
+        )
+
     # Polymorphic FK validation: object_id must name a row in the current
     # workspace, and object_type must be a known resource. Without this
     # guard a caller in workspace B can store custom fields keyed to a

--- a/backend/app/api/routes/parts_assets.py
+++ b/backend/app/api/routes/parts_assets.py
@@ -28,6 +28,7 @@ from app.core.responses import ok
 from app.core.secrets import decrypt
 from app.core.time import utcnow
 from app.domain.custom_fields.models import CustomField
+from app.domain.parts.provider_fields import PROVIDER_ASSET_CUSTOM_FIELD_KINDS
 from app.domain.parts.providers import make_provider
 from app.domain.parts.services.assets import fetch_provider_asset
 from app.domain.parts.services.provider_cache import lookup_fresh
@@ -118,12 +119,6 @@ def get_provider_asset(
     return FileResponse(abs_path, media_type=served_mime, headers=headers)
 
 
-# Reserved keys that surface elsewhere on PartInfo (Media card). These
-# are also treated as `source='provider'` rows but we keep them out of
-# the spec body when listing.
-_PROVIDER_RESERVED_KEYS = ("image_url", "datasheet_url")
-
-
 @router.post("/{part_id}/refresh-from-provider")
 @limiter.limit("60/minute", key_func=workspace_key)
 def refresh_from_provider(
@@ -202,12 +197,12 @@ def refresh_from_provider(
             desired[key] = value
     # Download provider assets locally — same fallback semantics as
     # bulk-import: failed downloads keep the upstream URL.
-    if r.get("image_url"):
-        local = fetch_provider_asset(r["image_url"], str(ws.id), "image")
-        desired["image_url"] = local or r["image_url"]
-    if r.get("datasheet_url"):
-        local = fetch_provider_asset(r["datasheet_url"], str(ws.id), "datasheet")
-        desired["datasheet_url"] = local or r["datasheet_url"]
+    for key, asset_kind in PROVIDER_ASSET_CUSTOM_FIELD_KINDS.items():
+        if r.get(key):
+            local = fetch_provider_asset(r[key], str(ws.id), asset_kind)
+            desired[key] = local or r[key]
+    if r.get("source_url"):
+        desired["source_url"] = str(r["source_url"])
 
     existing_rows = list(
         db.execute(

--- a/backend/app/core/errors.py
+++ b/backend/app/core/errors.py
@@ -209,4 +209,5 @@ class ErrorCodes:
     CATALOG_NOT_FOUND = "catalog.not_found"
 
     # Custom fields router.
+    CUSTOM_FIELD_RESERVED_KEY = "custom_field.reserved_key"
     CUSTOM_FIELD_NOT_OVERRIDE = "custom_field.not_override"

--- a/backend/app/domain/parts/provider_fields.py
+++ b/backend/app/domain/parts/provider_fields.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+PROVIDER_RESERVED_CUSTOM_FIELD_KEYS: tuple[str, ...] = (
+    "image_url",
+    "datasheet_url",
+    "source_url",
+)
+
+PROVIDER_ASSET_CUSTOM_FIELD_KINDS: dict[str, str] = {
+    "image_url": "image",
+    "datasheet_url": "datasheet",
+}
+
+
+def is_provider_reserved_custom_field_key(key: str) -> bool:
+    return key in PROVIDER_RESERVED_CUSTOM_FIELD_KEYS

--- a/backend/tests/test_bulk_delete.py
+++ b/backend/tests/test_bulk_delete.py
@@ -12,13 +12,18 @@ import uuid
 import pytest
 from fastapi.testclient import TestClient
 
+from app.domain.custom_fields.models import CustomField
 from app.main import app
 
 
 def _signup(c: TestClient) -> None:
     r = c.post(
         "/api/auth/signup",
-        json={"email": f"u-{uuid.uuid4().hex[:8]}@x.com", "name": "u", "password": "TestPass-2026-Stronk"},
+        json={
+            "email": f"u-{uuid.uuid4().hex[:8]}@x.com",
+            "name": "u",
+            "password": "TestPass-2026-Stronk",
+        },
     )
     assert r.status_code == 200, r.text
 
@@ -37,6 +42,12 @@ def _create(c: TestClient, name: str, mpn: str | None = None) -> str:
     r = c.post("/api/parts", json=body)
     assert r.status_code == 201, r.text
     return r.json()["data"]["id"]
+
+
+def _workspace_id(c: TestClient) -> uuid.UUID:
+    r = c.get("/api/auth/me")
+    assert r.status_code == 200, r.text
+    return uuid.UUID(r.json()["data"]["workspaces"][0]["id"])
 
 
 def test_bulk_delete_archives_listed_parts(authed):
@@ -97,22 +108,22 @@ def test_bulk_delete_rejects_too_many(authed):
     assert r.status_code == 422
 
 
-def test_list_parts_includes_image_url(authed):
+def test_list_parts_includes_image_url(authed, db):
     """When a part has an image_url custom_field, the list endpoint
     surfaces it as Part.image_url so the parts table can render a
     thumbnail without a per-row custom_field fetch."""
     pid = _create(authed, "Resistor", mpn="RC0402JR-070R")
-    # Backdoor: write the custom_field directly via the API.
-    r = authed.post(
-        "/api/custom-fields",
-        json={
-            "object_type": "part",
-            "object_id": pid,
-            "key": "image_url",
-            "value": "/api/parts/assets/abc/image.png",
-        },
+    db.add(
+        CustomField(
+            workspace_id=_workspace_id(authed),
+            object_type="part",
+            object_id=uuid.UUID(pid),
+            key="image_url",
+            value="/api/parts/assets/abc/image.png",
+            source="provider",
+        )
     )
-    assert r.status_code in (200, 201), r.text
+    db.flush()
     listed = authed.get("/api/parts").json()["data"]
     row = next(r for r in listed if r["id"] == pid)
     assert row["image_url"] == "/api/parts/assets/abc/image.png"

--- a/backend/tests/test_custom_fields_reserved_keys.py
+++ b/backend/tests/test_custom_fields_reserved_keys.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from app.domain.custom_fields.models import CustomField
+
+
+def _create_part(client) -> str:
+    r = client.post("/api/parts", json={"name": "Reserved key test", "part_type": "local"})
+    assert r.status_code == 201, r.text
+    return r.json()["data"]["id"]
+
+
+def _workspace_id(client) -> uuid.UUID:
+    r = client.get("/api/auth/me")
+    assert r.status_code == 200, r.text
+    return uuid.UUID(r.json()["data"]["workspaces"][0]["id"])
+
+
+@pytest.mark.parametrize("key", ["image_url", "datasheet_url", "source_url"])
+def test_post_reserved_key_blocked(authed_client, key):
+    part_id = _create_part(authed_client)
+
+    r = authed_client.post(
+        "/api/custom-fields",
+        json={
+            "object_type": "part",
+            "object_id": part_id,
+            "key": key,
+            "value": "https://example.com/tracker",
+        },
+    )
+
+    assert r.status_code == 400, r.text
+    body = r.json()
+    assert body["status"]["category"] == "validation_error"
+    assert body["code"] == "custom_field.reserved_key"
+    assert body["key"] == key
+
+
+def test_override_flip_reserved_key_blocked(authed_client, db):
+    part_id = _create_part(authed_client)
+    row = CustomField(
+        workspace_id=_workspace_id(authed_client),
+        object_type="part",
+        object_id=uuid.UUID(part_id),
+        key="image_url",
+        value="/api/parts/assets/ws/original.png",
+        source="provider",
+    )
+    db.add(row)
+    db.flush()
+
+    r = authed_client.post(
+        "/api/custom-fields",
+        json={
+            "object_type": "part",
+            "object_id": part_id,
+            "key": "image_url",
+            "value": "https://example.com/tracker.png",
+        },
+    )
+
+    assert r.status_code == 400, r.text
+    db.refresh(row)
+    assert row.source == "provider"
+    assert row.value == "/api/parts/assets/ws/original.png"
+    assert row.original_value is None

--- a/web/src/lib/__tests__/providerCatalog.test.ts
+++ b/web/src/lib/__tests__/providerCatalog.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { isReservedKey, isSpecKey, PROVIDER_RESERVED_KEYS } from "../providerCatalog";
+
+describe("providerCatalog reserved keys", () => {
+  it("matches backend provider-reserved custom field keys", () => {
+    expect(PROVIDER_RESERVED_KEYS).toEqual(["image_url", "datasheet_url", "source_url"]);
+  });
+
+  it("keeps provider metadata out of specs", () => {
+    for (const key of PROVIDER_RESERVED_KEYS) {
+      expect(isReservedKey(key)).toBe(true);
+      expect(isSpecKey(key)).toBe(false);
+    }
+  });
+});

--- a/web/src/lib/providerCatalog.ts
+++ b/web/src/lib/providerCatalog.ts
@@ -10,8 +10,8 @@
  * is the only thing to update when we add a new provider field, and we
  * don't need a DB migration to re-categorise historical rows.
  *
- * Reserved keys (`image_url`, `datasheet_url`) are surfaced separately
- * by the layout header / Media affordances and are NOT in either tab.
+ * Reserved keys (`image_url`, `datasheet_url`, `source_url`) are provider
+ * metadata and are NOT in either tab.
  */
 
 const CATALOG_LITERAL_KEYS = new Set<string>([
@@ -40,7 +40,9 @@ const CATALOG_REGEX_KEYS: RegExp[] = [
   /^Unit price \(\d+\+\)$/,
 ];
 
-const RESERVED_KEYS = new Set<string>(["image_url", "datasheet_url", "source_url"]);
+export const PROVIDER_RESERVED_KEYS = ["image_url", "datasheet_url", "source_url"] as const;
+
+const RESERVED_KEYS = new Set<string>(PROVIDER_RESERVED_KEYS);
 
 export function isReservedKey(key: string): boolean {
   return RESERVED_KEYS.has(key);


### PR DESCRIPTION
## Summary
- Block public `POST /api/custom-fields` upserts for provider-reserved keys: `image_url`, `datasheet_url`, and `source_url`.
- Move provider custom-field key constants into a shared backend module used by custom-field writes and provider refresh asset handling.
- Export the matching frontend reserved-key list and add focused backend/frontend regression tests.

Closes #541

## Validation
- `python -m pytest backend/tests/test_custom_fields_reserved_keys.py -q` failed locally because `python` is not on PATH.
- `uv run pytest tests/test_custom_fields_reserved_keys.py -q` passed: 4 tests.
- `uv run pytest tests/test_custom_fields_reserved_keys.py tests/test_bulk_delete.py::test_list_parts_includes_image_url -q` passed: 5 tests.
- `ruff check backend` was attempted and hit existing repo-wide non-baseline violations; focused touched-file ruff check passed with `uv run ruff check app/api/routes/custom_fields.py app/api/routes/parts_assets.py app/core/errors.py app/domain/parts/provider_fields.py tests/test_custom_fields_reserved_keys.py tests/test_bulk_delete.py`.
- `npm --prefix web ci` completed; npm reported Node 18 engine warnings for some packages and existing moderate audit findings.
- `npm --prefix web run test -- providerCatalog` passed: 1 file, 2 tests.
- `npm exec eslint -- src/lib/providerCatalog.ts src/lib/__tests__/providerCatalog.test.ts` passed.

## Merge Order / Conflicts
- Based on `origin/main` at `094142f` (`SA-11b sourcing alert threshold unions`).
- No migration changes.
- Likely conflict areas if merged alongside related work: `backend/app/api/routes/custom_fields.py`, `backend/app/api/routes/parts_assets.py`, `web/src/lib/providerCatalog.ts`, and tests around custom fields/provider media.
- Should merge after any PR that changes provider custom-field reserved/catalog key semantics, or be rebased over that PR.
