### PR TITLE
[codex] Scrub Sentry frontend query strings

### DIFF
--- a/web/src/instrument.test.ts
+++ b/web/src/instrument.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@sentry/react", () => ({
+  init: vi.fn(),
+  reactRouterV6BrowserTracingIntegration: vi.fn(() => ({ name: "router" })),
+  replayIntegration: vi.fn(() => ({ name: "replay" })),
+}));
+
+describe("Sentry beforeSend", () => {
+  it("test_beforesend_strips_query_string", async () => {
+    vi.resetModules();
+
+    const Sentry = await import("@sentry/react");
+    vi.mocked(Sentry.init).mockClear();
+
+    await import("./instrument");
+
+    const options = vi.mocked(Sentry.init).mock.calls[0]?.[0];
+    const beforeSend = options?.beforeSend;
+    expect(beforeSend).toBeTypeOf("function");
+    if (!beforeSend) {
+      throw new Error("Sentry beforeSend was not configured");
+    }
+
+    const event = {
+      type: undefined,
+      request: {
+        url: "https://parts.matescb.cz/parts/abc?token=secret&workspace_id=ws#stock?tab=lots",
+        query_string: "token=secret&workspace_id=ws",
+        method: "GET",
+        headers: {
+          Referer: "https://parts.matescb.cz/search?q=secret#results?sort=qty",
+        },
+      },
+      breadcrumbs: [
+        {
+          category: "fetch",
+          data: {
+            url: "/api/parts?search=secret",
+            to: "/projects?workspace=secret#bom?line=1",
+            method: "GET",
+          },
+        },
+      ],
+    } as Parameters<typeof beforeSend>[0];
+
+    const scrubbed = await Promise.resolve(beforeSend(event, {}));
+
+    expect(scrubbed?.request?.url).toBe("https://parts.matescb.cz/parts/abc#stock");
+    expect(scrubbed?.request?.query_string).toBeUndefined();
+    expect(scrubbed?.request?.headers?.Referer).toBe(
+      "https://parts.matescb.cz/search#results",
+    );
+    expect(scrubbed?.breadcrumbs?.[0]?.data?.url).toBe("/api/parts");
+    expect(scrubbed?.breadcrumbs?.[0]?.data?.to).toBe("/projects#bom");
+    expect(JSON.stringify(scrubbed)).not.toContain("secret");
+    expect(JSON.stringify(scrubbed)).not.toContain("?");
+  });
+});

--- a/web/src/instrument.ts
+++ b/web/src/instrument.ts
@@ -22,6 +22,31 @@ const tracesRaw = import.meta.env.VITE_SENTRY_TRACES_SAMPLE_RATE ?? "1.0";
 const tracesSampleRate = Number.isFinite(parseFloat(tracesRaw))
   ? parseFloat(tracesRaw)
   : 1.0;
+const requestHeaderDenylist = new Set(["cookie", "authorization", "x-workspace-id"]);
+const requestUrlHeaders = new Set(["referer", "referrer"]);
+const breadcrumbUrlKeys = new Set(["url", "from", "to"]);
+
+function stripQueryString(rawUrl: string): string {
+  const fragmentIndex = rawUrl.indexOf("#");
+  const beforeFragment = fragmentIndex === -1 ? rawUrl : rawUrl.slice(0, fragmentIndex);
+  const fragment = fragmentIndex === -1 ? "" : rawUrl.slice(fragmentIndex);
+  const queryIndex = beforeFragment.indexOf("?");
+  const fragmentQueryIndex = fragment.indexOf("?");
+
+  const cleanBeforeFragment =
+    queryIndex === -1 ? beforeFragment : beforeFragment.slice(0, queryIndex);
+  const cleanFragment =
+    fragmentQueryIndex === -1 ? fragment : fragment.slice(0, fragmentQueryIndex);
+  return `${cleanBeforeFragment}${cleanFragment}`;
+}
+
+function scrubUrlKeys(values: Record<string, unknown>, keys: ReadonlySet<string>) {
+  for (const key of Object.keys(values)) {
+    if (keys.has(key.toLowerCase()) && typeof values[key] === "string") {
+      values[key] = stripQueryString(values[key]);
+    }
+  }
+}
 
 Sentry.init({
   dsn,
@@ -55,13 +80,17 @@ Sentry.init({
   beforeSend(event) {
     const req = event.request;
     if (req) {
+      if (typeof req.url === "string") {
+        req.url = stripQueryString(req.url);
+      }
+      delete (req as Record<string, unknown>).query_string;
       if (req.headers) {
-        const drop = new Set(["cookie", "authorization", "x-workspace-id"]);
         for (const k of Object.keys(req.headers)) {
-          if (drop.has(k.toLowerCase())) {
+          if (requestHeaderDenylist.has(k.toLowerCase())) {
             delete (req.headers as Record<string, unknown>)[k];
           }
         }
+        scrubUrlKeys(req.headers as Record<string, unknown>, requestUrlHeaders);
       }
       const method = (req.method ?? "").toUpperCase();
       if (method && method !== "GET") {
@@ -69,6 +98,11 @@ Sentry.init({
           delete req.data;
           (req as Record<string, unknown>).body_redacted = true;
         }
+      }
+    }
+    for (const breadcrumb of event.breadcrumbs ?? []) {
+      if (breadcrumb.data) {
+        scrubUrlKeys(breadcrumb.data, breadcrumbUrlKeys);
       }
     }
     return event;


### PR DESCRIPTION
## Summary

- Strip query strings from Sentry frontend event request URLs and remove `request.query_string`.
- Scrub query strings from referrer headers and URL-bearing breadcrumb fields before events are sent.
- Add focused regression coverage for the frontend `beforeSend` scrubber.

## Validation

- `npm --prefix web run test -- instrument`
- `npx --prefix web eslint web/src/instrument.ts web/src/instrument.test.ts`
- `npm --prefix web run typecheck`
- `npm --prefix web run lint` fails on existing unrelated lint issues in `web/src/lib/bagCode.ts` (`no-control-regex`) plus unrelated unused-variable warnings.

Closes #600
