### PR TITLE
AUD-064: Drop legacy invitation token hash

### DIFF
--- a/backend/alembic/versions/0049_drop_invitation_token_hash.py
+++ b/backend/alembic/versions/0049_drop_invitation_token_hash.py
@@ -1,0 +1,45 @@
+"""Drop legacy workspace invitation token_hash.
+
+Revision ID: 0049
+Revises: 0048
+Create Date: 2026-05-14
+
+Invitation acceptance has used token_hmac since 0022, so the older
+plaintext SHA-256 token_hash no longer participates in lookups or
+validation. Keeping it only widens the data exposed by a DB dump.
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "0049"
+down_revision = "0048"
+branch_labels = None
+depends_on = None
+
+
+_TABLE = "workspace_invitations"
+_COLUMN = "token_hash"
+_CONSTRAINT = "uq_workspace_invitation_token_hash"
+
+
+def upgrade() -> None:
+    op.drop_constraint(_CONSTRAINT, _TABLE, type_="unique")
+    op.drop_column(_TABLE, _COLUMN)
+
+
+def downgrade() -> None:
+    """Structurally re-add the legacy column for rollback.
+
+    The SHA-256 digest cannot be recovered from token_hmac or from the
+    one-time plaintext invitation token, so restored rows get NULL.
+    PostgreSQL unique constraints allow multiple NULLs; newly created
+    rows from rolled-back application code can still write real digests.
+    """
+
+    op.add_column(
+        _TABLE,
+        sa.Column(_COLUMN, sa.String(length=64), nullable=True),
+    )
+    op.create_unique_constraint(_CONSTRAINT, _TABLE, [_COLUMN])

--- a/backend/app/api/routes/invitations.py
+++ b/backend/app/api/routes/invitations.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import hashlib
 import hmac as _hmac
 import secrets
 from uuid import UUID
@@ -28,17 +27,6 @@ from app.domain.workspaces.schemas import AcceptIn, InviteIn
 router = APIRouter()
 
 
-def _hash_token(plaintext: str) -> str:
-    """SHA-256 hex digest of the plaintext token.
-
-    Used only to populate `token_hash` at creation time (for backward
-    compatibility — the unique index on `token_hash` still exists).
-    Accept flow no longer queries by this value; it uses `_hmac_token`
-    + `hmac.compare_digest` instead (SEC2-013).
-    """
-    return hashlib.sha256(plaintext.encode("utf-8")).hexdigest()
-
-
 def _hmac_token(plaintext: str) -> str:
     """HMAC-SHA-256 (keyed on SESSION_SECRET) hex digest of the plaintext.
 
@@ -56,7 +44,7 @@ def _serialize(inv: WorkspaceInvitation, *, plaintext_token: str | None = None) 
 
     `plaintext_token` is set ONLY in the create response — the only
     moment the plaintext exists. Subsequent reads (list, revoke) never
-    have it, because the DB stores only the hash. The caller is
+    have it, because the DB stores only the keyed digest. The caller is
     responsible for delivering the plaintext to the invitee out-of-band
     immediately (typically via the link embedded in the response).
 
@@ -142,9 +130,8 @@ def create_invitation(
         return ok(_serialize(existing))
 
     # Mint a new token. 32 bytes urlsafe ≈ 256 bits of entropy — well
-    # past brute-force feasibility. Both the SHA-256 hash (for backward
-    # compatibility / unique index) and the HMAC digest (SEC2-013, used
-    # at accept time with compare_digest) go to the DB; the plaintext
+    # past brute-force feasibility. Only the HMAC digest (SEC2-013, used
+    # at accept time with compare_digest) goes to the DB; the plaintext
     # goes back to the caller exactly once via the response.
     plaintext = secrets.token_urlsafe(32)
     # Cache workspace_id as a plain Python value before the savepoint so
@@ -155,7 +142,6 @@ def create_invitation(
         workspace_id=ws_id,
         email=email,
         role=payload.role,
-        token_hash=_hash_token(plaintext),
         token_hmac=_hmac_token(plaintext),
         invited_by=user.id,
     )
@@ -398,4 +384,10 @@ def accept_invitation(request: Request, payload: AcceptIn, db: DbSession, user: 
             target_ids=[inv_id],
             comment=f"email={inv_email} role={inv_role}",
         )
-    return ok({"workspace_id": str(inv_workspace_id), "workspace_name": workspace.name if workspace else None, "role": inv_role})
+    return ok(
+        {
+            "workspace_id": str(inv_workspace_id),
+            "workspace_name": workspace.name if workspace else None,
+            "role": inv_role,
+        }
+    )

--- a/backend/app/domain/workspaces/models.py
+++ b/backend/app/domain/workspaces/models.py
@@ -143,7 +143,6 @@ class WorkspaceMember(Base):
 class WorkspaceInvitation(Base):
     __tablename__ = "workspace_invitations"
     __table_args__ = (
-        UniqueConstraint("token_hash", name="uq_workspace_invitation_token_hash"),
         # Partial unique index: at most one pending invitation per
         # (workspace, email) pair. Added by migration 0023 (BE2-020 / #65).
         # The partial condition (status = 'pending') allows a new invite
@@ -166,9 +165,6 @@ class WorkspaceInvitation(Base):
     )
     email = Column(String(320), nullable=False, index=True)
     role = Column(String(40), nullable=False, default="member")
-    # SHA-256 hex digest of the plaintext token. Kept for backward
-    # compatibility; new rows also set token_hmac. See token_hmac below.
-    token_hash = Column(String(64), nullable=False)
     # HMAC-SHA-256 (keyed on SESSION_SECRET) of the plaintext token.
     # SEC2-013: the accept flow looks up by id (PK) and then calls
     # hmac.compare_digest against this column — no timing oracle.

--- a/backend/tests/test_invitation_partial_unique.py
+++ b/backend/tests/test_invitation_partial_unique.py
@@ -87,7 +87,6 @@ def test_accept_then_reinvite_same_email_succeeds(admin):
             workspace_id=uuid.UUID(ws_id),
             email=invitee_email,
             role="member",
-            token_hash="new-hash-" + uuid.uuid4().hex,
             status="pending",
         )
         s.add(inv2)
