### PR TITLE
[codex] Support workspace secrets key rotation

### DIFF
--- a/backend/app/core/secrets.py
+++ b/backend/app/core/secrets.py
@@ -5,9 +5,10 @@ parts_provider_api_secret / scanner_license_key were stored as
 plaintext columns. A DB dump (legitimate backup, replica, log) leaked
 every workspace's third-party credentials.
 
-Uses Fernet (AES-128-CBC + HMAC-SHA256, with timestamp + version) keyed
-off `WORKSPACE_SECRETS_KEY` (a base64-encoded 32-byte Fernet key from
-env). Generate one with:
+Uses MultiFernet (AES-128-CBC + HMAC-SHA256, with timestamp + version)
+keyed off `WORKSPACE_SECRETS_KEY` (one or more comma-separated
+base64-encoded 32-byte Fernet keys from env). Encryptions use the first
+key; decryptions accept any listed key. Generate a key with:
 
     python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
 
@@ -36,7 +37,7 @@ from __future__ import annotations
 
 from functools import lru_cache
 
-from cryptography.fernet import Fernet, InvalidToken
+from cryptography.fernet import Fernet, InvalidToken, MultiFernet
 
 from app.core.logging import get_logger
 
@@ -44,7 +45,7 @@ log = get_logger(__name__)
 
 
 @lru_cache(maxsize=1)
-def _fernet() -> Fernet:
+def _fernet() -> MultiFernet:
     from app.core.config import settings
 
     key = settings().WORKSPACE_SECRETS_KEY
@@ -56,10 +57,15 @@ def _fernet() -> Fernet:
             "key. Encrypted workspace credentials will not survive a "
             "process restart. Set the env var to persist them. Generate "
             "one with: "
-            "python -c \"from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())\""
+            "python -c \"from cryptography.fernet import Fernet; "
+            "print(Fernet.generate_key().decode())\""
         )
-        return Fernet(Fernet.generate_key())
-    return Fernet(key.encode("ascii"))
+        return MultiFernet([Fernet(Fernet.generate_key())])
+
+    keys = [part.strip() for part in key.split(",") if part.strip()]
+    if not keys:
+        raise ValueError("WORKSPACE_SECRETS_KEY must contain at least one Fernet key")
+    return MultiFernet([Fernet(part.encode("ascii")) for part in keys])
 
 
 def encrypt(plaintext: str | None) -> str | None:

--- a/backend/tests/test_secrets_rotation.py
+++ b/backend/tests/test_secrets_rotation.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import pytest
+from cryptography.fernet import Fernet, InvalidToken
+
+from app.core import secrets
+from app.core.config import settings
+
+
+def test_multifernet_decrypts_old_ciphertext(monkeypatch):
+    old_key = Fernet.generate_key().decode("ascii")
+    new_key = Fernet.generate_key().decode("ascii")
+    plaintext = "rotatable-workspace-secret"
+
+    try:
+        monkeypatch.setenv("WORKSPACE_SECRETS_KEY", old_key)
+        settings.cache_clear()
+        secrets._fernet.cache_clear()
+        old_ciphertext = secrets.encrypt(plaintext)
+
+        monkeypatch.setenv("WORKSPACE_SECRETS_KEY", f"{new_key},{old_key}")
+        settings.cache_clear()
+        secrets._fernet.cache_clear()
+
+        assert secrets.decrypt(old_ciphertext) == plaintext
+
+        new_ciphertext = secrets.encrypt(plaintext)
+        assert new_ciphertext is not None
+        assert Fernet(new_key.encode("ascii")).decrypt(
+            new_ciphertext.encode("ascii")
+        ).decode("utf-8") == plaintext
+        with pytest.raises(InvalidToken):
+            Fernet(old_key.encode("ascii")).decrypt(new_ciphertext.encode("ascii"))
+
+    finally:
+        settings.cache_clear()
+        secrets._fernet.cache_clear()


### PR DESCRIPTION
## Summary

- Parse `WORKSPACE_SECRETS_KEY` as a comma-separated key ring and build a `MultiFernet` instance.
- Keep encryption on the first configured key while allowing decryption with any listed key.
- Add `test_multifernet_decrypts_old_ciphertext` for the prepend-new-key rotation path.

Closes #564

## Open PR overlap / merge order

Checked open PRs before editing. None touch `backend/app/core/secrets.py` or `backend/tests/test_secrets_rotation.py`, so no special merge order is required.

## Validation

- `PYTHONPATH=/mnt/data/WORK/stockManager-1/.codex-worktrees/aud-025-workspace-secrets-key-rotation/backend /mnt/data/WORK/stockManager-1/.codex-worktrees/aud-026-sentry-tunnel-origin-rate-limit/backend/.venv/bin/python -m ruff check app/core/secrets.py tests/test_secrets_rotation.py` - passed
- Direct rotation check with this worktree on `PYTHONPATH` - passed
- `python -m pytest backend/tests/test_secrets_rotation.py -q` - blocked locally because `python` is not installed on PATH
- `.../backend/.venv/bin/python -m pytest tests/test_secrets_rotation.py -q` with isolated `TEST_DATABASE_URL=.../stockmgr_test_aud025` - blocked locally because no Postgres server is listening on `127.0.0.1:5432`; repo pytest conftest initializes the DB session fixture even for this focused unit test
