### PR TITLE
AUD-012 provider upstream error envelopes

### DIFF
--- a/backend/app/api/routes/parts_assets.py
+++ b/backend/app/api/routes/parts_assets.py
@@ -30,6 +30,7 @@ from app.core.time import utcnow
 from app.domain.custom_fields.models import CustomField
 from app.domain.parts.provider_fields import PROVIDER_ASSET_CUSTOM_FIELD_KINDS
 from app.domain.parts.providers import make_provider
+from app.domain.parts.providers.base import ProviderUpstreamError
 from app.domain.parts.services.assets import fetch_provider_asset
 from app.domain.parts.services.provider_cache import lookup_fresh
 from app.domain.stock.service import reserved_quantity, total_for_part
@@ -151,7 +152,13 @@ def refresh_from_provider(
     # Use lookup_fresh (not lookup_with_cache) — the operator explicitly
     # triggered a refresh, so we always hit upstream.  The fresh result is
     # written back to the cache so subsequent lookup_with_cache calls see it.
-    out = lookup_fresh(provider, p.mpn.strip())
+    try:
+        out = lookup_fresh(provider, p.mpn.strip())
+    except ProviderUpstreamError as exc:
+        raise HTTPException(
+            status_code=exc.status_code,
+            detail={"message": exc.message, "provider": exc.provider},
+        ) from exc
     if not out.get("found") or not out.get("result"):
         return ok(
             {

--- a/backend/app/api/routes/parts_provider.py
+++ b/backend/app/api/routes/parts_provider.py
@@ -2,13 +2,14 @@
 provider + API key and dispatches."""
 from __future__ import annotations
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, HTTPException, Request
 
 from app.core.deps import CurrentWorkspace
 from app.core.ratelimit import limiter, workspace_key
 from app.core.responses import ok
 from app.core.secrets import decrypt
 from app.domain.parts.providers import make_provider
+from app.domain.parts.providers.base import ProviderUpstreamError
 from app.domain.parts.schemas import LookupIn
 from app.domain.parts.services.provider_cache import lookup_with_cache
 
@@ -32,7 +33,13 @@ def lookup_mpn(request: Request, payload: LookupIn, ws: CurrentWorkspace):
             "message": "no provider configured (set one in Workspace settings)",
             "provider": ws.parts_provider or "none",
         })
-    out = lookup_with_cache(provider, payload.mpn.strip())
+    try:
+        out = lookup_with_cache(provider, payload.mpn.strip())
+    except ProviderUpstreamError as exc:
+        raise HTTPException(
+            status_code=exc.status_code,
+            detail={"message": exc.message, "provider": exc.provider},
+        ) from exc
     # Tag the response with the provider name so the UI can label its
     # success/failure note.
     return ok({**out, "provider": provider.name})

--- a/backend/app/domain/parts/providers/base.py
+++ b/backend/app/domain/parts/providers/base.py
@@ -9,6 +9,22 @@ from __future__ import annotations
 from typing import Optional, Protocol, TypedDict
 
 
+class ProviderUpstreamError(Exception):
+    """Provider transport/server failure that callers should surface as 5xx."""
+
+    def __init__(
+        self,
+        provider: str,
+        message: str,
+        *,
+        status_code: int = 502,
+    ) -> None:
+        super().__init__(message)
+        self.provider = provider
+        self.message = message
+        self.status_code = status_code
+
+
 class MpnLookupResult(TypedDict, total=False):
     """The shape returned by every provider's `lookup_mpn`."""
     found: bool

--- a/backend/app/domain/parts/providers/digikey.py
+++ b/backend/app/domain/parts/providers/digikey.py
@@ -17,7 +17,9 @@ import time
 from typing import Any, Callable
 from urllib.parse import quote
 
-from app.domain.parts.providers.base import MpnLookupResult
+import httpx
+
+from app.domain.parts.providers.base import MpnLookupResult, ProviderUpstreamError
 from app.domain.sourcing.providers import make_retrying_client
 
 _API_BASE = "https://api.digikey.com"
@@ -55,6 +57,11 @@ def _post_token(client_id: str, client_secret: str) -> dict[str, Any]:
                 "Accept": "application/json",
             },
         )
+        if resp.status_code >= 500:
+            raise ProviderUpstreamError(
+                "digikey",
+                f"DigiKey upstream returned HTTP {resp.status_code}",
+            )
         resp.raise_for_status()
         return resp.json()
 
@@ -155,6 +162,13 @@ class DigiKeyProvider:
             status, data = self._request_with_retry(
                 lambda tok: _get_product_details(tok, self.client_id, mpn)
             )
+        except ProviderUpstreamError:
+            raise
+        except (httpx.TimeoutException, httpx.ConnectError) as exc:
+            raise ProviderUpstreamError(
+                "digikey",
+                f"DigiKey upstream unavailable ({type(exc).__name__})",
+            ) from exc
         except RuntimeError as exc:
             # Raised by _get_token when the OAuth response is malformed.
             return {
@@ -163,11 +177,15 @@ class DigiKeyProvider:
                 "message": f"DigiKey auth failed ({type(exc).__name__})",
             }
         except Exception as exc:
-            return {
-                "found": False,
-                "result": None,
-                "message": f"upstream unavailable ({type(exc).__name__})",
-            }
+            raise ProviderUpstreamError(
+                "digikey",
+                f"DigiKey upstream unavailable ({type(exc).__name__})",
+            ) from exc
+        if status >= 500:
+            raise ProviderUpstreamError(
+                "digikey",
+                f"DigiKey upstream returned HTTP {status}",
+            )
         if status == 429:
             return {
                 "found": False,
@@ -196,12 +214,18 @@ class DigiKeyProvider:
                 kw_status, kw_data = self._request_with_retry(
                     lambda tok: _post_keyword_search(tok, self.client_id, mpn, limit=1)
                 )
+            except ProviderUpstreamError:
+                raise
+            except (httpx.TimeoutException, httpx.ConnectError) as exc:
+                raise ProviderUpstreamError(
+                    "digikey",
+                    f"DigiKey upstream unavailable ({type(exc).__name__})",
+                ) from exc
             except Exception as exc:
-                return {
-                    "found": False,
-                    "result": None,
-                    "message": f"upstream unavailable ({type(exc).__name__})",
-                }
+                raise ProviderUpstreamError(
+                    "digikey",
+                    f"DigiKey upstream unavailable ({type(exc).__name__})",
+                ) from exc
             if kw_status == 200:
                 products = (kw_data or {}).get("Products") or []
                 if products and isinstance(products[0], dict):
@@ -210,6 +234,11 @@ class DigiKeyProvider:
                         "result": _record_from_product(products[0]),
                         "message": None,
                     }
+            if kw_status >= 500:
+                raise ProviderUpstreamError(
+                    "digikey",
+                    f"DigiKey upstream returned HTTP {kw_status}",
+                )
             return {"found": False, "result": None, "message": "no match for MPN"}
 
         return {

--- a/backend/app/domain/parts/providers/mouser.py
+++ b/backend/app/domain/parts/providers/mouser.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 import re
 from typing import Any
 
-from app.domain.parts.providers.base import MpnLookupResult
+import httpx
+
+from app.domain.parts.providers.base import MpnLookupResult, ProviderUpstreamError
 from app.domain.sourcing.providers import make_retrying_client
 
 _ENDPOINT = "https://api.mouser.com/api/v1/search/partnumber"
@@ -15,6 +17,11 @@ def _post_mouser(url: str, payload: dict[str, Any]) -> dict[str, Any]:
     """Network seam — tests monkeypatch this single function."""
     with make_retrying_client(provider_name="mouser", timeout=_TIMEOUT_SEC) as client:
         resp = client.post(url, json=payload, headers={"Accept": "application/json"})
+        if resp.status_code >= 500:
+            raise ProviderUpstreamError(
+                "mouser",
+                f"Mouser upstream returned HTTP {resp.status_code}",
+            )
         resp.raise_for_status()
         return resp.json()
 
@@ -129,12 +136,18 @@ class MouserProvider:
         body = {"SearchByPartRequest": {"mouserPartNumber": mpn}}
         try:
             data = _post_mouser(url, body)
+        except ProviderUpstreamError:
+            raise
+        except (httpx.TimeoutException, httpx.ConnectError) as exc:
+            raise ProviderUpstreamError(
+                "mouser",
+                f"Mouser upstream unavailable ({type(exc).__name__})",
+            ) from exc
         except Exception as exc:
-            return {
-                "found": False,
-                "result": None,
-                "message": f"upstream unavailable ({type(exc).__name__})",
-            }
+            raise ProviderUpstreamError(
+                "mouser",
+                f"Mouser upstream unavailable ({type(exc).__name__})",
+            ) from exc
 
         errors = data.get("Errors") or []
         if errors:

--- a/backend/app/domain/parts/services/provider_cache.py
+++ b/backend/app/domain/parts/services/provider_cache.py
@@ -4,8 +4,8 @@ Goals
 -----
 * Avoid burning upstream API quota on repeated lookups for the same MPN
   (e.g. scan-to-import batch, operator refreshing the same part repeatedly).
-* Return fast synthetic failures when a provider's upstream is clearly down
-  rather than stalling the only uvicorn worker for 8 s × N consecutive calls.
+* Fail fast when a provider's upstream is clearly down rather than stalling
+  the only uvicorn worker for 8 s × N consecutive calls.
 
 Design notes
 ------------
@@ -24,8 +24,8 @@ What is cached
 
 Circuit breaker
     Five consecutive failures → breaker opens for 60 s.  While open, calls
-    return `{"found": False, "message": "provider temporarily unavailable"}`
-    without hitting the network.  The counter resets on any success.
+    raise `ProviderUpstreamError` without hitting the network.  The counter
+    resets on any success.
 
     Per-provider, per-process state (in-memory dict).  Not persisted across
     restarts (CLAUDE.md hard constraint: `--workers 1` in prod).
@@ -39,6 +39,8 @@ from __future__ import annotations
 import time
 from collections import OrderedDict
 from typing import TYPE_CHECKING
+
+from app.domain.parts.providers.base import ProviderUpstreamError
 
 if TYPE_CHECKING:
     from app.domain.parts.providers.base import MpnLookupResult, PartsProvider
@@ -181,14 +183,18 @@ def lookup_with_cache(provider: "PartsProvider", mpn: str) -> "MpnLookupResult":
     #    failing.  This keeps the single uvicorn worker from stalling on a
     #    misbehaving upstream.
     if breaker.is_open:
-        return {
-            "found": False,
-            "result": None,
-            "message": "provider temporarily unavailable (circuit breaker open)",
-        }
+        raise ProviderUpstreamError(
+            provider.name,
+            "provider temporarily unavailable (circuit breaker open)",
+            status_code=503,
+        )
 
     # 3. Live call.
-    result = provider.lookup_mpn(normalized_mpn)
+    try:
+        result = provider.lookup_mpn(normalized_mpn)
+    except ProviderUpstreamError:
+        breaker.record_failure()
+        raise
 
     # 4. Update breaker state.
     if result.get("found"):
@@ -232,14 +238,18 @@ def lookup_fresh(provider: "PartsProvider", mpn: str) -> "MpnLookupResult":
     # Circuit breaker still applies — a manual refresh into a broken upstream
     # should fail fast, not pin the only uvicorn worker for 8 s.
     if breaker.is_open:
-        return {
-            "found": False,
-            "result": None,
-            "message": "provider temporarily unavailable (circuit breaker open)",
-        }
+        raise ProviderUpstreamError(
+            provider.name,
+            "provider temporarily unavailable (circuit breaker open)",
+            status_code=503,
+        )
 
     # Live call — deliberately no cache read here.
-    result = provider.lookup_mpn(normalized_mpn)
+    try:
+        result = provider.lookup_mpn(normalized_mpn)
+    except ProviderUpstreamError:
+        breaker.record_failure()
+        raise
 
     # Update breaker state.
     if result.get("found"):

--- a/backend/tests/test_bulk_import_from_scan.py
+++ b/backend/tests/test_bulk_import_from_scan.py
@@ -507,9 +507,7 @@ def test_bulk_import_provider_exception_does_not_abort_batch(authed, monkeypatch
     )
     assert r.status_code == 200, r.text
     statuses = [row["status"] for row in r.json()["data"]["rows"]]
-    # Mouser provider catches RuntimeError internally and returns
-    # `{"found": False, "message": "..."}`, so the row resolves as
-    # `lookup_failed` rather than `row_failed`. Either way, the
+    # Provider exceptions resolve as per-row lookup_failed results; the
     # surrounding batch keeps processing — that's the load-bearing pin.
     assert statuses[0] == "created"
     assert statuses[1] == "lookup_failed"

--- a/backend/tests/test_parts_provider.py
+++ b/backend/tests/test_parts_provider.py
@@ -232,10 +232,11 @@ def test_lookup_mouser_network_failure_is_graceful(authed, monkeypatch):
 
     monkeypatch.setattr("app.domain.parts.providers.mouser._post_mouser", fail)
     r = authed.post("/api/parts/lookup-mpn", json={"mpn": "ANY"})
-    assert r.status_code == 200, r.text
-    body = r.json()["data"]
-    assert body["found"] is False
-    assert "upstream unavailable" in body["message"]
+    assert r.status_code == 502, r.text
+    body = r.json()
+    assert body["data"] is None
+    assert "upstream unavailable" in body["status"]["message"]
+    assert body["provider"] == "mouser"
 
 
 def test_lookup_rejects_extra_fields(authed):

--- a/backend/tests/test_parts_provider_upstream_errors.py
+++ b/backend/tests/test_parts_provider_upstream_errors.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import uuid
+from contextlib import contextmanager
+
+import httpx
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+def _signup(c: TestClient) -> None:
+    r = c.post(
+        "/api/auth/signup",
+        json={
+            "email": f"u-{uuid.uuid4().hex[:8]}@x.com",
+            "name": "u",
+            "password": "TestPass-2026-Stronk",
+        },
+    )
+    assert r.status_code == 200, r.text
+
+
+def _reset_provider_state(provider_name: str) -> None:
+    import app.domain.parts.services.provider_cache as _cache
+
+    _cache._cache._store.clear()
+    _cache._breakers.pop(provider_name, None)
+
+
+def _authed_client() -> TestClient:
+    c = TestClient(app)
+    _signup(c)
+    return c
+
+
+def _enable_mouser(client: TestClient) -> None:
+    r = client.patch(
+        "/api/workspaces/current",
+        json={"parts_provider": "mouser", "parts_provider_api_key": "fake-key"},
+    )
+    assert r.status_code == 200, r.text
+
+
+def _enable_digikey(client: TestClient) -> None:
+    r = client.patch(
+        "/api/workspaces/current",
+        json={
+            "parts_provider": "digikey",
+            "parts_provider_api_key": "fake-client-id",
+            "parts_provider_api_secret": "fake-client-secret",
+        },
+    )
+    assert r.status_code == 200, r.text
+
+
+def test_mouser_503_returns_502(monkeypatch):
+    _reset_provider_state("mouser")
+    c = _authed_client()
+    _enable_mouser(c)
+
+    @contextmanager
+    def fake_client(*, provider_name: str, timeout: float):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(503, json={"message": "maintenance"})
+
+        with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+            yield client
+
+    monkeypatch.setattr(
+        "app.domain.parts.providers.mouser.make_retrying_client",
+        fake_client,
+    )
+
+    r = c.post("/api/parts/lookup-mpn", json={"mpn": "RC0402JR-070R"})
+    assert r.status_code == 502, r.text
+    body = r.json()
+    assert body["data"] is None
+    assert body["status"]["category"] == "server_error"
+    assert "HTTP 503" in body["status"]["message"]
+    assert body["provider"] == "mouser"
+
+
+def test_digikey_timeout_returns_502(monkeypatch):
+    _reset_provider_state("digikey")
+    c = _authed_client()
+    _enable_digikey(c)
+
+    monkeypatch.setattr(
+        "app.domain.parts.providers.digikey._post_token",
+        lambda client_id, client_secret: {"access_token": "tok", "expires_in": 600},
+    )
+
+    def timeout(token: str, client_id: str, mpn: str) -> tuple[int, dict]:
+        raise httpx.ReadTimeout("timed out")
+
+    monkeypatch.setattr(
+        "app.domain.parts.providers.digikey._get_product_details",
+        timeout,
+    )
+
+    r = c.post("/api/parts/lookup-mpn", json={"mpn": "TXU0204QWBQARQ1"})
+    assert r.status_code == 502, r.text
+    body = r.json()
+    assert body["data"] is None
+    assert body["status"]["category"] == "server_error"
+    assert "ReadTimeout" in body["status"]["message"]
+    assert body["provider"] == "digikey"
+
+
+def test_mouser_no_match_still_returns_200(monkeypatch):
+    _reset_provider_state("mouser")
+    c = _authed_client()
+    _enable_mouser(c)
+
+    monkeypatch.setattr(
+        "app.domain.parts.providers.mouser._post_mouser",
+        lambda url, payload: {
+            "Errors": [],
+            "SearchResults": {"NumberOfResult": 0, "Parts": []},
+        },
+    )
+
+    r = c.post("/api/parts/lookup-mpn", json={"mpn": "DOES-NOT-EXIST"})
+    assert r.status_code == 200, r.text
+    body = r.json()["data"]
+    assert body["found"] is False
+    assert "no match" in body["message"].lower()
+    assert body["provider"] == "mouser"

--- a/backend/tests/test_provider_circuit_breaker.py
+++ b/backend/tests/test_provider_circuit_breaker.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import pytest
 
-
 # ---------------------------------------------------------------------------
 # Unit tests against lookup_with_cache directly (no HTTP layer needed)
 # ---------------------------------------------------------------------------
@@ -73,11 +72,10 @@ def test_breaker_opens_after_threshold_failures(monkeypatch):
     )
 
     # The (threshold + 1)-th call should be intercepted by the open breaker.
-    result = _m.lookup_with_cache(provider, "MPN-EXTRA")
-    assert result["found"] is False
-    assert "circuit breaker" in (result.get("message") or "").lower(), (
-        f"Expected circuit-breaker message, got: {result.get('message')!r}"
-    )
+    with pytest.raises(_m.ProviderUpstreamError) as exc_info:
+        _m.lookup_with_cache(provider, "MPN-EXTRA")
+    assert exc_info.value.status_code == 503
+    assert "circuit breaker" in exc_info.value.message.lower()
     # Provider must NOT have been called again.
     assert call_count == threshold, (
         f"Provider should not be called when breaker is open, "
@@ -172,12 +170,14 @@ def test_clean_miss_does_not_trip_breaker(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_circuit_breaker_returns_503_like_message_via_route(monkeypatch):
-    """Exhausting the circuit breaker via the HTTP route returns a found=False
-    result with the unavailability message without a network round-trip."""
+def test_circuit_breaker_returns_503_via_route(monkeypatch):
+    """Exhausting the circuit breaker via the HTTP route returns a 503
+    envelope with the unavailability message without a network round-trip."""
     import uuid
-    import app.domain.parts.services.provider_cache as _m
+
     from fastapi.testclient import TestClient
+
+    import app.domain.parts.services.provider_cache as _m
     from app.main import app
 
     provider_name = "mouser"
@@ -214,18 +214,18 @@ def test_circuit_breaker_returns_503_like_message_via_route(monkeypatch):
     for i in range(threshold):
         mpn = f"TRIP-{uuid.uuid4().hex[:6]}"
         r = c.post("/api/parts/lookup-mpn", json={"mpn": mpn})
-        assert r.status_code == 200, r.text
+        assert r.status_code == 502, r.text
 
     assert call_count[0] == threshold
 
     # The breaker is now open — next call must not hit the network.
     mpn_after = f"AFTER-{uuid.uuid4().hex[:6]}"
     r = c.post("/api/parts/lookup-mpn", json={"mpn": mpn_after})
-    assert r.status_code == 200, r.text
-    data = r.json()["data"]
-    assert data["found"] is False
-    assert "circuit breaker" in (data.get("message") or "").lower(), (
-        f"Expected circuit-breaker message in response, got: {data}"
+    assert r.status_code == 503, r.text
+    body = r.json()
+    assert body["data"] is None
+    assert "circuit breaker" in body["status"]["message"].lower(), (
+        f"Expected circuit-breaker message in response, got: {body}"
     )
     # Provider not called again.
     assert call_count[0] == threshold, (


### PR DESCRIPTION
## Summary
- Add ProviderUpstreamError for parts provider transport/server failures.
- Return API error envelopes for lookup/refresh provider upstream failures instead of successful found:false misses.
- Keep clean not-found provider responses as 200 and add focused regression coverage for Mouser 503 and DigiKey timeout paths.

Closes #551

## Validation
- `uv run --extra dev ruff check app/api/routes/parts_provider.py app/api/routes/parts_assets.py app/domain/parts/providers/base.py app/domain/parts/providers/mouser.py app/domain/parts/providers/digikey.py app/domain/parts/services/provider_cache.py tests/test_parts_provider.py tests/test_provider_circuit_breaker.py tests/test_parts_provider_upstream_errors.py tests/test_bulk_import_from_scan.py`
- `uv run --extra dev pytest tests/test_parts_provider_upstream_errors.py tests/test_parts_provider.py tests/test_provider_circuit_breaker.py tests/test_mouser_extraction.py tests/test_digikey_provider.py tests/test_bulk_import_from_scan.py::test_bulk_import_provider_exception_does_not_abort_batch -q`
- `rg -n "verify=False|trust_env=False|ssl=False" backend/app || true`

## Merge Order / Conflicts
- Based on `origin/main` at `094142f` (`SA-11b sourcing alert threshold unions (#537)`).
- Touches only parts provider lookup/refresh, provider clients/cache, and focused backend tests. Expected conflict risk is low unless another branch edits the same provider error handling or circuit-breaker behavior.
- No migrations, frontend changes, or workspace-isolation query changes.
