### PR TITLE
[codex] AUD-069 distinguish verify expired links

### DIFF
--- a/web/src/routes/auth/Verify.tsx
+++ b/web/src/routes/auth/Verify.tsx
@@ -16,6 +16,19 @@ import AuthShell from "./AuthShell";
 
 type State = "verifying" | "success" | "error";
 
+function verificationErrorMessage(e: unknown): string {
+  if (!(e instanceof ApiError)) {
+    return "Verification failed — please try again.";
+  }
+  if (e.status === 410) {
+    return "Verification link expired.";
+  }
+  if (e.status === 404) {
+    return "Verification link not found.";
+  }
+  return e.userMessage;
+}
+
 export default function Verify() {
   const [params] = useSearchParams();
   const nav = useNavigate();
@@ -46,11 +59,7 @@ export default function Verify() {
       .catch((e: unknown) => {
         if (cancelled) return;
         setState("error");
-        setErrMsg(
-          e instanceof ApiError
-            ? e.userMessage
-            : "Verification failed — please try again.",
-        );
+        setErrMsg(verificationErrorMessage(e));
       });
 
     return () => {

--- a/web/src/routes/auth/__dom__/Verify.render.dom.test.tsx
+++ b/web/src/routes/auth/__dom__/Verify.render.dom.test.tsx
@@ -96,4 +96,34 @@ describe("Verify — ApiError render", () => {
     // The raw server string must NOT appear anywhere in the rendered output.
     expect(screen.queryByText(new RegExp(RAW_SERVER_MSG))).toBeNull();
   });
+
+  it("shows an expired-link message for 410", async () => {
+    mockPost.mockRejectedValue(
+      new ApiError(
+        410,
+        { data: null, status: { category: "not_found", message: "expired" } },
+        "expired",
+      ),
+    );
+
+    renderVerify("?id=x&token=y");
+
+    expect(await screen.findByText("Verification link expired.")).toBeDefined();
+    expect(screen.queryByText("Verification link not found.")).toBeNull();
+  });
+
+  it("shows an unknown-link message for 404", async () => {
+    mockPost.mockRejectedValue(
+      new ApiError(
+        404,
+        { data: null, status: { category: "not_found", message: "unknown" } },
+        "unknown",
+      ),
+    );
+
+    renderVerify("?id=x&token=y");
+
+    expect(await screen.findByText("Verification link not found.")).toBeDefined();
+    expect(screen.queryByText("Verification link expired.")).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
- distinguish expired verification links (410) from unknown verification links (404) in `Verify.tsx`
- add focused DOM coverage for both statuses

Closes #608

## Validation
- `npm --prefix web run test -- Verify`
- `npx eslint src/routes/auth/Verify.tsx src/routes/auth/__dom__/Verify.render.dom.test.tsx`
- `npm --prefix web run typecheck`
- `git diff --check`

Note: `npm --prefix web run lint -- src/routes/auth/Verify.tsx src/routes/auth/__dom__/Verify.render.dom.test.tsx` runs the repository script as `eslint src ...` and fails on pre-existing unrelated lint errors in `web/src/lib/bagCode.ts` plus warnings elsewhere; touched-file ESLint passes.

## Merge Order / Conflicts
- Based on latest `origin/main` at `e14964a`.
- Touches only `web/src/routes/auth/Verify.tsx` and `web/src/routes/auth/__dom__/Verify.render.dom.test.tsx`; conflict risk is limited to concurrent edits in the verify auth page/tests.