### PR TITLE
[codex] Normalize bag signatures for Unicode Zs whitespace

### DIFF
--- a/backend/app/domain/parts/services/bag_signature.py
+++ b/backend/app/domain/parts/services/bag_signature.py
@@ -31,21 +31,29 @@ from __future__ import annotations
 
 import hashlib
 
-# ECMAScript WhiteSpace + LineTerminator characters — the characters that
-# JavaScript's String.prototype.trim() removes.  This is intentionally a
-# strict subset of Python's str.isspace() universe: Python also considers
-# ASCII FS (0x1c), GS (0x1d), RS (0x1e), US (0x1f) as whitespace, but
-# JavaScript's trim() does NOT — those are field-separator control chars
+# ECMAScript WhiteSpace + LineTerminator characters: the characters that
+# JavaScript's String.prototype.trim() removes. This includes every Unicode
+# Space_Separator (Zs) codepoint, plus a small set of explicit controls.
+# It is still a strict subset of Python's str.isspace() universe: Python also
+# considers ASCII FS (0x1c), GS (0x1d), RS (0x1e), US (0x1f) as whitespace,
+# but JavaScript's trim() does NOT. Those are field-separator control chars
 # that appear legitimately inside bag codes, and stripping them would alter
 # the digest.
 #
 # ECMAScript spec references:
-#   WhiteSpace:     TAB(09) VT(0b) FF(0c) SP(20) NBSP(a0) ZWNBSP(feff) <USP>
+#   WhiteSpace:     TAB(09) VT(0b) FF(0c) ZWNBSP(feff) <USP / Zs>
 #   LineTerminator: LF(0a) CR(0d) LS(2028) PS(2029)
 _JS_WHITESPACE: frozenset[str] = frozenset(
     "\x09\x0a\x0b\x0c\x0d"   # TAB LF VT FF CR
     "\x20"                    # SPACE
     "\xa0"                    # NO-BREAK SPACE
+    "\u1680"                  # OGHAM SPACE MARK
+    "\u2000\u2001\u2002\u2003"  # EN QUAD, EM QUAD, EN SPACE, EM SPACE
+    "\u2004\u2005\u2006\u2007"  # THREE-PER-EM, FOUR-PER-EM, SIX-PER-EM, FIGURE
+    "\u2008\u2009\u200a"      # PUNCTUATION, THIN, HAIR SPACE
+    "\u202f"                  # NARROW NO-BREAK SPACE
+    "\u205f"                  # MEDIUM MATHEMATICAL SPACE
+    "\u3000"                  # IDEOGRAPHIC SPACE
     "﻿"                  # ZERO-WIDTH NO-BREAK SPACE (BOM)
     " "                  # LINE SEPARATOR
     " "                  # PARAGRAPH SEPARATOR

--- a/backend/tests/test_bag_signature_parity.py
+++ b/backend/tests/test_bag_signature_parity.py
@@ -17,7 +17,6 @@ import pytest
 
 from app.domain.parts.services.bag_signature import compute_bag_signature
 
-
 _FIXTURE_PATH = (
     Path(__file__).resolve().parent.parent.parent
     / "web" / "src" / "lib" / "__fixtures__" / "bagSignatures.json"
@@ -90,6 +89,12 @@ def test_trim_whitespace_gives_same_digest():
     base = compute_bag_signature("STM32F103C8T6")
     assert compute_bag_signature("  STM32F103C8T6  ") == base
     assert compute_bag_signature("\tSTM32F103C8T6\n") == base
+
+
+def test_zs_whitespace_parity():
+    """Unicode Zs whitespace mirrors JavaScript trim() for bag signatures."""
+    base = compute_bag_signature("STM32F103C8T6")
+    assert compute_bag_signature("\u3000STM32F103C8T6\u3000") == base
 
 
 def test_control_picture_eot_normalised():

--- a/web/src/lib/__fixtures__/bagSignatures.json
+++ b/web/src/lib/__fixtures__/bagSignatures.json
@@ -27,7 +27,8 @@
       "raws": [
         "STM32F103C8T6",
         "  STM32F103C8T6  ",
-        "\tSTM32F103C8T6\n"
+        "\tSTM32F103C8T6\n",
+        "\u3000STM32F103C8T6\u3000"
       ]
     },
     {

--- a/web/src/lib/bagCode.test.ts
+++ b/web/src/lib/bagCode.test.ts
@@ -112,6 +112,11 @@ describe("bagSignature", () => {
     expect(await bagSignature("")).toBeNull();
     expect(await bagSignature("   ")).toBeNull();
   });
+
+  it("test_zs_whitespace_parity", async () => {
+    const base = await bagSignature("STM32F103C8T6");
+    expect(await bagSignature("\u3000STM32F103C8T6\u3000")).toBe(base);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- expand backend bag-signature trimming to cover every Unicode `Zs` whitespace codepoint that JavaScript `String.prototype.trim()` removes
- add U+3000 ideographic-space parity coverage in backend, frontend, and the shared bag signature fixture

## Validation
- `npm --prefix web run test -- bagCode` passed (29 tests)
- `ruff check backend/app/domain/parts/services/bag_signature.py backend/tests/test_bag_signature_parity.py` passed
- direct backend signature check passed for U+3000 trimming while preserving U+001C field separators
- `python -m pytest backend/tests/test_bag_signature_parity.py -q` could not run as written in this environment: `python` is not installed; with `python3`/project venv the test harness requires Postgres at `127.0.0.1:5432`, but no local Postgres server is running and Docker is unavailable

## PR overlap / merge order
Open PRs were inspected before editing. None touched `backend/app/domain/parts/services/bag_signature.py`, `backend/tests/test_bag_signature_parity.py`, `web/src/lib/__fixtures__/bagSignatures.json`, or `web/src/lib/bagCode.test.ts`, so no special merge order is required.

Closes #558
