### PR TITLE
[codex] AUD-006 generic login lockout response

### DIFF
--- a/backend/tests/test_auth_lockout.py
+++ b/backend/tests/test_auth_lockout.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import uuid
 
 import pytest
+from fastapi import status
 from fastapi.testclient import TestClient
 
 from app.main import app
@@ -125,6 +126,40 @@ def test_unknown_email_also_gets_locked():
     r = _fail_login(c, ghost, n=1)[0]
     assert r.status_code == 429, r.text
     assert r.json()["code"] == "auth.account_locked"
+
+
+def test_lockout_shape_uniform_across_known_and_unknown():
+    """Known-account and phantom-email lockouts must return the same body shape."""
+    from app.core.auth import LOCKOUT_MAX_FAILURES
+
+    def response_shape(value):
+        if isinstance(value, dict):
+            return {key: response_shape(nested) for key, nested in sorted(value.items())}
+        if isinstance(value, list):
+            return [response_shape(item) for item in value]
+        return type(value).__name__
+
+    c = TestClient(app)
+    known = f"known-{uuid.uuid4().hex[:8]}@x.com"
+    unknown = f"ghost-{uuid.uuid4().hex[:8]}@nowhere.com"
+    signup_user(c, email=known)
+
+    _fail_login(c, known, n=LOCKOUT_MAX_FAILURES)
+    _fail_login(c, unknown, n=LOCKOUT_MAX_FAILURES)
+
+    known_response = c.post("/api/auth/login", json={"email": known, "password": "WrongPass!!X"})
+    unknown_response = c.post(
+        "/api/auth/login",
+        json={"email": unknown, "password": "WrongPass!!X"},
+    )
+
+    assert known_response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+    assert unknown_response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+    known_body = known_response.json()
+    unknown_body = unknown_response.json()
+    assert response_shape(known_body) == response_shape(unknown_body)
+    assert known_body["code"] == unknown_body["code"] == "auth.account_locked"
+    assert known_body["status"] == unknown_body["status"]
 
 
 def test_lockout_response_envelope():

