### PR TITLE
SA-2b: Re-validate/prune overrides against new available_offers after refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ the canonical record.
 
 ## 2026-05 — feedback brief fixes
 
+- **SA-2b / #538** Refresh now prunes overrides whose target offer disappeared
+  upstream; info toast surfaces the count.
 - **SA-10b / #539** Convert-orders route now uses explicit `raise_http` +
   `ErrorCodes.*` instead of the legacy `_error_response` mapper.
 - **SA-8b / #535** Split PurchasePlanReviewPage to keep sourcing files under 300-LOC headroom cap.

--- a/web/src/routes/projects/sourcing/PurchasePlanReviewPage.tsx
+++ b/web/src/routes/projects/sourcing/PurchasePlanReviewPage.tsx
@@ -14,6 +14,7 @@ import {
   formatMoney,
   groupLines,
   isRefreshFresh,
+  purchasePlanOverrideMatchesOffer,
   purchasePlanActionErrorMessage,
   recomputePlanFromLines,
   refreshedLabel,
@@ -100,6 +101,30 @@ export default function PurchasePlanReviewPage() {
     setBusyAction("refresh");
     try {
       const next = await api.post<PurchasePlan>(`/sourcing/purchase-plans/${plan.id}/refresh`);
+      setOverrides(current => {
+        const pruned: typeof current = {};
+        const dropped: string[] = [];
+        const linesById = new Map(next.lines.map(line => [line.id, line]));
+        for (const [lineId, override] of Object.entries(current)) {
+          const refreshedLine = linesById.get(lineId);
+          const stillAvailable = refreshedLine
+            ? (refreshedLine.available_offers ?? []).some(offer =>
+                purchasePlanOverrideMatchesOffer(refreshedLine, override, offer),
+              )
+            : false;
+          if (stillAvailable) {
+            pruned[lineId] = override;
+          } else {
+            dropped.push(lineId);
+          }
+        }
+        if (dropped.length > 0) {
+          toast.info(
+            `Removed ${dropped.length} override${dropped.length === 1 ? "" : "s"} no longer available after refresh.`,
+          );
+        }
+        return pruned;
+      });
       queryClient.setQueryData(purchasePlanKey, next);
       setRefreshAttention(false);
       toast.success("Prices refreshed");

--- a/web/src/routes/projects/sourcing/__tests__/PurchasePlanReviewPage.test.tsx
+++ b/web/src/routes/projects/sourcing/__tests__/PurchasePlanReviewPage.test.tsx
@@ -13,6 +13,7 @@ vi.mock("sonner", () => ({
   toast: {
     success: vi.fn(),
     error: vi.fn(),
+    info: vi.fn(),
   },
 }));
 
@@ -281,7 +282,46 @@ describe("PurchasePlanReviewPage", () => {
     expect(toast.success).toHaveBeenCalledWith("Prices refreshed");
   });
 
-  it("preserves overrides across a successful refresh", async () => {
+  it("prunes overrides whose offer disappears after refresh", async () => {
+    const base = plan();
+    const refreshed = plan({
+      lines: [
+        {
+          ...base.lines[0],
+          selected_distributor: "DigiKey",
+          selected_qty: 16,
+          selected_unit_price: "1.15",
+          available_offers: base.lines[0].available_offers?.slice(0, 1) ?? [],
+        },
+        base.lines[1],
+      ],
+      unfilled_count: 0,
+    });
+    const post = vi.spyOn(api, "post")
+      .mockResolvedValueOnce(refreshed)
+      .mockResolvedValueOnce({
+        orders: [{ id: "order-1", name: "Draft", supplier: "DigiKey", status: "draft", entries: [] }],
+      });
+    renderPage({ initialPlan: base });
+
+    await selectArrowOffer();
+    await userEvent.click(screen.getByRole("button", { name: /Refresh prices/ }));
+
+    await waitFor(() => {
+      expect(toast.info).toHaveBeenCalledWith(
+        "Removed 1 override no longer available after refresh.",
+      );
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: /Create draft orders/ }));
+
+    await waitFor(() => expect(screen.getByTestId("location").textContent).toBe("/orders"));
+    expect(post).toHaveBeenNthCalledWith(2, "/sourcing/purchase-plans/plan-12345678/orders", {
+      overrides: {},
+    });
+  });
+
+  it("keeps overrides whose offer is still present after refresh", async () => {
     const refreshed = plan({
       est_total_cost: "18.40",
       lines: [
@@ -320,9 +360,10 @@ describe("PurchasePlanReviewPage", () => {
         },
       },
     });
+    expect(toast.info).not.toHaveBeenCalled();
   });
 
-  it("shows error toast on refresh failure", async () => {
+  it("does not prune when refresh fails", async () => {
     const apiError = new ApiError(
       502,
       { data: null, status: { category: "trustedparts_unavailable", message: "TrustedParts unavailable" } },
@@ -340,6 +381,7 @@ describe("PurchasePlanReviewPage", () => {
     await userEvent.click(screen.getByRole("button", { name: /Refresh prices/ }));
 
     await waitFor(() => expect(toast.error).toHaveBeenCalledWith("TrustedParts unavailable. Retry later."));
+    expect(toast.info).not.toHaveBeenCalled();
 
     await userEvent.click(screen.getByRole("button", { name: /Create draft orders/ }));
 

--- a/web/src/routes/projects/sourcing/purchasePlanHelpers.ts
+++ b/web/src/routes/projects/sourcing/purchasePlanHelpers.ts
@@ -1,5 +1,10 @@
 import { ApiError } from "@/lib/api";
-import type { PurchasePlan, PurchasePlanLine, PurchasePlanOffer } from "./purchasePlanTypes";
+import type {
+  PurchasePlan,
+  PurchasePlanLine,
+  PurchasePlanOffer,
+  PurchasePlanOrderOverride,
+} from "./purchasePlanTypes";
 
 export const STALE_MS = 10 * 60 * 1000;
 
@@ -64,6 +69,22 @@ export function unitPriceForOffer(offer: PurchasePlanOffer, qty: number): string
     selected = candidate;
   }
   return selected.unitPrice;
+}
+
+export function purchasePlanOverrideMatchesOffer(
+  line: PurchasePlanLine,
+  override: PurchasePlanOrderOverride,
+  offer: PurchasePlanOffer,
+): boolean {
+  if ((offer.distributor ?? "").toLowerCase() !== override.selected_distributor.toLowerCase()) return false;
+  const stock = numberOrNull(offer.stock);
+  if (stock == null || stock < override.selected_qty) return false;
+  const moq = numberOrNull(offer.moq);
+  if (moq != null && override.selected_qty < moq) return false;
+  if (override.selected_qty < line.shortage_qty) return false;
+  if ((offer.currency ?? "").toUpperCase() !== override.selected_currency.toUpperCase()) return false;
+  const unitPrice = unitPriceForOffer(offer, override.selected_qty);
+  return unitPrice != null && numberOrNull(unitPrice) === numberOrNull(override.selected_unit_price);
 }
 
 export function recomputePlanFromLines(plan: PurchasePlan, lines: PurchasePlanLine[]): PurchasePlan {


### PR DESCRIPTION
## Summary
- Prunes purchase-plan order overrides after a successful refresh when the selected offer no longer matches any refreshed `available_offers` entry.
- Keeps valid refreshed overrides using the same distributor/qty/stock/MOQ/currency/unit-price matching shape used by conversion validation.
- Shows an informational toast with the number of dropped overrides and records the SA-2b changelog entry.

## Before / After
Before: an override for an offer that disappeared upstream stayed in state after refresh and failed later during conversion.
After: refresh removes the stale override immediately and tells the user how many overrides were removed.

## Validation
- `cd web && npm run typecheck` — passed.
- `cd web && npm test -- "PurchasePlanReviewPage"` — passed: 1 file, 16 tests.
- `cd web && npm run lint` — failed on pre-existing unrelated issues: `src/lib/bagCode.ts` `no-control-regex` errors plus existing warnings in scanner/routes files.
- `cd web && npx eslint src/routes/projects/sourcing/PurchasePlanReviewPage.tsx src/routes/projects/sourcing/purchasePlanHelpers.ts src/routes/projects/sourcing/__tests__/PurchasePlanReviewPage.test.tsx` — passed.

## Merge Order / Conflict Notes
- Based on `origin/main` at `094142f` (`SA-11b sourcing alert threshold unions`).
- Expected conflict surface is limited to `PurchasePlanReviewPage.tsx`, `purchasePlanHelpers.ts`, the PurchasePlanReviewPage test, and the top of `CHANGELOG.md` if nearby SA follow-ups land first.
- No backend/API envelope changes and no migration.

Refs #501
Closes #538
