### PR TITLE
[codex] Move session purge to cron job

### DIFF
--- a/backend/app/cli/run_job.py
+++ b/backend/app/cli/run_job.py
@@ -70,6 +70,12 @@ def _run_sourcing_alerts_evaluate(db: Session) -> int:
     return evaluate_all_alerts(db)
 
 
+def _run_session_purge(db: Session) -> int:
+    from app.core.auth import purge_expired_sessions
+
+    return purge_expired_sessions(db)
+
+
 JOBS: dict[str, JobSpec] = {
     "sourcing-cache-sweep": JobSpec(
         name="sourcing-cache-sweep",
@@ -89,6 +95,13 @@ JOBS: dict[str, JobSpec] = {
             "cooldown is a no-op."
         ),
         run=_run_sourcing_alerts_evaluate,
+    ),
+    "session-purge": JobSpec(
+        name="session-purge",
+        owner="backend/auth-security",
+        cadence="hourly",
+        idempotency="Deletes only session rows whose expires_at is already in the past.",
+        run=_run_session_purge,
     ),
 }
 

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -295,18 +295,10 @@ def purge_expired_sessions(db: Session, *, now: datetime | None = None) -> int:
     purged. Backed by `ix_user_sessions_expires_at` (alembic 0019), so
     the DELETE is an index range scan, not a full table scan.
 
-    DB-007 / issue #98. Called on a one-hour cadence by the lifespan
-    hook in `app/main.py`. The plan was to keep these rows around
-    forever (sessions were only deleted on explicit logout); a
-    long-running prod accumulates every expired row otherwise.
-
-    Single-worker invariant (CLAUDE.md): uvicorn runs `--workers 1` in
-    prod, so the periodic task fires from exactly one process. If a
-    future deploy moves to multiple workers, every worker will run the
-    DELETE — that's still correct (idempotent + no contention because
-    the rows being deleted are already past expiry, no live request
-    can hold a lock on them) but a future Redis/multi-worker rewrite
-    should pick an explicit leader.
+    DB-007 / issue #98. Called on a one-hour cadence by the
+    `session-purge` CLI job in the backend cron sidecar. The plan was to
+    keep these rows around forever (sessions were only deleted on explicit
+    logout); a long-running prod accumulates every expired row otherwise.
     """
     from app.domain.users.models import UserSession
 

--- a/backend/app/domain/users/models.py
+++ b/backend/app/domain/users/models.py
@@ -38,8 +38,8 @@ class UserSession(Base):
     # `expires_at` (the absolute lifetime) is still in the future.
     last_used_at = Column(DateTime(timezone=True), nullable=False, default=utcnow)
     # `ix_user_sessions_expires_at` (alembic 0019) lives in the migration
-    # rather than `index=True` here so the periodic purge in
-    # `app/main.py::_periodic_session_purge` is an index range scan,
+    # rather than `index=True` here so the `session-purge` CLI job is an
+    # index range scan,
     # not a seq scan. DB-007 / issue #98. Don't add `index=True` —
     # SQLAlchemy would emit a redundant CREATE INDEX in a future
     # autogenerate run.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import logging
 import os
 import sys
@@ -189,66 +188,12 @@ def assert_cors_origins_not_wildcard() -> None:
         )
 
 
-async def _periodic_session_purge(interval_seconds: int) -> None:
-    """Background task: every `interval_seconds` purge sessions whose
-    `expires_at` is in the past. DB-007 / issue #98.
-
-    Uses a fresh `SessionLocal()` each tick so the connection isn't
-    held across the sleep. The DELETE rides
-    `ix_user_sessions_expires_at` (alembic 0019).
-
-    Cancelled cleanly on app shutdown by the lifespan context manager
-    below — `asyncio.CancelledError` is the normal exit path; anything
-    else gets logged.
-    """
-    from app.core.auth import purge_expired_sessions
-    from app.infra.db import SessionLocal
-
-    while True:
-        try:
-            await asyncio.sleep(interval_seconds)
-            db = SessionLocal()
-            try:
-                n = purge_expired_sessions(db)
-                db.commit()
-                if n:
-                    _log.info("purge_expired_sessions: removed %d row(s)", n)
-            except Exception:  # noqa: BLE001 — keep the loop alive
-                db.rollback()
-                _log.exception("purge_expired_sessions failed; will retry next tick")
-            finally:
-                db.close()
-        except asyncio.CancelledError:
-            raise
-        except Exception:  # noqa: BLE001 — never let the loop die silently
-            _log.exception("periodic session purge: unexpected error")
-
-
 @asynccontextmanager
 async def lifespan(_app: FastAPI):
-    """Spawn the background session-purge task on startup; cancel it on
-    shutdown. DB-007 / issue #98."""
+    """Run synchronous startup assertions before serving requests."""
     assert_cors_origins_not_wildcard()
     assert_proxy_headers_trusted()