--- a/web/src/routes/auth/Login.test.tsx
+++ b/web/src/routes/auth/Login.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { api, ApiError, type ApiErr } from "@/lib/api";
+import { useAuth } from "@/lib/auth";
+import Login from "./Login";
+
+vi.mock("@/lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api")>();
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      post: vi.fn(),
+    },
+  };
+});
+
+vi.mock("@/lib/auth", () => ({
+  useAuth: vi.fn(),
+}));
+
+const mockPost = api.post as ReturnType<typeof vi.fn>;
+const mockUseAuth = useAuth as ReturnType<typeof vi.fn>;
+
+function renderLogin() {
+  const queryClient = new QueryClient({
+    defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={["/login"]}>
+        <Routes>
+          <Route path="/login" element={<Login />} />
+          <Route path="/parts" element={<div>parts-page</div>} />
+          <Route path="/signup" element={<div>signup-page</div>} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  mockUseAuth.mockReturnValue({
+    me: null,
+    loading: false,
+    refresh: vi.fn().mockResolvedValue(undefined),
+    logout: vi.fn(),
+    workspaceId: null,
+    switchWorkspace: vi.fn(),
+  });
+});
+
+describe("Login", () => {
+  it("test_429_renders_generic_message", async () => {
+    const body = {
+      data: null,
+      status: { category: "validation_error", message: "too many failed login attempts" },
+      code: "auth.account_locked",
+      retry_after_seconds: 900,
+    } as ApiErr;
+
+    mockPost.mockRejectedValue(new ApiError(429, body, body.status.message));
+
+    renderLogin();
+
+    fireEvent.change(screen.getByLabelText("Email"), { target: { value: "locked@example.com" } });
+    fireEvent.change(screen.getByLabelText("Password"), { target: { value: "WrongPass!!X" } });
+    fireEvent.click(screen.getByRole("button", { name: "Sign in" }));
+
+    expect(
+      await screen.findByText("Login failed. Check your credentials and try again."),
+    ).toBeDefined();
+    expect(screen.queryByText(/too many failed login attempts/i)).toBeNull();
+    expect(screen.queryByText(/try again in/i)).toBeNull();
+  });
+});

--- a/web/src/routes/auth/Login.tsx
+++ b/web/src/routes/auth/Login.tsx
@@ -12,9 +12,6 @@ export default function Login() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [err, setErr] = useState<string | null>(null);
-  // SEC2-014: the server returns retry_after_seconds on a 429 lockout
-  // response. Show a countdown so the user knows how long to wait.
-  const [retryAfter, setRetryAfter] = useState<number | null>(null);
 
   // `from` is set by `<Gate>` (and by the 401 handler in auth.tsx) when
   // an authed page bounced the user here. Replay the original target on
@@ -31,14 +28,7 @@ export default function Login() {
     },
     onError: (e) => {
       if (e instanceof ApiError) {
-        // SEC2-014: per-account lockout returns 429 with retry_after_seconds.
-        const body = e.body as Record<string, unknown> | null;
-        if (e.status === 429 && body && typeof body.retry_after_seconds === "number") {
-          setRetryAfter(body.retry_after_seconds);
-          setErr("Too many failed login attempts. Please try again later.");
-        } else {
-          setErr(e.userMessage);
-        }
+        setErr("Login failed. Check your credentials and try again.");
       } else {
         setErr("Login failed");
       }
@@ -50,7 +40,6 @@ export default function Login() {
   function submit(e: React.FormEvent) {
     e.preventDefault();
     setErr(null);
-    setRetryAfter(null);
     loginMutation.mutate({ email, password });
   }
 
@@ -60,11 +49,6 @@ export default function Login() {
         {err && (
           <div className="rounded-md border border-danger/40 bg-danger/10 px-3 py-2 text-danger text-sm">
             {err}
-            {retryAfter !== null && (
-              <span className="block mt-1 text-xs">
-                Try again in {Math.ceil(retryAfter / 60)} minute{retryAfter > 60 ? "s" : ""}.
-              </span>
-            )}
           </div>
         )}
         <div>


### PR DESCRIPTION
## Summary
- Remove the login page's special 429 lockout branch and retry countdown so failed login attempts render one generic message.
- Add a frontend regression test for 429 login lockout rendering.
- Add a backend regression test asserting known-account and phantom-email lockout responses have the same shape.

## Impact
Unauthenticated login users no longer see lockout-specific timing or wording. Authenticated account-page retry UX remains out of scope for this login form change.

## Open PR overlap / merge order
Inspected open PRs before editing and again after rebasing. Current open PRs #656, #655, #611, #483, and #482 do not touch `backend/tests/test_auth_lockout.py`, `web/src/routes/auth/Login.tsx`, or `web/src/routes/auth/Login.test.tsx`, so no special merge order is required.

## Validation
- `npm_config_cache=/mnt/data/WORK/stockManager-1/tmp/npm-cache TMPDIR=/mnt/data/WORK/stockManager-1/tmp npm --prefix web run test -- Login.test`
- `web/node_modules/.bin/eslint web/src/routes/auth/Login.tsx web/src/routes/auth/Login.test.tsx`
- `/mnt/data/WORK/stockManager-1/.codex-worktrees/aud-058-provider-narrow-exceptions/backend/.venv/bin/python -m ruff check backend/tests/test_auth_lockout.py`

Backend pytest blocker:
- `python -m pytest backend/tests/test_auth_lockout.py -q` could not run because `python` is not installed in the shell.
- `python3 -m pytest backend/tests/test_auth_lockout.py -q` could not import Alembic from the system Python.
- Running with an existing backend venv reached the test setup, but failed because Postgres is not listening at `127.0.0.1:5432` for `stockmgr_test`.

Closes #545
