### PR TITLE
[codex] Unify provider error taxonomy

### DIFF
--- a/backend/app/domain/parts/providers/__init__.py
+++ b/backend/app/domain/parts/providers/__init__.py
@@ -1,7 +1,15 @@
 from app.domain.parts.providers.base import (
     MpnLookupResult,
     PartsProvider,
+    ProviderError,
+    ProviderUpstreamError,
     make_provider,
 )
 
-__all__ = ["MpnLookupResult", "PartsProvider", "make_provider"]
+__all__ = [
+    "MpnLookupResult",
+    "PartsProvider",
+    "ProviderError",
+    "ProviderUpstreamError",
+    "make_provider",
+]

--- a/backend/app/domain/parts/providers/base.py
+++ b/backend/app/domain/parts/providers/base.py
@@ -8,21 +8,15 @@ from __future__ import annotations
 
 from typing import Optional, Protocol, TypedDict
 
+from app.domain.provider_errors import ProviderError, ProviderUpstreamError
 
-class ProviderUpstreamError(Exception):
-    """Provider transport/server failure that callers should surface as 5xx."""
-
-    def __init__(
-        self,
-        provider: str,
-        message: str,
-        *,
-        status_code: int = 502,
-    ) -> None:
-        super().__init__(message)
-        self.provider = provider
-        self.message = message
-        self.status_code = status_code
+__all__ = [
+    "MpnLookupResult",
+    "PartsProvider",
+    "ProviderError",
+    "ProviderUpstreamError",
+    "make_provider",
+]
 
 
 class MpnLookupResult(TypedDict, total=False):

