### PR TITLE
AUD-001: Wire polymorphic cleanup listeners

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,6 +172,12 @@ them, that's the bug.
   and the asset-side reserved-keys subset is `_PROVIDER_RESERVED_KEYS`
   in `backend/app/api/routes/parts_assets.py`. Adding a new catalog
   field needs the FE list AND the relevant server-side touchpoint.
+- **Polymorphic cleanup on hard delete.** `attachments`, `custom_fields`,
+  and `tag_links` have no FK on `object_id`. Hard-deleting a registered
+  parent (`part`, `order`, `project`, `build`, `lot`, `storage_location`)
+  relies on `domain/_polymorphic_cleanup.py` `before_delete` listeners,
+  registered by `domain/all_models.py` and the API helper import path; do
+  not bypass them with bulk ORM deletes.
 - **No `verify=False` on httpx clients.** CI greps for `verify=False`,
   `trust_env=False`, `ssl=False` under `backend/app/`. Annotate with
   `# noqa: tls-verify` if intentional (e.g. internal test doubles).

--- a/backend/app/api/_helpers.py
+++ b/backend/app/api/_helpers.py
@@ -11,6 +11,9 @@ from sqlalchemy.orm import Session
 from app.core.deps import _ROLE_RANK, _membership_role
 from app.core.errors import ErrorCodes, raise_http
 from app.domain._mixins import WorkspaceOwned
+from app.domain._polymorphic_cleanup import register_polymorphic_cleanup_listeners
+
+register_polymorphic_cleanup_listeners()
 
 # Generic type variable bound to WorkspaceOwned. Replaces the previous
 # `Any`-typed signatures so a typo (`Parts` instead of `Part`) is caught
@@ -62,10 +65,20 @@ def _polymorphic_resolvers() -> dict[str, type[WorkspaceOwned]]:
     # every attachment upload / custom-field write / tag link. Adding a
     # new entry requires a process restart — that's fine, this list is
     # static at deploy time.
+    from app.domain.builds.models import Build
+    from app.domain.lots.models import Lot
+    from app.domain.orders.models import Order
     from app.domain.parts.models import Part
+    from app.domain.projects.models import Project
+    from app.domain.storage.models import StorageLocation
 
     return {
+        "build": Build,
+        "lot": Lot,
+        "order": Order,
         "part": Part,
+        "project": Project,
+        "storage_location": StorageLocation,
     }
 
 

--- a/backend/app/domain/_polymorphic_cleanup.py
+++ b/backend/app/domain/_polymorphic_cleanup.py
@@ -22,14 +22,79 @@ See docs/ARCHITECTURE.md — Polymorphic tables contract.
 """
 from __future__ import annotations
 
+import logging
+from collections.abc import Mapping
 from uuid import UUID
 
-from sqlalchemy import delete
-from sqlalchemy.orm import Session
+from sqlalchemy import delete, event
+from sqlalchemy.engine import Connection
+from sqlalchemy.orm import Mapper, Session, object_session
 
 from app.domain.attachments.models import Attachment
 from app.domain.custom_fields.models import CustomField
 from app.domain.tags.models import TagLink
+
+_log = logging.getLogger(__name__)
+
+_CleanupExecutor = Session | Connection
+_CleanupModel = tuple[object, str]
+
+
+def _child_tables() -> tuple[_CleanupModel, ...]:
+    return (
+        (Attachment, "attachments"),
+        (CustomField, "custom_fields"),
+        (TagLink, "tag_links"),
+    )
+
+
+def polymorphic_parent_models() -> Mapping[str, type]:
+    """Object types whose hard-deletes must purge polymorphic children."""
+    from app.domain.builds.models import Build
+    from app.domain.lots.models import Lot
+    from app.domain.orders.models import Order
+    from app.domain.parts.models import Part
+    from app.domain.projects.models import Project
+    from app.domain.storage.models import StorageLocation
+
+    return {
+        "build": Build,
+        "lot": Lot,
+        "order": Order,
+        "part": Part,
+        "project": Project,
+        "storage_location": StorageLocation,
+    }
+
+
+def _object_type_for_parent(target: object) -> str | None:
+    target_type = type(target)
+    for object_type, Model in polymorphic_parent_models().items():
+        if target_type is Model:
+            return object_type
+    return None
+
+
+def _purge_polymorphic(
+    executor: _CleanupExecutor,
+    *,
+    workspace_id: UUID,
+    object_type: str,
+    object_id: UUID,
+) -> dict[str, int]:
+    counts: dict[str, int] = {}
+
+    for Model, table_name in _child_tables():
+        result = executor.execute(
+            delete(Model).where(
+                Model.workspace_id == workspace_id,
+                Model.object_type == object_type,
+                Model.object_id == object_id,
+            )
+        )
+        counts[table_name] = int(result.rowcount or 0)
+
+    return counts
 
 
 def purge_polymorphic(
@@ -48,33 +113,56 @@ def purge_polymorphic(
     This is intentionally a bulk DELETE, not a per-row ORM fetch, so it
     stays fast even for objects with hundreds of attachments/fields/links.
     """
