### PR TITLE
[codex] AUD-033 scrub Sentry exception values

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import re
 import sys
 from collections.abc import Sequence
 from contextlib import asynccontextmanager
@@ -20,6 +21,41 @@ from app.core.logging import configure_logging
 # tries to log. uvicorn replays logs through the root logger so this
 # captures its lifecycle messages too.
 configure_logging()
+
+_SENTRY_SENSITIVE_TEXT_RE = re.compile(
+    r"""(?ix)
+    (?P<prefix>
+        ["']?
+        \b(?:password|passwd|pass|token|secret|api[_-]?key|authorization|cookie|session(?:[_-]?id)?)
+        ["']?
+        \s*[:=]\s*
+        ["']?
+    )
+    (?P<value>[^"',&\s;}\]]+)
+    """
+)
+
+
+def _scrub_sensitive_text(value: str) -> str:
+    return _SENTRY_SENSITIVE_TEXT_RE.sub(r"\g<prefix>[Filtered]", value)
+
+
+def _scrub_event_strings(event: dict) -> None:
+    if isinstance(event.get("message"), str):
+        event["message"] = _scrub_sensitive_text(event["message"])
+
+    exception = event.get("exception")
+    if not isinstance(exception, dict):
+        return
+    values = exception.get("values")
+    if not isinstance(values, list):
+        return
+    for item in values:
+        if not isinstance(item, dict):
+            continue
+        for key in ("value", "message"):
+            if isinstance(item.get(key), str):
+                item[key] = _scrub_sensitive_text(item[key])
 
 
 # Top-level (testable) Sentry event scrubber. Runs as `before_send` so
@@ -45,6 +81,9 @@ configure_logging()
 # session-identifying on every method, so the header scrub runs first and
 # applies regardless of method.
 def _scrub_event(event, _hint):
+    if isinstance(event, dict):
+        _scrub_event_strings(event)
+
     request = event.get("request")
     if not isinstance(request, dict):
         return event

--- a/backend/tests/test_sentry_scrubber.py
+++ b/backend/tests/test_sentry_scrubber.py
@@ -150,6 +150,37 @@ def test_scrubber_handles_event_without_request():
     assert out == {"message": "hello"}
 
 
+def test_strips_exception_value_secrets():
+    event = {
+        "message": "provider failed api_key=frontend-key token=invite-token",
+        "exception": {
+            "values": [
+                {
+                    "type": "RuntimeError",
+                    "value": (
+                        "lookup failed password=plain-pass "
+                        "api_key=provider-key token=raw-token"
+                    ),
+                    "message": 'request failed with "secret":"json-secret"',
+                }
+            ]
+        },
+    }
+
+    out = _scrub_event(event, None)
+    serialized = str(out)
+
+    assert "plain-pass" not in serialized
+    assert "provider-key" not in serialized
+    assert "raw-token" not in serialized
+    assert "json-secret" not in serialized
+    assert "frontend-key" not in serialized
+    assert "invite-token" not in serialized
+    assert out["exception"]["values"][0]["value"] == (
+        "lookup failed password=[Filtered] api_key=[Filtered] token=[Filtered]"
+    )
+
+
 def test_scrubber_handles_request_without_method():
     """Defensive — older SDK shapes or partial captures might not set
     `method`. We treat that as 'unknown, do nothing destructive'."""

--- a/web/src/instrument.test.ts
+++ b/web/src/instrument.test.ts
@@ -42,7 +42,7 @@ describe("Sentry beforeSend", () => {
           },
         },
       ],
-    } as Parameters<typeof beforeSend>[0];
+    } as unknown as Parameters<typeof beforeSend>[0];
 
     const scrubbed = await Promise.resolve(beforeSend(event, {}));
 
