### PR TITLE
[codex] Bound Sentry tunnel chunk reassembly

### DIFF
--- a/backend/app/api/routes/sentry_tunnel.py
+++ b/backend/app/api/routes/sentry_tunnel.py
@@ -35,33 +35,66 @@ from app.core.ratelimit import limiter
 
 router = APIRouter()
 
+SENTRY_TUNNEL_MAX_CHUNKS = 1024
 
-def _allowed_endpoints() -> list[tuple[str, str]]:
-    """Parse the configured DSN(s) once per request. Returns the list of
-    (host, project_id) tuples that envelopes are allowed to target.
+
+def _parse_allowed_endpoints(*dsns: str) -> tuple[tuple[str, str], ...]:
+    """Return the (host, project_id) pairs envelopes may target.
 
     The tunnel exists for the React SDK, so VITE_SENTRY_DSN is the
     primary entry. SENTRY_DSN (the backend project's DSN) is included
     too for shops that point both runtimes at the same project, and for
-    forwarding any backend-emitted envelopes that ever route through
-    here. An empty string skips that slot."""
-    cfg = settings()
-    out: list[tuple[str, str]] = []
-    for dsn in (cfg.VITE_SENTRY_DSN, cfg.SENTRY_DSN):
+    forwarding any backend-emitted envelopes that ever route through here.
+    An empty string skips that slot.
+    """
+    out: set[tuple[str, str]] = set()
+    for dsn in dsns:
         if not dsn:
             continue
         parsed = urlparse(dsn)
         host = parsed.hostname
         project_id = parsed.path.strip("/")
         if host and project_id:
-            out.append((host, project_id))
-    return out
+            out.add((host, project_id))
+    return tuple(sorted(out))
+
+
+_cfg = settings()
+ALLOWED_ENDPOINTS = _parse_allowed_endpoints(_cfg.VITE_SENTRY_DSN, _cfg.SENTRY_DSN)
+
+
+async def _read_bounded_envelope(request: Request, max_bytes: int) -> bytes:
+    body = bytearray()
+    chunk_count = 0
+    total = 0
+    async for chunk in request.stream():
+        if not chunk:
+            continue
+        chunk_count += 1
+        if chunk_count > SENTRY_TUNNEL_MAX_CHUNKS:
+            raise_http(
+                status.HTTP_413_CONTENT_TOO_LARGE,
+                ErrorCodes.SENTRY_TUNNEL_TOO_LARGE,
+                "envelope has too many chunks",
+                max_chunks=SENTRY_TUNNEL_MAX_CHUNKS,
+            )
+
+        total += len(chunk)
+        if total > max_bytes:
+            raise_http(
+                status.HTTP_413_CONTENT_TOO_LARGE,
+                ErrorCodes.SENTRY_TUNNEL_TOO_LARGE,
+                f"envelope exceeds {max_bytes} bytes",
+                max_bytes=max_bytes,
+            )
+        body.extend(chunk)
+    return bytes(body)
 
 
 @router.post("/sentry-tunnel")
 @limiter.limit("60/minute")
 async def sentry_tunnel(request: Request) -> Response:
-    allowed = _allowed_endpoints()
+    allowed = ALLOWED_ENDPOINTS
     if not allowed:
         # No DSN on the server — there's nothing to forward to. Return a
         # soft 204 so SDK retries don't hammer the route.
@@ -72,19 +105,7 @@ async def sentry_tunnel(request: Request) -> Response:
     # could pump arbitrary bytes through this worker. Iterating the
     # stream lets us 413 the moment we cross the cap.
     max_bytes = settings().SENTRY_TUNNEL_MAX_BYTES
-    chunks: list[bytes] = []
-    total = 0
-    async for chunk in request.stream():
-        total += len(chunk)
-        if total > max_bytes:
-            raise_http(
-                status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
-                ErrorCodes.SENTRY_TUNNEL_TOO_LARGE,
-                f"envelope exceeds {max_bytes} bytes",
-                max_bytes=max_bytes,
-            )
-        chunks.append(chunk)
-    envelope = b"".join(chunks)
+    envelope = await _read_bounded_envelope(request, max_bytes)
 
     if not envelope:
         raise_http(

--- a/backend/tests/test_sentry_tunnel.py
+++ b/backend/tests/test_sentry_tunnel.py
@@ -17,12 +17,19 @@ import json
 import pytest
 from fastapi.testclient import TestClient
 
+from app.api.routes import sentry_tunnel as sentry_tunnel_route
 from app.main import app
+
+_ALLOWED_ENDPOINTS = (("o123.ingest.sentry.io", "456"),)
 
 
 @pytest.fixture
 def client() -> TestClient:
     return TestClient(app)
+
+
+def _allow_test_dsn(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sentry_tunnel_route, "ALLOWED_ENDPOINTS", _ALLOWED_ENDPOINTS)
 
 
 # ---------------------------------------------------------------------------
@@ -33,16 +40,11 @@ def client() -> TestClient:
 def test_sentry_tunnel_returns_204_when_no_dsn_configured(client, monkeypatch):
     """No DSN on the server → 204 No Content. SDK retries see this as a
     soft acknowledgement and back off."""
-    from app.core.config import settings
+    monkeypatch.setattr(sentry_tunnel_route, "ALLOWED_ENDPOINTS", ())
 
-    monkeypatch.setenv("SENTRY_DSN", "")
-    monkeypatch.setenv("VITE_SENTRY_DSN", "")
-    settings.cache_clear()
-    try:
-        r = client.post("/api/sentry-tunnel", content=b"anything")
-        assert r.status_code == 204, r.text
-    finally:
-        settings.cache_clear()
+    r = client.post("/api/sentry-tunnel", content=b"anything")
+
+    assert r.status_code == 204, r.text
 
 
 # ---------------------------------------------------------------------------
@@ -55,7 +57,7 @@ def test_sentry_tunnel_rejects_oversize_envelope(client, monkeypatch):
     from app.core.config import settings
 
     # A configured DSN is required to reach the size-check path.
-    monkeypatch.setenv("VITE_SENTRY_DSN", "https://abc@o123.ingest.sentry.io/456")
+    _allow_test_dsn(monkeypatch)
     monkeypatch.setenv("SENTRY_TUNNEL_MAX_BYTES", "1024")
     settings.cache_clear()
     try:
@@ -72,7 +74,7 @@ def test_sentry_tunnel_accepts_envelope_at_cap_boundary(client, monkeypatch):
     that arbitrary bytes are valid envelopes)."""
     from app.core.config import settings
 
-    monkeypatch.setenv("VITE_SENTRY_DSN", "https://abc@o123.ingest.sentry.io/456")
+    _allow_test_dsn(monkeypatch)
     monkeypatch.setenv("SENTRY_TUNNEL_MAX_BYTES", "1024")
     settings.cache_clear()
     try:
@@ -91,61 +93,43 @@ def test_sentry_tunnel_accepts_envelope_at_cap_boundary(client, monkeypatch):
 
 
 def test_sentry_tunnel_rejects_empty_envelope(client, monkeypatch):
-    from app.core.config import settings
+    _allow_test_dsn(monkeypatch)
 
-    monkeypatch.setenv("VITE_SENTRY_DSN", "https://abc@o123.ingest.sentry.io/456")
-    settings.cache_clear()
-    try:
-        r = client.post("/api/sentry-tunnel", content=b"")
-        assert r.status_code == 400, r.text
-    finally:
-        settings.cache_clear()
+    r = client.post("/api/sentry-tunnel", content=b"")
+
+    assert r.status_code == 400, r.text
 
 
 def test_sentry_tunnel_rejects_malformed_header(client, monkeypatch):
-    from app.core.config import settings
+    _allow_test_dsn(monkeypatch)
 
-    monkeypatch.setenv("VITE_SENTRY_DSN", "https://abc@o123.ingest.sentry.io/456")
-    settings.cache_clear()
-    try:
-        r = client.post("/api/sentry-tunnel", content=b"not-json\nrest")
-        assert r.status_code == 400, r.text
-    finally:
-        settings.cache_clear()
+    r = client.post("/api/sentry-tunnel", content=b"not-json\nrest")
+
+    assert r.status_code == 400, r.text
 
 
 def test_sentry_tunnel_rejects_dsn_mismatch(client, monkeypatch):
     """Envelope claims a DSN that's not in the server's allow-list →
     403. Without this, the route is an open egress to any Sentry-shaped
     URL the client cares to put in an envelope header."""
-    from app.core.config import settings
+    _allow_test_dsn(monkeypatch)
 
-    monkeypatch.setenv("VITE_SENTRY_DSN", "https://abc@o123.ingest.sentry.io/456")
-    settings.cache_clear()
-    try:
-        # Foreign DSN (different host + project_id).
-        envelope_header = json.dumps(
-            {"dsn": "https://xyz@o999.ingest.sentry.io/000"}
-        )
-        body = envelope_header.encode() + b"\n{}"
-        r = client.post("/api/sentry-tunnel", content=body)
-        assert r.status_code == 403, r.text
-    finally:
-        settings.cache_clear()
+    # Foreign DSN (different host + project_id).
+    envelope_header = json.dumps({"dsn": "https://xyz@o999.ingest.sentry.io/000"})
+    body = envelope_header.encode() + b"\n{}"
+    r = client.post("/api/sentry-tunnel", content=body)
+
+    assert r.status_code == 403, r.text
 
 
 def test_sentry_tunnel_rejects_envelope_missing_dsn(client, monkeypatch):
-    from app.core.config import settings
+    _allow_test_dsn(monkeypatch)
 
-    monkeypatch.setenv("VITE_SENTRY_DSN", "https://abc@o123.ingest.sentry.io/456")
-    settings.cache_clear()
-    try:
-        envelope_header = json.dumps({"event_id": "abc"})  # no `dsn`
-        body = envelope_header.encode() + b"\n{}"
-        r = client.post("/api/sentry-tunnel", content=body)
-        assert r.status_code == 400, r.text
-    finally:
-        settings.cache_clear()
+    envelope_header = json.dumps({"event_id": "abc"})  # no `dsn`
+    body = envelope_header.encode() + b"\n{}"
+    r = client.post("/api/sentry-tunnel", content=body)
+
+    assert r.status_code == 400, r.text
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_sentry_tunnel_chunks.py
+++ b/backend/tests/test_sentry_tunnel_chunks.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import anyio
+import pytest
+from fastapi import HTTPException, status
+
+from app.api.routes import sentry_tunnel as sentry_tunnel_route
+from app.core.errors import ErrorCodes
+
+
+class _ChunkedRequest:
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks = chunks
+
+    async def stream(self) -> AsyncIterator[bytes]:
+        for chunk in self._chunks:
+            yield chunk
+
+
+def test_chunk_count_cap(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sentry_tunnel_route, "SENTRY_TUNNEL_MAX_CHUNKS", 2)
+    request = _ChunkedRequest([b"a", b"b", b"c"])
+
+    async def read() -> bytes:
+        return await sentry_tunnel_route._read_bounded_envelope(request, 1024)
+
+    with pytest.raises(HTTPException) as exc:
+        anyio.run(read)
+
+    assert exc.value.status_code == status.HTTP_413_CONTENT_TOO_LARGE
+    assert exc.value.detail["code"] == ErrorCodes.SENTRY_TUNNEL_TOO_LARGE
+    assert exc.value.detail["max_chunks"] == 2


### PR DESCRIPTION
## Summary
- Bound `/api/sentry-tunnel` body reassembly with a `bytearray` accumulator and chunk-count cap.
- Parse allowed Sentry DSN endpoints once at module load.
- Added the requested chunk-count regression test and adjusted tunnel tests for module-level DSN state.

Closes #566

## Validation
- `/mnt/data/WORK/stockManager-1/.codex-worktrees/aud-027-sentry-tunnel-bound-reassembly/backend/.venv/bin/python -m pytest backend/tests/test_sentry_tunnel_chunks.py -q`
- `uv run --extra dev python -m pytest tests/test_sentry_tunnel.py tests/test_sentry_tunnel_chunks.py -q`
- `uv run --extra dev python -m ruff check app/api/routes/sentry_tunnel.py tests/test_sentry_tunnel.py tests/test_sentry_tunnel_chunks.py`

## Notes
- Host has no `python` shim, so validation used the backend venv interpreter / `uv run --extra dev python`.
- Pytest emits the existing Alembic `path_separator` deprecation warning.
