### PR TITLE
[codex] AUD-057 assert proxy headers on startup

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import sys
+from collections.abc import Sequence
 from contextlib import asynccontextmanager
 from urllib.parse import urlparse
 
@@ -133,6 +135,37 @@ _is_prod = settings().APP_ENV == "prod"
 _log = logging.getLogger(__name__)
 
 
+def _argv_option_value(argv: Sequence[str], option: str) -> str | None:
+    """Return a uvicorn CLI option value from either --opt=value or --opt value."""
+    for idx, arg in enumerate(argv):
+        if arg == option:
+            if idx + 1 < len(argv):
+                return argv[idx + 1]
+            return ""
+        prefix = f"{option}="
+        if arg.startswith(prefix):
+            return arg[len(prefix):]
+    return None
+
+
+def assert_proxy_headers_trusted(argv: Sequence[str] | None = None) -> None:
+    """Fail prod startup when uvicorn won't trust reverse-proxy client headers."""
+    if settings().APP_ENV != "prod":
+        return
+
+    args = tuple(sys.argv if argv is None else argv)
+    if "--proxy-headers" not in args or "--no-proxy-headers" in args:
+        raise RuntimeError(
+            "APP_ENV=prod requires uvicorn --proxy-headers so request.client.host "
+            "is derived from Apache/nginx X-Forwarded-For."
+        )
+    if _argv_option_value(args, "--forwarded-allow-ips") != "*":
+        raise RuntimeError(
+            "APP_ENV=prod requires uvicorn --forwarded-allow-ips=* so proxy "
+            "headers from the compose-network reverse proxy are trusted."
+        )
+
+
 async def _periodic_session_purge(interval_seconds: int) -> None:
     """Background task: every `interval_seconds` purge sessions whose
     `expires_at` is in the past. DB-007 / issue #98.
@@ -172,6 +205,7 @@ async def _periodic_session_purge(interval_seconds: int) -> None:
 async def lifespan(_app: FastAPI):
     """Spawn the background session-purge task on startup; cancel it on
     shutdown. DB-007 / issue #98."""
+    assert_proxy_headers_trusted()
     interval = settings().SESSION_PURGE_INTERVAL_SECONDS
     task: asyncio.Task | None = None
     if interval > 0:

--- a/backend/tests/test_startup_proxy_headers.py
+++ b/backend/tests/test_startup_proxy_headers.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import pytest
+
+from app.core.config import settings
+from app.main import assert_proxy_headers_trusted
+
+
+def test_assert_proxy_headers_enabled(monkeypatch):
+    cfg = settings()
+    monkeypatch.setattr(cfg, "APP_ENV", "prod")
+
+    with pytest.raises(RuntimeError, match="--proxy-headers"):
+        assert_proxy_headers_trusted(["uvicorn", "app.main:app"])
+
+
+def test_assert_proxy_headers_requires_trusted_forwarded_ips(monkeypatch):
+    cfg = settings()
+    monkeypatch.setattr(cfg, "APP_ENV", "prod")
+
+    with pytest.raises(RuntimeError, match=r"--forwarded-allow-ips=\*"):
+        assert_proxy_headers_trusted(["uvicorn", "app.main:app", "--proxy-headers"])
+
+
+def test_assert_proxy_headers_rejects_explicit_disable(monkeypatch):
+    cfg = settings()
+    monkeypatch.setattr(cfg, "APP_ENV", "prod")
+
+    with pytest.raises(RuntimeError, match="--proxy-headers"):
+        assert_proxy_headers_trusted([
+            "uvicorn",
+            "app.main:app",
+            "--proxy-headers",
+            "--no-proxy-headers",
+            "--forwarded-allow-ips=*",
+        ])
+
+
+def test_assert_proxy_headers_accepts_prod_compose_argv(monkeypatch):
+    cfg = settings()
+    monkeypatch.setattr(cfg, "APP_ENV", "prod")
+
+    assert_proxy_headers_trusted([
+        "uvicorn",
+        "app.main:app",
+        "--host",
+        "0.0.0.0",
+        "--port",
+        "8000",
+        "--workers",
+        "1",
+        "--proxy-headers",
+        "--forwarded-allow-ips=*",
+        "--timeout-graceful-shutdown",
+        "25",
+    ])


### PR DESCRIPTION
## Summary
- Add a prod-only FastAPI lifespan assertion that fails startup unless uvicorn is launched with trusted proxy-header handling.
- Validate both `--proxy-headers` and `--forwarded-allow-ips=*`, while rejecting an explicit `--no-proxy-headers`.
- Add focused regression coverage for the startup assertion and the current prod compose argv shape.

Closes #596

## Validation
- `uv run --extra dev python -m pytest tests/test_startup_proxy_headers.py -q`
- `git diff --check`
- `uv run --extra dev ruff check tests/test_startup_proxy_headers.py`
- `uv run --extra dev ruff check app/main.py --select I,F --ignore E402`
- `LINT_CMD="uv run --extra dev ruff check app" BASELINE_FILE="../.ruff-baseline.txt" WORK_DIR="." bash ../scripts/lint-delta.sh`

## Merge Order / Conflicts
- Based on latest `origin/main` at PR creation (`d3465d1`).
- Expected conflict risk is low: touches only `backend/app/main.py` startup code and a new focused test file.
- Coordinate with any PRs that also edit FastAPI lifespan/startup assertions in `backend/app/main.py`.
