### PR TITLE
[codex] Document Alembic revision gaps

### DIFF
--- a/backend/alembic/versions/_GAPS.md
+++ b/backend/alembic/versions/_GAPS.md
@@ -1,0 +1,24 @@
+# Alembic Revision Gaps
+
+Audience: engineer
+
+Known skipped revision IDs in `backend/alembic/versions/`.
+
+The Alembic chain is linear, but the numeric IDs are not fully
+contiguous. Do not renumber merged migrations to fill these gaps;
+merged migration IDs may already exist in deployed databases.
+
+| Missing ID | Why it is absent | Chain evidence |
+|---|---|---|
+| `0024` | `audit_log` was renumbered from `0024` to `0030` after a rebase. | `backend/alembic/versions/0030_audit_log.py:11-21` |
+| `0026` | Skipped during the same migration rebase sequence; no merged migration claims this revision ID. | `backend/alembic/versions/0025_catalog_token_hash.py:35-36`, `backend/alembic/versions/0028_login_lockout.py:22-23` |
+| `0027` | Skipped during the same migration rebase sequence; no merged migration claims this revision ID. | `backend/alembic/versions/0025_catalog_token_hash.py:35-36`, `backend/alembic/versions/0028_login_lockout.py:22-23` |
+
+Current chain segment:
+
+```text
+0023 -> 0025 -> 0028 -> 0029 -> 0030
+```
+
+When adding a new migration, continue from the current head. See the
+[migration workflow](../../../docs/development.md#migrations).

--- a/docs/development.md
+++ b/docs/development.md
@@ -184,6 +184,9 @@ Migrations stopped corresponding 1:1 with phase docs after `0005` —
 the per-phase doc model retired with Phase 10. Post-`0005` migrations
 are described in `CHANGELOG.md` instead.
 
+Known non-contiguous Alembic revision IDs are documented in
+[`backend/alembic/versions/_GAPS.md`](../backend/alembic/versions/_GAPS.md).
+
 ### Cyclic foreign keys
 
 The `parts ↔ projects` circular FK is broken with `use_alter=True` on


### PR DESCRIPTION
## Summary
- Add `backend/alembic/versions/_GAPS.md` documenting missing Alembic revision IDs `0024`, `0026`, and `0027`.
- Link the migration workflow docs to the new gap record.

Closes #610

## Validation
- `git diff --check`
- `test -f backend/alembic/versions/_GAPS.md && rg -n "0024|0026|0027|0023 -> 0025 -> 0028 -> 0029 -> 0030" backend/alembic/versions/_GAPS.md`
- `git diff --exit-code -- "backend/alembic/versions/*.py"`
- `for id in 0024 0026 0027; do if find backend/alembic/versions -maxdepth 1 -name "${id}_*.py" | rg .; then exit 1; fi; done`

## Merge Order / Conflicts
- Base: `origin/main` at `094142f`.
- Documentation-only; no Alembic migration files were edited.
- Low conflict risk unless another PR edits `docs/development.md` or adds `backend/alembic/versions/_GAPS.md`.
- Can merge independently of schema/code changes.
