### PR TITLE
[codex] AUD-029 CORS startup safety

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -134,6 +134,17 @@ _is_prod = settings().APP_ENV == "prod"
 
 _log = logging.getLogger(__name__)
 
+CORS_ALLOW_HEADERS = [
+    "Accept",
+    "Accept-Language",
+    "Baggage",
+    "Content-Language",
+    "Content-Type",
+    "Sentry-Trace",
+    "X-Request-Id",
+    "X-Workspace-Id",
+]
+
 
 def _argv_option_value(argv: Sequence[str], option: str) -> str | None:
     """Return a uvicorn CLI option value from either --opt=value or --opt value."""
@@ -163,6 +174,18 @@ def assert_proxy_headers_trusted(argv: Sequence[str] | None = None) -> None:
         raise RuntimeError(
             "APP_ENV=prod requires uvicorn --forwarded-allow-ips=* so proxy "
             "headers from the compose-network reverse proxy are trusted."
+        )
+
+
+def assert_cors_origins_not_wildcard() -> None:
+    """Fail prod startup when credentialed CORS is configured for every origin."""
+    cfg = settings()
+    if cfg.APP_ENV != "prod":
+        return
+    if "*" in cfg.cors_origin_list:
+        raise RuntimeError(
+            "APP_ENV=prod rejects CORS_ORIGINS=* because wildcard origins cannot "
+            "be used with credentialed CORS. Configure explicit frontend origins."
         )
 
 
@@ -205,6 +228,7 @@ async def _periodic_session_purge(interval_seconds: int) -> None:
 async def lifespan(_app: FastAPI):
     """Spawn the background session-purge task on startup; cancel it on
     shutdown. DB-007 / issue #98."""
+    assert_cors_origins_not_wildcard()
     assert_proxy_headers_trusted()
     interval = settings().SESSION_PURGE_INTERVAL_SECONDS
     task: asyncio.Task | None = None
@@ -385,7 +409,7 @@ app.add_middleware(
     allow_origins=settings().cors_origin_list,
     allow_credentials=True,
     allow_methods=["*"],
-    allow_headers=["*"],
+    allow_headers=CORS_ALLOW_HEADERS,
 )
 
 # Added last → outermost. Sees every request before CORS/CSRF run.

--- a/backend/tests/test_cors_startup_assert.py
+++ b/backend/tests/test_cors_startup_assert.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import pytest
+from fastapi.middleware.cors import CORSMiddleware
+
+from app.core.config import settings
+from app.main import CORS_ALLOW_HEADERS, app, lifespan
+
+
+@pytest.mark.asyncio
+async def test_wildcard_in_prod_rejected(monkeypatch):
+    cfg = settings()
+    monkeypatch.setattr(cfg, "APP_ENV", "prod")
+    monkeypatch.setattr(cfg, "CORS_ORIGINS", "https://parts.matescb.cz, *")
+
+    with pytest.raises(RuntimeError, match=r"CORS_ORIGINS=\*"):
+        async with lifespan(app):
+            pass
+
+
+def test_cors_allow_headers_are_explicit():
+    middleware = next(m for m in app.user_middleware if m.cls is CORSMiddleware)
+    allowed_headers = middleware.kwargs["allow_headers"]
+
+    assert allowed_headers == CORS_ALLOW_HEADERS
+    assert "*" not in allowed_headers


### PR DESCRIPTION
## Summary
- Reject `APP_ENV=prod` startup when `CORS_ORIGINS` includes the literal wildcard `*`.
- Replace wildcard CORS `allow_headers` with an explicit browser/app header list.
- Add regression coverage for prod wildcard rejection and header narrowing.

## Validation
- `python -m pytest backend/tests/test_cors_startup_assert.py -q` (blocked locally: no `python` executable on PATH)
- `uv run --extra dev python -m pytest tests/test_cors_startup_assert.py -q`
- `uv run --extra dev python -m pytest tests/test_cors_startup_assert.py tests/test_startup_proxy_headers.py -q`
- `uv run --extra dev ruff check tests/test_cors_startup_assert.py`
- `LINT_CMD="uv run --extra dev ruff check app --output-format=concise" BASELINE_FILE="../.ruff-baseline.txt" WORK_DIR="." bash ../scripts/lint-delta.sh`

Closes #568