### PR TITLE
[codex] Map stock nonnegative trigger to 409

### DIFF
--- a/backend/app/api/routes/_stock_integrity.py
+++ b/backend/app/api/routes/_stock_integrity.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from typing import NoReturn
+
+from fastapi import HTTPException, status
+from sqlalchemy.exc import IntegrityError
+
+_STOCK_NONNEG_NAMES = {
+    "ck_stock_nonneg",
+    "check_stock_nonneg",
+    "stock_nonneg_trigger",
+}
+
+
+def raise_integrity_as_409(exc: IntegrityError) -> NoReturn:
+    """Map the stock non-negative trigger to the public conflict contract."""
+    if _is_stock_nonneg_violation(exc):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "message": "insufficient stock",
+                "constraint": "stock_nonneg_trigger",
+            },
+        ) from exc
+    raise exc
+
+
+def _is_stock_nonneg_violation(exc: IntegrityError) -> bool:
+    orig = getattr(exc, "orig", None)
+    diag = getattr(orig, "diag", None)
+    if diag is None:
+        return False
+
+    diagnostic_names = {
+        getattr(diag, "constraint_name", None),
+        getattr(diag, "source_function", None),
+        getattr(diag, "trigger_name", None),
+    }
+    return bool(_STOCK_NONNEG_NAMES.intersection(diagnostic_names))

--- a/backend/app/api/routes/builds.py
+++ b/backend/app/api/routes/builds.py
@@ -5,9 +5,11 @@ from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, Query, Request, status
 from sqlalchemy import and_, or_, select
+from sqlalchemy.exc import IntegrityError
 
 from app.api._helpers import require_resource_access
 from app.api.routes._activity import _DEFAULT_LIMIT, _MAX_LIMIT, build_activity
+from app.api.routes._stock_integrity import raise_integrity_as_409
 from app.core.deps import CurrentUser, CurrentWorkspace, DbSession
 from app.core.responses import ok
 from app.core.time import utcnow
