### PR TITLE
[codex] AUD-032 split httpx provider timeouts

### DIFF
--- a/backend/app/domain/sourcing/providers/factory.py
+++ b/backend/app/domain/sourcing/providers/factory.py
@@ -9,6 +9,9 @@ import httpx
 
 from app.domain.sourcing.providers._retry_transport import RetryingHTTPTransport
 
+CONNECT_TIMEOUT_SECONDS = 2.0
+POOL_TIMEOUT_SECONDS = 2.0
+
 
 @contextmanager
 def make_retrying_client(
@@ -18,10 +21,16 @@ def make_retrying_client(
     transport: httpx.BaseTransport | None = None,
 ) -> Iterator[httpx.Client]:
     """Build a provider HTTP client with the shared retry policy."""
+    split_timeout = httpx.Timeout(
+        connect=CONNECT_TIMEOUT_SECONDS,
+        read=timeout,
+        write=timeout,
+        pool=POOL_TIMEOUT_SECONDS,
+    )
     retry_transport = RetryingHTTPTransport(
         verify=True,
         provider_name=provider_name,
         inner=transport,
     )
-    with httpx.Client(timeout=timeout, transport=retry_transport) as client:
+    with httpx.Client(timeout=split_timeout, transport=retry_transport) as client:
         yield client

--- a/backend/tests/test_provider_connect_timeout.py
+++ b/backend/tests/test_provider_connect_timeout.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import httpx
+
+from app.domain.sourcing.providers import make_retrying_client
+
+
+def test_retrying_client_splits_connect_read_write_pool_timeouts() -> None:
+    transport = httpx.MockTransport(lambda request: httpx.Response(200, request=request))
+
+    with make_retrying_client(
+        provider_name="trustedparts",
+        timeout=8.0,
+        transport=transport,
+    ) as client:
+        assert client.timeout.connect == 2.0
+        assert client.timeout.read == 8.0
+        assert client.timeout.write == 8.0
+        assert client.timeout.pool == 2.0


### PR DESCRIPTION
## Summary
- Split provider httpx timeout configuration in `make_retrying_client` into explicit connect/read/write/pool budgets.
- Preserve the existing provider read/write timeout argument while capping connect and pool acquisition at 2 seconds.
- Add the focused regression test requested by AUD-032.

Closes #571

## Validation
- `uv run --extra dev python -m pytest tests/test_provider_connect_timeout.py tests/test_sourcing_providers_retry.py -q`
- `uv run --extra dev ruff check app/domain/sourcing/providers/factory.py tests/test_provider_connect_timeout.py`
- `rg -n "verify\\s*=\\s*False|trust_env\\s*=\\s*False|ssl\\s*=\\s*False" backend/app; test $? -eq 1`
- `git diff --check origin/main..HEAD`

## Merge Order / Conflict Notes
- Based on current `origin/main` at `d3465d1` after a clean rebase.
- Touches only `backend/app/domain/sourcing/providers/factory.py` and `backend/tests/test_provider_connect_timeout.py`.
- Expected conflict risk: low, unless another PR edits the shared provider HTTP client factory or adds the same regression test file.