-    interval = settings().SESSION_PURGE_INTERVAL_SECONDS
-    task: asyncio.Task | None = None
-    if interval > 0:
-        _log.info("purge_expired_sessions: scheduled every %ds", interval)
-        task = asyncio.create_task(
-            _periodic_session_purge(interval),
-            name="purge_expired_sessions",
-        )
-    try:
-        yield
-    finally:
-        if task is not None:
-            task.cancel()
-            try:
-                await task
-            except (asyncio.CancelledError, Exception):
-                # CancelledError is the normal shutdown path; anything
-                # else has already been logged inside the task.
-                pass
+    yield
 
 
 app = FastAPI(

--- a/backend/tests/test_run_job.py
+++ b/backend/tests/test_run_job.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 import logging
+import uuid
+from datetime import timedelta
 
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import Session
 
 from app.cli.run_job import JOBS, JobSpec, UnknownJobError, main, run_job
+from app.core.time import utcnow
+from app.domain.users.models import User, UserSession
 
 
 class _FakeSession:
@@ -89,6 +93,58 @@ def test_sourcing_alerts_evaluate_registered() -> None:
     assert spec.cadence == "every 15 minutes"
     assert "enabled, non-archived sourcing_alerts" in spec.idempotency
     assert "cooldown" in spec.idempotency
+
+
+def test_session_purge_registered() -> None:
+    spec = JOBS["session-purge"]
+
+    assert spec.name == "session-purge"
+    assert spec.owner == "backend/auth-security"
+    assert spec.cadence == "hourly"
+    assert "expires_at" in spec.idempotency
+
+
+def test_session_purge_idempotent(db, tmp_path) -> None:
+    user = User(
+        id=uuid.uuid4(),
+        email=f"{uuid.uuid4()}@example.test",
+        name="Session Purge",
+        password_hash="hash",
+    )
+    now = utcnow()
+    db.add(user)
+    db.add_all(
+        [
+            UserSession(
+                token_hash="a" * 64,
+                user_id=user.id,
+                expires_at=now - timedelta(seconds=1),
+            ),
+            UserSession(
+                token_hash="b" * 64,
+                user_id=user.id,
+                expires_at=now + timedelta(hours=1),
+            ),
+        ]
+    )
+    db.flush()
+
+    first = run_job(
+        "session-purge",
+        session_factory=lambda: db,
+        heartbeat_dir=tmp_path,
+    )
+    second = run_job(
+        "session-purge",
+        session_factory=lambda: db,
+        heartbeat_dir=tmp_path,
+    )
+
+    remaining = db.query(UserSession).all()
+    assert first == 1
+    assert second == 0
+    assert [row.token_hash for row in remaining] == ["b" * 64]
+    assert (tmp_path / "session-purge").read_text(encoding="utf-8") == "ok\n"
 
 
 def test_sourcing_alerts_evaluate_dispatches_to_module(monkeypatch, tmp_path) -> None:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -266,6 +266,59 @@ services:
     security_opt: ["no-new-privileges:true"]
     cap_drop: ["ALL"]
 
+  backend-cron-sessions:
+    build: ./backend
+    restart: unless-stopped
+    mem_limit: 512m
+    cpus: "0.5"
+    pids_limit: 256
+    oom_kill_disable: false
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"
+    environment:
+      # Same runtime config shape as backend. Keep POSTGRES_* discrete so
+      # DATABASE_URL is assembled inside Settings without leaking the password
+      # through docker inspect interpolation.
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_HOST: db
+      POSTGRES_PORT: "5432"
+      SESSION_SECRET: ${SESSION_SECRET}
+      SESSION_PURGE_INTERVAL_SECONDS: ${SESSION_PURGE_INTERVAL_SECONDS:-3600}
+      UPLOAD_DIR: /data/uploads
+      APP_ENV: prod
+      CORS_ORIGINS: ${CORS_ORIGINS}
+      WORKSPACE_SECRETS_KEY: ${WORKSPACE_SECRETS_KEY}
+      SENTRY_DSN: ${SENTRY_DSN:-}
+      SENTRY_TRACES_SAMPLE_RATE: ${SENTRY_TRACES_SAMPLE_RATE:-0.0}
+      SENTRY_RELEASE: ${SENTRY_RELEASE:-}
+      VITE_SENTRY_DSN: ${VITE_SENTRY_DSN:-}
+      SMTP_HOST: ${SMTP_HOST}
+      SMTP_PORT: ${SMTP_PORT:-587}
+      SMTP_USER: ${SMTP_USER}
+      SMTP_PASSWORD: ${SMTP_PASSWORD}
+      MAIL_FROM: ${MAIL_FROM}
+      APP_BASE_URL: ${APP_BASE_URL}
+    depends_on:
+      backend:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "test -d /tmp/stockmanager-job-heartbeats && find /tmp/stockmanager-job-heartbeats -name session-purge -mmin +0 -mmin -90 -print -quit | grep -q ."]
+      interval: 60s
+      timeout: 5s
+      retries: 3
+      start_period: 11m
+    # Runs the session retention purge through the shared backend CLI.
+    # SESSION_PURGE_INTERVAL_SECONDS defaults to the previous one-hour
+    # lifespan cadence; setting it to 0 disables the loop.
+    command: ["sh", "-c", "interval=$${SESSION_PURGE_INTERVAL_SECONDS:-3600}; if [ $$interval -le 0 ]; then echo 'session-purge disabled'; sleep infinity; fi; while true; do timeout 600 python -m app.cli.run_job session-purge; rc=$$?; if [ $$rc -eq 124 ]; then echo 'session-purge timed out after 600s (exit=124)'; elif [ $$rc -ne 0 ]; then echo \"session-purge failed (exit=$$rc)\"; fi; sleep $$interval; done"]
+    security_opt: ["no-new-privileges:true"]
+    cap_drop: ["ALL"]
+
   web:
     build:
       # Context is the repo root so the Dockerfile can COPY both `web/` (sources)


