### PR TITLE
[codex] AUD-049 prod-compose smoke E2E

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -390,9 +390,19 @@ jobs:
     # INFRA2-012: validate docker-compose.prod.yml and build prod images so
     # Dockerfile / compose regressions are caught in CI instead of at deploy
     # time on the VPS (after git reset --hard has already swapped the tree).
+    # AUD-049: also boot the prod compose web/backend/db path and run a tiny
+    # unauthenticated Playwright smoke through nginx. Prod auth cookies are
+    # Secure by design, so this intentionally does not exercise login over
+    # the runner's plain HTTP loopback.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: web/package-lock.json
 
       # Build a CI-safe .env from the checked-in example.  We substitute a
       # syntactically valid Fernet key so `docker compose config` resolves
@@ -402,7 +412,19 @@ jobs:
       - name: Create CI env file
         run: |
           cp deploy/.env.prod.example .env.prod.ci
+          sed -i 's|^POSTGRES_PASSWORD=.*|POSTGRES_PASSWORD=stockmgr-prod-ci|' .env.prod.ci
+          sed -i 's|^SESSION_SECRET=.*|SESSION_SECRET=ci-prod-smoke-session-secret-2026|' .env.prod.ci
+          sed -i 's|^CORS_ORIGINS=.*|CORS_ORIGINS=http://127.0.0.1:8091|' .env.prod.ci
           sed -i 's|^WORKSPACE_SECRETS_KEY=.*|WORKSPACE_SECRETS_KEY=ZDZkYjI4NzM0YTQ4MjNhODNhZGFkNzE3ZGVkMGY5YWU=|' .env.prod.ci
+          sed -i 's|^SMTP_HOST=.*|SMTP_HOST=smtp.invalid|' .env.prod.ci
+          sed -i 's|^SMTP_USER=.*|SMTP_USER=stockmgr-ci|' .env.prod.ci
+          sed -i 's|^SMTP_PASSWORD=.*|SMTP_PASSWORD=stockmgr-ci-password|' .env.prod.ci
+          sed -i 's|^MAIL_FROM=.*|MAIL_FROM=noreply@example.invalid|' .env.prod.ci
+          sed -i 's|^APP_BASE_URL=.*|APP_BASE_URL=https://parts-ci.example.invalid|' .env.prod.ci
+
+      - name: Install web deps
+        working-directory: web
+        run: npm ci
 
       # Validate compose YAML / schema / variable substitution. Fails on
       # malformed YAML, unknown keys, or missing required variables.
@@ -503,6 +525,57 @@ jobs:
         run: |
           IMAGE=$(docker buildx build --load -f web/Dockerfile.prod -q .)
           docker run --rm "$IMAGE" test -f /usr/share/nginx/html/index.html
+
+      - name: Start prod compose smoke stack
+        run: docker compose -f docker-compose.prod.yml --env-file .env.prod.ci up -d --build db backend-init backend web
+
+      - name: Wait for prod /api/health through nginx (30 x 5s)
+        run: |
+          ok=0
+          for i in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:8091/api/health > /dev/null 2>&1; then
+              echo "prod /api/health OK after ${i} attempt(s) ($((i*5))s)"
+              ok=1
+              break
+            fi
+            sleep 5
+          done
+          if [ "${ok}" -ne 1 ]; then
+            echo "prod /api/health never became healthy — dumping compose state:"
+            docker compose -f docker-compose.prod.yml --env-file .env.prod.ci ps || true
+            docker compose -f docker-compose.prod.yml --env-file .env.prod.ci logs --tail=100 backend web || true
+            exit 1
+          fi
+
+      - name: Install Playwright + Chromium
+        working-directory: web
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Playwright @prod-smoke suite
+        working-directory: web
+        env:
+          PLAYWRIGHT_BASE_URL: "http://127.0.0.1:8091"
+          CI: "true"
+        run: npx playwright test prod-smoke.spec.ts --grep @prod-smoke
+
+      - name: Upload prod Playwright report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        if: failure()
+        with:
+          name: prod-playwright-report
+          path: |
+            web/playwright-report/
+            web/test-results/
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Dump prod compose logs on failure
+        if: failure()
+        run: docker compose -f docker-compose.prod.yml --env-file .env.prod.ci logs --tail=100 backend web || true
+
+      - name: Tear down prod compose smoke stack
+        if: always()
+        run: docker compose -f docker-compose.prod.yml --env-file .env.prod.ci down -v
 
   playwright-e2e:
     # TEST-004 / issue #256: run the @smoke Playwright suite against the dev
@@ -674,7 +747,7 @@ jobs:
   #   - tp-schema-drift   (#448)       — TrustedParts schema/model drift
   #   - backend-tests                  — pytest + alembic
   #   - web-build                      — tsc -b + vite build (+ sourcemap upload)
-  #   - prod-validate                  — docker compose config sanity check
+  #   - prod-validate                  — docker compose config/build + prod smoke
   #   - playwright-e2e                 — full-stack smoke
   #
   # If you add a new pre-deploy gate (lint, secrets-scan, SBOM, smoke, …), add

