### PR TITLE
[codex] Audit Sentry logger secret handling

### DIFF
--- a/docs/phases/12-observability-sentry.md
+++ b/docs/phases/12-observability-sentry.md
@@ -57,6 +57,12 @@ stack traces de-minify.
   VPS builds without the token produce no `.map` files.
   `find -name '*.map' -delete` in `web/Dockerfile.prod` is
   belt-and-braces for edge-case local builds.
+- **Structured log audit** — `enableLogs: true` is on in
+  `web/src/instrument.ts:105-106`, but AUD-070 found no
+  `Sentry.logger.*` call sites in `web/src` or `backend/app`.
+  `web/.eslintrc.cjs` rejects future `Sentry.logger.*` calls that pass
+  sensitive identifiers such as tokens, passwords, cookies, sessions,
+  DSNs, or workspace IDs.
 
 ## Invariants introduced
 
@@ -73,6 +79,10 @@ stack traces de-minify.
   bodies never reach Sentry. Tested at
   `backend/tests/test_sentry_scrubber.py` (TODO(verify): exact test
   filename).
+- **`Sentry.logger.*` calls must not receive secrets.** If structured
+  logs are added, pass only redacted scalar metadata. The frontend
+  lint guard in `web/.eslintrc.cjs` blocks common sensitive identifier
+  names at review time.
 - **Empty DSN → SDK no-op.** Dev environments stay quiet; no events,
   no network egress.
 

--- a/web/.eslintrc.cjs
+++ b/web/.eslintrc.cjs
@@ -36,6 +36,15 @@ module.exports = {
     // provider catalog / DataTable cells. Tighten in a follow-up.
     "@typescript-eslint/no-explicit-any": "off",
     "no-empty": ["warn", { allowEmptyCatch: true }],
+    "no-restricted-syntax": [
+      "error",
+      {
+        selector:
+          "CallExpression[callee.object.object.name='Sentry'][callee.object.property.name='logger'] Identifier[name=/token|secret|password|passwd|credential|authorization|cookie|session|csrf|dsn|apiKey|workspaceId/i]",
+        message:
+          "Do not pass sensitive identifiers to Sentry.logger.*; log a redacted scalar or omit the field.",
+      },
+    ],
   },
   ignorePatterns: [
     "dist/",


### PR DESCRIPTION
## Summary

- Audited `Sentry.logger.*` usage in `web/src` and `backend/app`; no executable call sites exist.
- Documented the AUD-070 audit result in the Sentry observability phase notes.
- Added a frontend ESLint guard that rejects future `Sentry.logger.*` calls when sensitive identifiers are passed.

Closes #609

## Validation

- `rg -n 'Sentry\.logger\.' web/src backend/app` → only `web/src/instrument.ts:105` comment.
- `npx eslint src/instrument.ts` → pass.
- Temporary bad `Sentry.logger.info("probe", { authToken })` probe → rejected by `no-restricted-syntax`.
- `rg -n 'verify\s*=\s*False|trust_env\s*=\s*False|ssl\s*=\s*False' backend/app` → no matches.
- `git diff --check` → pass.
- `npm run lint` → fails on pre-existing unrelated findings in `web/src/lib/bagCode.ts` (`no-control-regex`) plus existing warnings; no Sentry logger findings.

## Merge Order / Conflicts

- Based on latest `origin/main` at `2eb8179` before the final force-with-lease push.
- Touches only `web/.eslintrc.cjs` and `docs/phases/12-observability-sentry.md`; expected conflict risk is low unless another PR edits the frontend lint rules or Sentry phase notes.
