### PR TITLE
[codex] Complete polymorphic resolver registry

### DIFF
--- a/backend/app/api/_helpers.py
+++ b/backend/app/api/_helpers.py
@@ -11,7 +11,10 @@ from sqlalchemy.orm import Session
 from app.core.deps import _ROLE_RANK, _membership_role
 from app.core.errors import ErrorCodes, raise_http
 from app.domain._mixins import WorkspaceOwned
-from app.domain._polymorphic_cleanup import register_polymorphic_cleanup_listeners
+from app.domain._polymorphic_cleanup import (
+    polymorphic_parent_models,
+    register_polymorphic_cleanup_listeners,
+)
 
 register_polymorphic_cleanup_listeners()
 
@@ -60,26 +63,11 @@ def assert_in_workspace(
 # load-bearing.
 @lru_cache(maxsize=1)
 def _polymorphic_resolvers() -> dict[str, type[WorkspaceOwned]]:
-    # Lazy + cached: keeps the API layer from creating a hard import-time
-    # dependency on the parts domain, and avoids rebuilding the dict on
-    # every attachment upload / custom-field write / tag link. Adding a
-    # new entry requires a process restart — that's fine, this list is
-    # static at deploy time.
-    from app.domain.builds.models import Build
-    from app.domain.lots.models import Lot
-    from app.domain.orders.models import Order
-    from app.domain.parts.models import Part
-    from app.domain.projects.models import Project
-    from app.domain.storage.models import StorageLocation
-
-    return {
-        "build": Build,
-        "lot": Lot,
-        "order": Order,
-        "part": Part,
-        "project": Project,
-        "storage_location": StorageLocation,
-    }
+    # Lazy + cached: avoids rebuilding the dict on every attachment upload /
+    # custom-field write / tag link. The cleanup registry is the canonical
+    # list of polymorphic parent object types, so keep write validation in
+    # lockstep with hard-delete cleanup.
+    return dict(polymorphic_parent_models())
 
 
 def assert_polymorphic_in_workspace(

--- a/backend/tests/test_workspace_isolation.py
+++ b/backend/tests/test_workspace_isolation.py
@@ -6,8 +6,15 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import select
 
+from app.api._helpers import _polymorphic_resolvers, assert_polymorphic_in_workspace
+from app.domain.builds.models import Build
+from app.domain.lots.models import Lot
+from app.domain.orders.models import Order
+from app.domain.parts.models import Part
+from app.domain.projects.models import Project
 from app.domain.sourcing.budget import BUDGET
 from app.domain.sourcing.models import SourcingCache
+from app.domain.storage.models import StorageLocation
 from app.main import app
 from tests._factories import (
     add_stock as _factory_add_stock,
@@ -221,6 +228,59 @@ def _create_sourcing_alert(client: TestClient) -> str:
     )
     assert r.status_code == 200, r.text
     return r.json()["data"]["id"]
+
+
+# ---------------------------------------------------------------------------
+# polymorphic parent resolution registry
+# ---------------------------------------------------------------------------
+
+
+def test_polymorphic_resolvers_complete(db):
+    c = TestClient(app)
+    workspace_id = uuid.UUID(_signup(c, f"a-{uuid.uuid4().hex[:6]}@x.com"))
+
+    expected_types = {
+        "build": Build,
+        "lot": Lot,
+        "order": Order,
+        "part": Part,
+        "project": Project,
+        "storage_location": StorageLocation,
+    }
+    assert _polymorphic_resolvers() == expected_types
+
+    part = Part(workspace_id=workspace_id, name="Resolver Part", part_type="local")
+    project = Project(workspace_id=workspace_id, name="Resolver Project")
+    db.add_all([part, project])
+    db.flush()
+
+    parents = {
+        "build": Build(
+            workspace_id=workspace_id,
+            project_id=project.id,
+            name="Resolver Build",
+        ),
+        "lot": Lot(workspace_id=workspace_id, part_id=part.id, source_type="manual"),
+        "order": Order(workspace_id=workspace_id, name="Resolver Order"),
+        "part": part,
+        "project": project,
+        "storage_location": StorageLocation(
+            workspace_id=workspace_id,
+            name="Resolver Storage",
+        ),
+    }
+    db.add_all(parents.values())
+    db.flush()
+
+    for object_type, parent in parents.items():
+        resolved = assert_polymorphic_in_workspace(
+            db,
+            object_type,
+            parent.id,
+            workspace_id,
+        )
+        assert type(resolved) is expected_types[object_type]
+        assert resolved.id == parent.id
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Keep `_polymorphic_resolvers()` in lockstep with the canonical polymorphic parent model registry.
- Add `test_polymorphic_resolvers_complete` to cover part, order, project, build, lot, and storage location parent resolution.

## Validation
- `TEST_DATABASE_URL=postgresql+psycopg://stockmgr:stockmgr@127.0.0.1:5432/stockmgr_test_aud053 uv run --extra dev python -m pytest tests/test_workspace_isolation.py -q`
- `TEST_DATABASE_URL=postgresql+psycopg://stockmgr:stockmgr@127.0.0.1:5432/stockmgr_test_aud053 uv run --extra dev python -m pytest tests/test_polymorphic_cleanup.py -q`
- `uv run ruff check app/api/_helpers.py tests/test_workspace_isolation.py`

Closes #592