### PR TITLE
AUD-045: Skip undefined route query keys

### DIFF
--- a/web/src/routes/builds/BuildDetail.test.tsx
+++ b/web/src/routes/builds/BuildDetail.test.tsx
@@ -97,17 +97,53 @@ function makeClient() {
   });
 }
 
-function renderBuildDetail() {
-  return render(
-    <QueryClientProvider client={makeClient()}>
-      <MemoryRouter initialEntries={["/builds/build-1"]}>
-        <Routes>
-          <Route path="/builds/:buildId" element={<BuildDetail />} />
-        </Routes>
-      </MemoryRouter>
-    </QueryClientProvider>,
-  );
+function renderBuildDetail(initialEntry = "/builds/build-1", routePath = "/builds/:buildId") {
+  const client = makeClient();
+  return {
+    client,
+    ...render(
+      <QueryClientProvider client={client}>
+        <MemoryRouter initialEntries={[initialEntry]}>
+          <Routes>
+            <Route path={routePath} element={<BuildDetail />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    ),
+  };
 }
+
+function containsUndefined(value: unknown): boolean {
+  if (value === undefined) return true;
+  if (Array.isArray(value)) return value.some(containsUndefined);
+  if (value && typeof value === "object") {
+    return Object.values(value as Record<string, unknown>).some(containsUndefined);
+  }
+  return false;
+}
+
+describe("BuildDetail query keys", () => {
+  it("does not mount queries without a build id route param", () => {
+    const { client } = renderBuildDetail("/builds", "/builds");
+
+    expect(screen.getByText("Missing build id.")).toBeTruthy();
+    expect(client.getQueryCache().getAll()).toHaveLength(0);
+    expect(api.get).not.toHaveBeenCalled();
+  });
+
+  it("does not register undefined key segments while the build is loading", () => {
+    vi.mocked(api.get).mockImplementation((path: string) => {
+      if (path === "/builds/build-1") return new Promise<never>(() => {});
+      return Promise.resolve(null);
+    });
+
+    const { client } = renderBuildDetail();
+    const keys = client.getQueryCache().getAll().map(query => query.queryKey);
+
+    expect(keys).toEqual([["ws", "ws-1", "build", "build-1"]]);
+    expect(keys.some(containsUndefined)).toBe(false);
+  });
+});
 
 beforeEach(() => {
   cleanup();

--- a/web/src/routes/builds/BuildDetail.tsx
+++ b/web/src/routes/builds/BuildDetail.tsx
@@ -19,25 +19,40 @@ type ConsumeRow = { part_id: string; quantity: number; storage_location_id?: str
 
 export default function BuildDetail() {
   const { buildId } = useParams<{ buildId: string }>();
-  const qc = useQueryClient();
-  const nav = useNavigate();
-  const { workspaceId } = useAuth();
 
+  if (!buildId) {
+    return <div className="text-red-600 text-sm p-4">Missing build id.</div>;
+  }
+
+  return <BuildDetailQuery key={buildId} buildId={buildId} />;
+}
+
+function BuildDetailQuery({ buildId }: { buildId: string }) {
   const { data, isError, error } = useQuery({
     queryKey: useWsKey("build", buildId),
     queryFn: () => api.get<DetailOut>(`/builds/${buildId}`),
-    enabled: !!buildId,
   });
-  const projectId = data?.build.project_id;
+
+  if (isError) return <div className="text-red-600 text-sm p-4">Failed to load build. {error instanceof ApiError ? error.userMessage : ""}</div>;
+  if (!data) return <div className="text-muted">Loading…</div>;
+
+  return <BuildDetailBody buildId={buildId} detail={data} />;
+}
+
+function BuildDetailBody({ buildId, detail }: { buildId: string; detail: DetailOut }) {
+  const qc = useQueryClient();
+  const nav = useNavigate();
+  const { workspaceId } = useAuth();
+  const { build, shortage } = detail;
+  const projectId = build.project_id;
+
   const { data: project } = useQuery({
     queryKey: useWsKey("project", projectId),
     queryFn: () => api.get<Project>(`/projects/${projectId}`),
-    enabled: !!projectId,
   });
   const { data: entries } = useQuery({
     queryKey: useWsKey("project", projectId, "entries"),
     queryFn: () => api.get<ProjectEntry[]>(`/projects/${projectId}/entries`),
-    enabled: !!projectId,
   });
   const { data: parts } = useQuery({ queryKey: useWsKey("parts"), queryFn: () => api.get<Part[]>("/parts?limit=200") });
   const { data: storage } = useQuery({ queryKey: useWsKey("storage"), queryFn: () => api.get<StorageLocation[]>("/storage") });
@@ -88,9 +103,6 @@ export default function BuildDetail() {
   });
 
 
-  if (isError) return <div className="text-red-600 text-sm p-4">Failed to load build. {error instanceof ApiError ? error.userMessage : ""}</div>;
-  if (!data) return <div className="text-muted">Loading…</div>;
-  const { build, shortage } = data;
   const isEditable = build.status === "planned" || build.status === "in_progress";
   const shortageByEntry = new Map(shortage.map(s => [s.project_entry_id, s]));
   const reservationsActive = isEditable && !build.archived_at;

--- a/web/src/routes/parts/detail/PartLayout.tsx
+++ b/web/src/routes/parts/detail/PartLayout.tsx
@@ -8,10 +8,18 @@ import type { Part } from "@/types";
 
 export default function PartLayout() {
   const { partId } = useParams<{ partId: string }>();
+
+  if (!partId) {
+    return <div className="text-red-600 text-sm p-4">Missing part id.</div>;
+  }
+
+  return <PartLayoutQuery key={partId} partId={partId} />;
+}
+
+function PartLayoutQuery({ partId }: { partId: string }) {
   const { data: part, isError, error } = useQuery({
     queryKey: useWsKey("part", partId),
     queryFn: () => api.get<Part>(`/parts/${partId}`),
-    enabled: !!partId,
   });
 
   if (isError) return <div className="text-red-600 text-sm p-4">Failed to load part. {error instanceof ApiError ? error.userMessage : ""}</div>;

--- a/web/src/routes/parts/detail/__dom__/PartLayout.queryKeys.dom.test.tsx
+++ b/web/src/routes/parts/detail/__dom__/PartLayout.queryKeys.dom.test.tsx
@@ -1,0 +1,100 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+import PartLayout from "../PartLayout";
+
+vi.mock("@/lib/api", () => {
+  class ApiError extends Error {
+    status: number;
+    body: unknown;
+    userMessage: string;
+
+    constructor(status: number, body: unknown, msg = "api error") {
+      super(msg);
+      this.status = status;
+      this.body = body;
+      this.userMessage = msg;
+    }
+  }
+
+  return {
+    ApiError,
+    api: {
+      get: vi.fn(),
+      post: vi.fn(),
+      patch: vi.fn(),
+      delete: vi.fn(),
+      upload: vi.fn(),
+    },
+  };
+});
+
+vi.mock("@/lib/auth", () => ({
+  useAuth: () => ({ workspaceId: "ws-1" }),
+}));
+
+vi.mock("@/components/EntityHeader", () => ({
+  default: ({ title }: { title: string }) => <div data-testid="entity-header">{title}</div>,
+}));
+
+vi.mock("@/components/SubNav", () => ({
+  default: () => <nav />,
+}));
+
+function makeClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+}
+
+function renderPartLayout(initialEntry: string, routePath: string) {
+  const client = makeClient();
+  return {
+    client,
+    ...render(
+      <QueryClientProvider client={client}>
+        <MemoryRouter initialEntries={[initialEntry]}>
+          <Routes>
+            <Route path={routePath} element={<PartLayout />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    ),
+  };
+}
+
+function containsUndefined(value: unknown): boolean {
+  if (value === undefined) return true;
+  if (Array.isArray(value)) return value.some(containsUndefined);
+  if (value && typeof value === "object") {
+    return Object.values(value as Record<string, unknown>).some(containsUndefined);
+  }
+  return false;
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("PartLayout query keys", () => {
+  it("does not mount queries without a part id route param", () => {
+    const { client } = renderPartLayout("/parts", "/parts");
+
+    expect(screen.getByText("Missing part id.")).toBeTruthy();
+    expect(client.getQueryCache().getAll()).toHaveLength(0);
+    expect(api.get).not.toHaveBeenCalled();
+  });
+
+  it("uses only defined key segments while the part is loading", () => {
+    vi.mocked(api.get).mockImplementation(() => new Promise<never>(() => {}));
+
+    const { client } = renderPartLayout("/parts/part-1", "/parts/:partId");
+    const keys = client.getQueryCache().getAll().map(query => query.queryKey);
+
+    expect(keys).toEqual([["ws", "ws-1", "part", "part-1"]]);
+    expect(keys.some(containsUndefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Guard BuildDetail and PartLayout route params before mounting TanStack query components.
- Split BuildDetail so project and entry queries mount only after build.project_id is available.
- Add regression tests that assert missing/loading route IDs do not register undefined query key segments.

## Validation
- `npm --prefix web run test -- BuildDetail PartLayout.queryKeys`
- `npm --prefix web run test`
- `npm --prefix web run typecheck`
- `npm exec -- eslint src/routes/builds/BuildDetail.tsx src/routes/builds/BuildDetail.test.tsx src/routes/parts/detail/PartLayout.tsx src/routes/parts/detail/__dom__/PartLayout.queryKeys.dom.test.tsx` from `web/`
- `git diff --check HEAD~1..HEAD`

## Known Issue
- `npm --prefix web run lint` still fails on the existing repository baseline: `web/src/lib/bagCode.ts` has `no-control-regex` errors at lines 91 and 164, plus unrelated unused-var warnings outside this patch.

Closes #584
