### PR TITLE
[codex] AUD-046 require noopener on external links

### DIFF
--- a/web/.eslintrc.cjs
+++ b/web/.eslintrc.cjs
@@ -44,6 +44,10 @@ module.exports = {
         message:
           "Do not pass sensitive identifiers to Sentry.logger.*; log a redacted scalar or omit the field.",
       },
+      {
+        selector: 'JSXAttribute[name.name="rel"][value.value="noreferrer"]',
+        message: 'External links must use rel="noopener noreferrer".',
+      },
     ],
   },
   ignorePatterns: [

--- a/web/src/components/AttachmentsPanel.tsx
+++ b/web/src/components/AttachmentsPanel.tsx
@@ -297,7 +297,7 @@ export default function AttachmentsPanel({ objectType, objectId, canWrite }: Pro
                 className="btn text-xs"
                 href={`/api/attachments/${a.id}/download`}
                 target="_blank"
-                rel="noreferrer"
+                rel="noopener noreferrer"
               >
                 <Download className="inline w-3 h-3 mr-1" />
                 Download

--- a/web/src/components/EntityHeader.tsx
+++ b/web/src/components/EntityHeader.tsx
@@ -45,7 +45,7 @@ export default function EntityHeader({
             <a
               href={imageUrl}
               target="_blank"
-              rel="noreferrer"
+              rel="noopener noreferrer"
               className="shrink-0 block"
               aria-label="Open full image"
             >

--- a/web/src/routes/parts/PartCreate.tsx
+++ b/web/src/routes/parts/PartCreate.tsx
@@ -221,7 +221,7 @@ export default function PartCreate() {
           </div>
           {datasheetUrl && (
             <div className="text-xs text-muted mt-1">
-              Datasheet: <a className="underline" href={datasheetUrl} target="_blank" rel="noreferrer">{datasheetUrl}</a>
+              Datasheet: <a className="underline" href={datasheetUrl} target="_blank" rel="noopener noreferrer">{datasheetUrl}</a>
             </div>
           )}
         </div>

--- a/web/src/routes/parts/ScanImport/ScanImportQueue.tsx
+++ b/web/src/routes/parts/ScanImport/ScanImportQueue.tsx
@@ -161,7 +161,7 @@ function FoundDetails({
                 className="text-accent hover:underline inline-flex items-center gap-1"
                 href={r.source_url}
                 target="_blank"
-                rel="noreferrer"
+                rel="noopener noreferrer"
               >
                 <ExternalLink size={12} /> Product page
               </a>

--- a/web/src/routes/parts/detail/PartInfo.tsx
+++ b/web/src/routes/parts/detail/PartInfo.tsx
@@ -162,7 +162,7 @@ export default function PartInfo() {
           <a
             href={withDownloadName(datasheetUrl, part.mpn || part.name)}
             target="_blank"
-            rel="noreferrer"
+            rel="noopener noreferrer"
             className="inline-flex items-center gap-1.5 text-accent hover:underline text-sm"
           >
             <FileText size={14} /> Datasheet <ExternalLink size={12} />

--- a/web/src/routes/parts/detail/PartSourcing.tsx
+++ b/web/src/routes/parts/detail/PartSourcing.tsx
@@ -106,7 +106,7 @@ export default function PartSourcing() {
             <a
               href={externalUrl}
               target="_blank"
-              rel="noreferrer"
+              rel="noopener noreferrer"
               className="btn inline-flex items-center gap-1.5 text-sm"
             >
               <ExternalLink size={14} />

--- a/web/src/routes/parts/detail/PartSpecs.tsx
+++ b/web/src/routes/parts/detail/PartSpecs.tsx
@@ -168,7 +168,7 @@ export default function PartSpecs() {
             className="text-accent hover:underline"
             href={(PROVIDER_SEARCH_URL[part.linked_provider!] ?? PROVIDER_SEARCH_URL.mouser)(part.mpn ?? "")}
             target="_blank"
-            rel="noreferrer"
+            rel="noopener noreferrer"
           >
             product page
           </a>.


### PR DESCRIPTION
## Summary

- Replace audit-listed bare `rel="noreferrer"` external links with `rel="noopener noreferrer"`.
- Add a focused ESLint `no-restricted-syntax` guard against reintroducing bare `rel="noreferrer"` in JSX.

Closes #585

## Validation

- `npm --prefix web ci` (completed; current environment reports Node 18 engine warnings for packages requiring Node 20+ and existing moderate npm audit findings)
- `./node_modules/.bin/eslint src/components/AttachmentsPanel.tsx src/components/EntityHeader.tsx src/routes/parts/PartCreate.tsx src/routes/parts/ScanImport/ScanImportQueue.tsx src/routes/parts/detail/PartInfo.tsx src/routes/parts/detail/PartSourcing.tsx src/routes/parts/detail/PartSpecs.tsx`
- `./node_modules/.bin/eslint --print-config src/components/EntityHeader.tsx | rg -n 'no-restricted-syntax|External links must use'`
- `rg -n 'rel="noreferrer"' web/src web/.eslintrc.cjs || true`
- `git diff --check`

Full `npm --prefix web run lint` was also run after installing dependencies; it fails on pre-existing unrelated findings in `web/src/lib/bagCode.ts`, `web/src/components/scanner/ZxingScanner.tsx`, and existing unused-variable warnings outside this change.

## Merge Order / Conflicts

- Based on latest `origin/main` at `60710e6` before commit.
- Touches only frontend link attributes and the frontend ESLint config; expected conflict risk is low unless another PR edits the same link call sites or `.eslintrc.cjs`.
