### PR TITLE
[codex] Map provider HTTPX exceptions

### DIFF
--- a/backend/app/domain/parts/providers/digikey.py
+++ b/backend/app/domain/parts/providers/digikey.py
@@ -87,7 +87,7 @@ def _get_product_details(
         resp = client.get(url, headers=_digikey_headers(token, client_id))
     try:
         body = resp.json()
-    except Exception:
+    except ValueError:
         body = {}
     return resp.status_code, body
 
@@ -106,7 +106,7 @@ def _post_keyword_search(
         resp = client.post(url, headers=headers, json=payload)
     try:
         body = resp.json()
-    except Exception:
+    except ValueError:
         body = {}
     return resp.status_code, body
 
@@ -164,10 +164,15 @@ class DigiKeyProvider:
             )
         except ProviderUpstreamError:
             raise
-        except (httpx.TimeoutException, httpx.ConnectError) as exc:
+        except httpx.HTTPStatusError as exc:
             raise ProviderUpstreamError(
                 "digikey",
-                f"DigiKey upstream unavailable ({type(exc).__name__})",
+                f"DigiKey upstream returned HTTP {exc.response.status_code}",
+            ) from exc
+        except httpx.TimeoutException as exc:
+            raise ProviderUpstreamError(
+                "digikey",
+                f"DigiKey upstream unavailable: timed out ({type(exc).__name__})",
             ) from exc
         except RuntimeError as exc:
             # Raised by _get_token when the OAuth response is malformed.
@@ -176,10 +181,10 @@ class DigiKeyProvider:
                 "result": None,
                 "message": f"DigiKey auth failed ({type(exc).__name__})",
             }
-        except Exception as exc:
+        except httpx.ConnectError as exc:
             raise ProviderUpstreamError(
                 "digikey",
-                f"DigiKey upstream unavailable ({type(exc).__name__})",
+                f"DigiKey upstream unavailable: connection failed ({type(exc).__name__})",
             ) from exc
         if status >= 500:
             raise ProviderUpstreamError(
@@ -216,15 +221,20 @@ class DigiKeyProvider:
                 )
             except ProviderUpstreamError:
                 raise
-            except (httpx.TimeoutException, httpx.ConnectError) as exc:
+            except httpx.HTTPStatusError as exc:
                 raise ProviderUpstreamError(
                     "digikey",
-                    f"DigiKey upstream unavailable ({type(exc).__name__})",
+                    f"DigiKey upstream returned HTTP {exc.response.status_code}",
                 ) from exc
-            except Exception as exc:
+            except httpx.TimeoutException as exc:
                 raise ProviderUpstreamError(
                     "digikey",
-                    f"DigiKey upstream unavailable ({type(exc).__name__})",
+                    f"DigiKey upstream unavailable: timed out ({type(exc).__name__})",
+                ) from exc
+            except httpx.ConnectError as exc:
+                raise ProviderUpstreamError(
+                    "digikey",
+                    f"DigiKey upstream unavailable: connection failed ({type(exc).__name__})",
                 ) from exc
             if kw_status == 200:
                 products = (kw_data or {}).get("Products") or []

--- a/backend/app/domain/parts/providers/mouser.py
+++ b/backend/app/domain/parts/providers/mouser.py
@@ -138,15 +138,20 @@ class MouserProvider:
             data = _post_mouser(url, body)
         except ProviderUpstreamError:
             raise
-        except (httpx.TimeoutException, httpx.ConnectError) as exc:
+        except httpx.HTTPStatusError as exc:
             raise ProviderUpstreamError(
                 "mouser",
-                f"Mouser upstream unavailable ({type(exc).__name__})",
+                f"Mouser upstream returned HTTP {exc.response.status_code}",
             ) from exc
-        except Exception as exc:
+        except httpx.TimeoutException as exc:
             raise ProviderUpstreamError(
                 "mouser",
-                f"Mouser upstream unavailable ({type(exc).__name__})",
+                f"Mouser upstream unavailable: timed out ({type(exc).__name__})",
+            ) from exc
+        except httpx.ConnectError as exc:
+            raise ProviderUpstreamError(
+                "mouser",
+                f"Mouser upstream unavailable: connection failed ({type(exc).__name__})",
             ) from exc
 
         errors = data.get("Errors") or []

--- a/backend/tests/test_parts_provider.py
+++ b/backend/tests/test_parts_provider.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import uuid
 
+import httpx
 import pytest
 from fastapi.testclient import TestClient
 
@@ -228,7 +229,7 @@ def test_lookup_mouser_network_failure_is_graceful(authed, monkeypatch):
     _enable_mouser(authed)
 
     def fail(url, payload):
-        raise RuntimeError("simulated DNS failure")
+        raise httpx.ConnectError("simulated connection failure")
 
     monkeypatch.setattr("app.domain.parts.providers.mouser._post_mouser", fail)
     r = authed.post("/api/parts/lookup-mpn", json={"mpn": "ANY"})
@@ -236,6 +237,7 @@ def test_lookup_mouser_network_failure_is_graceful(authed, monkeypatch):
     body = r.json()
     assert body["data"] is None
     assert "upstream unavailable" in body["status"]["message"]
+    assert "connection failed" in body["status"]["message"]
     assert body["provider"] == "mouser"
 
 

