### PR TITLE
[codex] Surface stock lot form fields

### DIFF
--- a/web/src/routes/builds/BuildDetail.test.tsx
+++ b/web/src/routes/builds/BuildDetail.test.tsx
@@ -198,3 +198,71 @@ describe("BuildDetail archive mutation", () => {
     off();
   });
 });
+
+describe("BuildDetail consumption plan", () => {
+  it("submits output lot and storage fields", async () => {
+    vi.mocked(api.get).mockImplementation((path: string) => {
+      if (path === "/builds/build-1") {
+        return Promise.resolve({
+          build: buildDetail.build,
+          shortage: [{
+            project_entry_id: "entry-1",
+            part_id: "part-1",
+            part_name: "Part 1",
+            required: 2,
+            available: 2,
+            substitute_ids: [],
+            substitute_available: 0,
+            short_by: 0,
+          }],
+        });
+      }
+      if (path === "/projects/project-1") return Promise.resolve({ id: "project-1", name: "Project 1" });
+      if (path === "/projects/project-1/entries") {
+        return Promise.resolve([{
+          id: "entry-1",
+          project_id: "project-1",
+          entry_type: "part",
+          part_id: "part-1",
+          meta_part_id: null,
+          name: null,
+          quantity: 2,
+          comments: null,
+          designators: [],
+          cad_footprint: null,
+          cad_key: null,
+          dnp: false,
+          order_index: 0,
+        }]);
+      }
+      if (path === "/parts?limit=200") return Promise.resolve([{ id: "part-1", name: "Part 1" }]);
+      if (path === "/storage") {
+        return Promise.resolve([
+          { id: "storage-1", name: "Bin A", archived_at: null, is_full: false },
+        ]);
+      }
+      return Promise.resolve(null);
+    });
+    vi.mocked(api.post).mockResolvedValue(null);
+
+    renderBuildDetail();
+
+    fireEvent.click(await screen.findByRole("button", { name: "Auto-fill" }));
+    fireEvent.change(screen.getByLabelText("Output lot name"), { target: { value: "BUILD-LOT-1" } });
+    fireEvent.change(screen.getByLabelText("Output storage"), { target: { value: "storage-1" } });
+    fireEvent.click(screen.getByRole("button", { name: "Consume & complete build" }));
+
+    await waitFor(() => {
+      expect(api.post).toHaveBeenCalledWith("/builds/build-1/consume", {
+        lines: [{
+          project_entry_id: "entry-1",
+          part_id: "part-1",
+          quantity: 2,
+          storage_location_id: undefined,
+        }],
+        output_lot_name: "BUILD-LOT-1",
+        output_storage_location_id: "storage-1",
+      });
+    });
+  });
+});