@@ -114,7 +113,6 @@ def test_duplicate_pending_same_email_rejected_at_db(admin):
             workspace_id=uuid.UUID(ws_id),
             email=invitee_email,
             role="viewer",
-            token_hash="conflict-hash-" + uuid.uuid4().hex,
             status="pending",
         )
         s.add(inv2)

--- a/backend/tests/test_invitations.py
+++ b/backend/tests/test_invitations.py
@@ -72,18 +72,14 @@ def test_non_admin_cannot_invite():
     owner = TestClient(app)
     _signup(owner)
     invitee_email = f"member-{uuid.uuid4().hex[:6]}@x.com"
-    inv = owner.post("/api/invitations", json={"email": invitee_email, "role": "member"}).json()["data"]
+    inv = owner.post(
+        "/api/invitations", json={"email": invitee_email, "role": "member"}
+    ).json()["data"]
 
     invitee = TestClient(app)
     _do_signup_verify(invitee, email=invitee_email, name="M")
     invitee.post("/api/invitations/accept", json={"token": inv["token"]})
-    # Switch to the shared workspace
-    members_in_admin = owner.get("/api/workspaces/members").json()["data"]
-    shared_ws = members_in_admin[0]["user_id"]  # not actually used; cookie was set on signup
-    # Force switch via cookie
     me = invitee.get("/api/auth/me").json()["data"]
-    target_ws = next(w["id"] for w in me["workspaces"] if w["name"] != "Newbie's workspace") if False else owner.get("/api/workspaces/members").json()["data"]
-    # simpler: extract from list_workspaces
     wss = invitee.get("/api/workspaces").json()["data"]
     shared = next(w for w in wss if w["id"] != me["workspaces"][0]["id"])
     invitee.post(f"/api/workspaces/{shared['id']}/switch")
@@ -103,7 +99,9 @@ def test_invitation_email_must_match(admin):
 
 def test_revoke_invitation_blocks_acceptance(admin):
     invitee_email = f"r-{uuid.uuid4().hex[:6]}@x.com"
-    inv = admin.post("/api/invitations", json={"email": invitee_email, "role": "member"}).json()["data"]
+    inv = admin.post(
+        "/api/invitations", json={"email": invitee_email, "role": "member"}
+    ).json()["data"]
     r = admin.delete(f"/api/invitations/{inv['id']}")
     assert r.status_code == 200
 
@@ -122,7 +120,9 @@ def test_cannot_demote_last_owner(admin):
 
 def test_cannot_already_member(admin):
     invitee_email = f"dup-{uuid.uuid4().hex[:6]}@x.com"
-    inv = admin.post("/api/invitations", json={"email": invitee_email, "role": "member"}).json()["data"]
+    inv = admin.post(
+        "/api/invitations", json={"email": invitee_email, "role": "member"}
+    ).json()["data"]
     invitee = TestClient(app)
     _do_signup_verify(invitee, email=invitee_email, name="x")
     invitee.post("/api/invitations/accept", json={"token": inv["token"]})
@@ -138,14 +138,12 @@ def test_cannot_already_member(admin):
 
 def test_token_is_stored_as_hash_not_plaintext(admin):
     """The composite token returned to the caller must NOT appear in plaintext
-    in the DB.  The DB has only the SHA-256 digest (token_hash) and the
-    HMAC-SHA-256 digest (token_hmac).
+    in the DB.  The DB has only the HMAC-SHA-256 digest (token_hmac).
 
     SEC2-013: the create response now returns a composite token of the form
     "{invitation_id}:{plaintext_token}" so the accept flow can look up by
     PK rather than by hash (no timing oracle).
     """
