### PR TITLE
[codex] Harden Sentry tunnel origin checks

### DIFF
--- a/backend/app/api/routes/sentry_tunnel.py
+++ b/backend/app/api/routes/sentry_tunnel.py
@@ -8,13 +8,13 @@ the browser sends a same-origin request that we forward upstream.
 Reference: https://docs.sentry.io/platforms/javascript/troubleshooting/#using-the-tunnel-option
 
 Security posture:
-* No auth gate — Sentry's SDK is unauthenticated by design (the public DSN
-  is the identifier, ingest.sentry.io accepts any envelope tagged with a
-  valid project key).
+* Same-origin browser SDK posts are allowed pre-auth so login-screen errors
+  still reach Sentry. Requests without a trusted Origin must carry a valid
+  session cookie before we do any tunnel work.
 * Host allow-list against `SENTRY_DSN` / `VITE_SENTRY_DSN`. Without it,
   this endpoint would be an open egress to anywhere Sentry-shaped — we
   cap it to our own DSN's host + project id.
-* Rate-limited to 60/min/IP (Sec CRIT-5). Real Sentry SDKs do their own
+* Rate-limited to 30/min/IP (Sec CRIT-5). Real Sentry SDKs do their own
   client-side rate limiting and never hit this; the limit only catches
   abuse, not legitimate traffic.
 * Body cap at SENTRY_TUNNEL_MAX_BYTES (200 KiB default). Envelopes are
@@ -30,8 +30,10 @@ import httpx
 from fastapi import APIRouter, Request, Response, status
 
 from app.core.config import settings
+from app.core.deps import get_current_user
 from app.core.errors import ErrorCodes, raise_http
 from app.core.ratelimit import limiter
+from app.infra import db as infra_db
 
 router = APIRouter()
 
@@ -91,9 +93,53 @@ async def _read_bounded_envelope(request: Request, max_bytes: int) -> bytes:
     return bytes(body)
 
 
+def _origin_host(value: str | None) -> str | None:
+    if not value:
+        return None
+    try:
+        parsed = urlparse(value)
+    except Exception:
+        return None
+    if not parsed.scheme or not parsed.netloc:
+        return None
+    return f"{parsed.scheme}://{parsed.netloc}"
+
+
+def _has_trusted_origin(request: Request) -> bool:
+    origin = _origin_host(request.headers.get("origin"))
+    if origin is None:
+        return False
+    allowed = {
+        host
+        for host in (_origin_host(candidate) for candidate in settings().cors_origin_list)
+        if host
+    }
+    return origin in allowed
+
+
+def _require_session_or_trusted_origin(request: Request) -> None:
+    if _has_trusted_origin(request):
+        return
+
+    if not request.cookies.get(settings().SESSION_COOKIE_NAME):
+        raise_http(
+            status.HTTP_401_UNAUTHORIZED,
+            ErrorCodes.AUTH_NOT_AUTHENTICATED,
+            "not authenticated",
+        )
+
+    db = infra_db.SessionLocal()
+    try:
+        get_current_user(request, db)
+    finally:
+        db.close()
+
+
 @router.post("/sentry-tunnel")
-@limiter.limit("60/minute")
+@limiter.limit("30/minute")
 async def sentry_tunnel(request: Request) -> Response:
+    _require_session_or_trusted_origin(request)
+
     allowed = ALLOWED_ENDPOINTS
     if not allowed:
         # No DSN on the server — there's nothing to forward to. Return a

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -317,8 +317,8 @@ app.add_exception_handler(RateLimitExceeded, _rate_limit_handler)
 _CSRF_PROTECTED_METHODS = frozenset({"POST", "PATCH", "PUT", "DELETE"})
 
 # Routes that are deliberately reachable cross-origin or pre-auth.