--- a/backend/tests/test_parts_provider_upstream_errors.py
+++ b/backend/tests/test_parts_provider_upstream_errors.py
@@ -54,6 +54,16 @@ def _enable_digikey(client: TestClient) -> None:
     assert r.status_code == 200, r.text
 
 
+def _http_status_error(status_code: int, url: str) -> httpx.HTTPStatusError:
+    request = httpx.Request("GET", url)
+    response = httpx.Response(status_code, request=request)
+    return httpx.HTTPStatusError(
+        f"HTTP {status_code}",
+        request=request,
+        response=response,
+    )
+
+
 def test_mouser_503_returns_502(monkeypatch):
     _reset_provider_state("mouser")
     c = _authed_client()
@@ -81,6 +91,56 @@ def test_mouser_503_returns_502(monkeypatch):
     assert body["provider"] == "mouser"
 
 
+def test_mouser_http_status_error_returns_502(monkeypatch):
+    _reset_provider_state("mouser")
+    c = _authed_client()
+    _enable_mouser(c)
+
+    @contextmanager
+    def fake_client(*, provider_name: str, timeout: float):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(404, json={"message": "missing"}, request=request)
+
+        with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+            yield client
+
+    monkeypatch.setattr(
+        "app.domain.parts.providers.mouser.make_retrying_client",
+        fake_client,
+    )
+
+    r = c.post("/api/parts/lookup-mpn", json={"mpn": "RC0402JR-070R"})
+    assert r.status_code == 502, r.text
+    body = r.json()
+    assert body["data"] is None
+    assert body["status"]["category"] == "server_error"
+    assert "HTTP 404" in body["status"]["message"]
+    assert body["provider"] == "mouser"
+
+
+def test_mouser_connect_error_returns_502(monkeypatch):
+    _reset_provider_state("mouser")
+    c = _authed_client()
+    _enable_mouser(c)
+
+    def connect_error(url: str, payload: dict) -> dict:
+        raise httpx.ConnectError("connection failed")
+
+    monkeypatch.setattr(
+        "app.domain.parts.providers.mouser._post_mouser",
+        connect_error,
+    )
+
+    r = c.post("/api/parts/lookup-mpn", json={"mpn": "RC0402JR-070R"})
+    assert r.status_code == 502, r.text
+    body = r.json()
+    assert body["data"] is None
+    assert body["status"]["category"] == "server_error"
+    assert "connection failed" in body["status"]["message"]
+    assert "ConnectError" in body["status"]["message"]
+    assert body["provider"] == "mouser"
+
+
 def test_digikey_timeout_returns_502(monkeypatch):
     _reset_provider_state("digikey")
     c = _authed_client()
@@ -104,7 +164,30 @@ def test_digikey_timeout_returns_502(monkeypatch):
     body = r.json()
     assert body["data"] is None
     assert body["status"]["category"] == "server_error"
+    assert "timed out" in body["status"]["message"]
     assert "ReadTimeout" in body["status"]["message"]
+    assert body["provider"] == "digikey"
+
+
+def test_digikey_http_status_error_returns_502(monkeypatch):
+    _reset_provider_state("digikey")
+    c = _authed_client()
+    _enable_digikey(c)
+
+    def http_status_error(client_id: str, client_secret: str) -> dict:
+        raise _http_status_error(401, "https://api.digikey.com/v1/oauth2/token")
+
+    monkeypatch.setattr(
+        "app.domain.parts.providers.digikey._post_token",
+        http_status_error,
+    )
+
+    r = c.post("/api/parts/lookup-mpn", json={"mpn": "TXU0204QWBQARQ1"})
+    assert r.status_code == 502, r.text
+    body = r.json()
+    assert body["data"] is None
+    assert body["status"]["category"] == "server_error"
+    assert "HTTP 401" in body["status"]["message"]
     assert body["provider"] == "digikey"
 
 

--- a/backend/tests/test_provider_circuit_breaker.py
+++ b/backend/tests/test_provider_circuit_breaker.py
@@ -6,6 +6,7 @@ upstream.  The counter resets on a successful call.
 """
 from __future__ import annotations
 
+import httpx
 import pytest
 
 # ---------------------------------------------------------------------------
@@ -188,7 +189,7 @@ def test_circuit_breaker_returns_503_via_route(monkeypatch):
 
     def _fail_post_mouser(url: str, payload: dict) -> dict:
         call_count[0] += 1
-        raise RuntimeError("simulated upstream failure")
+        raise httpx.ConnectError("simulated upstream failure")
 
     monkeypatch.setattr(
         "app.domain.parts.providers.mouser._post_mouser",


### PR DESCRIPTION
## Summary
- replace broad Mouser and DigiKey provider exception handling with explicit HTTPX status, timeout, and connection mappings
- preserve DigiKey non-JSON response tolerance with narrow `ValueError` handling
- add upstream-error regression coverage for distinct provider failure categories

## Validation
- `uv run --extra dev python -m pytest tests/test_parts_provider_upstream_errors.py -q`
- `uv run --extra dev python -m pytest tests/test_parts_provider_upstream_errors.py tests/test_parts_provider.py tests/test_digikey_provider.py tests/test_mouser_extraction.py -q`
- `uv run --extra dev ruff check app/domain/parts/providers/mouser.py app/domain/parts/providers/digikey.py tests/test_parts_provider_upstream_errors.py tests/test_parts_provider.py`

Closes #597
