### PR TITLE
[codex] AUD-048 validate add-stock currency

### DIFF
--- a/web/src/routes/parts/detail/PartAddStock.tsx
+++ b/web/src/routes/parts/detail/PartAddStock.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { z } from "zod";
 import { api, ApiError } from "@/lib/api";
 import { useApiMutation } from "@/lib/mutations";
 import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
@@ -28,6 +29,8 @@ type AddStockRequest = {
   comments?: string;
 };
 
+const currencySchema = z.string().regex(/^[A-Z]{3}$/, "Currency must be a three-letter uppercase code.");
+
 export default function PartAddStock() {
   const { partId } = useParams<{ partId: string }>();
   const nav = useNavigate();
@@ -45,6 +48,7 @@ export default function PartAddStock() {
   const [serial, setSerial] = useState("");
   const [comments, setComments] = useState("");
   const [err, setErr] = useState<string | null>(null);
+  const [currencyErr, setCurrencyErr] = useState<string | null>(null);
 
   // FE2-006: stock-add is the most damaging double-submit on the
   // ledger model — two concurrent requests would append two
@@ -65,6 +69,7 @@ export default function PartAddStock() {
   function submit(e: React.FormEvent) {
     e.preventDefault();
     setErr(null);
+    setCurrencyErr(null);
     const payload: AddStockRequest = {
       part_id: partId!,
       quantity: Number(qty),
@@ -72,9 +77,14 @@ export default function PartAddStock() {
     };
     if (location) payload.storage_location_id = location;
     if (priceMode !== "none") {
+      const parsedCurrency = currencySchema.safeParse(currency);
+      if (!parsedCurrency.success) {
+        setCurrencyErr(parsedCurrency.error.issues[0]?.message ?? "Invalid currency.");
+        return;
+      }
       payload.price = {
         mode: priceMode,
-        currency,
+        currency: parsedCurrency.data,
         unit_price: priceMode === "per_component" ? Number(unitPrice) : undefined,
         total_price: priceMode === "entire_lot" ? Number(totalPrice) : undefined,
       };
@@ -127,7 +137,23 @@ export default function PartAddStock() {
         {priceMode !== "none" && (
           <div>
             <label className="label" htmlFor="add-stock-currency">Currency</label>
-            <input id="add-stock-currency" className="input" maxLength={3} value={currency} onChange={e => setCurrency(e.target.value.toUpperCase())} />
+            <input
+              id="add-stock-currency"
+              className="input"
+              maxLength={3}
+              value={currency}
+              aria-invalid={currencyErr ? "true" : undefined}
+              aria-describedby={currencyErr ? "add-stock-currency-error" : undefined}
+              onChange={e => {
+                setCurrency(e.target.value.toUpperCase());
+                setCurrencyErr(null);
+              }}
+            />
+            {currencyErr && (
+              <p id="add-stock-currency-error" className="mt-1 text-danger text-sm">
+                {currencyErr}
+              </p>
+            )}
           </div>
         )}
       </div>

--- a/web/src/routes/parts/detail/__tests__/PartAddStock.test.tsx
+++ b/web/src/routes/parts/detail/__tests__/PartAddStock.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { api } from "@/lib/api";
+import PartAddStock from "../PartAddStock";
+
+vi.mock("@/lib/auth", () => ({
+  useAuth: () => ({ workspaceId: "ws-1" }),
+}));
+
+function renderAddStock() {
+  const client = new QueryClient({
+    defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+  });
+
+  render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={["/parts/11111111-1111-1111-1111-111111111111/stock/add"]}>
+        <Routes>
+          <Route path="/parts/:partId/stock/add" element={<PartAddStock />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("PartAddStock", () => {
+  it("test_currency_regex rejects non-letter currency codes inline", async () => {
+    const user = userEvent.setup();
+    vi.spyOn(api, "get").mockResolvedValue([]);
+    const postSpy = vi.spyOn(api, "post").mockResolvedValue({});
+
+    renderAddStock();
+
+    await user.type(screen.getByLabelText("Quantity *"), "5");
+    await user.selectOptions(screen.getByLabelText("Price mode"), "per_component");
+    await user.type(screen.getByLabelText("Unit price"), "0.12");
+    const currency = screen.getByLabelText("Currency");
+    await user.clear(currency);
+    await user.type(currency, "EU1");
+    await user.click(screen.getByRole("button", { name: "Add" }));
+
+    expect(await screen.findByText("Currency must be a three-letter uppercase code.")).toBeDefined();
+    expect(currency.getAttribute("aria-invalid")).toBe("true");
+    await waitFor(() => {
+      expect(postSpy).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add Zod regex validation for the PartAddStock price currency field.
- Show an inline field error and block `/stock/add` submission when the visible currency code is not three uppercase letters.
- Add focused regression coverage for `test_currency_regex`.

Closes #587

## Validation
- `npm --prefix web ci` (completed; npm reported existing engine warnings under Node 18 and 6 moderate audit findings)
- `npm --prefix web run test -- PartAddStock`
- `npm --prefix web run typecheck`
- `npm exec eslint -- src/routes/parts/detail/PartAddStock.tsx src/routes/parts/detail/__tests__/PartAddStock.test.tsx` from `web/`
- `git diff --check HEAD~1 HEAD`

## Merge Order / Conflict Notes
- Based on latest `origin/main` after rebasing before push.
- Touches only `PartAddStock.tsx` and its focused test; no expected conflicts unless another branch edits the same add-stock form or test path.