### PR TITLE
[codex] Add purchase plan line project entry FK

### DIFF
--- a/backend/alembic/versions/0051_purchase_plan_line_project_entry_fk.py
+++ b/backend/alembic/versions/0051_purchase_plan_line_project_entry_fk.py
@@ -1,0 +1,42 @@
+"""Add purchase plan line project entry foreign key.
+
+Revision ID: 0051
+Revises: 0050
+Create Date: 2026-05-14
+"""
+
+from alembic import op
+
+revision = "0051"
+down_revision = "0050"
+branch_labels = None
+depends_on = None
+
+CONSTRAINT_NAME = "fk_purchase_plan_lines_project_entry_id_project_entries"
+
+
+def upgrade() -> None:
+    op.execute(
+        f"""
+        ALTER TABLE purchase_plan_lines
+        ADD CONSTRAINT {CONSTRAINT_NAME}
+        FOREIGN KEY (project_entry_id)
+        REFERENCES project_entries (id)
+        ON DELETE SET NULL
+        NOT VALID
+        """
+    )
+    op.execute(
+        f"""
+        ALTER TABLE purchase_plan_lines
+        VALIDATE CONSTRAINT {CONSTRAINT_NAME}
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        CONSTRAINT_NAME,
+        "purchase_plan_lines",
+        type_="foreignkey",
+    )

--- a/backend/app/domain/sourcing/models.py
+++ b/backend/app/domain/sourcing/models.py
@@ -181,7 +181,15 @@ class PurchasePlanLine(Base):
         ForeignKey("purchase_plans.id", ondelete="CASCADE"),
         nullable=False,
     )
-    project_entry_id = Column(UUID(as_uuid=True), nullable=True)
+    project_entry_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey(
+            "project_entries.id",
+            name="fk_purchase_plan_lines_project_entry_id_project_entries",
+            ondelete="SET NULL",
+        ),
+        nullable=True,
+    )
     part_id = Column(
         UUID(as_uuid=True),
         ForeignKey("parts.id", ondelete="CASCADE"),

--- a/backend/tests/test_purchase_plan_line_fk.py
+++ b/backend/tests/test_purchase_plan_line_fk.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import uuid
+from datetime import timedelta
+
+from sqlalchemy.orm import Session
+
+from app.core.time import utcnow
+from app.domain.parts.models import Part
+from app.domain.projects.models import Project, ProjectEntry
+from app.domain.sourcing.models import PurchasePlan, PurchasePlanLine
+from app.domain.users.models import User
+from app.domain.workspaces.models import Workspace
+
+
+def test_parent_delete_sets_null(db: Session) -> None:
+    user = User(
+        email=f"purchase-plan-fk-{uuid.uuid4().hex[:8]}@example.com",
+        name="Purchase Plan FK Tester",
+        password_hash="test",
+    )
+    db.add(user)
+    db.flush()
+
+    workspace = Workspace(
+        name=f"purchase-plan-fk-ws-{uuid.uuid4().hex[:8]}",
+        kind="organization",
+        owner_user_id=user.id,
+    )
+    db.add(workspace)
+    db.flush()
+
+    project = Project(
+        workspace_id=workspace.id,
+        name=f"FK BOM {uuid.uuid4().hex[:8]}",
+        created_by=user.id,
+        updated_by=user.id,
+    )
+    part = Part(
+        workspace_id=workspace.id,
+        name=f"FK Part {uuid.uuid4().hex[:8]}",
+        part_type="local",
+        mpn=f"FK-{uuid.uuid4().hex[:8]}",
+        created_by=user.id,
+        updated_by=user.id,
+    )
+    db.add_all([project, part])
+    db.flush()
+
+    entry = ProjectEntry(
+        workspace_id=workspace.id,
+        project_id=project.id,
+        entry_type="part",
+        part_id=part.id,
+        name=part.name,
+        quantity=5,
+        created_by=user.id,
+        updated_by=user.id,
+    )
+    db.add(entry)
+    db.flush()
+
+    now = utcnow()
+    plan = PurchasePlan(
+        workspace_id=workspace.id,
+        project_id=project.id,
+        build_quantity=1,
+        strategy="lowest_total_price",
+        status="draft",
+        created_at=now,
+        expires_at=now + timedelta(days=1),
+        created_by=user.id,
+    )
+    line = PurchasePlanLine(
+        project_entry_id=entry.id,
+        part_id=part.id,
+        mpn_searched=part.mpn,
+        required_qty=5,
+        internal_available_qty=0,
+        shortage_qty=5,
+        risk_flags=[],
+    )
+    plan.lines.append(line)
+    db.add(plan)
+    db.flush()
+    line_id = line.id
+
+    db.delete(entry)
+    db.flush()
+    db.expire_all()
+
+    persisted = db.get(PurchasePlanLine, line_id)
+    assert persisted is not None
+    assert persisted.project_entry_id is None


### PR DESCRIPTION
## Summary
- add Alembic revision `0051` after current `0050_stock_entries_workspace_fk_trigger.py` to attach `purchase_plan_lines.project_entry_id` to `project_entries.id`
- use `ON DELETE SET NULL` with `NOT VALID` followed by `VALIDATE CONSTRAINT`
- mirror the FK in the SQLAlchemy model and add the focused regression for parent deletes

## Merge order
Current open PRs do not touch Alembic migrations, `backend/app/domain/sourcing/models.py`, or `backend/tests/test_purchase_plan_line_fk.py`. This PR is based on current `origin/main`, where `0050_stock_entries_workspace_fk_trigger.py` is the latest migration head. If another migration PR opens or merges first, merge that migration PR before this one, then rebase this branch and renumber this migration from the new Alembic head if `0051` is taken.

## Validation
- `DATABASE_URL=postgresql+psycopg://stockmgr:stockmgr@127.0.0.1:5432/stockmgr_test_aud_031 TEST_DATABASE_URL=postgresql+psycopg://stockmgr:stockmgr@127.0.0.1:5432/stockmgr_test_aud_031 uv run --extra dev python -m pytest tests/test_purchase_plan_line_fk.py -q`
- `uv run --extra dev ruff check app/domain/sourcing/models.py tests/test_purchase_plan_line_fk.py alembic/versions/0051_purchase_plan_line_project_entry_fk.py`

Closes #570