-# - /api/sentry-tunnel: Sentry's SDK is unauthenticated by design and
-#   the host allow-list inside the route is the actual gate.
+# - /api/sentry-tunnel: the route enforces its own session-or-trusted-Origin
+#   gate so pre-auth same-origin SDK events can still be reported.
 # - /api/auth/login + /signup: not yet authenticated; the threat
 #   here is brute force, handled by slowapi rate limiting.
 _CSRF_EXEMPT_PATHS = frozenset({
@@ -439,7 +439,8 @@ app.include_router(bom_presets.router, prefix="/api/bom-presets", tags=["bom_pre
 app.include_router(invitations.router, prefix="/api/invitations", tags=["invitations"])
 # Sentry tunnel: same-origin proxy for /api/sentry-tunnel to Sentry's
 # ingest endpoint, so ad-blockers don't drop the SDK's events. NOT gated
-# on workspace membership — the SDK fires from the login screen too.
+# on workspace membership — the SDK fires from the login screen too — but
+# the route enforces its own session-or-trusted-Origin gate.
 app.include_router(sentry_tunnel.router, prefix="/api", tags=["sentry"])
 app.include_router(attachments.router, prefix="/api/attachments", tags=["attachments"], dependencies=_member_gate)
 app.include_router(custom_fields.router, prefix="/api/custom-fields", tags=["custom_fields"], dependencies=_member_gate)

--- a/backend/tests/test_sentry_tunnel.py
+++ b/backend/tests/test_sentry_tunnel.py
@@ -1,7 +1,7 @@
 """Tests for the /api/sentry-tunnel hardening (Sec CRIT-5).
 
-The route is unauthenticated by design (Sentry SDKs don't carry a session
-cookie). What we pin here:
+The route allows unauthenticated same-origin SDK posts so login-screen
+errors can still report. What we pin here:
 - 204 short-circuit when no DSN is configured (no upstream egress).
 - 400 on empty / malformed / DSN-missing envelopes.
 - 403 on a DSN that doesn't match the server's allow-list.
@@ -13,6 +13,7 @@ cookie). What we pin here:
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
@@ -141,7 +142,11 @@ def test_sentry_tunnel_route_has_rate_limit_decorator():
     """slowapi's `enabled=False` outside prod means we can't trip the
     limit in tests, but we can verify the decorator was applied — its
     presence is the load-bearing check."""
-    from app.api.routes.sentry_tunnel import sentry_tunnel
+    import app.api.routes.sentry_tunnel as sentry_tunnel_mod
+
+    sentry_tunnel = sentry_tunnel_mod.sentry_tunnel
+    source = Path(sentry_tunnel_mod.__file__).read_text()
+    assert '@limiter.limit("30/minute")' in source
 
     # slowapi attaches a `limiter_kwargs` attribute on the wrapped
     # callable. The exact attribute name is internal; check for any of

--- a/backend/tests/test_sentry_tunnel_auth.py
+++ b/backend/tests/test_sentry_tunnel_auth.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import json
+
+from app.api.routes import sentry_tunnel as sentry_tunnel_route
+
+
+def test_unauthenticated_cross_origin_rejected(client, monkeypatch):
+    monkeypatch.setattr(
+        sentry_tunnel_route,
+        "ALLOWED_ENDPOINTS",
+        (("o123.ingest.sentry.io", "456"),),
+    )
+
+    envelope_header = json.dumps({"dsn": "https://abc@o123.ingest.sentry.io/456"})
+    response = client.post(
+        "/api/sentry-tunnel",
+        content=envelope_header.encode() + b"\n{}",
+        headers={"Origin": "https://evil.example.com"},
+    )
+
+    assert response.status_code in {401, 403}, response.text
+    body = response.json()
+    assert body["data"] is None
+    assert body["status"]["category"] in {"unauthenticated", "forbidden"}

--- a/docs/api/sentry-tunnel.md
+++ b/docs/api/sentry-tunnel.md
@@ -8,7 +8,7 @@ Reference: https://docs.sentry.io/platforms/javascript/troubleshooting/#using-th
 
 ## Conventions
 
-See [API conventions](./README.md) for envelope, errors. Mounted at `/api/sentry-tunnel` (the prefix is `/api`, route path is `/sentry-tunnel`; `backend/app/main.py:382`). Not gated by workspace membership — the SDK fires from the login screen too (see the `app/main.py:379-381` comment).
+See [API conventions](./README.md) for envelope, errors. Mounted at `/api/sentry-tunnel` (the prefix is `/api`, route path is `/sentry-tunnel`). Not gated by workspace membership — the SDK fires from the login screen too — but requests must either carry a trusted same-origin `Origin` header or a valid session cookie.
 
 ## Routes
 
@@ -18,21 +18,22 @@ Forward a Sentry envelope upstream.
 
 **Request** — Sentry envelope bytes (`Content-Type: application/x-sentry-envelope`, but we don't enforce on input).
 
-**Response — no DSN configured** — `204 No Content`. Returned when neither `VITE_SENTRY_DSN` nor `SENTRY_DSN` is set, so SDK retries don't hammer the route (`sentry_tunnel.py:64-68`).
+**Response — no DSN configured** — `204 No Content`. Returned when neither `VITE_SENTRY_DSN` nor `SENTRY_DSN` is set, so SDK retries don't hammer the route.
 
-**Response — happy path** — Sentry's response body, status, and `Content-Type` are forwarded verbatim so the SDK sees the real outcome (rate limits, errors) (`sentry_tunnel.py:135-141`).
+**Response — happy path** — Sentry's response body, status, and `Content-Type` are forwarded verbatim so the SDK sees the real outcome (rate limits, errors).
 
 **Errors**
 
-- `413 sentry_tunnel.too_large` — envelope exceeds `SENTRY_TUNNEL_MAX_BYTES` (200 KiB default). Body includes `max_bytes`. The body is streamed and the running total is checked per chunk so an oversize payload is rejected before buffering (`sentry_tunnel.py:74-85`).
-- `400 sentry_tunnel.empty` — zero-byte envelope (`sentry_tunnel.py:89-94`).
-- `400 sentry_tunnel.malformed_header` — first line is not valid JSON / UTF-8 (`sentry_tunnel.py:100-108`).
-- `400 sentry_tunnel.missing_dsn` — envelope header has no `dsn` key (`sentry_tunnel.py:109-115`).
-- `403 sentry_tunnel.dsn_mismatch` — `(host, project_id)` parsed from the envelope's `dsn` is not in the server's allow-list (`sentry_tunnel.py:116-124`).
+- `401 auth.not_authenticated` — request has no trusted `Origin` header and no usable session cookie.
+- `413 sentry_tunnel.too_large` — envelope exceeds `SENTRY_TUNNEL_MAX_BYTES` (200 KiB default) or the chunk-count guard. The body is streamed and checked per chunk so abusive payloads are rejected before unbounded buffering.
+- `400 sentry_tunnel.empty` — zero-byte envelope.
+- `400 sentry_tunnel.malformed_header` — first line is not valid JSON / UTF-8.
+- `400 sentry_tunnel.missing_dsn` — envelope header has no `dsn` key.
+- `403 sentry_tunnel.dsn_mismatch` — `(host, project_id)` parsed from the envelope's `dsn` is not in the server's allow-list.
 
 **Notes**
 
-- Rate limit: `60/minute` per IP (`sentry_tunnel.py:62`).
-- Allow-list is `(host, project_id)` tuples derived from `VITE_SENTRY_DSN` and `SENTRY_DSN` (`sentry_tunnel.py:39-58`).
-- Upstream POST: `https://{host}/api/{project_id}/envelope/` with `Content-Type: application/x-sentry-envelope`, 10s timeout (`sentry_tunnel.py:126-134`).
-- Source: `backend/app/api/routes/sentry_tunnel.py:61-141`.
+- Rate limit: `30/minute` per IP.
+- Allow-list is `(host, project_id)` tuples derived from `VITE_SENTRY_DSN` and `SENTRY_DSN`.
+- Upstream POST: `https://{host}/api/{project_id}/envelope/` with `Content-Type: application/x-sentry-envelope`, 10s timeout.
+- Source: `backend/app/api/routes/sentry_tunnel.py`.


### PR DESCRIPTION
Closes #565

## Summary
- Require a trusted same-origin `Origin` or a valid session before `/api/sentry-tunnel` processes envelopes.
- Lower the tunnel rate limit from 60/minute to 30/minute.
- Add the requested cross-origin unauthenticated regression test and update the tunnel API docs.

## Validation
- `PATH=/mnt/data/WORK/stockManager-1/.codex-worktrees/aud-026-sentry-tunnel-origin-rate-limit/backend/.venv/bin:$PATH python -m pytest backend/tests/test_sentry_tunnel_auth.py -q`
- `PATH=/mnt/data/WORK/stockManager-1/.codex-worktrees/aud-026-sentry-tunnel-origin-rate-limit/backend/.venv/bin:$PATH python -m pytest backend/tests/test_sentry_tunnel.py backend/tests/test_sentry_tunnel_auth.py backend/tests/test_sentry_tunnel_chunks.py -q`
- `PATH=/mnt/data/WORK/stockManager-1/.codex-worktrees/aud-026-sentry-tunnel-origin-rate-limit/backend/.venv/bin:$PATH python -m ruff check backend/app/api/routes/sentry_tunnel.py backend/tests/test_sentry_tunnel.py backend/tests/test_sentry_tunnel_auth.py`
- `PATH=/mnt/data/WORK/stockManager-1/.codex-worktrees/aud-026-sentry-tunnel-origin-rate-limit/backend/.venv/bin:$PATH LINT_CMD="ruff check app --output-format=concise" BASELINE_FILE="../.ruff-baseline.txt" WORK_DIR="." bash ../scripts/lint-delta.sh`

## Notes
- The first standalone run of `backend/tests/test_sentry_tunnel_chunks.py` hit a shared Postgres schema setup collision before test execution; an immediate retry and the combined Sentry tunnel run passed.