### PR DESCRIPTION
## Summary
- Registers `session-purge` in `backend/app/cli/run_job.py`, preserving the existing advisory transaction lock path.
- Removes the FastAPI lifespan background purge task from `backend/app/main.py`.
- Adds `backend-cron-sessions` in `docker-compose.prod.yml` to run `python -m app.cli.run_job session-purge` on the existing hourly cadence.

Closes #550

## Validation
- `DATABASE_URL=postgresql+psycopg://stockmgr:stockmgr@127.0.0.1:5432/stockmgr_test_aud011 TEST_DATABASE_URL=postgresql+psycopg://stockmgr:stockmgr@127.0.0.1:5432/stockmgr_test_aud011 uv run --extra dev python -m pytest tests/test_run_job.py -q`
- `uv run --extra dev ruff check app/cli/run_job.py app/core/auth.py tests/test_run_job.py`
- `uv run --extra dev python - <<PY ... PY` parsed `docker-compose.prod.yml` and asserted `backend-cron-sessions` schedules `session-purge`.
- `git diff --check`

## Not Run
- `docker compose -f docker-compose.prod.yml config -q` could not run because `docker` is not installed in this environment (`docker: command not found`).

## Open PR Overlap / Merge Order
- Checked open PRs #659, #658, #657, #656, #611, #483, and #482 before editing. None modify `backend/app/cli/run_job.py`, `backend/app/main.py`, `backend/app/core/auth.py`, `backend/app/domain/users/models.py`, `backend/tests/test_run_job.py`, or `docker-compose.prod.yml`.
- No special merge ordering is required beyond rebasing on current `main` before merge.