--- a/docs/frontend/testing.md
+++ b/docs/frontend/testing.md
@@ -203,14 +203,23 @@ listener three times.
 
 ## Playwright smoke
 
-`web/playwright.config.ts` + `web/e2e/smoke.spec.ts`. One spec, one
-project (`chromium`), `fullyParallel: false`, `workers: 1`. Opt-in via
-`npm run test:e2e`; the default `npm test` (vitest) keeps doing what it
-does (`playwright.config.ts:9-11`).
+`web/playwright.config.ts` + `web/e2e/smoke.spec.ts` cover one
+intentional full-stack dev-compose flow: signup → create part → add
+stock → confirm ledger row. The suite uses one project (`chromium`),
+`fullyParallel: false`, and `workers: 1`. Opt-in via `npm run test:e2e`;
+the default `npm test` (vitest) keeps doing what it does
+(`playwright.config.ts:9-11`).
 
 The CI job is `playwright-e2e` (GitHub Actions). It brings up the dev
 docker-compose stack, polls `/api/health`, then invokes
 `npx playwright test --grep @smoke` (`playwright.config.ts:7-13`).
+
+`web/e2e/prod-smoke.spec.ts` is the separate prod-compose smoke used by
+the `prod-validate` job. It boots `docker-compose.prod.yml`, loads the
+SPA through the web container's nginx port, and fetches `/api/health`
+through the same origin. It intentionally stays unauthenticated because
+`APP_ENV=prod` marks session cookies `Secure`, while CI reaches the stack
+over plain HTTP loopback.
 
 ```ts
 // web/e2e/smoke.spec.ts:18-57 (excerpt)
@@ -245,9 +254,9 @@ Two E2E gotchas worth pinning here:
   the form lives. The "Stock" tab is read-only
   (`smoke.spec.ts:48-49`).
 
-The suite is intentionally minimal: the v2 plan called out page-level
-component tests as out of scope. This is the one end-to-end signal that
-the routing + API + ledger glue all line up
+The dev-compose suite is intentionally minimal: the v2 plan called out
+page-level component tests as out of scope. This is the one end-to-end
+signal that the routing + API + ledger glue all line up
 (`smoke.spec.ts:11-14`).
 
 `PLAYWRIGHT_BASE_URL` overrides the default `http://localhost:5173`

--- a/web/e2e/prod-smoke.spec.ts
+++ b/web/e2e/prod-smoke.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Prod compose smoke (AUD-049 / @prod-smoke).
+ *
+ * Runs against docker-compose.prod.yml through the web container's nginx port.
+ * Keep this unauthenticated: APP_ENV=prod correctly marks session cookies as
+ * Secure, and CI reaches the stack over plain HTTP loopback.
+ */
+test("@prod-smoke SPA shell and proxied health endpoint are reachable", async ({ page }) => {
+  await page.goto("/login");
+
+  await expect(page.getByRole("heading", { name: "Sign in" })).toBeVisible();
+  await expect(page.getByLabel("Email")).toBeVisible();
+
+  const health = await page.evaluate(async () => {
+    const res = await fetch("/api/health");
+    const body = await res.json();
+    return { ok: res.ok, status: res.status, body };
+  });
+
+  expect(health).toMatchObject({
+    ok: true,
+    status: 200,
+    body: {
+      data: { status: "ok", db: "ok", uploads: "ok" },
+      status: { category: "ok" },
+    },
+  });
+});

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -6,9 +6,8 @@ import { defineConfig, devices } from "@playwright/test";
  * Local: assumes `docker compose up` is running on
  * http://localhost:5173. Use `npm run test:e2e` to run.
  *
- * CI: runs in the `playwright-e2e` GitHub Actions job (see #256),
- * which brings up the dev docker-compose stack and polls /api/health
- * before invoking `npx playwright test --grep @smoke`.
+ * CI: runs `@smoke` in the `playwright-e2e` job against dev compose, and
+ * `@prod-smoke` in `prod-validate` against docker-compose.prod.yml.
  * The suite is opt-in via `npm run test:e2e` so the default
  * `npm test` (vitest) keeps doing what it does.
  */


### PR DESCRIPTION
Closes #588

## Summary
- Adds `web/e2e/prod-smoke.spec.ts`, a minimal unauthenticated Playwright smoke for the production compose stack.
- Extends `prod-validate` to create CI-safe prod env values, start the prod web/backend/db path from `docker-compose.prod.yml`, wait on `/api/health` through nginx, and run `@prod-smoke`.
- Updates frontend testing docs and Playwright config comments for the separate dev and prod smoke suites.

## Validation
- `npm ci` in `web` (passed locally; worker has Node 18, CI uses Node 20)
- `npx playwright test prod-smoke.spec.ts --grep @prod-smoke --list`
- `python3` YAML parse for `.github/workflows/ci.yml` and `docker-compose.prod.yml`
- `ci-policy` equivalent deploy-needs check
- `git diff --check`

## Not run locally
- `docker compose -f docker-compose.prod.yml --env-file .env.prod.ci config -q`
- Full prod compose boot + Playwright execution

Local blocker: this worker does not have the `docker` CLI installed (`docker: command not found`). The new CI path is intended to run that validation on GitHub Actions.
