### PR TITLE
[codex] Surface request IDs in frontend errors

### DIFF
--- a/web/src/components/__dom__/ThemedToaster.dom.test.tsx
+++ b/web/src/components/__dom__/ThemedToaster.dom.test.tsx
@@ -1,0 +1,37 @@
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { toast } from "sonner";
+import { ApiError } from "@/lib/api";
+import ThemedToaster from "../ThemedToaster";
+
+vi.mock("@/lib/theme", () => ({
+  useTheme: () => ({ resolved: "light" }),
+}));
+
+afterEach(() => {
+  act(() => {
+    toast.dismiss();
+  });
+  cleanup();
+});
+
+describe("ThemedToaster", () => {
+  it("test_request_id_shown_on_error", async () => {
+    const error = new ApiError(
+      500,
+      {
+        data: null,
+        status: { category: "server_error", message: "boom" },
+        request_id: "req-aud-062",
+      },
+      "boom",
+    );
+
+    render(<ThemedToaster />);
+    act(() => {
+      toast.error(error.userMessage);
+    });
+
+    expect(await screen.findByText(/Request ID: req-aud-062/i)).toBeDefined();
+  });
+});

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -20,12 +20,12 @@ beforeEach(() => {
   vi.restoreAllMocks();
 });
 
-function mockFetch(status: number, body: unknown) {
+function mockFetch(status: number, body: unknown, headers: Record<string, string> = {}) {
   global.fetch = vi.fn().mockResolvedValue({
     ok: status >= 200 && status < 300,
     status,
     statusText: "ok",
-    headers: new Headers({ "content-type": "application/json" }),
+    headers: new Headers({ "content-type": "application/json", ...headers }),
     json: async () => body,
   } as Response);
 }
@@ -203,5 +203,40 @@ describe("ApiError.userMessage", () => {
     expect(caught).not.toBeNull();
     expect(caught!.userMessage).toBe("Not found.");
     expect(caught!.message).toBe("part not found");
+  });
+
+  it("exposes request_id from the error envelope and includes it in userMessage", () => {
+    const err = new ApiError(
+      500,
+      {
+        data: null,
+        status: { category: "server_error", message: "boom" },
+        request_id: "req-aud-062",
+      },
+      "boom",
+    );
+    expect(err.request_id).toBe("req-aud-062");
+    expect(err.requestId).toBe("req-aud-062");
+    expect(err.userMessage).toContain("Request ID: req-aud-062");
+  });
+
+  it("falls back to X-Request-Id when the error body omits request_id", async () => {
+    mockFetch(
+      429,
+      {
+        data: null,
+        status: { category: "rate_limited", message: "rate limit exceeded" },
+      },
+      { "x-request-id": "req-from-header" },
+    );
+    let caught: ApiError | null = null;
+    try {
+      await api.parsed.get("/whatever", Schema);
+    } catch (e) {
+      if (e instanceof ApiError) caught = e;
+    }
+    expect(caught).not.toBeNull();
+    expect(caught!.request_id).toBe("req-from-header");
+    expect(caught!.userMessage).toContain("Request ID: req-from-header");
   });
 });

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -24,6 +24,7 @@ export type ApiErr = {
   status: { category: string; message: string };
   code?: string;
   errors?: { field: string; message: string }[];
+  request_id?: string;
 };
 
 const BASE = "/api";
@@ -50,16 +51,43 @@ export function categoryToUserMessage(category: string | undefined | null): stri
   }
 }
 
+function normalizeRequestId(value: string | null | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed || undefined;
+}
+
+function requestIdFromBody(body: ApiErr | null): string | undefined {
+  return normalizeRequestId(body?.request_id);
+}
+
+function messageWithRequestId(message: string, requestId: string | undefined): string {
+  return requestId ? `${message} Request ID: ${requestId}` : message;
+}
+
 export class ApiError extends Error {
   status: number;
   body: ApiErr | null;
+  /** Backend correlation id from `request_id` / `X-Request-Id`, safe to show to users. */
+  request_id: string | undefined;
+  /** Camel-case alias for call sites that do not mirror the API envelope field name. */
+  requestId: string | undefined;
   /** Safe, human-readable message for display in toasts and banners. */
   userMessage: string;
-  constructor(status: number, body: ApiErr | null, message: string) {
+  constructor(
+    status: number,
+    body: ApiErr | null,
+    message: string,
+    requestId?: string | null,
+  ) {
     super(message);
     this.status = status;
     this.body = body;
-    this.userMessage = categoryToUserMessage(body?.status?.category);
+    this.request_id = requestIdFromBody(body) ?? normalizeRequestId(requestId);
+    this.requestId = this.request_id;
+    this.userMessage = messageWithRequestId(
+      categoryToUserMessage(body?.status?.category),
+      this.request_id,
+    );
   }
 
   get code(): string | undefined {
@@ -83,7 +111,7 @@ async function rawRequest(path: string, init: RequestInit = {}): Promise<unknown
     // envelope; narrow on the shape rather than reaching through `any`.
     const errBody = (body && typeof body === "object" ? (body as ApiErr) : null);
     const msg = errBody?.status?.message || res.statusText;
-    throw new ApiError(res.status, errBody, msg);
+    throw new ApiError(res.status, errBody, msg, res.headers.get("x-request-id"));
   }
   // Successful envelope — body is `{data, status}`. Pull `.data` after a
   // structural check so a non-conforming response surfaces as `null`


### PR DESCRIPTION
## Summary

- Carry backend `request_id` / `X-Request-Id` through `ApiError`.
- Include the request id in the safe frontend error message used by toasts and banners.
- Add a `ThemedToaster` DOM regression for an error toast that includes the request id.

Closes #601

## Validation

- `npm --prefix web run test -- ThemedToaster`
- `npm --prefix web run test -- api.test`
- `web/node_modules/.bin/eslint src/lib/api.ts src/lib/api.test.ts src/components/ThemedToaster.tsx src/components/__dom__/ThemedToaster.dom.test.tsx`
- `npm --prefix web run typecheck`

## Known Gate

- `npm --prefix web run lint` still fails on existing unrelated `web/src/lib/bagCode.ts` `no-control-regex` errors, plus existing unused-var warnings.
