### PR TITLE
AUD-016: Add Compose healthchecks for web and cron

### DIFF
--- a/backend/app/cli/run_job.py
+++ b/backend/app/cli/run_job.py
@@ -7,6 +7,7 @@ import logging
 import sys
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
+from pathlib import Path
 
 from sqlalchemy.orm import Session
 
@@ -14,6 +15,7 @@ logger = logging.getLogger(__name__)
 
 SessionFactory = Callable[[], Session]
 JobCallable = Callable[[Session], int]
+HEARTBEAT_DIR = Path("/tmp/stockmanager-job-heartbeats")
 
 
 @dataclass(frozen=True)
@@ -77,6 +79,7 @@ def run_job(
     *,
     jobs: Mapping[str, JobSpec] = JOBS,
     session_factory: SessionFactory = _default_session_factory,
+    heartbeat_dir: Path = HEARTBEAT_DIR,
 ) -> int:
     """Run one registered job and return the job's affected-row count."""
     job = jobs.get(job_name)
@@ -95,6 +98,7 @@ def run_job(
     finally:
         db.close()
 
+    _write_heartbeat(job.name, heartbeat_dir=heartbeat_dir)
     logger.info(
         "job=%s status=ok affected=%s cadence=%s owner=%s",
         job.name,
@@ -103,6 +107,14 @@ def run_job(
         job.owner,
     )
     return affected
+
+
+def _write_heartbeat(job_name: str, *, heartbeat_dir: Path = HEARTBEAT_DIR) -> None:
+    heartbeat_dir.mkdir(parents=True, exist_ok=True)
+    heartbeat_path = heartbeat_dir / job_name
+    tmp_path = heartbeat_dir / f".{job_name}.tmp"
+    tmp_path.write_text("ok\n", encoding="utf-8")
+    tmp_path.replace(heartbeat_path)
 
 
 def _parser() -> argparse.ArgumentParser:

--- a/backend/tests/test_ci_workflow.py
+++ b/backend/tests/test_ci_workflow.py
@@ -155,6 +155,31 @@ def test_compose_prod_backend_cron_command_shape():
     assert "uvicorn" not in joined
 
 
+def test_compose_prod_has_web_and_cron_healthchecks():
+    """docker compose ps must expose health for web and cron sidecars."""
+    assert _COMPOSE_PROD_PATH.exists(), (
+        f"missing compose file at {_COMPOSE_PROD_PATH}"
+    )
+    data = yaml.safe_load(_COMPOSE_PROD_PATH.read_text())
+    services = data["services"]
+
+    web_healthcheck = services["web"].get("healthcheck", {})
+    web_test = " ".join(web_healthcheck.get("test", []))
+    assert "wget -qO- http://127.0.0.1/" in web_test
+
+    cron_healthcheck = services["backend-cron"].get("healthcheck", {})
+    cron_test = " ".join(cron_healthcheck.get("test", []))
+    assert "find /tmp/stockmanager-job-heartbeats" in cron_test
+    assert "sourcing-cache-sweep" in cron_test
+    assert "-mmin -90" in cron_test
+
+    alerts_healthcheck = services["backend-cron-alerts"].get("healthcheck", {})
+    alerts_test = " ".join(alerts_healthcheck.get("test", []))
+    assert "find /tmp/stockmanager-job-heartbeats" in alerts_test
+    assert "sourcing-alerts-evaluate" in alerts_test
+    assert "-mmin -90" in alerts_test
+
+
 def test_compose_prod_backend_cron_alerts_command_shape():
     """backend-cron-alerts must use the shared CLI scheduler path."""
     assert _COMPOSE_PROD_PATH.exists(), (

--- a/backend/tests/test_run_job.py
+++ b/backend/tests/test_run_job.py
@@ -21,7 +21,7 @@ class _FakeSession:
         self.closed = True
 
 
-def test_run_job_dispatches_allow_listed_job() -> None:
+def test_run_job_dispatches_allow_listed_job(tmp_path) -> None:
     session = _FakeSession()
     calls: list[Session] = []
 
@@ -41,6 +41,7 @@ def test_run_job_dispatches_allow_listed_job() -> None:
             )
         },
         session_factory=lambda: session,  # type: ignore[return-value]
+        heartbeat_dir=tmp_path,
     )
 
     assert affected == 4
@@ -48,6 +49,7 @@ def test_run_job_dispatches_allow_listed_job() -> None:
     assert session.committed is True
     assert session.rolled_back is False
     assert session.closed is True
