### PR TITLE
AUD-010: Recheck storage flag flips

### DIFF
--- a/backend/app/api/routes/storage.py
+++ b/backend/app/api/routes/storage.py
@@ -13,8 +13,10 @@ from app.core.responses import ok
 from app.core.time import utcnow
 from app.domain.stock.models import StockEntry
 from app.domain.stock.service import (
+    StockConflictError,
     history_for_storage,
     stock_for_storage,
+    validate_storage_constraint_flag_update,
 )
 from app.domain.storage.models import StorageLocation
 from app.domain.storage.schemas import StorageIn, StoragePatch
@@ -85,7 +87,24 @@ def get_storage(storage_id: UUID, db: DbSession, ws: CurrentWorkspace):
 @router.patch("/{storage_id}")
 def patch_storage(storage_id: UUID, payload: StoragePatch, db: DbSession, ws: CurrentWorkspace, user: CurrentUser):
     s = _get(db, ws.id, storage_id)
-    for k, v in payload.model_dump(exclude_unset=True).items():
+    data = payload.model_dump(exclude_unset=True)
+    try:
+        validate_storage_constraint_flag_update(
+            db,
+            workspace_id=ws.id,
+            storage=s,
+            requested_single_part_only=data.get("single_part_only"),
+            requested_existing_parts_only=data.get("existing_parts_only"),
+        )
+    except StockConflictError as exc:
+        raise_http(
+            status.HTTP_409_CONFLICT,
+            code=ErrorCodes.STORAGE_CONSTRAINT_VIOLATION,
+            message=str(exc),
+            constraint=exc.constraint,
+            storage_location_id=str(exc.storage_location_id),
+        )
+    for k, v in data.items():
         setattr(s, k, v)
     s.updated_by = user.id
     return ok(_serialize(s))

--- a/backend/app/core/errors.py
+++ b/backend/app/core/errors.py
@@ -186,6 +186,7 @@ class ErrorCodes:
     # Storage router.
     STORAGE_NOT_FOUND = "storage.not_found"
     STORAGE_HAS_STOCK = "storage.has_stock"
+    STORAGE_CONSTRAINT_VIOLATION = "storage.constraint_violation"
 
     # Attachments router.
     ATTACHMENT_TOO_LARGE = "attachment.too_large"

