### PR TITLE
[codex] AUD-005 flatten login timing

### DIFF
--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -38,6 +38,10 @@ log = get_logger(__name__)
 
 # How long a pending signup verification is valid (in hours).
 _VERIFY_TTL_HOURS = 24
+_DUMMY_ARGON2 = (
+    "$argon2id$v=19$m=65536,t=3,p=4$"
+    "yEZFbIMmBabse2MdUks7RA$Iggj8Dn26NU39IQQb7Vs8ADgvJayYRb194wtzFzGsF0"
+)
 
 
 def _set_session_cookie(response: Response, token: str) -> None:
@@ -179,7 +183,10 @@ def signup(
         _set_session_cookie(response, sess.token)
         log.info("signup (immediate)", extra={"user_id": str(user.id), "workspace_id": str(ws.id)})
         return ok(
-            {"user": {"id": str(user.id), "email": user.email, "name": user.name}, "workspace_id": str(ws.id)},
+            {
+                "user": {"id": str(user.id), "email": user.email, "name": user.name},
+                "workspace_id": str(ws.id),
+            },
         )
 
     # --- Prod path: email-verification two-step flow ---
@@ -343,7 +350,10 @@ def verify(
         extra={"user_id": str(user.id), "workspace_id": str(ws.id)},
     )
     return ok(
-        {"user": {"id": str(user.id), "email": user.email, "name": user.name}, "workspace_id": str(ws.id)},
+        {
+            "user": {"id": str(user.id), "email": user.email, "name": user.name},
+            "workspace_id": str(ws.id),
+        },
         "email verified",
     )
 
@@ -375,7 +385,9 @@ def login(
         )
 
     user = db.query(User).filter(User.email == payload.email).first()
-    if not user or not verify_password(user.password_hash, payload.password):
+    password_hash = user.password_hash if user is not None else _DUMMY_ARGON2
+    password_valid = verify_password(password_hash, payload.password)
+    if user is None or not password_valid:
         # Record the failure before raising so the row is committed even
         # though the route exits via HTTPException.  The DB session is
         # committed by the dep on clean exit; on exception we must flush

--- a/backend/tests/test_login_timing.py
+++ b/backend/tests/test_login_timing.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import time
+import uuid
+
+from fastapi.testclient import TestClient
+
+from app.api.routes import auth as auth_routes
+from tests._factories import signup_user
+
+
+def test_known_vs_unknown_timing_within_tolerance(
+    client: TestClient,
+    monkeypatch,
+) -> None:
+    email = f"timing-{uuid.uuid4().hex[:8]}@x.com"
+    signup_user(client, email=email)
+
+    calls: list[str] = []
+
+    def fake_verify_password(hash_: str, password: str) -> bool:
+        calls.append(hash_)
+        time.sleep(0.05)
+        return False
+
+    monkeypatch.setattr(auth_routes, "verify_password", fake_verify_password)
+
+    def fail_login(login_email: str) -> float:
+        start = time.perf_counter()
+        response = client.post(
+            "/api/auth/login",
+            json={"email": login_email, "password": "WrongPass!!X"},
+        )
+        elapsed = time.perf_counter() - start
+        assert response.status_code == 401, response.text
+        return elapsed
+
+    known_elapsed = fail_login(email)
+    unknown_elapsed = fail_login(f"missing-{uuid.uuid4().hex[:8]}@x.com")
+
+    assert len(calls) == 2
+    assert calls[0] != auth_routes._DUMMY_ARGON2
+    assert calls[1] == auth_routes._DUMMY_ARGON2
+    assert abs(known_elapsed - unknown_elapsed) <= 0.03


### PR DESCRIPTION
## Summary
- Add a module-level dummy Argon2 hash for missing-user login attempts.
- Always run `verify_password` before returning invalid credentials, using the real user hash when present and the dummy hash otherwise.
- Add a focused regression test proving known-email and unknown-email failed login paths both pay the verify cost.

Closes #544

## Validation
- `TEST_DATABASE_URL=postgresql+psycopg://stockmgr:stockmgr@127.0.0.1:5432/stockmgr_test_aud005_final uv run --extra dev python -m pytest tests/test_login_timing.py tests/test_auth_lockout.py tests/test_session_hashing.py -q` — 11 passed, 1 Alembic deprecation warning.
- `TEST_DATABASE_URL=postgresql+psycopg://stockmgr:stockmgr@127.0.0.1:5432/stockmgr_test_aud005_single uv run --extra dev python -m pytest tests/test_login_timing.py -q` — 1 passed, 1 Alembic deprecation warning.
- `uv run --extra dev ruff check app/api/routes/auth.py tests/test_login_timing.py` — passed.
- `LINT_CMD="ruff check app --output-format=concise" BASELINE_FILE="../.ruff-baseline.txt" WORK_DIR="." bash ../scripts/lint-delta.sh` — no new violations.
- `uv run --extra dev python scripts/check_no_traceback_leaks.py` — passed.
- `grep -RnE "verify=False|trust_env=False|ssl=False" app/ --include="*.py" | grep -v "# noqa: tls-verify"` — no matches.
- `uv lock --check` — passed.
- `git diff --check` — passed.

## Merge Order / Conflict Notes
- Based on latest `origin/main` at `2eb8179` when committed.
- Touches only `backend/app/api/routes/auth.py` and `backend/tests/test_login_timing.py`.
- No known conflicts; likely conflict surface is limited to concurrent auth-route edits.