-    import hashlib
     import hmac as _hmac
 
     invitee_email = f"hash-{uuid.uuid4().hex[:6]}@x.com"
@@ -167,11 +165,9 @@ def test_token_is_stored_as_hash_not_plaintext(admin):
     with SessionLocal() as s:
         row = s.get(WorkspaceInvitation, uuid.UUID(inv["id"]))
         assert row is not None
-        # The plaintext is gone — the model only has token_hash and token_hmac.
+        # The plaintext and legacy SHA-256 digest are gone; only token_hmac remains.
         assert not hasattr(row, "token") or getattr(row, "token", None) is None
-        assert row.token_hash == hashlib.sha256(plaintext.encode("utf-8")).hexdigest()
-        # token_hash is NOT the plaintext.
-        assert row.token_hash != plaintext
+        assert not hasattr(row, "token_hash")
         # token_hmac is present and is the HMAC-SHA-256 of the plaintext.
         assert row.token_hmac is not None
         key = settings().SESSION_SECRET.encode("utf-8")

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import os
 import uuid
+from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
 
@@ -183,11 +184,19 @@ def _snapshot_schema(url: str) -> dict:
 
 
 @pytest.fixture(scope="module")
-def round_trip_url() -> str:
+def round_trip_url() -> Iterator[str]:
     url = _migration_db_url()
     _ensure_db_exists(url)
     _reset_schema(url)
-    return url
+    previous_url = os.environ.get("DATABASE_URL")
+    os.environ["DATABASE_URL"] = url
+    try:
+        yield url
+    finally:
+        if previous_url is None:
+            os.environ.pop("DATABASE_URL", None)
+        else:
+            os.environ["DATABASE_URL"] = previous_url
 
 
 def test_workspace_member_role_check_constraint_enforced(round_trip_url: str) -> None:
@@ -302,6 +311,48 @@ def test_downgrade_to_base_leaves_only_alembic_version(
         f"downgrade base left tables behind: {leftover}. Some "
         "migration's downgrade() is incomplete."
     )
+
+
+@pytest.mark.slow
+def test_invitation_token_hash_drop_round_trips(round_trip_url: str) -> None:
+    """0049 drops the legacy SHA-256 invitation token_hash column."""
+    cfg = _alembic_config(round_trip_url)
+
+    def invitation_columns() -> set[str]:
+        eng = create_engine(round_trip_url, future=True)
+        try:
+            insp = inspect(eng)
+            return {col["name"] for col in insp.get_columns("workspace_invitations")}
+        finally:
+            eng.dispose()
+
+    def invitation_unique_constraints() -> set[str]:
+        eng = create_engine(round_trip_url, future=True)
+        try:
+            insp = inspect(eng)
+            return {
+                constraint["name"]
+                for constraint in insp.get_unique_constraints("workspace_invitations")
+            }
+        finally:
+            eng.dispose()
+
+    _reset_schema(round_trip_url)
+    command.upgrade(cfg, "0048")
+    assert "token_hash" in invitation_columns()
+    assert "uq_workspace_invitation_token_hash" in invitation_unique_constraints()
+
+    command.upgrade(cfg, "0049")
+    assert "token_hash" not in invitation_columns()
+    assert "uq_workspace_invitation_token_hash" not in invitation_unique_constraints()
+
+    command.downgrade(cfg, "0048")
+    assert "token_hash" in invitation_columns()
+    assert "uq_workspace_invitation_token_hash" in invitation_unique_constraints()
+
+    command.upgrade(cfg, "0049")
+    assert "token_hash" not in invitation_columns()
+    assert "uq_workspace_invitation_token_hash" not in invitation_unique_constraints()
 
 
 @pytest.mark.slow


### PR DESCRIPTION
## Summary
- add migration 0048 to drop workspace_invitations.token_hash and its unique constraint
- stop writing the legacy SHA-256 invitation digest; keep token_hmac as the only stored invitation token verifier
- update invitation and migration tests for the dropped column

## Validation
- MIGRATION_TEST_DATABASE_URL=postgresql+psycopg://stockmgr:stockmgr@127.0.0.1:5432/stockmgr_test_aud064_migration_rt_final uv run --project backend --extra dev python -m pytest backend/tests/test_migrations.py -q -m slow
- DATABASE_URL=postgresql+psycopg://stockmgr:stockmgr@127.0.0.1:5432/stockmgr_test_aud064_final uv run --project backend --extra dev python -m pytest backend/tests/test_invitations.py backend/tests/test_invitation_partial_unique.py -q
- LINT_CMD="ruff check app --output-format=concise" BASELINE_FILE="../.ruff-baseline.txt" WORK_DIR="." bash ../scripts/lint-delta.sh
- uv run --project backend --extra dev ruff check backend/tests/test_migrations.py
- uv run --extra dev alembic heads

Closes #603