--- a/backend/app/domain/stock/service.py
+++ b/backend/app/domain/stock/service.py
@@ -359,6 +359,7 @@ def enforce_storage_constraints(
     Raises StockConflictError on violation.
     """
     _lock_for_storage_constraint(db, workspace_id=workspace_id, storage_location_id=storage.id)
+    db.refresh(storage)
 
     if storage.single_part_only:
         # Any part other than the one being added/moved-in currently has
@@ -386,6 +387,57 @@ def enforce_storage_constraints(
         if not prior:
             raise StockConflictError(
                 "destination only accepts previously-stocked parts and this part has no prior stock here",
+                constraint="existing_parts_only",
+                storage_location_id=storage.id,
+            )
+
+
+def validate_storage_constraint_flag_update(
+    db: Session,
+    *,
+    workspace_id: UUID,
+    storage: StorageLocation,
+    requested_single_part_only: bool | None = None,
+    requested_existing_parts_only: bool | None = None,
+) -> None:
+    """Reject flag enables that conflict with current on-hand contents."""
+    enable_single = requested_single_part_only is True and not storage.single_part_only
+    enable_existing = requested_existing_parts_only is True and not storage.existing_parts_only
+    if not enable_single and not enable_existing:
+        return
+
+    _lock_for_storage_constraint(db, workspace_id=workspace_id, storage_location_id=storage.id)
+    db.refresh(storage)
+    enable_single = requested_single_part_only is True and not storage.single_part_only
+    enable_existing = requested_existing_parts_only is True and not storage.existing_parts_only
+    if not enable_single and not enable_existing:
+        return
+
+    current_rows = stock_for_storage(db, workspace_id=workspace_id, storage_location_id=storage.id)
+    current_part_ids = {row["part_id"] for row in current_rows if int(row["quantity"]) > 0}
+
+    if enable_single and len(current_part_ids) > 1:
+        raise StockConflictError(
+            "storage cannot be marked single-part-only while it holds multiple parts",
+            constraint="single_part_only",
+            storage_location_id=storage.id,
+        )
+
+    if enable_existing and current_part_ids:
+        prior_part_ids = set(
+            db.execute(
+                select(StockEntry.part_id)
+                .where(StockEntry.workspace_id == workspace_id)
+                .where(StockEntry.storage_location_id == storage.id)
+                .where(StockEntry.part_id.in_(current_part_ids))
+                .where(StockEntry.quantity_delta > 0)
+                .distinct()
+            ).scalars()
+        )
+        if current_part_ids - prior_part_ids:
+            raise StockConflictError(
+                "storage cannot be marked existing-parts-only while it holds a part "
+                "with no prior positive entry",
                 constraint="existing_parts_only",
                 storage_location_id=storage.id,
             )

--- a/backend/app/domain/storage/README.md
+++ b/backend/app/domain/storage/README.md
@@ -11,7 +11,7 @@ Owns `StorageLocation` — the place a part / lot lives. Hierarchical (`parent_i
 | `models.py` | `StorageLocation` |
 | `schemas.py` | Pydantic shapes for storage CRUD |
 
-(No `service.py` — CRUD lives in the route module; constraint enforcement on stock writes lives in `domain/stock/service.py::_enforce_storage_constraints`.)
+(No `service.py` — CRUD lives in the route module; constraint enforcement lives in `domain/stock/service.py`.)
 
 ## Public surface
 
@@ -20,7 +20,7 @@ This module's surface is its model + schemas; reads/writes are done by callers v
 ## Hard rules (this module)
 
 1. **`parts.default_storage_location_id` cross-workspace is blocked by a Postgres BEFORE trigger** (`parts_default_storage_workspace_check`, migration 0036). The only DB-enforced workspace check in the codebase. See [ADR-0002](../../../../docs/adr/0002-code-enforced-workspace-isolation.md).
-2. **Storage constraints (capacity / allowed part types) are enforced on stock writes**, not on `StorageLocation` updates. The check lives in `domain/stock/service.py::_enforce_storage_constraints`.
+2. **Storage constraints are enforced in the stock domain**. Stock writes call `domain/stock/service.py::enforce_storage_constraints`; `StorageLocation` PATCH calls `validate_storage_constraint_flag_update` when enabling flags.
 3. **Workspace isolation is code-enforced** for every other reference. See [ADR-0002](../../../../docs/adr/0002-code-enforced-workspace-isolation.md).
 
 ## See also
@@ -31,6 +31,6 @@ This module's surface is its model + schemas; reads/writes are done by callers v
 
 ## Don't
 
-- Don't enforce capacity / part-type constraints in routes — keep it inside `domain/stock/service.py::_enforce_storage_constraints` so add / move / receive all share one path.
+- Don't reimplement capacity / part-type checks in routes — keep them inside `domain/stock/service.py` so add / move / receive and PATCH rechecks share one path.
 - Don't follow `parts.default_storage_location_id` without re-checking workspace; the trigger only catches *writes*, not joins.
 - Don't allow a storage location to become its own ancestor via `parent_id` — guard at the schema level.

--- a/backend/tests/test_storage_patch_single_part_only_recheck.py
+++ b/backend/tests/test_storage_patch_single_part_only_recheck.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import uuid
+
+from app.core.errors import ErrorCodes
+from tests._factories import add_stock, create_part, create_storage
+
+
+def test_flip_blocked_when_multiple_parts(authed_client):
+    storage_id = create_storage(authed_client, name=f"Patch-SPO-{uuid.uuid4().hex[:8]}")
+    part_a = create_part(authed_client, name=f"Patch-SPO-A-{uuid.uuid4().hex[:8]}")
+    part_b = create_part(authed_client, name=f"Patch-SPO-B-{uuid.uuid4().hex[:8]}")
+    add_stock(authed_client, part_a, 5, storage_id=storage_id)
+    add_stock(authed_client, part_b, 3, storage_id=storage_id)
+
+    response = authed_client.patch(
+        f"/api/storage/{storage_id}",
+        json={"single_part_only": True},
+    )
+
+    assert response.status_code == 409, response.text
+    body = response.json()
+    assert body["code"] == ErrorCodes.STORAGE_CONSTRAINT_VIOLATION
+    assert body["constraint"] == "single_part_only"
+    assert body["storage_location_id"] == storage_id
+
+    after = authed_client.get(f"/api/storage/{storage_id}")
+    assert after.status_code == 200, after.text
+    assert after.json()["data"]["single_part_only"] is False

--- a/docs/domain/ledger.md
+++ b/docs/domain/ledger.md
@@ -79,7 +79,7 @@ Helpers:
 
 - `_lock_for_stock_write(db, *, workspace_id, part_id)` — single-part lock, called by every mutating ledger entry (producer **and** consumer; see the docstring for why the producer side isn't optional).
 - `lock_parts_for_stock_write(db, *, workspace_id, part_ids)` — multi-part lock taken in deterministic UUID-string order to prevent AB/BA deadlocks. Used by `builds.consume`, `builds.apply_reservations`, `builds.release_reservations`, and `orders.receive` (`backend/app/domain/stock/service.py:87-102`).
-- `_lock_for_storage_constraint(db, *, workspace_id, storage_location_id)` — second lock for the `single_part_only`/`existing_parts_only` cross-part race on a destination location. Always acquired *after* the per-part lock to keep the lock-ordering invariant (`backend/app/domain/stock/service.py:105-137`).
+- `_lock_for_storage_constraint(db, *, workspace_id, storage_location_id)` — second lock for the `single_part_only`/`existing_parts_only` cross-part race on a destination location. Stock writers acquire it after the per-part lock to keep the lock-ordering invariant; storage PATCH rechecks acquire only this lock before enabling flags (`backend/app/domain/stock/service.py:105-137`).
 
 The DB-side fall-back is the `0013` trigger (`backend/alembic/versions/0013_stock_nonneg_trigger.py`). It re-aggregates the bucket on every INSERT and raises `check_violation` if the cumulative sum is negative. The trigger is what catches a raw SQL write (or a future bug) that bypasses the advisory lock — it is intentionally not the primary defence because it converts every concurrent-write race into a 500 instead of a clean 4xx.
 


### PR DESCRIPTION
Closes #549

## Summary
- Rechecks `single_part_only` and `existing_parts_only` enables during `PATCH /api/storage/{id}` before mutating the storage row.
- Keeps the on-hand read in the stock domain via `stock_for_storage`, under the per-storage advisory lock, and refreshes storage flags after taking that lock so concurrent stock writes see newly enabled constraints.
- Adds a focused regression test for rejecting `single_part_only` when a location currently holds multiple parts.
- Updates storage/ledger docs to reflect PATCH rechecks sharing the stock-domain constraint path.

## Validation
- `TEST_DATABASE_URL=postgresql+psycopg://stockmgr:stockmgr@127.0.0.1:5432/stockmgr_test_aud010 uv run --extra dev python -m pytest tests/test_storage_patch_single_part_only_recheck.py -q` - 1 passed
- `TEST_DATABASE_URL=postgresql+psycopg://stockmgr:stockmgr@127.0.0.1:5432/stockmgr_test_aud010 uv run --extra dev python -m pytest tests/test_storage_constraints.py -q` - 14 passed
- `LINT_CMD="uv run --extra dev ruff check app --output-format=concise" BASELINE_FILE=".ruff-baseline.txt" WORK_DIR="backend" bash scripts/lint-delta.sh` - no new violations
- `uv run --extra dev ruff check tests/test_storage_patch_single_part_only_recheck.py --output-format=concise` - passed
- `git diff --check` - passed

## Merge Order / Conflicts
- Branched from and rebased onto current `origin/main` at `caf4dd1` before commit.
- Expected conflict risk is limited to `backend/app/domain/stock/service.py`, `backend/app/api/routes/storage.py`, and nearby storage docs if other AUD stock-integrity work lands first.
- No database migration required.