### PR TITLE
[codex] AUD-036 confirm dialog a11y

### DIFF
--- a/web/src/components/ConfirmDialog.test.tsx
+++ b/web/src/components/ConfirmDialog.test.tsx
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ConfirmDialogProvider, useConfirm } from "./ConfirmDialog";
+
+beforeEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+function ConfirmHarness() {
+  const confirm = useConfirm();
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        void confirm({
+          title: "Delete part",
+          message: "Delete this part?",
+          severity: "danger",
+        });
+      }}
+    >
+      Open confirm
+    </button>
+  );
+}
+
+function renderConfirmDialog() {
+  return render(
+    <ConfirmDialogProvider>
+      <button type="button">Outside</button>
+      <ConfirmHarness />
+    </ConfirmDialogProvider>,
+  );
+}
+
+describe("ConfirmDialog", () => {
+  it("labels the dialog with aria-labelledby", async () => {
+    const user = userEvent.setup();
+    renderConfirmDialog();
+
+    await user.click(screen.getByRole("button", { name: "Open confirm" }));
+
+    const dialog = await screen.findByRole("dialog", { name: "Delete part" });
+    const labelledBy = dialog.getAttribute("aria-labelledby");
+    expect(dialog.getAttribute("aria-modal")).toBe("true");
+    expect(labelledBy).toBeTruthy();
+    expect(labelledBy ? document.getElementById(labelledBy)?.textContent : null).toBe("Delete part");
+  });
+
+  it("test_focus_trapped", async () => {
+    const user = userEvent.setup();
+    renderConfirmDialog();
+
+    await user.click(screen.getByRole("button", { name: "Open confirm" }));
+
+    const dialog = await screen.findByRole("dialog", { name: "Delete part" });
+    const cancelButton = within(dialog).getByRole("button", { name: "Cancel" });
+    const confirmButton = within(dialog).getByRole("button", { name: "Delete" });
+    await waitFor(() => expect(document.activeElement).toBe(confirmButton));
+
+    fireEvent.keyDown(window, { key: "Tab" });
+    expect(document.activeElement).toBe(cancelButton);
+
+    fireEvent.keyDown(window, { key: "Tab", shiftKey: true });
+    expect(document.activeElement).toBe(confirmButton);
+
+    screen.getByRole("button", { name: "Outside" }).focus();
+    fireEvent.keyDown(window, { key: "Tab" });
+    expect(document.activeElement).toBe(cancelButton);
+  });
+});

--- a/web/src/components/ConfirmDialog.tsx
+++ b/web/src/components/ConfirmDialog.tsx
@@ -28,6 +28,7 @@ import {
   type ReactNode,
 } from "react";
 import { createPortal } from "react-dom";
+import { Modal } from "./Modal";
 
 type Severity = "default" | "danger" | "warning";
 
@@ -84,22 +85,6 @@ export function ConfirmDialogProvider({ children }: { children: ReactNode }) {
     }
   }, [state]);
 
-  // Esc closes (cancels) the dialog. Capture-phase so app-wide handlers
-  // don't swallow it first.
-  useEffect(() => {
-    if (state.kind === "none") return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        e.preventDefault();
-        if (state.kind === "confirm") state.resolve(false);
-        if (state.kind === "prompt") state.resolve(null);
-        setState({ kind: "none" });
-      }
-    };
-    window.addEventListener("keydown", onKey, true);
-    return () => window.removeEventListener("keydown", onKey, true);
-  }, [state]);
-
   const confirm = useCallback((opts: ConfirmOptions) => {
     return new Promise<boolean>((resolve) => {
       // If something else is already open, drop it (resolve false) and
@@ -119,6 +104,14 @@ export function ConfirmDialogProvider({ children }: { children: ReactNode }) {
         if (prev.kind === "prompt") prev.resolve(null);
         return { kind: "prompt", opts, resolve };
       });
+    });
+  }, []);
+
+  const cancelActiveDialog = useCallback(() => {
+    setState((prev) => {
+      if (prev.kind === "confirm") prev.resolve(false);
+      if (prev.kind === "prompt") prev.resolve(null);
+      return { kind: "none" };
     });
   }, []);
 
@@ -147,10 +140,7 @@ export function ConfirmDialogProvider({ children }: { children: ReactNode }) {
               if (state.kind === "confirm") closeWith(true);
               if (state.kind === "prompt") closeWith(inputValue);
             }}