@@ -90,9 +92,12 @@ def create_build(payload: BuildCreateIn, db: DbSession, ws: CurrentWorkspace, us
     db.flush()
     # `get_db` rolls back on any raised exception (BE2-010), so the
     # explicit try/except db.rollback() shape becomes redundant here.
-    apply_reservations(
-        db, workspace_id=ws.id, user_id=user.id, build=b, project=project
-    )
+    try:
+        apply_reservations(
+            db, workspace_id=ws.id, user_id=user.id, build=b, project=project
+        )
+    except IntegrityError as exc:
+        raise_integrity_as_409(exc)
     return ok(_serialize(b))
 
 
@@ -124,14 +129,21 @@ def patch_build(build_id: UUID, payload: BuildPatchIn, db: DbSession, ws: Curren
     b.updated_by = user.id
     db.flush()
 
-    if cancelling:
-        release_reservations(db, workspace_id=ws.id, user_id=user.id, build=b)
-    elif quantity_changed and was_planned_or_in_progress and b.status in ("planned", "in_progress"):
-        project = _get_project(db, ws.id, b.project_id)
-        release_reservations(db, workspace_id=ws.id, user_id=user.id, build=b)
-        apply_reservations(
-            db, workspace_id=ws.id, user_id=user.id, build=b, project=project
-        )
+    try:
+        if cancelling:
+            release_reservations(db, workspace_id=ws.id, user_id=user.id, build=b)
+        elif (
+            quantity_changed
+            and was_planned_or_in_progress
+            and b.status in ("planned", "in_progress")
+        ):
+            project = _get_project(db, ws.id, b.project_id)
+            release_reservations(db, workspace_id=ws.id, user_id=user.id, build=b)
+            apply_reservations(
+                db, workspace_id=ws.id, user_id=user.id, build=b, project=project
+            )
+    except IntegrityError as exc:
+        raise_integrity_as_409(exc)
 
     return ok(_serialize(b))
 
@@ -144,7 +156,10 @@ def archive_build(build_id: UUID, db: DbSession, ws: CurrentWorkspace, user: Cur
     b = require_resource_access(
         db, Build, build_id, ws=ws, user=user, role="admin", label="build"
     )
-    release_reservations(db, workspace_id=ws.id, user_id=user.id, build=b)
+    try:
+        release_reservations(db, workspace_id=ws.id, user_id=user.id, build=b)
+    except IntegrityError as exc:
+        raise_integrity_as_409(exc)
     b.archived_at = utcnow()
     return ok(None, "archived")
 
@@ -185,6 +200,8 @@ def consume_build(
         # `get_db` rolls back on raise (BE2-010), so dropping the
         # explicit db.rollback() here is safe.
         raise HTTPException(status_code=400, detail=str(exc))
+    except IntegrityError as exc:
+        raise_integrity_as_409(exc)
     return ok(result)
 
 

--- a/backend/app/api/routes/lots.py
+++ b/backend/app/api/routes/lots.py
@@ -5,7 +5,9 @@ from uuid import UUID
 
 from fastapi import APIRouter, Query, status
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 
+from app.api.routes._stock_integrity import raise_integrity_as_409
 from app.core.deps import CurrentUser, CurrentWorkspace, DbSession
 from app.core.errors import ErrorCodes, raise_http
 from app.core.pagination import decode_cursor, paginate
@@ -105,6 +107,8 @@ def move_lot(lot_id: UUID, payload: MoveStockIn, db: DbSession, ws: CurrentWorks
     except StockError as exc:
         # `get_db` rolls back on raise (BE2-010).
         raise_http(400, code=ErrorCodes.LOT_MOVE_STOCK_ERROR, message=str(exc))
+    except IntegrityError as exc:
+        raise_integrity_as_409(exc)
     return ok({"out": str(out_e.id), "in": str(in_e.id)})
 
 
@@ -122,6 +126,8 @@ def adjust_lot(lot_id: UUID, payload: LotAdjustIn, db: DbSession, ws: CurrentWor
         e = adjust_stock(db, workspace_id=ws.id, user_id=user.id, payload=aip)
     except StockError as exc:
         raise_http(400, code=ErrorCodes.LOT_ADJUST_STOCK_ERROR, message=str(exc))
+    except IntegrityError as exc:
+        raise_integrity_as_409(exc)
     return ok({"id": str(e.id) if e else None, "delta": e.quantity_delta if e else 0})
 
 

--- a/backend/app/api/routes/orders.py
+++ b/backend/app/api/routes/orders.py
@@ -6,9 +6,11 @@ from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, Query, Request, status
 from sqlalchemy import and_, or_, select
+from sqlalchemy.exc import IntegrityError
 
 from app.api._helpers import assert_child_in_parent, assert_in_workspace, require_resource_access
 from app.api.routes._activity import _DEFAULT_LIMIT, _MAX_LIMIT, build_activity
+from app.api.routes._stock_integrity import raise_integrity_as_409
 from app.core.deps import CurrentUser, CurrentWorkspace, DbSession
 from app.core.responses import ok
 from app.core.time import utcnow
@@ -314,6 +316,8 @@ def receive_order(order_id: UUID, payload: ReceiveIn, db: DbSession, ws: Current
         # the route raises (BE2-010), so we don't need an explicit
         # db.rollback() here.
         raise HTTPException(status_code=400, detail=str(exc))
+    except IntegrityError as exc:
+        raise_integrity_as_409(exc)
     return ok(result)
 
 

--- a/backend/app/api/routes/stock.py
+++ b/backend/app/api/routes/stock.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, HTTPException, Query, status
+from sqlalchemy.exc import IntegrityError
 
+from app.api.routes._stock_integrity import raise_integrity_as_409
 from app.core.deps import CurrentUser, CurrentWorkspace, DbSession
 from app.core.responses import Envelope, ok
 from app.domain.parts.services.bag_signature import compute_bag_signature
@@ -74,6 +76,8 @@ def add(
         )
     except StockError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
+    except IntegrityError as exc:
+        raise_integrity_as_409(exc)
     return ok(_serialize_entry(e))
 
 
@@ -85,6 +89,8 @@ def remove(
         e = remove_stock(db, workspace_id=ws.id, user_id=user.id, payload=payload)
     except StockError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
+    except IntegrityError as exc:
+        raise_integrity_as_409(exc)
     return ok(_serialize_entry(e))
 
 
@@ -103,6 +109,8 @@ def move(payload: MoveStockIn, db: DbSession, ws: CurrentWorkspace, user: Curren
         )
     except StockError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
+    except IntegrityError as exc:
+        raise_integrity_as_409(exc)
     return ok({"out": _serialize_entry(out_e), "in": _serialize_entry(in_e)})
 
 
@@ -112,6 +120,8 @@ def adjust(payload: AdjustStockIn, db: DbSession, ws: CurrentWorkspace, user: Cu
         e = adjust_stock(db, workspace_id=ws.id, user_id=user.id, payload=payload)
     except StockError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
+    except IntegrityError as exc:
+        raise_integrity_as_409(exc)
     return ok(_serialize_entry(e) if e is not None else None, "no change" if e is None else "OK")
 
 

--- a/backend/tests/test_stock_nonneg_trigger_to_409.py
+++ b/backend/tests/test_stock_nonneg_trigger_to_409.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.exc import IntegrityError
+
+from app.api.routes import stock as stock_routes
+from app.main import app
+from tests._factories import signup_user
+
+pytestmark = pytest.mark.real_db
+
+
+class _FakeDiag:
+    constraint_name = "stock_nonneg_trigger"
+
+
+class _FakeOrig(Exception):
+    diag = _FakeDiag()
+
+
+def _stock_nonneg_integrity_error() -> IntegrityError:
+    return IntegrityError("INSERT INTO stock_entries ...", {}, _FakeOrig("stock trigger"))
+
+
+def test_stock_nonneg_integrityerror_returns_409_envelope(monkeypatch):
+    client = TestClient(app)
+    signup_user(client)
+
+    def raise_from_trigger(*args, **kwargs):
+        raise _stock_nonneg_integrity_error()
+
+    monkeypatch.setattr(stock_routes, "remove_stock", raise_from_trigger)
+
+    r = client.post(
+        "/api/stock/remove",
+        json={
+            "part_id": str(uuid4()),
+            "quantity": 1,
+        },
+    )
+
+    assert r.status_code == 409, r.text
+    body = r.json()
+    assert body["data"] is None
+    assert body["status"]["category"] == "conflict"
+    assert body["status"]["message"] == "insufficient stock"
+    assert body["constraint"] == "stock_nonneg_trigger"


### PR DESCRIPTION
## What changed

- Added a route-layer helper that maps `stock_nonneg_trigger` / `ck_stock_nonneg` / `check_stock_nonneg` `IntegrityError` diagnostics to a 409 API envelope.
- Applied the mapper around stock-ledger mutating routes in stock, lots, orders receive, and build reservation/consume flows.
- Added a focused regression test proving the trigger-sourced `IntegrityError` returns a 409 conflict envelope instead of escaping as a 500.

Closes #547

## Validation

- `TEST_DATABASE_URL=postgresql+psycopg://stockmgr:stockmgr@127.0.0.1:5432/stockmgr_test_aud008 uv run python -m pytest tests/test_stock_nonneg_trigger_to_409.py -q` — passed
- `TEST_DATABASE_URL=postgresql+psycopg://stockmgr:stockmgr@127.0.0.1:5432/stockmgr_test_aud008 uv run python -m pytest tests/test_stock_concurrency.py -q` — passed
- `TEST_DATABASE_URL=postgresql+psycopg://stockmgr:stockmgr@127.0.0.1:5432/stockmgr_test_aud008 uv run python -m pytest tests/test_stock_null_bucket.py -q` — passed
- `LINT_CMD="ruff check app --output-format=concise" BASELINE_FILE="../.ruff-baseline.txt" WORK_DIR="." bash ../scripts/lint-delta.sh` — passed
- `uv run python scripts/check_no_traceback_leaks.py` — passed
- TLS verify guard grep — passed

Note: a combined/parallel real-DB pytest run was discarded because concurrent pytest processes reset the same schema and collided during Alembic setup. The listed reruns were sequential against a dedicated test database.

## Merge order / conflicts

- Based on latest `origin/main` at PR creation time after rebasing twice while main advanced.
- No known merge-order dependency.
- Likely conflict surface, if main moves again: `backend/app/api/routes/{stock,builds,lots,orders}.py` stock mutation error handling.
