### PR TITLE
[codex] AUD-034 add run_job advisory lock

### DIFF
--- a/backend/app/cli/run_job.py
+++ b/backend/app/cli/run_job.py
@@ -8,7 +8,10 @@ import sys
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
+from uuid import uuid4
 
+from sqlalchemy import text
+from sqlalchemy.exc import DBAPIError
 from sqlalchemy.orm import Session
 
 logger = logging.getLogger(__name__)
@@ -16,6 +19,7 @@ logger = logging.getLogger(__name__)
 SessionFactory = Callable[[], Session]
 JobCallable = Callable[[Session], int]
 HEARTBEAT_DIR = Path("/tmp/stockmanager-job-heartbeats")
+LOCK_NOT_AVAILABLE_SQLSTATE = "55P03"
 
 
 @dataclass(frozen=True)
@@ -31,6 +35,21 @@ class JobSpec:
 
 class UnknownJobError(ValueError):
     """Raised when the requested job name is not registered."""
+
+
+def _is_lock_not_available(exc: DBAPIError) -> bool:
+    orig = getattr(exc, "orig", None)
+    return (
+        getattr(orig, "sqlstate", None) == LOCK_NOT_AVAILABLE_SQLSTATE
+        or getattr(orig, "pgcode", None) == LOCK_NOT_AVAILABLE_SQLSTATE
+    )
+
+
+def _acquire_job_lock(db: Session, job_name: str) -> None:
+    db.execute(
+        text("SELECT pg_advisory_xact_lock(hashtext(:job_name))"),
+        {"job_name": job_name},
+    )
 
 
 def _default_session_factory() -> Session:
@@ -89,6 +108,14 @@ def run_job(
 
     db = session_factory()
     try:
+        try:
+            _acquire_job_lock(db, job.name)
+        except DBAPIError as exc:
+            if _is_lock_not_available(exc):
+                db.rollback()
+                logger.info("job=%s status=skipped reason=lock_denied", job.name)
+                return 0
+            raise
         affected = job.run(db)
         db.commit()
     except Exception:
@@ -112,7 +139,7 @@ def run_job(
 def _write_heartbeat(job_name: str, *, heartbeat_dir: Path = HEARTBEAT_DIR) -> None:
     heartbeat_dir.mkdir(parents=True, exist_ok=True)
     heartbeat_path = heartbeat_dir / job_name
-    tmp_path = heartbeat_dir / f".{job_name}.tmp"
+    tmp_path = heartbeat_dir / f".{job_name}.{uuid4().hex}.tmp"
     tmp_path.write_text("ok\n", encoding="utf-8")
     tmp_path.replace(heartbeat_path)
 

--- a/backend/tests/test_run_job.py
+++ b/backend/tests/test_run_job.py
@@ -1,15 +1,25 @@
 from __future__ import annotations
 
+import logging
+
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import Session
 
 from app.cli.run_job import JOBS, JobSpec, UnknownJobError, main, run_job
 
 
 class _FakeSession:
-    def __init__(self) -> None:
+    def __init__(self, *, execute_error: Exception | None = None) -> None:
         self.committed = False
         self.rolled_back = False
         self.closed = False
+        self.executed: list[tuple[str, dict[str, object] | None]] = []
+        self.execute_error = execute_error
+
+    def execute(self, statement, params=None) -> None:
+        self.executed.append((str(statement), params))
+        if self.execute_error is not None:
+            raise self.execute_error
 
     def commit(self) -> None:
         self.committed = True
@@ -46,6 +56,9 @@ def test_run_job_dispatches_allow_listed_job(tmp_path) -> None:
 
     assert affected == 4
     assert calls == [session]
+    assert session.executed == [
+        ("SELECT pg_advisory_xact_lock(hashtext(:job_name))", {"job_name": "example"})
+    ]
     assert session.committed is True
     assert session.rolled_back is False
     assert session.closed is True
@@ -103,3 +116,46 @@ def test_sourcing_alerts_evaluate_dispatches_to_module(monkeypatch, tmp_path) ->
     assert session.rolled_back is False
     assert session.closed is True
     assert (tmp_path / "sourcing-alerts-evaluate").exists()
+
+
+class _FakeLockDenied(Exception):
+    sqlstate = "55P03"
+
+
+def test_run_job_skips_when_advisory_lock_denied(caplog, tmp_path) -> None:
+    session = _FakeSession(
+        execute_error=OperationalError(
+            "SELECT pg_advisory_xact_lock(hashtext(:job_name))",
+            {"job_name": "example"},
+            _FakeLockDenied(),
+        )
+    )
+    calls: list[Session] = []
+
+    def _job(db: Session) -> int:
+        calls.append(db)
+        return 4
+
+    with caplog.at_level(logging.INFO, logger="app.cli.run_job"):
+        affected = run_job(
+            "example",
+            jobs={
+                "example": JobSpec(
+                    name="example",
+                    owner="tests",
+                    cadence="manual",
+                    idempotency="test-only",
+                    run=_job,
+                )
+            },
+            session_factory=lambda: session,  # type: ignore[return-value]
+            heartbeat_dir=tmp_path,
+        )
+
+    assert affected == 0
+    assert calls == []
+    assert session.committed is False
+    assert session.rolled_back is True
+    assert session.closed is True
+    assert not (tmp_path / "example").exists()
+    assert "job=example status=skipped reason=lock_denied" in caplog.text

--- a/backend/tests/test_run_job_advisory_lock.py
+++ b/backend/tests/test_run_job_advisory_lock.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+from sqlalchemy.orm import Session, sessionmaker
+
+from app.cli.run_job import JobSpec, run_job
+
+pytestmark = pytest.mark.real_db
+
+
+def test_concurrent_invocations_serialise(engine, tmp_path) -> None:
+    SessionLocal = sessionmaker(
+        bind=engine,
+        autoflush=False,
+        expire_on_commit=False,
+        future=True,
+    )
+    first_entered = threading.Event()
+    release_first = threading.Event()
+    second_attempting = threading.Event()
+    state_lock = threading.Lock()
+    entered: list[int] = []
+    completed: list[int] = []
+    errors: list[BaseException] = []
+    results: dict[str, int] = {}
+
+    def _job(db: Session) -> int:
+        with state_lock:
+            run_index = len(entered) + 1
+            entered.append(run_index)
+
+        if run_index == 1:
+            first_entered.set()
+            if not release_first.wait(timeout=5):
+                raise AssertionError("timed out waiting to release the first job")
+
+        with state_lock:
+            completed.append(run_index)
+        return run_index
+
+    jobs = {
+        "example": JobSpec(
+            name="example",
+            owner="tests",
+            cadence="manual",
+            idempotency="test-only",
+            run=_job,
+        )
+    }
+
+    def invoke(label: str) -> None:
+        try:
+            if label == "second":
+                second_attempting.set()
+            results[label] = run_job(
+                "example",
+                jobs=jobs,
+                session_factory=SessionLocal,
+                heartbeat_dir=tmp_path,
+            )
+        except BaseException as exc:
+            errors.append(exc)
+
+    first = threading.Thread(target=invoke, args=("first",), daemon=True)
+    first.start()
+    assert first_entered.wait(timeout=5)
+
+    second = threading.Thread(target=invoke, args=("second",), daemon=True)
+    second.start()
+    assert second_attempting.wait(timeout=5)
+
+    time.sleep(0.5)
+    with state_lock:
+        assert entered == [1]
+        assert completed == []
+    assert second.is_alive()
+
+    release_first.set()
+    first.join(timeout=5)
+    second.join(timeout=5)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert errors == []
+    assert results == {"first": 1, "second": 2}
+    assert completed == [1, 2]
+    assert (tmp_path / "example").read_text(encoding="utf-8") == "ok\n"


### PR DESCRIPTION
Closes #573

## Summary
- Acquire a per-job transaction-scoped Postgres advisory lock before dispatching run_job callables.
- Treat lock-not-available SQLSTATE as a logged skip without running the job.
- Add a real Postgres concurrency regression test and keep heartbeat writes safe after serialized commits.

## Validation
- PATH=/mnt/data/WORK/stockManager-1/.codex-worktrees/aud-034-run-job-advisory-lock/backend/.venv/bin:$PATH python -m pytest backend/tests/test_run_job_advisory_lock.py -q
- PATH=/mnt/data/WORK/stockManager-1/.codex-worktrees/aud-034-run-job-advisory-lock/backend/.venv/bin:$PATH python -m pytest backend/tests/test_run_job.py backend/tests/test_run_job_advisory_lock.py -q
- PATH=/mnt/data/WORK/stockManager-1/.codex-worktrees/aud-034-run-job-advisory-lock/backend/.venv/bin:$PATH python -m ruff check backend/app/cli/run_job.py backend/tests/test_run_job.py backend/tests/test_run_job_advisory_lock.py