### PR TITLE
[codex] AUD-052 stock entry workspace trigger

### DIFF
--- a/backend/alembic/versions/0050_stock_entries_workspace_fk_trigger.py
+++ b/backend/alembic/versions/0050_stock_entries_workspace_fk_trigger.py
@@ -1,0 +1,140 @@
+"""Enforce stock_entries foreign-key workspace isolation.
+
+Revision ID: 0050
+Revises: 0049
+Create Date: 2026-05-14
+
+AUD-052 / issue #591.
+
+The service layer verifies workspace ownership before inserting ledger rows.
+This trigger provides the same defense at the database boundary so direct SQL
+cannot attach a stock_entries row to objects owned by another workspace.
+"""
+
+from alembic import op
+
+revision = "0050"
+down_revision = "0049"
+branch_labels = None
+depends_on = None
+
+
+_FUNCTION_SQL = """
+CREATE OR REPLACE FUNCTION check_stock_entries_workspace_fks()
+RETURNS trigger AS $$
+BEGIN
+  PERFORM 1 FROM parts
+   WHERE id = NEW.part_id
+     AND workspace_id = NEW.workspace_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'stock_entries.part_id (%) not in workspace (%)',
+      NEW.part_id, NEW.workspace_id
+      USING ERRCODE = '23514';
+  END IF;
+
+  IF NEW.lot_id IS NOT NULL THEN
+    PERFORM 1 FROM lots
+     WHERE id = NEW.lot_id
+       AND workspace_id = NEW.workspace_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'stock_entries.lot_id (%) not in workspace (%)',
+        NEW.lot_id, NEW.workspace_id
+        USING ERRCODE = '23514';
+    END IF;
+  END IF;
+
+  IF NEW.storage_location_id IS NOT NULL THEN
+    PERFORM 1 FROM storage_locations
+     WHERE id = NEW.storage_location_id
+       AND workspace_id = NEW.workspace_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'stock_entries.storage_location_id (%) not in workspace (%)',
+        NEW.storage_location_id, NEW.workspace_id
+        USING ERRCODE = '23514';
+    END IF;
+  END IF;
+
+  IF NEW.related_entry_id IS NOT NULL THEN
+    PERFORM 1 FROM stock_entries
+     WHERE id = NEW.related_entry_id
+       AND workspace_id = NEW.workspace_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'stock_entries.related_entry_id (%) not in workspace (%)',
+        NEW.related_entry_id, NEW.workspace_id
+        USING ERRCODE = '23514';
+    END IF;
+  END IF;
+
+  IF NEW.order_id IS NOT NULL THEN
+    PERFORM 1 FROM orders
+     WHERE id = NEW.order_id
+       AND workspace_id = NEW.workspace_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'stock_entries.order_id (%) not in workspace (%)',
+        NEW.order_id, NEW.workspace_id
+        USING ERRCODE = '23514';
+    END IF;
+  END IF;
+
+  IF NEW.order_entry_id IS NOT NULL THEN
+    PERFORM 1 FROM order_entries
+     WHERE id = NEW.order_entry_id
+       AND workspace_id = NEW.workspace_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'stock_entries.order_entry_id (%) not in workspace (%)',
+        NEW.order_entry_id, NEW.workspace_id
+        USING ERRCODE = '23514';
+    END IF;
+  END IF;
+
+  IF NEW.project_id IS NOT NULL THEN
+    PERFORM 1 FROM projects
+     WHERE id = NEW.project_id
+       AND workspace_id = NEW.workspace_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'stock_entries.project_id (%) not in workspace (%)',
+        NEW.project_id, NEW.workspace_id
+        USING ERRCODE = '23514';
+    END IF;
+  END IF;
+
+  IF NEW.build_id IS NOT NULL THEN
+    PERFORM 1 FROM builds
+     WHERE id = NEW.build_id
+       AND workspace_id = NEW.workspace_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'stock_entries.build_id (%) not in workspace (%)',
+        NEW.build_id, NEW.workspace_id
+        USING ERRCODE = '23514';
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+"""
+
+
+def upgrade() -> None:
+    op.execute(_FUNCTION_SQL)
+    op.execute("""
+    CREATE TRIGGER stock_entries_workspace_fk_check
+      BEFORE INSERT OR UPDATE OF
+        workspace_id,
+        part_id,
+        lot_id,
+        storage_location_id,
+        related_entry_id,
+        order_id,
+        order_entry_id,
+        project_id,
+        build_id
+      ON stock_entries
+      FOR EACH ROW
+      EXECUTE FUNCTION check_stock_entries_workspace_fks();
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP TRIGGER IF EXISTS stock_entries_workspace_fk_check ON stock_entries;")
+    op.execute("DROP FUNCTION IF EXISTS check_stock_entries_workspace_fks();")

--- a/backend/tests/test_workspace_isolation.py
+++ b/backend/tests/test_workspace_isolation.py
@@ -864,6 +864,101 @@ def test_raw_insert_cross_workspace_default_storage_rejected():
             s.commit()
 
 
+def test_stock_entries_ws_trigger():
+    """AUD-052 / migration 0050. Direct SQL must not be able to attach a
+    stock_entries row to workspace-scoped objects from another workspace."""
+    from sqlalchemy import text
+    from sqlalchemy.exc import DBAPIError, IntegrityError, ProgrammingError
+
+    from app.infra.db import SessionLocal
+
+    a = TestClient(app)
+    b = TestClient(app)
+    _signup(a, f"a-{uuid.uuid4().hex[:6]}@x.com")
+    ws_b = _signup(b, f"b-{uuid.uuid4().hex[:6]}@x.com")
+
+    part_a = _create_part(a, "A-stock-trigger-part")
+    part_b = _create_part(b, "B-stock-trigger-part")
+    storage_a = _create_storage(a, "A-stock-trigger-bin")
+    stock_a = _add_stock(
+        a,
+        part_id=part_a,
+        storage_id=storage_a,
+        quantity=5,
+        lot_name="A-stock-trigger-lot",
+    )
+    project_a = a.post("/api/projects", json={"name": "A-stock-trigger-project"}).json()[
+        "data"
+    ]["id"]
+    build_a = a.post(
+        "/api/builds",
+        json={"name": "A-stock-trigger-build", "project_id": project_a},
+    ).json()["data"]["id"]
+    order_a = a.post(
+        "/api/orders",
+        json={
+            "name": "A-stock-trigger-order",
+            "entries": [{"part_id": part_a, "quantity_ordered": 1}],
+        },
+    ).json()["data"]["id"]
+    order_entry_a = a.get(f"/api/orders/{order_a}").json()["data"]["entries"][0]["id"]
+
+    insert_sql = text(
+        "INSERT INTO stock_entries ("
+        "id, workspace_id, part_id, lot_id, storage_location_id, "
+        "quantity_delta, status, operation_type, related_entry_id, "
+        "order_id, order_entry_id, project_id, build_id, occurred_at, created_at"
+        ") VALUES ("
+        ":id, :workspace_id, :part_id, :lot_id, :storage_location_id, "
+        "1, 'on_hand', 'audit_probe', :related_entry_id, "
+        ":order_id, :order_entry_id, :project_id, :build_id, NOW(), NOW()"
+        ")"
+    )
+
+    def insert_stock_entry(**overrides):
+        params = {
+            "id": str(uuid.uuid4()),
+            "workspace_id": ws_b,
+            "part_id": part_b,
+            "lot_id": None,
+            "storage_location_id": None,
+            "related_entry_id": None,
+            "order_id": None,
+            "order_entry_id": None,
+            "project_id": None,
+            "build_id": None,
+        }
+        params.update(overrides)
+        with SessionLocal() as s:
+            s.execute(insert_sql, params)
+            s.commit()
+        return params["id"]
+
+    valid_entry_id = insert_stock_entry()
+
+    with SessionLocal() as s:
+        with pytest.raises((IntegrityError, ProgrammingError, DBAPIError)):
+            s.execute(
+                text("UPDATE stock_entries SET part_id = :part_id WHERE id = :id"),
+                {"part_id": part_a, "id": valid_entry_id},
+            )
+            s.commit()
+
+    cross_workspace_refs = [
+        {"part_id": part_a},
+        {"lot_id": stock_a["lot_id"]},
+        {"storage_location_id": storage_a},
+        {"related_entry_id": stock_a["id"]},
+        {"order_id": order_a},
+        {"order_entry_id": order_entry_a},
+        {"project_id": project_a},
+        {"build_id": build_a},
+    ]
+    for overrides in cross_workspace_refs:
+        with pytest.raises((IntegrityError, ProgrammingError, DBAPIError)):
+            insert_stock_entry(**overrides)
+
+
 def test_parts_bulk_import_rejects_foreign_storage():
     """bulk-import-from-scan must validate row.storage_location_id against
     the caller's workspace BEFORE creating the part. The whole-batch loop


### PR DESCRIPTION
## Summary
- Add migration 0050 with a BEFORE INSERT/UPDATE trigger that rejects stock_entries foreign-key references outside the row workspace.
- Cover raw SQL insert/update rejection in backend/tests/test_workspace_isolation.py::test_stock_entries_ws_trigger.

## Validation
- DATABASE_URL=postgresql+psycopg://stockmgr:stockmgr@127.0.0.1:5432/stockmgr_test_aud052 TEST_DATABASE_URL=postgresql+psycopg://stockmgr:stockmgr@127.0.0.1:5432/stockmgr_test_aud052 uv run --project backend --extra dev python -m pytest backend/tests/test_workspace_isolation.py -q
- uv run --project backend --extra dev ruff check backend/tests/test_workspace_isolation.py
- uv run --project backend --extra dev python -m py_compile backend/alembic/versions/0050_stock_entries_workspace_fk_trigger.py

Closes #591
