### PR TITLE
[codex] AUD-021 preserve bulk import row order in content key

### DIFF
--- a/backend/app/api/routes/parts_scan.py
+++ b/backend/app/api/routes/parts_scan.py
@@ -65,16 +65,15 @@ _BULK_IMPORT_IDEMPOTENCY_TTL_H = 24       # hours before cache rows are swept
 def _bulk_import_content_key(ws_id: str, rows) -> str:
     """Derive a deterministic 64-hex-char SHA-256 key from request content.
 
-    Serialises every field of every row (sorted by a stable key) so that
+    Serialises every field of every row in request order so that
     two calls with different quantities / storage locations / lot names hash
-    to different keys even when the MPNs and bag signatures are identical.
-    Order-independent: rows are sorted by (bag_signature or "", mpn) before
-    serialisation so the operator may re-order rows between retries.
+    to different keys even when the MPNs and bag signatures are identical,
+    and distinct ordered submissions are not collapsed onto the same cache key.
     """
-    row_blobs = sorted(
+    row_blobs = [
         json.dumps(r.model_dump(), sort_keys=True, default=str)
         for r in rows
-    )
+    ]
     raw = f"{ws_id}|{'||'.join(row_blobs)}"
     return hashlib.sha256(raw.encode()).hexdigest()
 
@@ -108,8 +107,9 @@ def bulk_import_from_scan(
     *after* that commit, the client did not see the response body — but
     the rows are durably persisted. Retrying with the same `idempotency_key`
     returns the cached envelope verbatim (no new Parts created). Retrying
-    *without* an idempotency key will re-derive the same content-hash and
-    likewise return the cached result (BE2-003).
+    *without* an idempotency key will re-derive the same order-sensitive
+    content-hash for identical row bytes and use it for the cache write
+    (BE2-003).
 
     Bounded latency (BE2-003):
     - Row cap: max 50 rows per request (ScanImportIn.rows max_length=50).
@@ -124,10 +124,9 @@ def bulk_import_from_scan(
     #
     # The key is FE-supplied (UUID4 generated once per submit attempt,
     # re-sent unchanged on retry) or falls back to a SHA-256 content
-    # hash of the full row payload so that true retries of identical
-    # bytes are deduplicated even without an explicit key. The content
-    # hash includes all fields (quantity, storage_location_id, etc.) so
-    # two calls that differ in any detail are treated as distinct.
+    # hash of the full ordered row payload. The content hash includes
+    # all fields (quantity, storage_location_id, etc.) and preserves row
+    # order so two calls that differ in any detail are treated as distinct.
     # ------------------------------------------------------------------
     explicit_key = (payload.idempotency_key or "").strip() or None
     idempotency_key = explicit_key or _bulk_import_content_key(str(ws.id), payload.rows)

--- a/backend/tests/test_bulk_import_idempotency.py
+++ b/backend/tests/test_bulk_import_idempotency.py
@@ -139,6 +139,24 @@ def test_different_key_same_mpns_hits_duplicate_branch(authed):
     assert body["rows"][0]["status"] == "duplicate"
 
 
+def test_distinct_orders_distinct_hashes():
+    """Implicit content keys preserve row order so distinct submits do not
+    collapse onto the same idempotency cache row."""
+    from app.api.routes.parts_scan import _bulk_import_content_key
+    from app.domain.parts.schemas import ScanImportRow
+
+    rows_ab = [
+        ScanImportRow(mpn="RC0402JR-070R", quantity=1),
+        ScanImportRow(mpn="RC0603FR-0710K", quantity=2),
+    ]
+    rows_ba = list(reversed(rows_ab))
+
+    assert _bulk_import_content_key("workspace-a", rows_ab) != _bulk_import_content_key(
+        "workspace-a",
+        rows_ba,
+    )
+
+
 def test_idempotency_cache_write_is_upsert_not_plain_insert():
     """Direct unit-level check: the bulk-import route must use
     `INSERT … ON CONFLICT DO NOTHING` for the cache write so a race


### PR DESCRIPTION
## Summary
- Make the implicit bulk-import content key preserve scan row order instead of sorting rows before hashing.
- Update the helper comments to describe the order-sensitive fallback key.
- Add `test_distinct_orders_distinct_hashes` for AUD-021.

Closes #560

## Validation
- `uv run --frozen --extra dev pytest tests/test_bulk_import_idempotency.py -q` -> 6 passed, 1 warning
- `uv run --frozen --extra dev ruff check app/api/routes/parts_scan.py` -> passed
- `LINT_CMD="uv run --frozen --extra dev ruff check app --output-format=concise" BASELINE_FILE="../.ruff-baseline.txt" WORK_DIR="." bash ../scripts/lint-delta.sh` -> no new violations
- `uv run --frozen --extra dev python scripts/check_no_traceback_leaks.py` -> passed
- TLS verify guard grep -> passed
- `uv run --frozen --extra dev python scripts/check_stockentry_constructors.py` -> passed
- `uv run --frozen --extra dev python -m alembic heads --resolve-dependencies` -> `0047 (head)`
- `uv lock --check` -> passed

## Merge Order / Conflict Notes
- Based on latest `origin/main` at `e14964a` (`AUD-012: provider upstream error envelopes`).
- No schema or migration changes.
- Expected conflict surface is limited to `backend/app/api/routes/parts_scan.py` and `backend/tests/test_bulk_import_idempotency.py` if another AUD branch changes bulk-import idempotency behavior.

## Blockers
- None.