-            onCancel={() => {
-              if (state.kind === "confirm") closeWith(false);
-              if (state.kind === "prompt") closeWith(null);
-            }}
+            onCancel={cancelActiveDialog}
           />,
           document.body,
         )}
@@ -180,6 +170,7 @@ function DialogShell({
     state.kind === "prompt" ? "Enter a value" : severity === "danger" ? "Confirm delete" : "Confirm";
   const defaultConfirmLabel =
     isPrompt ? "OK" : severity === "danger" ? "Delete" : severity === "warning" ? "Continue" : "OK";
+  const title = opts.title ?? defaultTitle;
 
   const confirmClass =
     severity === "danger"
@@ -187,52 +178,51 @@ function DialogShell({
       : severity === "warning"
         ? "btn border-warning/50 bg-warning/10 text-warning hover:bg-warning/20"
         : "btn-primary";
+  const confirmButtonRef = useRef<HTMLButtonElement>(null);
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
-      role="dialog"
-      aria-modal="true"
-      onMouseDown={(e) => {
-        // Click outside the panel cancels.
-        if (e.target === e.currentTarget) onCancel();
-      }}
+    <Modal
+      open
+      onClose={onCancel}
+      title={title}
+      initialFocusRef={isPrompt ? inputRef : confirmButtonRef}
+      size="sm"
+      className="card max-w-md w-full p-4 space-y-3 shadow-lg"
     >
-      <div className="card max-w-md w-full p-4 space-y-3 shadow-lg">
-        <h2 className="text-base font-semibold text-text">
-          {opts.title ?? defaultTitle}
-        </h2>
-        <p className="text-sm text-text whitespace-pre-wrap">{opts.message}</p>
-        {state.kind === "prompt" && (
-          <input
-            ref={inputRef}
-            className="input"
-            value={inputValue}
-            onChange={(e) => setInputValue(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") {
-                e.preventDefault();
-                onConfirm();
-              }
-            }}
-            placeholder={(state.opts as PromptOptions).placeholder}
-          />
-        )}
-        <div className="flex justify-end gap-2 pt-2">
-          <button type="button" className="btn-ghost" onClick={onCancel}>
-            {opts.cancelLabel ?? "Cancel"}
-          </button>
-          <button
-            type="button"
-            className={confirmClass}
-            onClick={onConfirm}
-            autoFocus={!isPrompt}
-          >
-            {opts.confirmLabel ?? defaultConfirmLabel}
-          </button>
-        </div>
+      <h2 className="text-base font-semibold text-text">
+        {title}
+      </h2>
+      <p className="text-sm text-text whitespace-pre-wrap">{opts.message}</p>
+      {state.kind === "prompt" && (
+        <input
+          ref={inputRef}
+          className="input"
+          value={inputValue}
+          onChange={(e) => setInputValue(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              onConfirm();
+            }
+          }}
+          placeholder={(state.opts as PromptOptions).placeholder}
+        />
+      )}
+      <div className="flex justify-end gap-2 pt-2">
+        <button type="button" className="btn-ghost" onClick={onCancel}>
+          {opts.cancelLabel ?? "Cancel"}
+        </button>
+        <button
+          ref={confirmButtonRef}
+          type="button"
+          className={confirmClass}
+          onClick={onConfirm}
+          autoFocus={!isPrompt}
+        >
+          {opts.confirmLabel ?? defaultConfirmLabel}
+        </button>
       </div>
-    </div>
+    </Modal>
   );
 }
 


### PR DESCRIPTION
## Summary
- Render ConfirmDialog through the shared Modal shell so it gets aria-labelledby, focus trapping, ESC/backdrop close, and focus restoration.
- Add ConfirmDialog regression coverage for the dialog label and Tab wrapping behavior.

## Validation
- npm --prefix web run test -- ConfirmDialog
- npm --prefix web run test -- ConfirmDialog Modal
- npm --prefix web run typecheck
- npm exec eslint -- src/components/ConfirmDialog.tsx src/components/ConfirmDialog.test.tsx (from web/)
- git diff --check

## Notes
- Full npm --prefix web run lint is currently blocked by unrelated pre-existing no-control-regex errors in web/src/lib/bagCode.ts; scoped eslint on changed files passes.

Closes #575
