### PR TITLE
[codex] Add StockEntry constructor CI guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,6 +258,13 @@ jobs:
             exit 1
           fi
 
+      # AUD-055: keep direct StockEntry() construction confined to the
+      # ledger-writing services. Other code must use those services instead
+      # of bypassing their workspace and append-only semantics.
+      - name: StockEntry constructor guard
+        working-directory: backend
+        run: python scripts/check_stockentry_constructors.py
+
       - name: alembic single-head check
         working-directory: backend
         env:

--- a/backend/scripts/check_stockentry_constructors.py
+++ b/backend/scripts/check_stockentry_constructors.py
@@ -1,0 +1,82 @@
+"""
+AUD-055 — CI guard: StockEntry() constructors stay in ledger-writing services.
+
+The stock ledger is append-only. New StockEntry rows should be created only by
+the stock, orders, and builds services, where workspace checks and operation
+semantics are centralized. This guard scans backend/app/ and fails on raw
+StockEntry() construction anywhere else.
+"""
+
+import ast
+import sys
+from pathlib import Path
+
+_ALLOWED_APP_PATHS = {
+    Path("domain/stock/service.py"),
+    Path("domain/orders/service.py"),
+    Path("domain/builds/service.py"),
+}
+
+
+def _is_stockentry_call(node: ast.Call) -> bool:
+    func = node.func
+    return (isinstance(func, ast.Name) and func.id == "StockEntry") or (
+        isinstance(func, ast.Attribute) and func.attr == "StockEntry"
+    )
+
+
+def check_file(path: Path, *, app_dir: Path) -> list[int]:
+    """Return line numbers where *path* constructs StockEntry outside the allowlist."""
+    rel = path.resolve().relative_to(app_dir.resolve())
+    if rel in _ALLOWED_APP_PATHS:
+        return []
+
+    source = path.read_text(encoding="utf-8")
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError:
+        return []
+
+    return [
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and _is_stockentry_call(node)
+    ]
+
+
+def check_app_tree(app_dir: Path) -> list[tuple[Path, int]]:
+    violations: list[tuple[Path, int]] = []
+    for py_file in sorted(app_dir.rglob("*.py")):
+        for lineno in check_file(py_file, app_dir=app_dir):
+            violations.append((py_file, lineno))
+    return violations
+
+
+def main() -> int:
+    scripts_dir = Path(__file__).resolve().parent
+    backend_dir = scripts_dir.parent
+    app_dir = backend_dir / "app"
+
+    if not app_dir.is_dir():
+        print(f"ERROR: app directory not found at {app_dir}", file=sys.stderr)
+        return 2
+
+    violations = check_app_tree(app_dir)
+    for path, lineno in violations:
+        rel = path.relative_to(backend_dir.parent)
+        print(f"{rel}:{lineno}: StockEntry() construction is not allow-listed")
+
+    if violations:
+        allowed = ", ".join(str(path) for path in sorted(_ALLOWED_APP_PATHS))
+        print(
+            "\nFAIL: StockEntry() may only be constructed in approved services: "
+            f"{allowed}.",
+            file=sys.stderr,
+        )
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/tests/test_stockentry_constructor_guard.py
+++ b/backend/tests/test_stockentry_constructor_guard.py
@@ -1,0 +1,69 @@
+import importlib.util
+import textwrap
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "check_stockentry_constructors.py"
+
+
+def _load_checker():
+    spec = importlib.util.spec_from_file_location("stockentry_checker", _SCRIPT)
+    assert spec is not None
+    checker = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(checker)  # type: ignore[union-attr]
+    return checker
+
+
+def test_clean_app_tree_passes():
+    checker = _load_checker()
+    app_dir = Path(__file__).resolve().parent.parent / "app"
+
+    violations = checker.check_app_tree(app_dir)
+
+    assert violations == []
+
+
+def test_offending_app_file_detected(tmp_path: Path):
+    checker = _load_checker()
+    app_dir = tmp_path / "app"
+    route_dir = app_dir / "api" / "routes"
+    route_dir.mkdir(parents=True)
+    bad_py = route_dir / "stock_shortcut.py"
+    bad_py.write_text(
+        textwrap.dedent(
+            """\
+            from app.domain.stock.models import StockEntry
+
+            def bad_insert():
+                return StockEntry(quantity_delta=1)
+            """
+        )
+    )
+
+    violations = checker.check_app_tree(app_dir)
+
+    assert [(path.relative_to(app_dir), lineno) for path, lineno in violations] == [
+        (Path("api/routes/stock_shortcut.py"), 4)
+    ]
+
+
+def test_allowed_service_file_not_flagged(tmp_path: Path):
+    checker = _load_checker()
+    app_dir = tmp_path / "app"
+    service_dir = app_dir / "domain" / "stock"
+    service_dir.mkdir(parents=True)
+    service_py = service_dir / "service.py"
+    service_py.write_text(
+        textwrap.dedent(
+            """\
+            from app.domain.stock.models import StockEntry
+
+            def add_stock():
+                return StockEntry(quantity_delta=1)
+            """
+        )
+    )
+
+    violations = checker.check_app_tree(app_dir)
+
+    assert violations == []


### PR DESCRIPTION
## Summary

- Add an AST-based backend guard that rejects `StockEntry()` construction outside the approved ledger-writing services.
- Wire the guard into the backend CI job after the TLS verify guard.
- Add focused tests for the real app tree, a disallowed call site, and an allow-listed service file.

Closes #594

## Validation

- `uv run python scripts/check_stockentry_constructors.py`
- `uv run python scripts/check_no_traceback_leaks.py`
- `uv run ruff check scripts/check_stockentry_constructors.py tests/test_stockentry_constructor_guard.py`
- `uv run --extra dev pytest tests/test_stockentry_constructor_guard.py -q`
- `uv run --extra dev pytest tests/test_ci_workflow.py tests/test_stockentry_constructor_guard.py -q`

Note: direct `python` / `python3 -m pytest` was not used for final validation because the host Python sees `backend/alembic/` as a namespace package and cannot import installed `alembic.command`; `uv run --extra dev` matches the project test environment.

## Merge Order / Conflicts

- Based on `origin/main` at `094142f`.
- Expected conflict surface is limited to `.github/workflows/ci.yml` if another PR edits backend CI steps near the existing static guards.
- No stock behavior, migrations, or `current_quantity()` logic changed.