--- a/web/src/routes/builds/BuildDetail.tsx
+++ b/web/src/routes/builds/BuildDetail.tsx
@@ -59,6 +59,8 @@ function BuildDetailBody({ buildId, detail }: { buildId: string; detail: DetailO
 
   // consumption plan: project_entry_id → list of consume rows
   const [plan, setPlan] = useState<Record<string, ConsumeRow[]>>({});
+  const [outputLotName, setOutputLotName] = useState("");
+  const [outputStorageLocationId, setOutputStorageLocationId] = useState("");
   const [err, setErr] = useState<string | null>(null);
 
   const partsById = useMemo(() => new Map(parts?.map(p => [p.id, p]) ?? []), [parts]);
@@ -70,6 +72,8 @@ function BuildDetailBody({ buildId, detail }: { buildId: string; detail: DetailO
       quantity: number;
       storage_location_id?: string;
     }[];
+    output_storage_location_id?: string;
+    output_lot_name?: string;
   };
 
   const consumeMutation = useApiMutation<unknown, ConsumePayload>({
@@ -144,7 +148,11 @@ function BuildDetailBody({ buildId, detail }: { buildId: string; detail: DetailO
       setErr("No lines.");
       return;
     }
-    consumeMutation.mutate({ lines });
+    consumeMutation.mutate({
+      lines,
+      output_lot_name: outputLotName || undefined,
+      output_storage_location_id: outputStorageLocationId || undefined,
+    });
   }
 
   function doArchive() {
@@ -251,6 +259,32 @@ function BuildDetailBody({ buildId, detail }: { buildId: string; detail: DetailO
           <div className="text-sm text-muted mb-2">
             One line per consumed part. Multiple lines per entry are allowed (e.g. main part + substitute).
             Use <strong>Auto-fill</strong> for a default plan, then tweak.
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-3">
+            <div>
+              <label className="label" htmlFor="build-output-lot-name">Output lot name</label>
+              <input
+                id="build-output-lot-name"
+                className="input"
+                value={outputLotName}
+                onChange={e => setOutputLotName(e.target.value)}
+                placeholder={`${build.name}-out`}
+              />
+            </div>
+            <div>
+              <label className="label" htmlFor="build-output-storage">Output storage</label>
+              <select
+                id="build-output-storage"
+                className="input"
+                value={outputStorageLocationId}
+                onChange={e => setOutputStorageLocationId(e.target.value)}
+              >
+                <option value="">— none —</option>
+                {storage?.filter(s => !s.archived_at && !s.is_full).map(s => (
+                  <option key={s.id} value={s.id}>{s.name}</option>
+                ))}
+              </select>
+            </div>
           </div>
           <table className="table">
             <thead>

--- a/web/src/routes/orders/OrderDetail.test.tsx
+++ b/web/src/routes/orders/OrderDetail.test.tsx
@@ -1,0 +1,131 @@
+// @vitest-environment jsdom
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { api } from "@/lib/api";
+import OrderDetail from "./OrderDetail";
+
+vi.mock("@/lib/api", () => ({
+  ApiError: class ApiError extends Error {
+    userMessage: string;
+
+    constructor(_status: number, _body: unknown, msg = "api error") {
+      super(msg);
+      this.userMessage = msg;
+    }
+  },
+  api: {
+    get: vi.fn(),
+    post: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({
+  useAuth: () => ({ workspaceId: "ws-1" }),
+}));
+
+vi.mock("@/components/ConfirmDialog", () => ({
+  useConfirm: () => vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock("@/components/AttachmentsPanel", () => ({
+  default: () => <div data-testid="attachments-panel" />,
+}));
+
+vi.mock("@/components/ActivityTimeline", () => ({
+  default: () => <div data-testid="activity-timeline" />,
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+function renderOrderDetail() {
+  const client = new QueryClient({
+    defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+  });
+
+  render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={["/orders/order-1"]}>
+        <Routes>
+          <Route path="/orders/:orderId" element={<OrderDetail />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("OrderDetail receive", () => {
+  it("submits lot name on receive lines", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.get).mockImplementation((path: string) => {
+      if (path === "/orders/order-1") {
+        return Promise.resolve({
+          order: {
+            id: "order-1",
+            name: "PO-100",
+            order_type: "purchase",
+            supplier: "Supplier",
+            status: "open",
+            ordered_on: null,
+            expected_on: null,
+            received_on: null,
+            currency: "USD",
+            comments: null,
+            archived_at: null,
+            totals: { ordered: 10, received: 0 },
+            created_at: "2026-01-01T00:00:00Z",
+            updated_at: "2026-01-01T00:00:00Z",
+          },
+          entries: [{
+            id: "entry-1",
+            order_id: "order-1",
+            part_id: "part-1",
+            name: null,
+            quantity_ordered: 10,
+            quantity_received: 0,
+            unit_price: null,
+            currency: null,
+            comments: null,
+            order_index: 0,
+          }],
+        });
+      }
+      if (path === "/parts?limit=200") return Promise.resolve([{ id: "part-1", name: "Part 1", serialized: false }]);
+      if (path === "/storage") return Promise.resolve([]);
+      return Promise.resolve(null);
+    });
+    vi.mocked(api.post).mockResolvedValue(null);
+
+    renderOrderDetail();
+
+    await user.type(await screen.findByRole("spinbutton"), "4");
+    await user.type(screen.getByPlaceholderText("PO-100#1"), "LOT-PO-100");
+    await user.click(screen.getByRole("button", { name: "Receive" }));
+
+    await waitFor(() => {
+      expect(api.post).toHaveBeenCalledWith("/orders/order-1/receive", {
+        received_on: undefined,
+        lines: [{
+          order_entry_id: "entry-1",
+          quantity: 4,
+          storage_location_id: undefined,
+          lot_name: "LOT-PO-100",
+          serial_number: undefined,
+        }],
+      });
+    });
+  });
+});

--- a/web/src/routes/orders/OrderDetail.tsx
+++ b/web/src/routes/orders/OrderDetail.tsx
@@ -27,6 +27,7 @@ type ReceiveLine = {
   order_entry_id: string;
   quantity: number;
   storage_location_id?: string;
+  lot_name?: string;
   serial_number?: string;
 };
 
@@ -60,7 +61,7 @@ export default function OrderDetail() {
   const [newPrice, setNewPrice] = useState<string>("");
 
   // Per-entry receive state
-  const [receiveLines, setReceiveLines] = useState<Record<string, { qty: number; storage: string; serial?: string }>>({});
+  const [receiveLines, setReceiveLines] = useState<Record<string, { qty: number; storage: string; lotName?: string; serial?: string }>>({});
   const [receivedOn, setReceivedOn] = useState("");
   // Inline error surface — preserved for the handful of branches that
   // still want a banner (e.g. "enter a quantity on at least one row");
@@ -163,6 +164,7 @@ export default function OrderDetail() {
         order_entry_id: entryId,
         quantity: v.qty,
         storage_location_id: v.storage || undefined,
+        lot_name: v.lotName?.trim() || undefined,
         serial_number: v.serial?.trim() || undefined,
       }));
     if (lines.length === 0) {
@@ -295,13 +297,14 @@ export default function OrderDetail() {
                 <th className="w-24">Outstanding</th>
                 <th className="w-28">Receive</th>
                 <th className="w-64">Storage</th>
+                <th className="w-40">Lot name</th>
                 <th className="w-40">Serial #</th>
               </tr>
             </thead>
             <tbody>
               {entries.filter(e => e.part_id && e.quantity_received < e.quantity_ordered).map(e => {
                 const outstanding = e.quantity_ordered - e.quantity_received;
-                const cur = receiveLines[e.id] ?? { qty: 0, storage: "", serial: "" };
+                const cur = receiveLines[e.id] ?? { qty: 0, storage: "", lotName: "", serial: "" };
                 const part = partsById.get(e.part_id!);
                 return (
                   <tr key={e.id}>
@@ -332,6 +335,14 @@ export default function OrderDetail() {
                           <option key={s.id} value={s.id}>{s.name}</option>
                         ))}
                       </select>
+                    </td>
+                    <td>
+                      <input
+                        className="input"
+                        value={cur.lotName ?? ""}
+                        onChange={ev => setReceiveLines(s => ({ ...s, [e.id]: { ...cur, lotName: ev.target.value } }))}
+                        placeholder={`${order.name}#${e.order_index + 1}`}
+                      />
                     </td>
                     <td>
                       <input

--- a/web/src/routes/parts/detail/PartAddStock.tsx
+++ b/web/src/routes/parts/detail/PartAddStock.tsx
@@ -25,7 +25,7 @@ type AddStockRequest = {
     unit_price?: number;
     total_price?: number;
   };
-  lot?: { name?: string; serial_number?: string };
+  lot?: { name?: string; expiration_date?: string; serial_number?: string };
   comments?: string;
 };
 
@@ -45,6 +45,7 @@ export default function PartAddStock() {
   const [totalPrice, setTotalPrice] = useState<string>("");
   const [currency, setCurrency] = useState("USD");
   const [lotName, setLotName] = useState("");
+  const [lotExpiration, setLotExpiration] = useState("");
   const [serial, setSerial] = useState("");
   const [comments, setComments] = useState("");
   const [err, setErr] = useState<string | null>(null);
@@ -89,7 +90,13 @@ export default function PartAddStock() {
         total_price: priceMode === "entire_lot" ? Number(totalPrice) : undefined,
       };
     }
-    if (lotName || serial) payload.lot = { name: lotName || undefined, serial_number: serial || undefined };
+    if (lotName || lotExpiration || serial) {
+      payload.lot = {
+        name: lotName || undefined,
+        expiration_date: lotExpiration || undefined,
+        serial_number: serial || undefined,
+      };
+    }
     addMutation.mutate(payload);
   }
 
@@ -157,10 +164,15 @@ export default function PartAddStock() {
           </div>
         )}
       </div>
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
         <div>
           <label className="label" htmlFor="add-stock-lot-name">Lot name (optional)</label>
           <input id="add-stock-lot-name" className="input" value={lotName} onChange={e => setLotName(e.target.value)} placeholder="LOT-2026-001" />
+        </div>
+        <div>
+          <label className="label" htmlFor="add-stock-lot-expiration">Lot expiration (optional)</label>
+          <input id="add-stock-lot-expiration" className="input" type="date" value={lotExpiration} onChange={e => setLotExpiration(e.target.value)} />
+          <p className="mt-1 text-xs text-muted">Use the date printed on the supplier lot or bag label.</p>
         </div>
         <div>
           <label className="label" htmlFor="add-stock-serial">Serial number (optional)</label>

--- a/web/src/routes/parts/detail/__tests__/PartAddStock.test.tsx
+++ b/web/src/routes/parts/detail/__tests__/PartAddStock.test.tsx
@@ -33,6 +33,32 @@ afterEach(() => {
 });
 
 describe("PartAddStock", () => {
+  it("test_lot_expiry_submits", async () => {
+    const user = userEvent.setup();
+    vi.spyOn(api, "get").mockResolvedValue([]);
+    const postSpy = vi.spyOn(api, "post").mockResolvedValue({});
+
+    renderAddStock();
+
+    await user.type(screen.getByLabelText("Quantity *"), "5");
+    await user.type(screen.getByLabelText("Lot name (optional)"), "LOT-2026-001");
+    await user.type(screen.getByLabelText("Lot expiration (optional)"), "2026-12-31");
+    await user.click(screen.getByRole("button", { name: "Add" }));
+
+    await waitFor(() => {
+      expect(postSpy).toHaveBeenCalledWith("/stock/add", {
+        part_id: "11111111-1111-1111-1111-111111111111",
+        quantity: 5,
+        comments: undefined,
+        lot: {
+          name: "LOT-2026-001",
+          expiration_date: "2026-12-31",
+          serial_number: undefined,
+        },
+      });
+    });
+  });
+
   it("test_currency_regex rejects non-letter currency codes inline", async () => {
     const user = userEvent.setup();
     vi.spyOn(api, "get").mockResolvedValue([]);


### PR DESCRIPTION
## Summary
- Add lot expiration date entry to the part add-stock form and submit it in `lot.expiration_date`.
- Add build output lot name/storage controls and submit `output_lot_name` plus `output_storage_location_id` with consume payloads.
- Add order receive lot-name input and submit `lot_name` per receive line.
- Add focused frontend tests for all three submit paths.

## Open PR overlap / merge order
- Inspected current open PRs before editing and again before publishing. None touch these files, so no special merge order is required.

## Validation
- `npm --prefix web run test -- PartAddStock`
- `npm --prefix web run test -- BuildDetail OrderDetail`
- `npm --prefix web run build`

Closes #574