### PR TITLE
AUD-023 tighten session cookie attributes

### DIFF
--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -21,6 +21,11 @@ from app.core.auth import (
     verify_password,
 )
 from app.core.config import settings
+from app.core.cookies import (
+    WORKSPACE_COOKIE_NAME,
+    session_cookie_attrs,
+    workspace_cookie_attrs,
+)
 from app.core.deps import CurrentUser, DbSession
 from app.core.errors import ErrorCodes, raise_http
 from app.core.logging import get_logger
@@ -48,14 +53,8 @@ def _set_session_cookie(response: Response, token: str) -> None:
     response.set_cookie(
         key=settings().SESSION_COOKIE_NAME,
         value=token,
-        httponly=True,
-        # Mark Secure in prod where the proxy terminates TLS, so browsers
-        # never re-send the cookie over plaintext. Stays off in dev where
-        # we serve plain HTTP on localhost.
-        secure=settings().APP_ENV == "prod",
-        samesite="lax",
         max_age=settings().SESSION_LIFETIME_DAYS * 24 * 3600,
-        path="/",
+        **session_cookie_attrs(),
     )
 
 
@@ -72,7 +71,7 @@ def _hmac_token(plaintext: str) -> str:
 
 
 def _workspace_for_logout_audit(db, request: Request, user: User) -> Workspace | None:
-    raw = request.headers.get("X-Workspace-Id") or request.cookies.get("stockmgr_workspace")
+    raw = request.headers.get("X-Workspace-Id") or request.cookies.get(WORKSPACE_COOKIE_NAME)
     if raw:
         try:
             workspace_id = UUID(raw)
@@ -445,7 +444,8 @@ def logout(request: Request, response: Response, db: DbSession) -> Envelope[None
                 request_id=getattr(request.state, "request_id", None),
             )
         revoke_session(db, token)
-    response.delete_cookie(cookie_name, path="/")
+    response.delete_cookie(cookie_name, **session_cookie_attrs())
+    response.delete_cookie(WORKSPACE_COOKIE_NAME, **workspace_cookie_attrs())
     log.info("logout")
     return ok(None, "logged out")
 

--- a/backend/app/api/routes/workspaces.py
+++ b/backend/app/api/routes/workspaces.py
@@ -11,6 +11,7 @@ from fastapi import APIRouter, Depends, Request, Response, status
 from sqlalchemy import select
 
 from app.core.config import settings
+from app.core.cookies import WORKSPACE_COOKIE_NAME, workspace_cookie_attrs
 from app.core.deps import CurrentUser, CurrentWorkspace, DbSession, require_role
 from app.core.errors import ErrorCodes, raise_http
 from app.core.ratelimit import limiter
@@ -664,12 +665,9 @@ def switch_workspace(
     #   stays Lax because login-like top-level redirects do depend
     #   on it.
     response.set_cookie(
-        key="stockmgr_workspace",
+        key=WORKSPACE_COOKIE_NAME,
         value=str(workspace_id),
-        httponly=True,
-        secure=settings().APP_ENV == "prod",
-        samesite="strict",
         max_age=365 * 24 * 3600,
-        path="/",
+        **workspace_cookie_attrs(),
     )
     return ok({"workspace_id": str(workspace_id)})

--- a/backend/app/core/cookies.py
+++ b/backend/app/core/cookies.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from app.core.config import settings
+
+SESSION_COOKIE_PATH = "/api"
+WORKSPACE_COOKIE_NAME = "stockmgr_workspace"
+WORKSPACE_COOKIE_PATH = "/api"
+
+
+def secure_cookie_enabled() -> bool:
+    return settings().APP_ENV == "prod"
+
+
+def session_cookie_attrs() -> dict[str, bool | str]:
+    return {
+        "httponly": True,
+        "secure": secure_cookie_enabled(),
+        "samesite": "lax",
+        "path": SESSION_COOKIE_PATH,
+    }
+
+
+def workspace_cookie_attrs() -> dict[str, bool | str]:
+    return {
+        "httponly": True,
+        "secure": secure_cookie_enabled(),
+        "samesite": "strict",
+        "path": WORKSPACE_COOKIE_PATH,
+    }

--- a/backend/tests/test_auth_cookie_attrs.py
+++ b/backend/tests/test_auth_cookie_attrs.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from http.cookies import Morsel, SimpleCookie
+from typing import Any
+
+from app.core.config import settings
+from app.core.cookies import WORKSPACE_COOKIE_NAME
+from tests._factories import signup_user
+
+
+def _cookie_from(response: Any, name: str) -> Morsel[str]:
+    for header in response.headers.get_list("set-cookie"):
+        parsed = SimpleCookie()
+        parsed.load(header)
+        if name in parsed:
+            return parsed[name]
+    raise AssertionError(f"missing Set-Cookie for {name}: {response.headers!r}")
+
+
+def _security_attrs(cookie: Morsel[str]) -> dict[str, bool | str]:
+    return {
+        "path": cookie["path"],
+        "httponly": bool(cookie["httponly"]),
+        "secure": bool(cookie["secure"]),
+        "samesite": cookie["samesite"].lower(),
+    }
+
+
+def test_set_and_delete_attributes_match(client):
+    signup = signup_user(client)
+    workspace_id = signup.json()["data"]["workspace_id"]
+    session_cookie_name = settings().SESSION_COOKIE_NAME
+
+    session_set = _cookie_from(signup, session_cookie_name)
+    assert _security_attrs(session_set) == {
+        "path": "/api",
+        "httponly": True,
+        "secure": False,
+        "samesite": "lax",
+    }
+
+    switch = client.post(f"/api/workspaces/{workspace_id}/switch")
+    assert switch.status_code == 200, switch.text
+    workspace_set = _cookie_from(switch, WORKSPACE_COOKIE_NAME)
+    assert _security_attrs(workspace_set) == {
+        "path": "/api",
+        "httponly": True,
+        "secure": False,
+        "samesite": "strict",
+    }
+
+    logout = client.post("/api/auth/logout")
+    assert logout.status_code == 200, logout.text
+
+    session_delete = _cookie_from(logout, session_cookie_name)
+    assert session_delete.value == ""
+    assert session_delete["max-age"] == "0"
+    assert _security_attrs(session_delete) == _security_attrs(session_set)
+
+    workspace_delete = _cookie_from(logout, WORKSPACE_COOKIE_NAME)
+    assert workspace_delete.value == ""
+    assert workspace_delete["max-age"] == "0"
+    assert _security_attrs(workspace_delete) == _security_attrs(workspace_set)


### PR DESCRIPTION
## Summary

- Scope session and workspace cookies to `/api`.
- Reuse shared cookie attribute helpers so set and delete operations use matching `HttpOnly`, `Secure`, `SameSite`, and `Path` attributes.
- Clear the workspace cookie on logout with the same hardened attributes.

## Validation

- `python -m pytest backend/tests/test_auth_cookie_attrs.py -q` (blocked: shell has no `python` executable)
- `uv run --project backend --extra dev python -m pytest backend/tests/test_auth_cookie_attrs.py -q`
- `uv run --project backend --extra dev python -m pytest backend/tests/test_auth_cookie_attrs.py backend/tests/test_auth_logout.py backend/tests/test_security_hardening.py -q`
- `uv run --project backend --extra dev ruff check backend/app/api/routes/auth.py backend/app/api/routes/workspaces.py backend/app/core/cookies.py backend/tests/test_auth_cookie_attrs.py`

Closes #562