--- a/backend/app/domain/provider_errors.py
+++ b/backend/app/domain/provider_errors.py
@@ -1,0 +1,50 @@
+"""Shared exception taxonomy for external provider integrations."""
+from __future__ import annotations
+
+
+class ProviderError(Exception):
+    """Base error raised by external provider clients."""
+
+    default_status_code = 502
+
+    def __init__(
+        self,
+        provider: str,
+        message: str,
+        *,
+        status_code: int | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.provider = provider
+        self.message = message
+        self.status_code = status_code if status_code is not None else self.default_status_code
+
+
+class ProviderAuthError(ProviderError):
+    """Provider rejected configured credentials."""
+
+    default_status_code = 401
+
+
+class ProviderRateLimitError(ProviderError):
+    """Provider rate-limited the request."""
+
+    default_status_code = 429
+
+
+class ProviderUpstreamError(ProviderError):
+    """Provider transport/server failure."""
+
+    default_status_code = 502
+
+
+class ProviderTimeoutError(ProviderUpstreamError):
+    """Provider request timed out."""
+
+    default_status_code = 504
+
+
+class ProviderValidationError(ProviderError):
+    """Provider returned an unparsable or invalid response."""
+
+    default_status_code = 502

--- a/backend/app/domain/sourcing/client.py
+++ b/backend/app/domain/sourcing/client.py
@@ -10,6 +10,14 @@ from typing import Any
 import httpx
 from pydantic import ValidationError as PydanticValidationError
 
+from app.domain.provider_errors import (
+    ProviderAuthError,
+    ProviderError,
+    ProviderRateLimitError,
+    ProviderTimeoutError,
+    ProviderUpstreamError,
+    ProviderValidationError,
+)
 from app.domain.sourcing._generated.trustedparts_v2 import (
     InventoryApiResponse,
     InventoryDistributorResult,
@@ -40,28 +48,43 @@ MAX_SEARCH_TOKEN_LENGTH = 100
 logger = logging.getLogger(__name__)
 
 
-class SourcingClientError(Exception):
+class SourcingClientError(ProviderError):
     """Base error for TrustedParts sourcing client failures."""
 
+    provider_name = "trustedparts"
 
-class SourcingAuthError(SourcingClientError):
+    def __init__(self, message: str, *, status_code: int | None = None) -> None:
+        super().__init__(self.provider_name, message, status_code=status_code)
+
+
+class SourcingAuthError(SourcingClientError, ProviderAuthError):
     """TrustedParts rejected the supplied credentials."""
 
+    default_status_code = ProviderAuthError.default_status_code
 
-class SourcingRateLimitError(SourcingClientError):
+
+class SourcingRateLimitError(SourcingClientError, ProviderRateLimitError):
     """TrustedParts rate-limited the request."""
 
+    default_status_code = ProviderRateLimitError.default_status_code
 
-class SourcingUpstreamError(SourcingClientError):
+
+class SourcingUpstreamError(SourcingClientError, ProviderUpstreamError):
     """TrustedParts returned a server-side error."""
 
+    default_status_code = ProviderUpstreamError.default_status_code
 
-class SourcingTimeoutError(SourcingClientError):
+
+class SourcingTimeoutError(SourcingClientError, ProviderTimeoutError):
     """TrustedParts did not respond before the client timeout."""
 
+    default_status_code = ProviderTimeoutError.default_status_code
 
-class SourcingValidationError(SourcingClientError):
+
+class SourcingValidationError(SourcingClientError, ProviderValidationError):
     """TrustedParts returned a response this client cannot parse."""
+
+    default_status_code = ProviderValidationError.default_status_code
 
 
 def _post_tp(

--- a/backend/tests/test_provider_error_taxonomy.py
+++ b/backend/tests/test_provider_error_taxonomy.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from app.domain.parts.providers.base import ProviderUpstreamError as PartsProviderUpstreamError
+from app.domain.provider_errors import (
+    ProviderAuthError,
+    ProviderError,
+    ProviderRateLimitError,
+    ProviderTimeoutError,
+    ProviderUpstreamError,
+    ProviderValidationError,
+)
+from app.domain.sourcing.client import (
+    SourcingAuthError,
+    SourcingClientError,
+    SourcingRateLimitError,
+    SourcingTimeoutError,
+    SourcingUpstreamError,
+    SourcingValidationError,
+)
+
+
+def test_all_providers_use_same_base():
+    assert issubclass(PartsProviderUpstreamError, ProviderUpstreamError)
+    assert issubclass(SourcingClientError, ProviderError)
+    assert issubclass(SourcingAuthError, ProviderAuthError)
+    assert issubclass(SourcingRateLimitError, ProviderRateLimitError)
+    assert issubclass(SourcingTimeoutError, ProviderTimeoutError)
+    assert issubclass(SourcingUpstreamError, ProviderUpstreamError)
+    assert issubclass(SourcingValidationError, ProviderValidationError)
+
+    provider_errors = [
+        PartsProviderUpstreamError("mouser", "mouser unavailable"),
+        PartsProviderUpstreamError("digikey", "digikey unavailable"),
+        SourcingClientError("trustedparts failed"),
+        SourcingAuthError("trustedparts rejected credentials"),
+        SourcingRateLimitError("trustedparts rate limit reached"),
+        SourcingTimeoutError("trustedparts timed out"),
+        SourcingUpstreamError("trustedparts returned 500"),
+        SourcingValidationError("trustedparts returned invalid data"),
+    ]
+
+    assert all(isinstance(error, ProviderError) for error in provider_errors)
+    assert [error.provider for error in provider_errors[:3]] == [
+        "mouser",
+        "digikey",
+        "trustedparts",
+    ]


### PR DESCRIPTION
## Summary
- Add a shared provider error hierarchy under backend/app/domain/provider_errors.py.
- Re-export the common ProviderError/ProviderUpstreamError from the parts provider package for compatibility.
- Make TrustedParts sourcing exceptions inherit the same provider base/categories while keeping existing Sourcing* exception names and route mappings unchanged.
- Add the requested taxonomy regression test.

## Validation
- PYTHONPATH=backend backend/.venv/bin/python -m pytest backend/tests/test_provider_error_taxonomy.py -q
- uv run --extra dev python -m pytest tests/test_sourcing_client.py tests/test_parts_provider_upstream_errors.py tests/test_digikey_provider.py tests/test_mouser_extraction.py tests/test_provider_circuit_breaker.py -q
- uv run --extra dev ruff check app/domain/provider_errors.py app/domain/parts/providers/base.py app/domain/parts/providers/__init__.py app/domain/sourcing/client.py tests/test_provider_error_taxonomy.py

## Coordination
This intentionally leaves AUD-058/#597 narrow Mouser/DigiKey exception mapping out of scope. Merge order should be #597 first if it lands soon, then this branch can rebase; otherwise this taxonomy branch should be safe to land first because it preserves ProviderUpstreamError compatibility.

Closes #598