### PR TITLE
[codex] AUD-056 handle malformed argon2 hashes

### DIFF
--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -8,7 +8,7 @@ from datetime import datetime, timedelta
 
 import httpx
 from argon2 import PasswordHasher
-from argon2.exceptions import VerifyMismatchError
+from argon2.exceptions import InvalidHashError, VerificationError
 from sqlalchemy.orm import Session
 
 from app.core.config import settings
@@ -125,7 +125,7 @@ def validate_password_strength(password: str) -> None:
 def verify_password(hash_: str, password: str) -> bool:
     try:
         return _hasher.verify(hash_, password)
-    except VerifyMismatchError:
+    except (VerificationError, InvalidHashError):
         return False
 
 

--- a/backend/tests/test_verify_password.py
+++ b/backend/tests/test_verify_password.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.domain.users.models import User
+from app.main import app
+
+
+def test_malformed_hash_returns_401(db):
+    email = "bad-hash@example.com"
+    db.add(User(email=email, name="Bad Hash", password_hash="not-an-argon2-hash"))
+    db.commit()
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/auth/login",
+        json={"email": email, "password": "TestPass-2026-Stronk"},
+    )
+
+    assert response.status_code == 401, response.text
+    body = response.json()
+    assert body["status"]["category"] == "unauthenticated"
+    assert body["code"] == "auth.invalid_credentials"


### PR DESCRIPTION
Closes #595

## Summary
- Treat Argon2 verification failures and invalid hash formats as failed password verification.
- Add a focused login regression proving a malformed stored hash returns the normal 401 invalid-credentials envelope.

## Validation
- `.venv/bin/python -m pytest tests/test_verify_password.py -q`
- `/home/matyas/.local/bin/ruff check backend/app/core/auth.py backend/tests/test_verify_password.py`
- `git diff --check`

## Merge Order / Conflicts
- Base: latest `origin/main` at worktree creation (`e14964a`).
- Scope is limited to `backend/app/core/auth.py` and `backend/tests/test_verify_password.py`; no expected merge-order dependencies or conflicts.

## Notes
- Local `uv run pytest` initially failed before collection because the locked Alembic install did not expose `alembic.command`; validation used the worktree `.venv` after installing a compatible Alembic package for the test run.