@@ -55,5 +55,48 @@ describe("Sentry beforeSend", () => {
     expect(scrubbed?.breadcrumbs?.[0]?.data?.to).toBe("/projects#bom");
     expect(JSON.stringify(scrubbed)).not.toContain("secret");
     expect(JSON.stringify(scrubbed)).not.toContain("?");
+  });
+
+  it("test_beforesend_strips_exception_value_secrets", async () => {
+    vi.resetModules();
+
+    const Sentry = await import("@sentry/react");
+    vi.mocked(Sentry.init).mockClear();
+
+    await import("./instrument");
+
+    const options = vi.mocked(Sentry.init).mock.calls[0]?.[0];
+    const beforeSend = options?.beforeSend;
+    expect(beforeSend).toBeTypeOf("function");
+    if (!beforeSend) {
+      throw new Error("Sentry beforeSend was not configured");
+    }
+
+    const event = {
+      type: undefined,
+      message: "provider failed api_key=frontend-key token=invite-token",
+      exception: {
+        values: [
+          {
+            type: "Error",
+            value: "lookup failed password=plain-pass api_key=provider-key token=raw-token",
+            message: 'request failed with "secret":"json-secret"',
+          },
+        ],
+      },
+    } as unknown as Parameters<typeof beforeSend>[0];
+
+    const scrubbed = await Promise.resolve(beforeSend(event, {}));
+    const serialized = JSON.stringify(scrubbed);
+
+    expect(serialized).not.toContain("plain-pass");
+    expect(serialized).not.toContain("provider-key");
+    expect(serialized).not.toContain("raw-token");
+    expect(serialized).not.toContain("json-secret");
+    expect(serialized).not.toContain("frontend-key");
+    expect(serialized).not.toContain("invite-token");
+    expect(scrubbed?.exception?.values?.[0]?.value).toBe(
+      "lookup failed password=[Filtered] api_key=[Filtered] token=[Filtered]",
+    );
   });
 });

--- a/web/src/instrument.ts
+++ b/web/src/instrument.ts
@@ -25,6 +25,8 @@ const tracesSampleRate = Number.isFinite(parseFloat(tracesRaw))
 const requestHeaderDenylist = new Set(["cookie", "authorization", "x-workspace-id"]);
 const requestUrlHeaders = new Set(["referer", "referrer"]);
 const breadcrumbUrlKeys = new Set(["url", "from", "to"]);
+const sensitiveTextPattern =
+  /(["']?\b(?:password|passwd|pass|token|secret|api[_-]?key|authorization|cookie|session(?:[_-]?id)?)["']?\s*[:=]\s*["']?)([^"',&\s;}\]]+)/gi;
 
 function stripQueryString(rawUrl: string): string {
   const fragmentIndex = rawUrl.indexOf("#");
@@ -44,6 +46,32 @@ function scrubUrlKeys(values: Record<string, unknown>, keys: ReadonlySet<string>
   for (const key of Object.keys(values)) {
     if (keys.has(key.toLowerCase()) && typeof values[key] === "string") {
       values[key] = stripQueryString(values[key]);
+    }
+  }
+}
+
+function scrubSensitiveText(value: string): string {
+  return value.replace(sensitiveTextPattern, "$1[Filtered]");
+}
+
+function scrubEventStrings(event: Record<string, unknown>) {
+  if (typeof event.message === "string") {
+    event.message = scrubSensitiveText(event.message);
+  }
+
+  const exception = event.exception as { values?: unknown } | undefined;
+  if (!exception || !Array.isArray(exception.values)) {
+    return;
+  }
+  for (const item of exception.values) {
+    if (!item || typeof item !== "object") {
+      continue;
+    }
+    const exceptionValue = item as Record<string, unknown>;
+    for (const key of ["value", "message"]) {
+      if (typeof exceptionValue[key] === "string") {
+        exceptionValue[key] = scrubSensitiveText(exceptionValue[key]);
+      }
     }
   }
 }
@@ -78,6 +106,8 @@ Sentry.init({
   // session-identifying on every method, so the header scrub applies
   // regardless of body method.
   beforeSend(event) {
+    scrubEventStrings(event as unknown as Record<string, unknown>);
+
     const req = event.request;
     if (req) {
       if (typeof req.url === "string") {


### PR DESCRIPTION
## Summary

- Add backend Sentry text scrubbing for `event.message` and `exception.values[*].value/message`.
- Add matching frontend `beforeSend` scrubbing for the same event fields.
- Add positive backend and frontend regression coverage for exception value leaks.

## Root Cause

The existing Sentry scrubbers removed request bodies, sensitive headers, query strings, and breadcrumb URLs, but left exception value strings and event messages untouched. Secrets echoed into exception text could therefore still be sent to Sentry.

## Merge Order

Potential overlap: PR #662 also edits `backend/app/main.py`. There is no semantic dependency, but if #662 lands first, rebase this PR afterward and keep the AUD-033 Sentry scrubber block on top of the final `main.py`.

## Validation

- `uv run --project backend --extra dev python -m pytest backend/tests/test_sentry_scrubber.py -q`
- `npm --prefix web run test -- instrument`
- `npm --prefix web run typecheck`
- `uv run --project backend --extra dev ruff check --select F backend/app/main.py backend/tests/test_sentry_scrubber.py`

Closes #572
