### PR TITLE
AUD-047: Scope DataTable prefs by workspace

### DIFF
--- a/web/src/components/DataTable.test.tsx
+++ b/web/src/components/DataTable.test.tsx
@@ -9,7 +9,7 @@
  * tests pure and deterministic.
  */
 import { describe, expect, it } from "vitest";
-import { buildCsv, escapeCsvCell, pruneSelection } from "./DataTable";
+import { buildCsv, dataTableStorageKey, escapeCsvCell, pruneSelection } from "./DataTable";
 
 describe("escapeCsvCell — formula injection mitigation", () => {
   it("prefixes a leading '=' with a quote", () => {
@@ -93,5 +93,14 @@ describe("pruneSelection", () => {
     const next = pruneSelection(sel, ["b", "a"]);
     expect(next.has("a")).toBe(true);
     expect(next.has("b")).toBe(true);
+  });
+});
+
+describe("DataTable persistence", () => {
+  it("test_prefs_per_workspace", () => {
+    expect(dataTableStorageKey("parts", "ws-a")).toBe("ws:ws-a:dt:parts");
+    expect(dataTableStorageKey("parts", "ws-b")).toBe("ws:ws-b:dt:parts");
+    expect(dataTableStorageKey("parts", undefined)).toBe("ws:none:dt:parts");
+    expect(dataTableStorageKey(undefined, "ws-a")).toBeUndefined();
   });
 });

--- a/web/src/components/DataTable.tsx
+++ b/web/src/components/DataTable.tsx
@@ -1,6 +1,7 @@
-import React, { ReactNode, useEffect, useMemo, useState } from "react";
+import React, { ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import { Rows3, Rows4 } from "lucide-react";
 import { cn } from "@/lib/cn";
+import { useOptionalAuth } from "@/lib/auth";
 
 // ---------------------------------------------------------------------
 // CSV-export helpers — extracted so they can be unit-tested without
@@ -114,18 +115,44 @@ type Props<T> = {
 
 type Persisted = { hidden?: Record<string, boolean>; density?: Density };
 
-function loadPersisted(tableId: string | undefined): Persisted {
-  if (!tableId) return {};
+export function dataTableStorageKey(
+  tableId: string | undefined,
+  workspaceId: string | null | undefined,
+): string | undefined {
+  if (!tableId) return undefined;
+  return `ws:${workspaceId ?? "none"}:dt:${tableId}`;
+}
+
+function loadPersisted(storageKey: string | undefined): Persisted {
+  if (!storageKey) return {};
   try {
-    return JSON.parse(localStorage.getItem(`dt:${tableId}`) || "{}");
+    return JSON.parse(localStorage.getItem(storageKey) || "{}");
   } catch {
     return {};
   }
 }
 
-function savePersisted(tableId: string | undefined, p: Persisted) {
-  if (!tableId) return;
-  localStorage.setItem(`dt:${tableId}`, JSON.stringify(p));
+function savePersisted(storageKey: string | undefined, p: Persisted) {
+  if (!storageKey) return;
+  localStorage.setItem(storageKey, JSON.stringify(p));
+}
+
+function storedWorkspaceId(): string | null {
+  try {
+    return localStorage.getItem("workspaceId");
+  } catch {
+    return null;
+  }
+}
+
+function initialHiddenFor<T>(
+  columns: Column<T>[],
+  persistedHidden: Persisted["hidden"],
+): Record<string, boolean> {
+  return {
+    ...Object.fromEntries(columns.filter(c => c.hidden).map(c => [c.key, true])),
+    ...(persistedHidden ?? {}),
+  };
 }
 
 function defaultAlignFor<T>(col: Column<T>, sample: T | undefined): Align {
@@ -155,17 +182,26 @@ export function DataTable<T>({
   selectable = false,
   selectionAccessory,
 }: Props<T>) {
-  const persisted = useMemo(() => loadPersisted(tableId), [tableId]);
+  const auth = useOptionalAuth();
+  const workspaceId = auth ? auth.workspaceId : storedWorkspaceId();
+  const storageKey = useMemo(
+    () => dataTableStorageKey(tableId, workspaceId),
+    [tableId, workspaceId],
+  );
+  const columnsRef = useRef(columns);
+  const activeStorageKeyRef = useRef(storageKey);
+
+  useEffect(() => {
+    columnsRef.current = columns;
+  }, [columns]);
 
   const [search, setSearch] = useState(initialSearch ?? "");
   const [sort, setSort] = useState<{ key: string; dir: "asc" | "desc" } | null>(null);
-  const [hidden, setHidden] = useState<Record<string, boolean>>(
-    () => ({
-      ...Object.fromEntries(columns.filter(c => c.hidden).map(c => [c.key, true])),
-      ...(persisted.hidden ?? {}),
-    })
-  );
-  const [density, setDensity] = useState<Density>(() => persisted.density ?? "comfortable");
+  const [hidden, setHidden] = useState<Record<string, boolean>>(() => {
+    const persisted = loadPersisted(storageKey);
+    return initialHiddenFor(columns, persisted.hidden);
+  });
+  const [density, setDensity] = useState<Density>(() => loadPersisted(storageKey).density ?? "comfortable");
   const [selected, setSelected] = useState<Set<string>>(() => new Set());
 
   function toggleSelected(id: string) {
@@ -179,8 +215,17 @@ export function DataTable<T>({
   function clearSelection() { setSelected(new Set()); }
 
   useEffect(() => {
-    savePersisted(tableId, { hidden, density });
-  }, [tableId, hidden, density]);
+    if (activeStorageKeyRef.current !== storageKey) return;
+    savePersisted(storageKey, { hidden, density });
+  }, [storageKey, hidden, density]);
+
+  useEffect(() => {
+    if (activeStorageKeyRef.current === storageKey) return;
+    activeStorageKeyRef.current = storageKey;
+    const persisted = loadPersisted(storageKey);
+    setHidden(initialHiddenFor(columnsRef.current, persisted.hidden));
+    setDensity(persisted.density ?? "comfortable");
+  }, [storageKey]);
 
   // FE2-007 — clear the selection set whenever the table changes
   // identity. Without this, navigating from /parts to /orders carried

--- a/web/src/components/DataTable.tsx
+++ b/web/src/components/DataTable.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import { Rows3, Rows4 } from "lucide-react";
 import { cn } from "@/lib/cn";
-import { useOptionalAuth } from "@/lib/auth";
+import { useOptionalAuth } from "@/lib/authContext";
 
 // ---------------------------------------------------------------------
 // CSV-export helpers — extracted so they can be unit-tested without

--- a/web/src/components/__dom__/DataTable.dom.test.tsx
+++ b/web/src/components/__dom__/DataTable.dom.test.tsx
@@ -33,6 +33,7 @@ const COLUMNS = [
 
 beforeEach(() => {
   cleanup();
+  localStorage.clear();
 });
 
 describe("DataTable (DOM)", () => {
@@ -208,5 +209,43 @@ describe("DataTable (DOM)", () => {
       .getAllByRole("checkbox")
       .filter((c) => c.getAttribute("aria-label") === "Deselect row");
     expect(afterPrune.length).toBe(1);
+  });
+
+  it("resets persisted column prefs when the workspace changes", () => {
+    localStorage.setItem("workspaceId", "ws-a");
+    const { rerender } = render(
+      <DataTable<Row>
+        rows={ROWS}
+        columns={COLUMNS}
+        rowKey={(r) => r.id}
+        tableId="prefs-test"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "Qty" }));
+    expect(screen.queryByRole("columnheader", { name: /qty/i })).toBeNull();
+    expect(localStorage.getItem("ws:ws-a:dt:prefs-test")).toContain('"qty":true');
+
+    localStorage.setItem("workspaceId", "ws-b");
+    rerender(
+      <DataTable<Row>
+        rows={ROWS}
+        columns={COLUMNS}
+        rowKey={(r) => r.id}
+        tableId="prefs-test"
+      />,
+    );
+    expect(screen.getByRole("columnheader", { name: /qty/i })).toBeDefined();
+
+    localStorage.setItem("workspaceId", "ws-a");
+    rerender(
+      <DataTable<Row>
+        rows={ROWS}
+        columns={COLUMNS}
+        rowKey={(r) => r.id}
+        tableId="prefs-test"
+      />,
+    );
+    expect(screen.queryByRole("columnheader", { name: /qty/i })).toBeNull();
   });
 });

--- a/web/src/lib/auth.tsx
+++ b/web/src/lib/auth.tsx
@@ -172,3 +172,7 @@ export function useAuth(): Ctx {
   if (!ctx) throw new Error("useAuth must be used inside <AuthProvider>");
   return ctx;
 }
+
+export function useOptionalAuth(): Ctx | undefined {
+  return useContext(AuthCtx);
+}

--- a/web/src/lib/auth.tsx
+++ b/web/src/lib/auth.tsx
@@ -1,5 +1,4 @@
 import {
-  createContext,
   ReactNode,
   useCallback,
   useContext,
@@ -11,21 +10,12 @@ import { useNavigate, useLocation } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
 import * as Sentry from "@sentry/react";
 import { api, ApiError } from "./api";
+import { AuthCtx, useOptionalAuth, type AuthContextValue } from "./authContext";
 import { authBus } from "./queryKeys";
 import { MeSchema, type Me } from "./schemas";
 
 export type { Me };
-
-type Ctx = {
-  me: Me | null;
-  loading: boolean;
-  refresh: () => Promise<void>;
-  logout: () => Promise<void>;
-  workspaceId: string | null;
-  switchWorkspace: (id: string) => Promise<void>;
-};
-
-const AuthCtx = createContext<Ctx | undefined>(undefined);
+export { useOptionalAuth };
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [me, setMe] = useState<Me | null>(null);
@@ -167,12 +157,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   );
 }
 
-export function useAuth(): Ctx {
+export function useAuth(): AuthContextValue {
   const ctx = useContext(AuthCtx);
   if (!ctx) throw new Error("useAuth must be used inside <AuthProvider>");
   return ctx;
-}
-
-export function useOptionalAuth(): Ctx | undefined {
-  return useContext(AuthCtx);
 }

--- a/web/src/lib/authContext.tsx
+++ b/web/src/lib/authContext.tsx
@@ -1,0 +1,18 @@
+import { createContext, useContext } from "react";
+
+import type { Me } from "./schemas";
+
+export type AuthContextValue = {
+  me: Me | null;
+  loading: boolean;
+  refresh: () => Promise<void>;
+  logout: () => Promise<void>;
+  workspaceId: string | null;
+  switchWorkspace: (id: string) => Promise<void>;
+};
+
+export const AuthCtx = createContext<AuthContextValue | undefined>(undefined);
+
+export function useOptionalAuth(): AuthContextValue | undefined {
+  return useContext(AuthCtx);
+}


### PR DESCRIPTION
## Summary
- Scope DataTable localStorage preference keys by active workspace id.
- Reload hidden-column and density preferences when the workspace-scoped key changes.
- Add pure key and DOM regression coverage for per-workspace preferences.

## Validation
- npm --prefix web run test -- DataTable
- npm --prefix web run typecheck
- npm exec eslint -- src/components/DataTable.tsx src/components/DataTable.test.tsx src/components/__dom__/DataTable.dom.test.tsx src/lib/auth.tsx
- npm --prefix web run lint (fails on existing web/src/lib/bagCode.ts no-control-regex errors unrelated to this change)

Closes #586