+    assert (tmp_path / "example").read_text(encoding="utf-8") == "ok\n"
 
 
 def test_run_job_rejects_unknown_job() -> None:
@@ -76,7 +78,7 @@ def test_sourcing_alerts_evaluate_registered() -> None:
     assert "cooldown" in spec.idempotency
 
 
-def test_sourcing_alerts_evaluate_dispatches_to_module(monkeypatch) -> None:
+def test_sourcing_alerts_evaluate_dispatches_to_module(monkeypatch, tmp_path) -> None:
     session = _FakeSession()
     calls: list[Session] = []
 
@@ -92,6 +94,7 @@ def test_sourcing_alerts_evaluate_dispatches_to_module(monkeypatch) -> None:
     affected = run_job(
         "sourcing-alerts-evaluate",
         session_factory=lambda: session,  # type: ignore[return-value]
+        heartbeat_dir=tmp_path,
     )
 
     assert affected == 7
@@ -99,3 +102,4 @@ def test_sourcing_alerts_evaluate_dispatches_to_module(monkeypatch) -> None:
     assert session.committed is True
     assert session.rolled_back is False
     assert session.closed is True
+    assert (tmp_path / "sourcing-alerts-evaluate").exists()

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -201,6 +201,12 @@ services:
     depends_on:
       backend:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "test -d /tmp/stockmanager-job-heartbeats && find /tmp/stockmanager-job-heartbeats -name sourcing-cache-sweep -mmin -90 -print -quit | grep -q ."]
+      interval: 60s
+      timeout: 5s
+      retries: 3
+      start_period: 11m
     # Runs the hourly TrustedParts cache retention sweep through the shared
     # backend CLI. Each run is capped at 600s; failures are logged and the
     # loop sleeps on the same cadence before trying again.
@@ -247,6 +253,12 @@ services:
     depends_on:
       backend:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "test -d /tmp/stockmanager-job-heartbeats && find /tmp/stockmanager-job-heartbeats -name sourcing-alerts-evaluate -mmin -90 -print -quit | grep -q ."]
+      interval: 60s
+      timeout: 5s
+      retries: 3
+      start_period: 11m
     # Runs the 15-minute sourcing alert evaluator through the shared backend
     # CLI. Alert-level cooldowns enforce per-alert notification frequency.
     # Each run is capped at 600s; failures are logged and the loop continues.
@@ -295,6 +307,12 @@ services:
     # parts.matescb.cz → 127.0.0.1:8091. See deploy/parts.matescb.cz.conf.
     ports:
       - "127.0.0.1:8091:80"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1/ >/dev/null || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 6
+      start_period: 30s
     security_opt: ["no-new-privileges:true"]
     cap_drop: ["ALL"]
     cap_add: ["CHOWN", "SETUID", "SETGID", "NET_BIND_SERVICE"]


### PR DESCRIPTION
## Summary

- Add prod Compose healthchecks for `web`, `backend-cron`, and `backend-cron-alerts`.
- Write successful backend job heartbeats from `app.cli.run_job` so cron sidecar healthchecks can detect stale or wedged jobs.
- Add focused tests pinning the Compose healthcheck contracts and heartbeat write path.

Closes #555

## Validation

- `uv run --extra dev python -c "..."` direct assertions for prod Compose healthcheck wiring and `run_job` heartbeat output: passed.
- `uv run ruff check app/cli/run_job.py tests/test_run_job.py tests/test_ci_workflow.py`: passed.
- `python3 -c "from pathlib import Path; import yaml; yaml.safe_load(Path('docker-compose.prod.yml').read_text()); print('ok')"`: passed.
- `git diff --check`: passed.
- `uv run --extra dev python -m pytest tests/test_run_job.py tests/test_ci_workflow.py -q`: blocked by the existing autouse DB fixture running the full Alembic chain; local migration setup fails at `0020_partial_bag_signature_index.py` with `relation "stock_entries" does not exist` before these tests execute.
- `docker compose -f docker-compose.prod.yml config -q`: not run because `docker` is not installed in this environment.

## Merge Order / Conflicts

- Based on `origin/main` at `094142f781488e20ef4416ce3059f5f6c75fc0c1`.
- Expected conflict surface is limited to `docker-compose.prod.yml`, `backend/app/cli/run_job.py`, `backend/tests/test_run_job.py`, and `backend/tests/test_ci_workflow.py` if adjacent deploy or scheduler PRs land first.
- No production secret or `.env.prod` changes are required.
