### PR TITLE
AUD-037: Validate external URL schemes

### DIFF
--- a/web/src/components/AttachmentsPanel.tsx
+++ b/web/src/components/AttachmentsPanel.tsx
@@ -7,6 +7,7 @@ import { useWsKey } from "@/lib/queryKeys";
 import { useConfirm } from "@/components/ConfirmDialog";
 import { InlineQueryError } from "@/components/QueryStateBoundary";
 import { formatDateTime } from "@/lib/format";
+import { isSafeSameOriginPath } from "@/lib/url";
 
 type Attachment = {
   id: string;
@@ -282,33 +283,39 @@ export default function AttachmentsPanel({ objectType, objectId, canWrite }: Pro
         <div className="text-muted text-sm">No attachments yet.</div>
       ) : (
         <ul className="divide-y divide-border">
-          {data.map(a => (
-            <li key={a.id} className="py-2 flex items-center gap-3">
-              <div className="min-w-0 flex-1">
-                <div className="flex items-center gap-2">
-                  <span className="truncate font-medium text-sm">{a.file_name}</span>
-                  <span className="pill text-[10px] uppercase">{a.file_type}</span>
+          {data.map(a => {
+            const downloadUrl = `/api/attachments/${a.id}/download`;
+            const safeDownloadUrl = isSafeSameOriginPath(downloadUrl) ? downloadUrl : null;
+            return (
+              <li key={a.id} className="py-2 flex items-center gap-3">
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <span className="truncate font-medium text-sm">{a.file_name}</span>
+                    <span className="pill text-[10px] uppercase">{a.file_type}</span>
+                  </div>
+                  <div className="text-xs text-muted">
+                    {humanSize(a.size_bytes)} · {formatDateTime(a.created_at)}
+                  </div>
                 </div>
-                <div className="text-xs text-muted">
-                  {humanSize(a.size_bytes)} · {formatDateTime(a.created_at)}
-                </div>
-              </div>
-              <a
-                className="btn text-xs"
-                href={`/api/attachments/${a.id}/download`}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                <Download className="inline w-3 h-3 mr-1" />
-                Download
-              </a>
-              {canWrite && (
-                <button className="btn-danger text-xs" onClick={() => doDelete(a)}>
-                  <Trash2 className="inline w-3 h-3" />
-                </button>
-              )}
-            </li>
-          ))}
+                {safeDownloadUrl && (
+                  <a
+                    className="btn text-xs"
+                    href={safeDownloadUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <Download className="inline w-3 h-3 mr-1" />
+                    Download
+                  </a>
+                )}
+                {canWrite && (
+                  <button className="btn-danger text-xs" onClick={() => doDelete(a)}>
+                    <Trash2 className="inline w-3 h-3" />
+                  </button>
+                )}
+              </li>
+            );
+          })}
         </ul>
       )}
     </div>

--- a/web/src/components/EntityHeader.tsx
+++ b/web/src/components/EntityHeader.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from "react";
+import { isSafeHttpOrSameOriginUrl } from "@/lib/url";
 
 export type Stat = { label: string; value: ReactNode; tone?: "default" | "danger" | "warning" | "success" };
 
@@ -36,21 +37,23 @@ export default function EntityHeader({
   stats,
   imageUrl,
 }: Props) {
+  const safeImageUrl = isSafeHttpOrSameOriginUrl(imageUrl) ? imageUrl : null;
+
   return (
     <div className="card p-4 mb-4">
       {breadcrumb && <div className="text-xs text-muted mb-2">{breadcrumb}</div>}
       <div className="flex items-start justify-between gap-4">
         <div className="flex items-start gap-3 min-w-0">
-          {imageUrl && (
+          {safeImageUrl && (
             <a
-              href={imageUrl}
+              href={safeImageUrl}
               target="_blank"
               rel="noopener noreferrer"
               className="shrink-0 block"
               aria-label="Open full image"
             >
               <img
-                src={imageUrl}
+                src={safeImageUrl}
                 alt=""
                 className="h-14 w-14 object-contain rounded bg-panel"
               />

--- a/web/src/components/PoweredByTrustedParts.tsx
+++ b/web/src/components/PoweredByTrustedParts.tsx
@@ -1,3 +1,5 @@
+import { isSafeHttpUrl } from "@/lib/url";
+
 const DEFAULT_TRUSTEDPARTS_URL = "https://www.trustedparts.com";
 
 type Props = {
@@ -18,11 +20,14 @@ export function PoweredByTrustedParts({
     size === "md" ? "text-sm" : "",
     className ?? "",
   ].filter(Boolean).join(" ");
+  const href = primaryUrl && isSafeHttpUrl(primaryUrl)
+    ? primaryUrl
+    : DEFAULT_TRUSTEDPARTS_URL;
 
   return (
     <a
       className={classes}
-      href={primaryUrl ?? DEFAULT_TRUSTEDPARTS_URL}
+      href={href}
       target="_blank"
       rel="noopener noreferrer"
     >

--- a/web/src/lib/url.test.ts
+++ b/web/src/lib/url.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import {
+  isSafeHttpOrSameOriginUrl,
+  isSafeHttpUrl,
+  isSafeSameOriginPath,
+} from "./url";
+
+describe("isSafeHttpUrl", () => {
+  it("test_isSafeHttpUrl_rejects_javascript", () => {
+    expect(isSafeHttpUrl("javascript:alert(1)")).toBe(false);
+  });
+
+  it("rejects data URLs", () => {
+    expect(isSafeHttpUrl("data:text/html,<script>alert(1)</script>")).toBe(false);
+  });
+
+  it("rejects non-http schemes and relative URLs", () => {
+    expect(isSafeHttpUrl("mailto:ops@example.com")).toBe(false);
+    expect(isSafeHttpUrl("/api/parts/assets/abc123")).toBe(false);
+    expect(isSafeHttpUrl("//example.com/path")).toBe(false);
+  });
+
+  it("rejects whitespace and control character obfuscation", () => {
+    expect(isSafeHttpUrl(" https://example.com")).toBe(false);
+    expect(isSafeHttpUrl("java\nscript:alert(1)")).toBe(false);
+    expect(isSafeHttpUrl("https://example.com/a b")).toBe(false);
+  });
+
+  it("accepts http and https URLs", () => {
+    expect(isSafeHttpUrl("http://example.com/path")).toBe(true);
+    expect(isSafeHttpUrl("https://example.com/path?x=1")).toBe(true);
+    expect(isSafeHttpUrl("HTTPS://example.com/path")).toBe(true);
+  });
+});
+
+describe("isSafeSameOriginPath", () => {
+  it("accepts same-origin app paths", () => {
+    expect(isSafeSameOriginPath("/api/parts/assets/abc123")).toBe(true);
+    expect(isSafeSameOriginPath("/img/stm32.png")).toBe(true);
+  });
+
+  it("rejects protocol-relative and unsafe paths", () => {
+    expect(isSafeSameOriginPath("//evil.example/path")).toBe(false);
+    expect(isSafeSameOriginPath("/api/parts/assets/a b")).toBe(false);
+  });
+});
+
+describe("isSafeHttpOrSameOriginUrl", () => {
+  it("accepts http URLs and same-origin paths only", () => {
+    expect(isSafeHttpOrSameOriginUrl("https://example.com")).toBe(true);
+    expect(isSafeHttpOrSameOriginUrl("/api/attachments/1/download")).toBe(true);
+    expect(isSafeHttpOrSameOriginUrl("data:image/svg+xml,<svg></svg>")).toBe(false);
+  });
+});

--- a/web/src/lib/url.ts
+++ b/web/src/lib/url.ts
@@ -1,0 +1,45 @@
+const SAME_ORIGIN_BASE = "https://stockmanager.local";
+
+function hasDisallowedUrlChars(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code <= 0x20 || code === 0x7f) return true;
+  }
+  return false;
+}
+
+export function isSafeHttpUrl(value: string | null | undefined): value is string {
+  if (typeof value !== "string" || value === "" || hasDisallowedUrlChars(value)) {
+    return false;
+  }
+
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+export function isSafeSameOriginPath(value: string | null | undefined): value is string {
+  if (
+    typeof value !== "string" ||
+    value === "" ||
+    hasDisallowedUrlChars(value) ||
+    !value.startsWith("/") ||
+    value.startsWith("//")
+  ) {
+    return false;
+  }
+
+  try {
+    const url = new URL(value, SAME_ORIGIN_BASE);
+    return url.origin === SAME_ORIGIN_BASE;
+  } catch {
+    return false;
+  }
+}
+
+export function isSafeHttpOrSameOriginUrl(value: string | null | undefined): value is string {
+  return isSafeHttpUrl(value) || isSafeSameOriginPath(value);
+}

--- a/web/src/routes/parts/PartCreate.tsx
+++ b/web/src/routes/parts/PartCreate.tsx
@@ -4,6 +4,7 @@ import { api, ApiError, getConflictDetail } from "@/lib/api";
 import { useApiMutation } from "@/lib/mutations";
 import { useQuery } from "@tanstack/react-query";
 import { useWsKey } from "@/lib/queryKeys";
+import { isSafeHttpOrSameOriginUrl } from "@/lib/url";
 import type { MpnLookupResult, ProviderSpec, StorageLocation } from "@/types";
 import MpnLookup from "@/components/MpnLookup";
 import { InlineQueryError } from "@/components/QueryStateBoundary";
@@ -61,6 +62,8 @@ export default function PartCreate() {
   const [refreshFailed, setRefreshFailed] = useState<{ partId: string } | null>(null);
   const storageQuery = useQuery({ queryKey: useWsKey("storage"), queryFn: () => api.get<StorageLocation[]>("/storage") });
   const { data: storage } = storageQuery;
+  const safeDatasheetUrl = isSafeHttpOrSameOriginUrl(datasheetUrl) ? datasheetUrl : null;
+  const safeImageUrl = isSafeHttpOrSameOriginUrl(imageUrl) ? imageUrl : null;
 
   // FE2-006: gate concurrent submits via mutationKey so a double-click
   // on Create can't post two parts; the 409 conflict-link branch stays
@@ -219,18 +222,18 @@ export default function PartCreate() {
             <input id="part-create-mpn" className="input flex-1" value={form.mpn} onChange={e => set("mpn", e.target.value)} />
             {form.part_type === "linked" && <MpnLookup mpn={form.mpn} onResult={applyLookup} />}
           </div>
-          {datasheetUrl && (
+          {safeDatasheetUrl && (
             <div className="text-xs text-muted mt-1">
-              Datasheet: <a className="underline" href={datasheetUrl} target="_blank" rel="noopener noreferrer">{datasheetUrl}</a>
+              Datasheet: <a className="underline" href={safeDatasheetUrl} target="_blank" rel="noopener noreferrer">{safeDatasheetUrl}</a>
             </div>
           )}
         </div>
       </div>
-      {(imageUrl || specs.length > 0) && (
+      {(safeImageUrl || specs.length > 0) && (
         <div className="rounded-md border border-border bg-panel2/50 p-3 space-y-2 text-sm">
           <div className="flex items-start gap-3">
-            {imageUrl && (
-              <img src={imageUrl} alt="Part" className="h-16 w-16 object-contain rounded bg-panel" />
+            {safeImageUrl && (
+              <img src={safeImageUrl} alt="Part" className="h-16 w-16 object-contain rounded bg-panel" />
             )}
             <div className="flex-1 text-xs text-muted">
               Found via provider lookup. After Create, the part will be linked

--- a/web/src/routes/parts/PartsList.tsx
+++ b/web/src/routes/parts/PartsList.tsx
@@ -1,4 +1,4 @@
-import { useRef, useCallback, useState } from "react";
+import { useRef, useCallback } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
@@ -9,6 +9,7 @@ import { PagedPartsSchema } from "@/lib/schemas";
 import type { Part } from "@/lib/schemas";
 import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
 import { useAuth } from "@/lib/auth";
+import { isSafeHttpOrSameOriginUrl } from "@/lib/url";
 import { DataTable } from "@/components/DataTable";
 import EmptyState from "@/components/EmptyState";
 import PartsTopNav from "@/components/PartsTopNav";
@@ -175,10 +176,11 @@ export default function PartsList({ archived = false }: { archived?: boolean }) 
                   key: "image",
                   header: "",
                   width: "44px",
-                  render: (r) =>
-                    r.image_url ? (
+                  render: (r) => {
+                    const safeImageUrl = isSafeHttpOrSameOriginUrl(r.image_url) ? r.image_url : null;
+                    return safeImageUrl ? (
                       <img
-                        src={r.image_url}
+                        src={safeImageUrl}
                         alt=""
                         loading="lazy"
                         className="h-8 w-8 object-contain rounded bg-panel"
@@ -187,7 +189,8 @@ export default function PartsList({ archived = false }: { archived?: boolean }) 
                       <div className="h-8 w-8 rounded bg-panel2/40 flex items-center justify-center text-muted">
                         <ImageOff size={14} />
                       </div>
-                    ),
+                    );
+                  },
                 },
                 { key: "part_type", header: "Type", accessor: (r) => r.part_type, width: "100px" },
                 {

--- a/web/src/routes/parts/ScanImport/ScanImportQueue.tsx
+++ b/web/src/routes/parts/ScanImport/ScanImportQueue.tsx
@@ -26,6 +26,7 @@ import {
   Trash2,
 } from "lucide-react";
 import { bagLotName, bagComments, type BagCode } from "@/lib/bagCode";
+import { isSafeHttpOrSameOriginUrl, isSafeHttpUrl } from "@/lib/url";
 import { PROVIDER_LABEL, manufacturerMatches, type LookupState, type Row } from "./types";
 
 // ─── BagRescanCard ────────────────────────────────────────────────────────────
@@ -125,6 +126,8 @@ function FoundDetails({
   const mfrMismatch = !manufacturerMatches(bag.manufacturer, r.manufacturer);
   const lotName = bagLotName(bag);
   const comments = bagComments(bag);
+  const safeSourceUrl = isSafeHttpUrl(r.source_url) ? r.source_url : null;
+  const safeImageUrl = isSafeHttpOrSameOriginUrl(r.image_url) ? r.image_url : null;
   return (
     <div>
       <div className="flex items-start gap-2">
@@ -156,10 +159,10 @@ function FoundDetails({
               </span>
             )}
             {r.category && <span className="text-muted">{r.category}</span>}
-            {r.source_url && (
+            {safeSourceUrl && (
               <a
                 className="text-accent hover:underline inline-flex items-center gap-1"
-                href={r.source_url}
+                href={safeSourceUrl}
                 target="_blank"
                 rel="noopener noreferrer"
               >
@@ -168,9 +171,9 @@ function FoundDetails({
             )}
           </div>
         </div>
-        {r.image_url ? (
+        {safeImageUrl ? (
           <img
-            src={r.image_url}
+            src={safeImageUrl}
             alt=""
             className="w-12 h-12 rounded border border-border object-contain bg-white"
             onError={e => {

--- a/web/src/routes/parts/detail/AuthorizedSupplyTab.tsx
+++ b/web/src/routes/parts/detail/AuthorizedSupplyTab.tsx
@@ -8,6 +8,7 @@ import { useAuth } from "@/lib/auth";
 import { formatDateTime } from "@/lib/format";
 import { useApiMutation } from "@/lib/mutations";
 import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
+import { isSafeHttpUrl } from "@/lib/url";
 import {
   bestUnitPriceAtQty,
   extendedPrice,
@@ -607,10 +608,11 @@ export function AuthorizedSupplyTab({ partId }: { partId: string }) {
         key: "link",
         header: "Link",
         accessor: row => row.link,
-        render: row =>
-          row.link ? (
+        render: row => {
+          const safeLink = isSafeHttpUrl(row.link) ? row.link : null;
+          return safeLink ? (
             <a
-              href={row.link}
+              href={safeLink}
               target="_blank"
               rel="noopener noreferrer"
               className="inline-flex items-center gap-1 text-accent hover:underline"
@@ -620,7 +622,8 @@ export function AuthorizedSupplyTab({ partId }: { partId: string }) {
             </a>
           ) : (
             <span className="text-muted">—</span>
-          ),
+          );
+        },
       },
       {
         key: "order",
@@ -631,6 +634,7 @@ export function AuthorizedSupplyTab({ partId }: { partId: string }) {
             className="btn btn-sm"
             onClick={() => {
               const best = bestUnitPriceAtQty(row.priceBreaks, quantity);
+              const safeProductUrl = isSafeHttpUrl(row.link) ? row.link : null;
               setOrderLineSource({
                 partId,
                 distributor: row.distributor,
@@ -640,7 +644,7 @@ export function AuthorizedSupplyTab({ partId }: { partId: string }) {
                 quantity,
                 unitPrice: best?.unitPrice ?? row.unitPrice,
                 currency: row.currency,
-                productUrl: row.link,
+                productUrl: safeProductUrl,
               });
             }}
           >

--- a/web/src/routes/parts/detail/CreateOrderLineModal.tsx
+++ b/web/src/routes/parts/detail/CreateOrderLineModal.tsx
@@ -7,6 +7,7 @@ import { ApiError, api } from "@/lib/api";
 import { useAuth } from "@/lib/auth";
 import { useApiMutation } from "@/lib/mutations";
 import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
+import { isSafeHttpUrl } from "@/lib/url";
 import type { Order, OrderEntry } from "@/types";
 
 const CREATE_NEW = "__create_new__";
@@ -160,6 +161,7 @@ export function CreateOrderLineModal({
   });
 
   if (!open || !source) return null;
+  const safeProductUrl = isSafeHttpUrl(source.productUrl) ? source.productUrl : null;
 
   function submit(event: FormEvent) {
     event.preventDefault();
@@ -308,9 +310,9 @@ export function CreateOrderLineModal({
             />
           </label>
 
-          {source.productUrl && (
+          {safeProductUrl && (
             <a
-              href={source.productUrl}
+              href={safeProductUrl}
               target="_blank"
               rel="noopener noreferrer"
               className="inline-flex items-center gap-1 text-sm text-accent hover:underline"

--- a/web/src/routes/parts/detail/PartInfo.tsx
+++ b/web/src/routes/parts/detail/PartInfo.tsx
@@ -7,6 +7,7 @@ import { api, ApiError } from "@/lib/api";
 import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
 import { useAuth } from "@/lib/auth";
 import { InlineQueryError } from "@/components/QueryStateBoundary";
+import { isSafeHttpOrSameOriginUrl } from "@/lib/url";
 import type { CustomFieldRow, Part } from "@/types";
 
 const PROVIDER_LABEL: Record<string, string> = {
@@ -65,6 +66,7 @@ export default function PartInfo() {
   // the only Media-card affordance that still belongs on this page is the
   // datasheet link.
   const datasheetUrl = lookupBy("datasheet_url");
+  const safeDatasheetUrl = isSafeHttpOrSameOriginUrl(datasheetUrl) ? datasheetUrl : null;
 
   const [refreshing, setRefreshing] = useState(false);
   async function refresh() {
@@ -157,10 +159,10 @@ export default function PartInfo() {
         <Field label="Low-stock threshold" value={part.low_stock_report_quantity != null ? String(part.low_stock_report_quantity) : null} />
         <Field label="Attrition" value={`${part.attrition_percentage}% (min ${part.attrition_min_quantity})`} />
       </div>
-      {datasheetUrl && (
+      {safeDatasheetUrl && (
         <div className="card p-4 col-span-2">
           <a
-            href={withDownloadName(datasheetUrl, part.mpn || part.name)}
+            href={withDownloadName(safeDatasheetUrl, part.mpn || part.name)}
             target="_blank"
             rel="noopener noreferrer"
             className="inline-flex items-center gap-1.5 text-accent hover:underline text-sm"

--- a/web/src/routes/parts/detail/PartSourcing.tsx
+++ b/web/src/routes/parts/detail/PartSourcing.tsx
@@ -9,6 +9,7 @@ import { isCatalogKey } from "@/lib/providerCatalog";
 import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
 import { useAuth } from "@/lib/auth";
 import { formatDateTime } from "@/lib/format";
+import { isSafeHttpUrl } from "@/lib/url";
 import type { CustomFieldRow, Part } from "@/types";
 
 const PROVIDER_LABEL: Record<string, string> = {
@@ -66,6 +67,7 @@ export default function PartSourcing() {
     part.linked_provider && part.mpn
       ? PROVIDER_SEARCH_URL[part.linked_provider]?.(part.mpn)
       : null;
+  const safeExternalUrl = isSafeHttpUrl(externalUrl) ? externalUrl : null;
   const columns: Column<CustomFieldRow>[] = [
     {
       key: "key",
@@ -102,9 +104,9 @@ export default function PartSourcing() {
           </div>
         </div>
         <div className="flex items-center gap-2 shrink-0">
-          {externalUrl && (
+          {safeExternalUrl && (
             <a
-              href={externalUrl}
+              href={safeExternalUrl}
               target="_blank"
               rel="noopener noreferrer"
               className="btn inline-flex items-center gap-1.5 text-sm"

--- a/web/src/routes/parts/detail/PartSpecs.tsx
+++ b/web/src/routes/parts/detail/PartSpecs.tsx
@@ -8,6 +8,7 @@ import { useApiMutation } from "@/lib/mutations";
 import { isSpecKey } from "@/lib/providerCatalog";
 import { useWsKey } from "@/lib/queryKeys";
 import { useConfirm } from "@/components/ConfirmDialog";
+import { isSafeHttpUrl } from "@/lib/url";
 import type { CustomFieldRow, Part, SpecSource } from "@/types";
 
 const SOURCE_BADGE: Record<SpecSource, string> = {
@@ -149,6 +150,11 @@ export default function PartSpecs() {
   const providerCount = rows.filter(r => r.source === "provider").length;
   const showSparseHint =
     !!part.linked_provider && providerCount > 0 && providerCount < 4;
+  const productPageUrl =
+    part.linked_provider && part.mpn
+      ? (PROVIDER_SEARCH_URL[part.linked_provider] ?? PROVIDER_SEARCH_URL.mouser)(part.mpn)
+      : null;
+  const safeProductPageUrl = isSafeHttpUrl(productPageUrl) ? productPageUrl : null;
 
   return (
     <div className="card p-4 max-w-3xl">
@@ -164,14 +170,18 @@ export default function PartSpecs() {
           shown above is what we could pull. Add specs below, or copy
           remaining ones from the
           {" "}
-          <a
-            className="text-accent hover:underline"
-            href={(PROVIDER_SEARCH_URL[part.linked_provider!] ?? PROVIDER_SEARCH_URL.mouser)(part.mpn ?? "")}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            product page
-          </a>.
+          {safeProductPageUrl ? (
+            <a
+              className="text-accent hover:underline"
+              href={safeProductPageUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              product page
+            </a>
+          ) : (
+            "product page"
+          )}.
         </div>
       )}
 

--- a/web/src/routes/projects/detail/AddPartFromLibraryModal.tsx
+++ b/web/src/routes/projects/detail/AddPartFromLibraryModal.tsx
@@ -6,6 +6,7 @@ import { api, ApiError } from "@/lib/api";
 import { useAuth } from "@/lib/auth";
 import { useApiMutation } from "@/lib/mutations";
 import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
+import { isSafeHttpOrSameOriginUrl } from "@/lib/url";
 import type { Part, ProjectEntry } from "@/types";
 
 type Props = {
@@ -177,6 +178,7 @@ export default function AddPartFromLibraryModal({ open, projectId, onClose }: Pr
               <ul className="divide-y divide-border">
                 {parts.map(part => {
                   const checked = selected.has(part.id);
+                  const safeImageUrl = isSafeHttpOrSameOriginUrl(part.image_url) ? part.image_url : null;
                   return (
                     <li key={part.id}>
                       <label className="flex cursor-pointer items-center gap-3 p-3 hover:bg-panel2/40">
@@ -187,9 +189,9 @@ export default function AddPartFromLibraryModal({ open, projectId, onClose }: Pr
                           disabled={addMutation.isPending}
                           aria-label={checked ? `Deselect ${part.name}` : `Select ${part.name}`}
                         />
-                        {part.image_url ? (
+                        {safeImageUrl ? (
                           <img
-                            src={part.image_url}
+                            src={safeImageUrl}
                             alt=""
                             loading="lazy"
                             className="h-10 w-10 rounded bg-panel object-contain"

--- a/web/src/routes/projects/detail/ProjectBOM.tsx
+++ b/web/src/routes/projects/detail/ProjectBOM.tsx
@@ -6,6 +6,7 @@ import { api, ApiError } from "@/lib/api";
 import { useApiMutation } from "@/lib/mutations";
 import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
 import { useAuth } from "@/lib/auth";
+import { isSafeHttpOrSameOriginUrl } from "@/lib/url";
 import type { Part, ProjectEntry } from "@/types";
 import { useState } from "react";
 import { DataTable } from "@/components/DataTable";
@@ -209,9 +210,11 @@ export default function ProjectBOM() {
             width: "44px",
             render: r => {
               const part = r.part_id ? partsById.get(r.part_id) : null;
-              return part?.image_url ? (
+              const imageUrl = part?.image_url;
+              const safeImageUrl = isSafeHttpOrSameOriginUrl(imageUrl) ? imageUrl : null;
+              return safeImageUrl ? (
                 <img
-                  src={part.image_url}
+                  src={safeImageUrl}
                   alt=""
                   loading="lazy"
                   className="h-8 w-8 rounded bg-panel object-contain"

--- a/web/src/routes/projects/sourcing/BomDistributorsModal.tsx
+++ b/web/src/routes/projects/sourcing/BomDistributorsModal.tsx
@@ -5,6 +5,7 @@ import { DataTable, type Column } from "@/components/DataTable";
 import { Modal } from "@/components/Modal";
 import { PoweredByTrustedParts } from "@/components/PoweredByTrustedParts";
 import { lifecycleRiskTone, riskToneClass } from "@/lib/sourcing";
+import { isSafeHttpUrl } from "@/lib/url";
 import type {
   SourcingBomLine,
   SourcingBomOffer,
@@ -200,17 +201,20 @@ export function BomDistributorsModal({ open, onClose, line, workspaceCurrency }:
       key: "distributor",
       header: "Distributor",
       accessor: row => row.distributor,
-      render: row => row.link ? (
-        <a
-          href={row.link}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="inline-flex items-center gap-1 text-accent hover:underline"
-        >
-          {row.distributor}
-          <ExternalLink size={14} aria-hidden="true" />
-        </a>
-      ) : row.distributor,
+      render: row => {
+        const safeLink = isSafeHttpUrl(row.link) ? row.link : null;
+        return safeLink ? (
+          <a
+            href={safeLink}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 text-accent hover:underline"
+          >
+            {row.distributor}
+            <ExternalLink size={14} aria-hidden="true" />
+          </a>
+        ) : row.distributor;
+      },
     },
     {
       key: "stock",

--- a/web/src/routes/projects/sourcing/BomRows.tsx
+++ b/web/src/routes/projects/sourcing/BomRows.tsx
@@ -5,6 +5,7 @@ import { RiskLegendPopover } from "@/components/RiskLegendPopover";
 import { SourcingSourceLabel } from "@/components/SourcingSourceLabel";
 import { LIFECYCLE_LEGEND, SUPPLY_CHAIN_LEGEND } from "@/lib/riskLegends";
 import { lifecycleRiskTone, type RiskTone } from "@/lib/sourcing";
+import { isSafeHttpUrl } from "@/lib/url";
 import { BomDistributorsModal } from "./BomDistributorsModal";
 import {
   formatLeadTime,
@@ -95,17 +96,21 @@ export function BomRows({ rows, workspaceCurrency }: { rows: SourcingBomLine[]; 
       key: "distributor",
       header: "Distributor",
       accessor: row => row.best_offer?.distributor ?? "",
-      render: row => row.best_offer?.url ? (
-        <a
-          className="text-accent hover:underline"
-          href={row.best_offer.url}
-          target="_blank"
-          rel="noopener noreferrer"
-          onClick={event => event.stopPropagation()}
-        >
-          {row.best_offer.distributor}
-        </a>
-      ) : row.best_offer?.distributor ?? "—",
+      render: row => {
+        const offerUrl = row.best_offer?.url;
+        const safeOfferUrl = isSafeHttpUrl(offerUrl) ? offerUrl : null;
+        return safeOfferUrl ? (
+          <a
+            className="text-accent hover:underline"
+            href={safeOfferUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={event => event.stopPropagation()}
+          >
+            {row.best_offer?.distributor}
+          </a>
+        ) : row.best_offer?.distributor ?? "—";
+      },
     },
     {
       key: "cost",

--- a/web/src/routes/projects/sourcing/OverrideOfferModal.tsx
+++ b/web/src/routes/projects/sourcing/OverrideOfferModal.tsx
@@ -1,5 +1,6 @@
 import { DataTable, type Column } from "@/components/DataTable";
 import { Modal } from "@/components/Modal";
+import { isSafeHttpUrl } from "@/lib/url";
 import type { PurchasePlanLine, PurchasePlanOffer } from "./purchasePlanTypes";
 
 type Props = {
@@ -142,16 +143,19 @@ export default function OverrideOfferModal({ line, onSelect, onClose }: Props) {
       key: "offer",
       header: "Offer",
       accessor: row => row.offer.url ?? "",
-      render: row => row.offer.url ? (
-        <a
-          className="text-accent hover:underline"
-          href={row.offer.url}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Open
-        </a>
-      ) : "-",
+      render: row => {
+        const safeOfferUrl = isSafeHttpUrl(row.offer.url) ? row.offer.url : null;
+        return safeOfferUrl ? (
+          <a
+            className="text-accent hover:underline"
+            href={safeOfferUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Open
+          </a>
+        ) : "-";
+      },
     },
     {
       key: "action",

--- a/web/src/routes/projects/sourcing/PurchasePlanLinesTable.tsx
+++ b/web/src/routes/projects/sourcing/PurchasePlanLinesTable.tsx
@@ -1,5 +1,6 @@
 import { DataTable, type Column } from "@/components/DataTable";
 import { SourcingSourceLabel } from "@/components/SourcingSourceLabel";
+import { isSafeHttpUrl } from "@/lib/url";
 import {
   extendedCost,
   formatLeadTime,
@@ -72,11 +73,14 @@ export default function PurchasePlanLinesTable({
       key: "link",
       header: "Offer",
       accessor: line => line.selected_url ?? "",
-      render: line => line.selected_url ? (
-        <a className="text-accent hover:underline" href={line.selected_url} target="_blank" rel="noopener noreferrer">
-          Open
-        </a>
-      ) : "-",
+      render: line => {
+        const safeSelectedUrl = isSafeHttpUrl(line.selected_url) ? line.selected_url : null;
+        return safeSelectedUrl ? (
+          <a className="text-accent hover:underline" href={safeSelectedUrl} target="_blank" rel="noopener noreferrer">
+            Open
+          </a>
+        ) : "-";
+      },
     },
     {
       key: "override",


### PR DESCRIPTION
## Summary

- Adds `isSafeHttpUrl()` in `web/src/lib/url.ts` with regression coverage for rejecting `javascript:` and `data:` schemes.
- Gates provider, offer, datasheet, attribution, attachment download, and image URL rendering through safe http/same-origin checks.
- Leaves internal same-origin asset paths unchanged while suppressing unsafe external schemes.

Closes #576

## Validation

- `npm --prefix web run test -- url`
- `npm --prefix web run test -- PartSourcing AttachmentsPanel AuthorizedSupplyTab OverrideOfferModal BomDistributorsModal AddPartFromLibraryModal ProjectBOM ScanImportQueue CreateOrderLineModal ScanImport.draft`
- `npm --prefix web run typecheck`
- Focused eslint on changed frontend files

## Notes

- Full `npm --prefix web run lint` still fails on unchanged baseline issues in `web/src/lib/bagCode.ts` (`no-control-regex`) plus existing unused-var warnings outside this change.
