### PR TITLE
[codex] Make part MPN creation race-safe

### DIFF
--- a/backend/app/api/routes/parts_core.py
+++ b/backend/app/api/routes/parts_core.py
@@ -12,6 +12,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from sqlalchemy import or_, select
+from sqlalchemy.exc import IntegrityError
 
 from app.api._helpers import assert_in_workspace, require_resource_access
 from app.api.routes._activity import _DEFAULT_LIMIT, _MAX_LIMIT, build_activity
@@ -39,6 +40,10 @@ from app.domain.parts.schemas import (
     PartPatch,
     SubstituteIn,
 )
+from app.domain.parts.services.mpn_unique import (
+    active_part_by_mpn as _active_part_by_mpn,
+)
+from app.domain.parts.services.mpn_unique import is_mpn_unique_violation
 from app.domain.stock.models import StockEntry
 from app.domain.stock.service import (
     bulk_current_quantities,
@@ -50,6 +55,17 @@ from app.domain.storage.models import StorageLocation
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
+
+
+def _raise_mpn_conflict(existing: Part) -> None:
+    raise HTTPException(
+        status_code=status.HTTP_409_CONFLICT,
+        detail={
+            "message": f"MPN already used by part \"{existing.name}\"",
+            "existing_id": str(existing.id),
+            "existing_name": existing.name,
+        },
+    )
 
 
 @router.get("")
@@ -165,20 +181,9 @@ def create_part(
         name = mpn
 
     if mpn:
-        existing = (
-            db.query(Part)
-            .filter(Part.workspace_id == ws.id, Part.mpn == mpn, Part.archived_at.is_(None))
-            .first()
-        )
+        existing = _active_part_by_mpn(db, workspace_id=ws.id, mpn=mpn)
         if existing:
-            raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT,
-                detail={
-                    "message": f"MPN already used by part \"{existing.name}\"",
-                    "existing_id": str(existing.id),
-                    "existing_name": existing.name,
-                },
-            )
+            _raise_mpn_conflict(existing)
 
     # default_storage_location_id is caller-supplied; it must point at a
     # storage row in this workspace. Without this guard a caller in
@@ -209,12 +214,20 @@ def create_part(
         created_by=user.id,
         updated_by=user.id,
     )
-    db.add(p)
-    # `get_db` commits on clean route exit (BE2-010). No explicit
-    # db.commit() here — a route-local commit would split the
-    # transaction boundary and partial state could outlive a later
-    # raise.
-    db.flush()
+    try:
+        with db.begin_nested():
+            db.add(p)
+            # `get_db` commits on clean route exit (BE2-010). No explicit
+            # db.commit() here — a route-local commit would split the
+            # transaction boundary and partial state could outlive a later
+            # raise.
+            db.flush()
+    except IntegrityError as exc:
+        if mpn and is_mpn_unique_violation(exc):
+            existing = _active_part_by_mpn(db, workspace_id=ws.id, mpn=mpn)
+            if existing is not None:
+                _raise_mpn_conflict(existing)
+        raise
     return ok(_serialize(p, on_hand=0, reserved=0))
 
 

--- a/backend/app/api/routes/parts_scan.py
+++ b/backend/app/api/routes/parts_scan.py
@@ -19,16 +19,21 @@ from uuid import UUID
 from fastapi import APIRouter, HTTPException, Request
 from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.exc import IntegrityError
 
 from app.api.routes._parts_shared import get_part as _get_part
 from app.core.deps import CurrentUser, CurrentWorkspace, DbSession
 from app.core.ratelimit import limiter, workspace_key
 from app.core.responses import ok
 from app.core.secrets import decrypt
-from app.domain.parts.models import BulkImportIdempotency, Part
+from app.domain.parts.models import BulkImportIdempotency
 from app.domain.parts.providers import make_provider
 from app.domain.parts.schemas import QuickRemoveBagIn, ScanImportIn, ScanImportRow
 from app.domain.parts.services.bag_signature import compute_bag_signature
+from app.domain.parts.services.mpn_unique import (
+    active_part_by_mpn as _active_part_by_mpn,
+)
+from app.domain.parts.services.mpn_unique import is_mpn_unique_violation
 from app.domain.parts.services.provider_cache import lookup_with_cache
 from app.domain.parts.services.provider_import import create_from_provider_lookup
 from app.domain.stock.models import StockEntry
@@ -263,13 +268,7 @@ def bulk_import_from_scan(
 
         # Duplicate check — workspace-scoped, case-sensitive (mirrors how
         # GET /parts?mpn= matches).
-        existing = db.execute(
-            select(Part)
-            .where(Part.workspace_id == ws.id)
-            .where(Part.mpn == mpn)
-            .where(Part.archived_at.is_(None))
-            .limit(1)
-        ).scalars().first()
+        existing = _active_part_by_mpn(db, workspace_id=ws.id, mpn=mpn)
         if existing is not None:
             out_rows.append({
                 "mpn": mpn,
@@ -351,6 +350,27 @@ def bulk_import_from_scan(
                     db, ws=ws, user=user, row=row, mpn=mpn,
                     provider_name=provider.name, lookup_result=r,
                 )
+        except IntegrityError as exc:
+            if is_mpn_unique_violation(exc):
+                existing = _active_part_by_mpn(db, workspace_id=ws.id, mpn=mpn)
+                if existing is not None:
+                    out_rows.append({
+                        "mpn": mpn,
+                        "status": "duplicate",
+                        "part_id": str(existing.id),
+                    })
+                    continue
+            try:
+                import sentry_sdk
+                sentry_sdk.capture_exception(exc)
+            except Exception:
+                pass
+            out_rows.append({
+                "mpn": mpn,
+                "status": "row_failed",
+                "error": f"{type(exc).__name__}: {exc}",
+            })
+            continue
         except Exception as exc:
             try:
                 import sentry_sdk

--- a/backend/app/domain/parts/services/mpn_unique.py
+++ b/backend/app/domain/parts/services/mpn_unique.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+
+from app.domain.parts.models import Part
+
+UQ_PARTS_WS_MPN = "uq_parts_ws_mpn"
+
+
+def active_part_by_mpn(db, *, workspace_id: UUID, mpn: str | None) -> Part | None:
+    if not mpn:
+        return None
+    return (
+        db.execute(
+            select(Part)
+            .where(Part.workspace_id == workspace_id)
+            .where(Part.archived_at.is_(None))
+            .where(Part.mpn == mpn)
+            .limit(1)
+        )
+        .scalars()
+        .first()
+    )
+
+
+def is_mpn_unique_violation(exc: IntegrityError) -> bool:
+    diag = getattr(getattr(exc, "orig", None), "diag", None)
+    return getattr(diag, "constraint_name", None) == UQ_PARTS_WS_MPN

--- a/backend/tests/test_parts_create_mpn_race.py
+++ b/backend/tests/test_parts_create_mpn_race.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import threading
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+from tests._factories import signup_user
+
+pytestmark = pytest.mark.real_db
+
+
+def _session_cookie(client: TestClient):
+    return next(cookie for cookie in client.cookies.jar)
+
+
+@pytest.fixture
+def authed_owner():
+    client = TestClient(app)
+    signup_user(client)
+    return client
+
+
+def test_concurrent_create_same_mpn(authed_owner, monkeypatch):
+    import app.api.routes.parts_core as parts_core
+
+    original_lookup = parts_core._active_part_by_mpn
+    barrier = threading.Barrier(2)
+    lock = threading.Lock()
+    precheck_calls = 0
+
+    def racing_lookup(db, *, workspace_id, mpn):
+        nonlocal precheck_calls
+        existing = original_lookup(db, workspace_id=workspace_id, mpn=mpn)
+        with lock:
+            should_wait = existing is None and precheck_calls < 2
+            if should_wait:
+                precheck_calls += 1
+        if should_wait:
+            barrier.wait(timeout=10)
+        return existing
+
+    monkeypatch.setattr(parts_core, "_active_part_by_mpn", racing_lookup)
+
+    cookie = _session_cookie(authed_owner)
+    mpn = f"RACE-{uuid.uuid4().hex[:8]}"
+    results: list[tuple[int, dict]] = []
+
+    def do_create(name: str) -> None:
+        client = TestClient(app)
+        client.cookies.set(cookie.name, cookie.value, domain=cookie.domain, path=cookie.path)
+        response = client.post("/api/parts", json={"name": name, "mpn": mpn})
+        results.append((response.status_code, response.json()))
+
+    threads = [
+        threading.Thread(target=do_create, args=("Race winner",)),
+        threading.Thread(target=do_create, args=("Race loser",)),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert len(results) == 2, results
+    assert sorted(status_code for status_code, _body in results) == [201, 409]
+
+    created = next(body for status_code, body in results if status_code == 201)["data"]
+    conflict = next(body for status_code, body in results if status_code == 409)
+    assert conflict["existing_id"] == created["id"]
+    assert conflict["existing_name"] == created["name"]
+    assert conflict["status"]["category"] == "conflict"
+
+    parts = authed_owner.get("/api/parts", params={"mpn": mpn}).json()["data"]
+    assert len(parts) == 1
+    assert parts[0]["id"] == created["id"]
+
+
+def test_bulk_import_same_mpn_race_returns_duplicate(authed_owner, monkeypatch):
+    import app.api.routes.parts_scan as parts_scan
+    import app.domain.parts.providers.mouser as mouser_mod
+
+    authed_owner.patch(
+        "/api/workspaces/current",
+        json={"parts_provider": "mouser", "parts_provider_api_key": "fake-key"},
+    )
+
+    original_lookup = parts_scan._active_part_by_mpn
+    barrier = threading.Barrier(2)
+    lock = threading.Lock()
+    precheck_calls = 0
+
+    def racing_lookup(db, *, workspace_id, mpn):
+        nonlocal precheck_calls
+        existing = original_lookup(db, workspace_id=workspace_id, mpn=mpn)
+        with lock:
+            should_wait = existing is None and precheck_calls < 2
+            if should_wait:
+                precheck_calls += 1
+        if should_wait:
+            barrier.wait(timeout=10)
+        return existing
+
+    def fake_mouser(_url, payload):
+        mpn = payload["SearchByPartRequest"]["mouserPartNumber"]
+        return {
+            "Errors": [],
+            "SearchResults": {
+                "NumberOfResult": 1,
+                "Parts": [
+                    {
+                        "Manufacturer": "Yageo",
+                        "ManufacturerPartNumber": mpn,
+                        "Description": "Race import resistor",
+                        "ProductAttributes": [],
+                    }
+                ],
+            },
+        }
+
+    monkeypatch.setattr(parts_scan, "_active_part_by_mpn", racing_lookup)
+    monkeypatch.setattr(mouser_mod, "_post_mouser", fake_mouser)
+
+    cookie = _session_cookie(authed_owner)
+    mpn = f"BULK-RACE-{uuid.uuid4().hex[:8]}"
+    results: list[dict] = []
+
+    def do_import(key: str) -> None:
+        client = TestClient(app)
+        client.cookies.set(cookie.name, cookie.value, domain=cookie.domain, path=cookie.path)
+        response = client.post(
+            "/api/parts/bulk-import-from-scan",
+            json={"rows": [{"mpn": mpn}], "idempotency_key": key},
+        )
+        assert response.status_code == 200, response.text
+        results.append(response.json()["data"])
+
+    threads = [
+        threading.Thread(target=do_import, args=("race-one",)),
+        threading.Thread(target=do_import, args=("race-two",)),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=15)
+
+    assert len(results) == 2, results
+    row_statuses = sorted(result["rows"][0]["status"] for result in results)
+    assert row_statuses == ["created", "duplicate"]
+
+    duplicate = next(
+        result["rows"][0]
+        for result in results
+        if result["rows"][0]["status"] == "duplicate"
+    )
+    created = next(
+        result["rows"][0]
+        for result in results
+        if result["rows"][0]["status"] == "created"
+    )
+    assert duplicate["part_id"] == created["part_id"]
+    assert sum(result["summary"]["created"] for result in results) == 1
+    assert sum(result["summary"]["duplicate"] for result in results) == 1


### PR DESCRIPTION
## Summary
- Catch `uq_parts_ws_mpn` `IntegrityError` races in `POST /api/parts` and re-select the active workspace part before returning the existing 409 envelope.
- Share the active MPN lookup/constraint-name check with scan import so concurrent bulk imports report `status: duplicate` instead of `row_failed`/500.
- Add real cross-connection race tests for direct part create and scan bulk import.

Closes #548

## Validation
- `TEST_DATABASE_URL=postgresql+psycopg://stockmgr:stockmgr@127.0.0.1:5432/stockmgr_test_aud009 uv run --extra dev pytest tests/test_parts_create_mpn_race.py -q`
- `uv run --extra dev ruff check app/domain/parts/services/mpn_unique.py tests/test_parts_create_mpn_race.py app/api/routes/parts_scan.py --output-format=concise`
- `WORK_DIR=. LINT_CMD="uv run --extra dev ruff check app --output-format=concise" BASELINE_FILE="../.ruff-baseline.txt" ../scripts/lint-delta.sh`
- `git diff --check HEAD~1..HEAD`

## Notes
- Branch was rebased onto latest `origin/main` before push.
- Merge-order/conflict risk: low; touched only parts create/scan MPN conflict handling and a focused test file. Watch for conflicts with other work editing `backend/app/api/routes/parts_core.py` or `backend/app/api/routes/parts_scan.py`.
- Additional adjacent pytest attempt (`tests/test_parts_mpn_unique.py tests/test_bulk_import_idempotency.py`) reached 9 passed, then hit local test DB schema-reset errors (`users` table missing) in setup after repeated local Alembic resets; focused tests pass against a fresh DB.