-    counts: dict[str, int] = {}
-
-    result = db.execute(
-        delete(Attachment).where(
-            Attachment.workspace_id == workspace_id,
-            Attachment.object_type == object_type,
-            Attachment.object_id == object_id,
-        )
+    return _purge_polymorphic(
+        db,
+        workspace_id=workspace_id,
+        object_type=object_type,
+        object_id=object_id,
     )
-    counts["attachments"] = result.rowcount
 
-    result = db.execute(
-        delete(CustomField).where(
-            CustomField.workspace_id == workspace_id,
-            CustomField.object_type == object_type,
-            CustomField.object_id == object_id,
-        )
+
+def _purge_polymorphic_on_delete(
+    _mapper: Mapper,
+    connection: Connection,
+    target: object,
+) -> None:
+    object_type = _object_type_for_parent(target)
+    if object_type is None:
+        return
+
+    workspace_id = getattr(target, "workspace_id", None)
+    object_id = getattr(target, "id", None)
+    if workspace_id is None or object_id is None:
+        return
+
+    session = object_session(target)
+    if session is not None:
+        seen = session.info.setdefault("polymorphic_cleanup_seen", set())
+        key = (object_type, object_id, id(target))
+        if key in seen:
+            return
+        seen.add(key)
+
+    counts = _purge_polymorphic(
+        connection,
+        workspace_id=workspace_id,
+        object_type=object_type,
+        object_id=object_id,
     )
-    counts["custom_fields"] = result.rowcount
-
-    result = db.execute(
-        delete(TagLink).where(
-            TagLink.workspace_id == workspace_id,
-            TagLink.object_type == object_type,
-            TagLink.object_id == object_id,
-        )
+    _log.info(
+        "polymorphic_cleanup hard_delete object_type=%s object_id=%s "
+        "workspace_id=%s attachments=%d custom_fields=%d tag_links=%d",
+        object_type,
+        object_id,
+        workspace_id,
+        counts["attachments"],
+        counts["custom_fields"],
+        counts["tag_links"],
     )
-    counts["tag_links"] = result.rowcount
 
-    return counts
+
+def register_polymorphic_cleanup_listeners() -> None:
+    """Register idempotent before_delete listeners for polymorphic parents."""
+    for Model in polymorphic_parent_models().values():
+        if not event.contains(Model, "before_delete", _purge_polymorphic_on_delete):
+            event.listen(Model, "before_delete", _purge_polymorphic_on_delete)

--- a/backend/app/domain/all_models.py
+++ b/backend/app/domain/all_models.py
@@ -23,6 +23,7 @@ The test in step (1) does not replace step (2) — it only catches the
 case where step (1) was forgotten.
 """
 
+from app.domain._polymorphic_cleanup import register_polymorphic_cleanup_listeners
 from app.domain.attachments.models import Attachment  # noqa: F401
 from app.domain.audit.models import AuditLog  # noqa: F401
 from app.domain.builds.models import Build  # noqa: F401
@@ -58,3 +59,5 @@ from app.domain.workspaces.models import (  # noqa: F401
     WorkspaceInvitation,
     WorkspaceMember,
 )
+
+register_polymorphic_cleanup_listeners()

--- a/backend/scripts/purge_polymorphic_orphans.py
+++ b/backend/scripts/purge_polymorphic_orphans.py
@@ -1,0 +1,123 @@
+"""One-off cleanup for orphaned polymorphic child rows.
+
+Dry-run by default. Pass --apply to delete rows whose (object_type,
+object_id, workspace_id) no longer resolves to a parent row.
+
+Usage::
+
+    DATABASE_URL=postgresql+psycopg://... python scripts/purge_polymorphic_orphans.py
+    DATABASE_URL=postgresql+psycopg://... python scripts/purge_polymorphic_orphans.py --apply
+"""
+# ruff: noqa: E402,I001
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+# Allow running from the backend directory without installing the package.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+os.environ.setdefault("SESSION_SECRET", "unused-for-maintenance-script")
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+import app.domain.all_models  # noqa: F401,E402 — registers model metadata
+
+
+CHILD_TABLES = ("attachments", "custom_fields", "tag_links")
+
+
+def _build_session():
+    url = os.environ.get("DATABASE_URL")
+    if not url:
+        sys.exit("DATABASE_URL environment variable is required")
+    engine = create_engine(url, future=True)
+    Session = sessionmaker(bind=engine, autoflush=False, future=True)
+    return Session()
+
+
+def _orphan_count_sql(child_table: str, parent_table: str):
+    return text(f"""
+        SELECT count(*)
+        FROM {child_table} c
+        WHERE c.object_type = :object_type
+          AND NOT EXISTS (
+            SELECT 1
+            FROM {parent_table} p
+            WHERE p.id = c.object_id
+              AND p.workspace_id = c.workspace_id
+          )
+    """)
+
+
+def _orphan_delete_sql(child_table: str, parent_table: str):
+    return text(f"""
+        DELETE FROM {child_table} c
+        WHERE c.object_type = :object_type
+          AND NOT EXISTS (
+            SELECT 1
+            FROM {parent_table} p
+            WHERE p.id = c.object_id
+              AND p.workspace_id = c.workspace_id
+          )
+    """)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="delete orphan rows; without this flag the script only reports counts",
+    )
+    args = parser.parse_args()
+
+    from app.domain._polymorphic_cleanup import polymorphic_parent_models
+
+    parents = {
+        object_type: Model.__tablename__  # type: ignore[attr-defined]
+        for object_type, Model in polymorphic_parent_models().items()
+    }
+
+    db = _build_session()
+    total = 0
+    try:
+        for child_table in CHILD_TABLES:
+            print(f"\n=== {child_table} ===")
+            for object_type, parent_table in parents.items():
+                count = int(
+                    db.execute(
+                        _orphan_count_sql(child_table, parent_table),
+                        {"object_type": object_type},
+                    ).scalar_one()
+                )
+                if not count:
+                    continue
+                total += count
+                print(
+                    f"  object_type={object_type} parent={parent_table} "
+                    f"orphans={count}"
+                )
+                if args.apply:
+                    result = db.execute(
+                        _orphan_delete_sql(child_table, parent_table),
+                        {"object_type": object_type},
+                    )
+                    print(f"    deleted={int(result.rowcount or 0)}")
+
+        if args.apply:
+            db.commit()
+        else:
+            db.rollback()
+        print(f"\nTotal orphan rows {'deleted' if args.apply else 'found'}: {total}")
+    except Exception:
+        db.rollback()
+        raise
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_polymorphic_cleanup.py
+++ b/backend/tests/test_polymorphic_cleanup.py
@@ -5,6 +5,8 @@ Covers:
   belonging to the given (workspace_id, object_type, object_id).
 - Cross-workspace safety: purge with workspace_id=B deletes 0 rows from
   workspace A's data.
+- SQLAlchemy before_delete listeners purge rows when polymorphic parents
+  are hard-deleted.
 """
 from __future__ import annotations
 
@@ -14,12 +16,17 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import select
 
-from app.main import app
 from app.domain._polymorphic_cleanup import purge_polymorphic
 from app.domain.attachments.models import Attachment
+from app.domain.builds.models import Build
 from app.domain.custom_fields.models import CustomField
-from app.domain.tags.models import TagLink
-
+from app.domain.lots.models import Lot
+from app.domain.orders.models import Order
+from app.domain.parts.models import Part
+from app.domain.projects.models import Project
+from app.domain.storage.models import StorageLocation
+from app.domain.tags.models import Tag, TagLink
+from app.main import app
 
 DEFAULT_PASSWORD = "TestPass-2026-Stronk"
 
@@ -71,6 +78,101 @@ def _row_count(db, Model, workspace_id, object_id):
             Model.object_id == uuid.UUID(object_id),
         )
     ).scalars().all().__len__()
+
+
+def _add_polymorphic_rows(
+    db,
+    *,
+    workspace_id: uuid.UUID,
+    object_type: str,
+    object_id: uuid.UUID,
+) -> None:
+    tag = Tag(
+        workspace_id=workspace_id,
+        name=f"tag-{uuid.uuid4().hex[:8]}",
+        color="#f00",
+    )
+    db.add(tag)
+    db.flush()
+    db.add_all(
+        [
+            Attachment(
+                workspace_id=workspace_id,
+                object_type=object_type,
+                object_id=object_id,
+                file_name="file.pdf",
+                file_type="datasheet",
+                mime_type="application/pdf",
+                size_bytes=12,
+                storage_key=f"{workspace_id}/{uuid.uuid4()}-file.pdf",
+            ),
+            CustomField(
+                workspace_id=workspace_id,
+                object_type=object_type,
+                object_id=object_id,
+                key=f"field-{uuid.uuid4().hex[:8]}",
+                value="v",
+            ),
+            TagLink(
+                workspace_id=workspace_id,
+                tag_id=tag.id,
+                object_type=object_type,
+                object_id=object_id,
+            ),
+        ]
+    )
+    db.flush()
+
+
+def _polymorphic_counts(
+    db,
+    *,
+    workspace_id: uuid.UUID,
+    object_type: str,
+    object_id: uuid.UUID,
+) -> dict[str, int]:
+    counts = {}
+    for name, Model in (
+        ("attachments", Attachment),
+        ("custom_fields", CustomField),
+        ("tag_links", TagLink),
+    ):
+        counts[name] = len(
+            db.execute(
+                select(Model).where(
+                    Model.workspace_id == workspace_id,
+                    Model.object_type == object_type,
+                    Model.object_id == object_id,
+                )
+            ).scalars().all()
+        )
+    return counts
+
+
+def _make_parent(db, *, workspace_id: uuid.UUID, object_type: str):
+    if object_type == "part":
+        parent = Part(workspace_id=workspace_id, name="Parent Part", part_type="local")
+    elif object_type == "project":
+        parent = Project(workspace_id=workspace_id, name="Parent Project")
+    elif object_type == "order":
+        parent = Order(workspace_id=workspace_id, name="Parent Order")
+    elif object_type == "storage_location":
+        parent = StorageLocation(workspace_id=workspace_id, name="Parent Bin")
+    elif object_type == "build":
+        project = Project(workspace_id=workspace_id, name="Build Project")
+        db.add(project)
+        db.flush()
+        parent = Build(workspace_id=workspace_id, project_id=project.id, name="Parent Build")
+    elif object_type == "lot":
+        part = Part(workspace_id=workspace_id, name="Lot Part", part_type="local")
+        db.add(part)
+        db.flush()
+        parent = Lot(workspace_id=workspace_id, part_id=part.id, source_type="manual")
+    else:
+        raise AssertionError(f"unknown test object_type {object_type}")
+    db.add(parent)
+    db.flush()
+    return parent
 
 
 # ---------------------------------------------------------------------------
@@ -169,3 +271,70 @@ def test_purge_polymorphic_is_idempotent(db):
     assert second["custom_fields"] == 0
     assert second["attachments"] == 0
     assert second["tag_links"] == 0
+
+
+@pytest.mark.parametrize(
+    "object_type",
+    ["part", "order", "project", "build", "lot", "storage_location"],
+)
+def test_hard_delete_parent_purges_polymorphic_rows(db, object_type):
+    c = TestClient(app)
+    ws_id = _signup(c)
+    ws_uuid = uuid.UUID(ws_id)
+    parent = _make_parent(db, workspace_id=ws_uuid, object_type=object_type)
+    _add_polymorphic_rows(
+        db,
+        workspace_id=ws_uuid,
+        object_type=object_type,
+        object_id=parent.id,
+    )
+
+    assert _polymorphic_counts(
+        db,
+        workspace_id=ws_uuid,
+        object_type=object_type,
+        object_id=parent.id,
+    ) == {"attachments": 1, "custom_fields": 1, "tag_links": 1}
+
+    db.delete(parent)
+    db.flush()
+
+    assert _polymorphic_counts(
+        db,
+        workspace_id=ws_uuid,
+        object_type=object_type,
+        object_id=parent.id,
+    ) == {"attachments": 0, "custom_fields": 0, "tag_links": 0}
+
+
+def test_polymorphic_cleanup_listener_registration_is_idempotent(db, monkeypatch):
+    from app.domain import _polymorphic_cleanup as cleanup
+
+    cleanup.register_polymorphic_cleanup_listeners()
+    cleanup.register_polymorphic_cleanup_listeners()
+
+    calls = 0
+    real_purge = cleanup._purge_polymorphic
+
+    def counted_purge(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return real_purge(*args, **kwargs)
+
+    monkeypatch.setattr(cleanup, "_purge_polymorphic", counted_purge)
+
+    c = TestClient(app)
+    ws_id = _signup(c)
+    ws_uuid = uuid.UUID(ws_id)
+    parent = _make_parent(db, workspace_id=ws_uuid, object_type="part")
+    _add_polymorphic_rows(
+        db,
+        workspace_id=ws_uuid,
+        object_type="part",
+        object_id=parent.id,
+    )
+
+    db.delete(parent)
+    db.flush()
+
+    assert calls == 1

--- a/backend/tests/test_workspace_isolation.py
+++ b/backend/tests/test_workspace_isolation.py
@@ -249,7 +249,7 @@ def test_custom_fields_unknown_object_type_returns_400():
     part_a = _create_part(a)
     r = a.post(
         "/api/custom-fields",
-        json={"object_type": "lot", "object_id": part_a, "key": "k", "value": "v"},
+        json={"object_type": "not_a_type", "object_id": part_a, "key": "k", "value": "v"},
     )
     assert r.status_code == 400, r.text
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -226,13 +226,13 @@ rules are:
    resolver registry (`_polymorphic_resolvers()`) is the single place to
    register new object types.
 
-2. **Orphan cleanup** — when a parent row is hard-deleted, call
-   `purge_polymorphic(db, workspace_id=…, object_type=…, object_id=…)`
-   from `backend/app/domain/_polymorphic_cleanup.py`. Every DELETE inside
-   filters by `workspace_id` (workspace-isolation invariant from CLAUDE.md).
-   The function returns a `dict[str, int]` of row counts per table; log it
-   for observability. Currently parents are soft-archived rather than
-   hard-deleted, so orphans accumulate only on rare explicit hard-deletes.
+2. **Orphan cleanup** — registered parent models have SQLAlchemy
+   `before_delete` listeners from
+   `backend/app/domain/_polymorphic_cleanup.py`. A hard-delete purges
+   `attachments`, `custom_fields`, and `tag_links` in the same transaction.
+   Every DELETE inside filters by `workspace_id` (workspace-isolation
+   invariant from CLAUDE.md). Manual cleanup uses the same helper,
+   `purge_polymorphic(db, workspace_id=…, object_type=…, object_id=…)`.
 
 3. **Indexes** — migration 0033 added `(workspace_id, object_id)` indexes
    on all three tables so the cleanup query and the orphan-report script

--- a/docs/api/attachments-tags-cf.md
+++ b/docs/api/attachments-tags-cf.md
@@ -2,7 +2,7 @@
 
 Audience: engineer
 
-The three polymorphic surfaces — file attachments, tag links, and key/value custom fields — that hang off any first-class entity (`part`, `project`, `order`, `build`, `lot`, `storage`, …). Each shares an `(object_type, object_id)` pair pinned by `assert_polymorphic_in_workspace` to the caller's workspace.
+The three polymorphic surfaces — file attachments, tag links, and key/value custom fields — that hang off registered first-class entities (`part`, `project`, `order`, `build`, `lot`, `storage_location`). Each shares an `(object_type, object_id)` pair pinned by `assert_polymorphic_in_workspace` to the caller's workspace.
 
 ## Conventions
 

--- a/docs/domain/polymorphic.md
+++ b/docs/domain/polymorphic.md
@@ -19,7 +19,7 @@ Common shape:
 | Column | Notes |
 |---|---|
 | `workspace_id` | FK, **CASCADE**. Inherited from `WorkspaceOwned`. |
-| `object_type` | `varchar(40)`. The discriminator. Values like `part`, `order`, `project`, `build`, `lot`, `storage_location`. No DB enum — the value is decided at the call site. |
+| `object_type` | `varchar(40)`. The discriminator. Registered values are `part`, `order`, `project`, `build`, `lot`, `storage_location`. No DB enum — the value is decided at the call site. |
 | `object_id` | `UUID`. **No FK.** Free-form. |
 | `archived_at` | Universal soft-archive. |
 
@@ -35,7 +35,7 @@ If `object_id` had a FK, that FK would be to one parent table. A polymorphic tab
 - The "exactly one of N FKs is non-NULL" invariant has to be enforced by application code anyway — a CHECK constraint is verbose and brittle.
 - Cross-cutting reads (e.g. "all attachments for this object") get a uniform shape.
 
-Trade-off: **no automatic ON DELETE behaviour.** A hard-deleted parent leaves the child rows as orphans. The cleanup is the application's responsibility — see below.
+Trade-off: **no DB-level ON DELETE behaviour.** The application owns cleanup through SQLAlchemy `before_delete` listeners — see below.
 
 ## Orphan-cleanup helper
 
@@ -60,7 +60,7 @@ Behaviour:
 - Bulk DELETE rather than per-row ORM fetch — stays fast for objects with hundreds of attachments/fields/links.
 - Idempotent: a second call with the same parameters returns `{0, 0, 0}`.
 
-Source: `backend/app/domain/_polymorphic_cleanup.py:35-79`. Currently exported as the canonical helper but **no caller in the tree invokes it yet** (`grep purge_polymorphic backend/app` matches only the helper itself). It exists for the day a route hard-deletes a parent — soft-archive (the universal pattern) doesn't need it.
+Source: `backend/app/domain/_polymorphic_cleanup.py`. The helper is used by the registered `before_delete` listeners for `Part`, `Order`, `Project`, `Build`, `Lot`, and `StorageLocation`; `backend/app/domain/all_models.py` and `backend/app/api/_helpers.py` register the listeners at import time. Soft-archive paths do not invoke it.
 
 ## Indexing
 
@@ -103,6 +103,8 @@ There is no dedicated `polymorphic/service.py`. The helpers live at module level
 | Operation | Entry point | Notes |
 |---|---|---|
 | Bulk orphan cleanup | `domain/_polymorphic_cleanup.py::purge_polymorphic` | Workspace-filtered bulk DELETE on all three tables. Returns per-table counts. |
+| Hard-delete listener registration | `domain/_polymorphic_cleanup.py::register_polymorphic_cleanup_listeners` | Idempotently attaches `before_delete` listeners for registered parent models. |
+| One-off orphan backfill | `scripts/purge_polymorphic_orphans.py` | Dry-run by default; pass `--apply` to delete orphan rows for registered object types. |
 | Attachment CRUD | `api/routes/attachments.py` | TODO(verify): list the create/list/delete operations. |
 | Custom-field CRUD | `api/routes/custom_fields.py` | TODO(verify): same. |
 | Tag CRUD + link/unlink | `api/routes/tags.py` | TODO(verify): same. |


### PR DESCRIPTION
## Summary
- Register idempotent SQLAlchemy `before_delete` cleanup listeners for polymorphic parents: `part`, `order`, `project`, `build`, `lot`, and `storage_location`.
- Expand polymorphic target validation to the same registered parent set and add a dry-run-by-default orphan purge script.
- Update the architecture/domain docs and CLAUDE.md to match listener-based cleanup.

Closes #540

## Validation
- `TEST_DATABASE_URL=postgresql+psycopg://stockmgr:stockmgr@127.0.0.1:5432/stockmgr_test_aud001 uv run --extra dev python -m pytest tests/test_polymorphic_cleanup.py -q` — 10 passed.
- `TEST_DATABASE_URL=postgresql+psycopg://stockmgr:stockmgr@127.0.0.1:5432/stockmgr_test_aud001 uv run --extra dev python -m pytest tests/test_workspace_isolation.py -q` — 49 passed.
- `.venv/bin/ruff check app/domain/_polymorphic_cleanup.py app/api/_helpers.py app/domain/all_models.py scripts/purge_polymorphic_orphans.py tests/test_polymorphic_cleanup.py tests/test_workspace_isolation.py` — passed.
- `LINT_CMD=".venv/bin/ruff check app --output-format=concise" BASELINE_FILE="../.ruff-baseline.txt" WORK_DIR="." bash ../scripts/lint-delta.sh` — no new violations.

Note: a raw `backend/.venv/bin/ruff check backend` still reports the repository's existing baseline violations; CI uses `scripts/lint-delta.sh` for the backend Ruff gate.

## Merge Order / Conflicts
- Based on `origin/main` at `094142f781488e20ef4416ce3059f5f6c75fc0c1`.
- Likely conflict areas: polymorphic helper/registry docs and tests if another AUD cleanup branch edits `backend/app/domain/_polymorphic_cleanup.py`, `backend/app/api/_helpers.py`, or `backend/tests/test_polymorphic_cleanup.py`.
- No migration required; no changes to stock quantity aggregation, API envelope handling, TLS verification, or session cookie security.