### PR TITLE
[codex] Thread TanStack query abort signals

### DIFF
--- a/web/.eslintrc.cjs
+++ b/web/.eslintrc.cjs
@@ -48,6 +48,24 @@ module.exports = {
         selector: 'JSXAttribute[name.name="rel"][value.value="noreferrer"]',
         message: 'External links must use rel="noopener noreferrer".',
       },
+      {
+        selector: "Property[key.name='queryFn'] > ArrowFunctionExpression[params.length=0]",
+        message: "TanStack queryFn must accept the query context and thread signal to API reads.",
+      },
+      {
+        selector:
+          "Property[key.name='queryFn'] > ArrowFunctionExpression > ObjectPattern:not(:has(Property[key.name='signal']))",
+        message: "TanStack queryFn object context must destructure signal.",
+      },
+      {
+        selector: "Property[key.name='queryFn'] > FunctionExpression[params.length=0]",
+        message: "TanStack queryFn must accept the query context and thread signal to API reads.",
+      },
+      {
+        selector:
+          "Property[key.name='queryFn'] > FunctionExpression > ObjectPattern:not(:has(Property[key.name='signal']))",
+        message: "TanStack queryFn object context must destructure signal.",
+      },
     ],
   },
   ignorePatterns: [

--- a/web/src/components/ActivityTimeline.tsx
+++ b/web/src/components/ActivityTimeline.tsx
@@ -151,7 +151,7 @@ export default function ActivityTimeline({ endpoint }: Props) {
     isFetchingNextPage,
   } = useInfiniteQuery<ActivityPage>({
     queryKey: useWsKey("activity", endpoint),
-    queryFn: ({ pageParam }) => {
+    queryFn: ({ pageParam, signal }) => {
       let url = endpoint;
       if (
         pageParam &&
@@ -166,7 +166,7 @@ export default function ActivityTimeline({ endpoint }: Props) {
         });
         url = `${endpoint}?${qs.toString()}`;
       }
-      return api.get<ActivityPage>(url);
+      return api.get<ActivityPage>(url, { signal });
     },
     initialPageParam: null,
     getNextPageParam: (lastPage) => {

--- a/web/src/components/AttachmentsPanel.tsx
+++ b/web/src/components/AttachmentsPanel.tsx
@@ -127,8 +127,8 @@ export default function AttachmentsPanel({ objectType, objectId, canWrite }: Pro
   const queryKey = useWsKey("attachments", objectType, objectId);
   const attachmentsQuery = useQuery({
     queryKey,
-    queryFn: () =>
-      api.get<Attachment[]>(`/attachments/by-object/${objectType}/${objectId}`),
+    queryFn: ({ signal }) =>
+      api.get<Attachment[]>(`/attachments/by-object/${objectType}/${objectId}`, { signal }),
   });
   const { data, isLoading, isError } = attachmentsQuery;
 

--- a/web/src/components/CommandPalette.tsx
+++ b/web/src/components/CommandPalette.tsx
@@ -49,7 +49,7 @@ export default function CommandPalette() {
 
   const searchQuery = useQuery({
     queryKey: useWsKey("cp-search", q),
-    queryFn: () => api.get<SearchData>(`/search?q=${encodeURIComponent(q)}`),
+    queryFn: ({ signal }) => api.get<SearchData>(`/search?q=${encodeURIComponent(q)}`, { signal }),
     enabled: open && q.trim().length >= 2,
     staleTime: 30_000,
   });

--- a/web/src/components/scanner/Scanner.tsx
+++ b/web/src/components/scanner/Scanner.tsx
@@ -43,7 +43,7 @@ export default function Scanner({ onScan, className, symbologies }: Props) {
   // scanner mounts and the settings page.
   const wsQuery = useQuery({
     queryKey: useWsKey("ws", "current"),
-    queryFn: () => api.get<WsScanner>("/workspaces/current"),
+    queryFn: ({ signal }) => api.get<WsScanner>("/workspaces/current", { signal }),
   });
   const { data: ws, isLoading, isError } = wsQuery;
 
@@ -118,7 +118,7 @@ function ScanditScannerWithKey({
 }) {
   const { data, isLoading, error } = useQuery({
     queryKey: useWsKey("ws", "scanner", "license-key"),
-    queryFn: () => api.get<{ license_key: string }>("/workspaces/current/scanner-license-key"),
+    queryFn: ({ signal }) => api.get<{ license_key: string }>("/workspaces/current/scanner-license-key", { signal }),
   });
   if (isLoading) return <div className={className}>Fetching license…</div>;
   if (error || !data?.license_key) {

--- a/web/src/lib/api.abort.test.ts
+++ b/web/src/lib/api.abort.test.ts
@@ -1,0 +1,50 @@
+/* @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider, useQuery } from "@tanstack/react-query";
+import { render, waitFor } from "@testing-library/react";
+import { createElement } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { api } from "./api";
+
+function SlowQuery() {
+  useQuery({
+    queryKey: ["api-abort-test"],
+    queryFn: ({ signal }) => api.get("/slow", { signal }),
+  });
+  return null;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("api query aborts", () => {
+  it("passes TanStack query signals to fetch so unmount aborts in-flight reads", async () => {
+    let observedSignal: AbortSignal | undefined;
+    const pendingFetch = new Promise<Response>(() => {});
+    global.fetch = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+      observedSignal = init?.signal ?? undefined;
+      return pendingFetch;
+    });
+
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    const view = render(
+      createElement(
+        QueryClientProvider,
+        { client },
+        createElement(SlowQuery),
+      ),
+    );
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    expect(observedSignal).toBeDefined();
+    expect(observedSignal?.aborted).toBe(false);
+
+    view.unmount();
+
+    await waitFor(() => expect(observedSignal?.aborted).toBe(true));
+    client.clear();
+  });
+});

--- a/web/src/routes/builds/BuildCreate.tsx
+++ b/web/src/routes/builds/BuildCreate.tsx
@@ -19,7 +19,7 @@ export default function BuildCreate() {
   const [params] = useSearchParams();
   const projectsQuery = useQuery({
     queryKey: useWsKey("projects"),
-    queryFn: () => api.get<Project[]>("/projects"),
+    queryFn: ({ signal }) => api.get<Project[]>("/projects", { signal }),
   });
   const { data: projects } = projectsQuery;
   const [name, setName] = useState("");

--- a/web/src/routes/builds/BuildDetail.tsx
+++ b/web/src/routes/builds/BuildDetail.tsx
@@ -30,7 +30,7 @@ export default function BuildDetail() {
 function BuildDetailQuery({ buildId }: { buildId: string }) {
   const { data, isError, error } = useQuery({
     queryKey: useWsKey("build", buildId),
-    queryFn: () => api.get<DetailOut>(`/builds/${buildId}`),
+    queryFn: ({ signal }) => api.get<DetailOut>(`/builds/${buildId}`, { signal }),
   });
 
   if (isError) return <div className="text-red-600 text-sm p-4">Failed to load build. {error instanceof ApiError ? error.userMessage : ""}</div>;
@@ -48,14 +48,14 @@ function BuildDetailBody({ buildId, detail }: { buildId: string; detail: DetailO
 
   const { data: project } = useQuery({
     queryKey: useWsKey("project", projectId),
-    queryFn: () => api.get<Project>(`/projects/${projectId}`),
+    queryFn: ({ signal }) => api.get<Project>(`/projects/${projectId}`, { signal }),
   });
   const { data: entries } = useQuery({
     queryKey: useWsKey("project", projectId, "entries"),
-    queryFn: () => api.get<ProjectEntry[]>(`/projects/${projectId}/entries`),
+    queryFn: ({ signal }) => api.get<ProjectEntry[]>(`/projects/${projectId}/entries`, { signal }),
   });
-  const { data: parts } = useQuery({ queryKey: useWsKey("parts"), queryFn: () => api.get<Part[]>("/parts?limit=200") });
-  const { data: storage } = useQuery({ queryKey: useWsKey("storage"), queryFn: () => api.get<StorageLocation[]>("/storage") });
+  const { data: parts } = useQuery({ queryKey: useWsKey("parts"), queryFn: ({ signal }) => api.get<Part[]>("/parts?limit=200", { signal }) });
+  const { data: storage } = useQuery({ queryKey: useWsKey("storage"), queryFn: ({ signal }) => api.get<StorageLocation[]>("/storage", { signal }) });
 
   // consumption plan: project_entry_id → list of consume rows
   const [plan, setPlan] = useState<Record<string, ConsumeRow[]>>({});

--- a/web/src/routes/builds/BuildsList.tsx
+++ b/web/src/routes/builds/BuildsList.tsx
@@ -20,12 +20,12 @@ export default function BuildsList({ archived = false }: { archived?: boolean })
   const nav = useNavigate();
   const query = useQuery({
     queryKey: useWsKey("builds", { archived }),
-    queryFn: () => api.get<Build[]>(`/builds${archived ? "?archived=true" : ""}`),
+    queryFn: ({ signal }) => api.get<Build[]>(`/builds${archived ? "?archived=true" : ""}`, { signal }),
   });
   const { data } = query;
   const { data: projects } = useQuery({
     queryKey: useWsKey("projects"),
-    queryFn: () => api.get<Project[]>("/projects"),
+    queryFn: ({ signal }) => api.get<Project[]>("/projects", { signal }),
   });
   const projectsById = new Map(projects?.map(p => [p.id, p]) ?? []);
 

--- a/web/src/routes/lots/LotDetail.tsx
+++ b/web/src/routes/lots/LotDetail.tsx
@@ -11,8 +11,8 @@ import type { Lot, Part, StockEntry, StorageLocation } from "@/types";
 
 export function LotLayout() {
   const { lotId } = useParams<{ lotId: string }>();
-  const { data, isError, error } = useQuery({ queryKey: useWsKey("lot", lotId), queryFn: () => api.get<Lot>(`/lots/${lotId}`), enabled: !!lotId });
-  const { data: parts } = useQuery({ queryKey: useWsKey("parts"), queryFn: () => api.get<Part[]>("/parts?limit=200") });
+  const { data, isError, error } = useQuery({ queryKey: useWsKey("lot", lotId), queryFn: ({ signal }) => api.get<Lot>(`/lots/${lotId}`, { signal }), enabled: !!lotId });
+  const { data: parts } = useQuery({ queryKey: useWsKey("parts"), queryFn: ({ signal }) => api.get<Part[]>("/parts?limit=200", { signal }) });
   if (isError) return <div className="text-red-600 text-sm p-4">Failed to load lot. {error instanceof ApiError ? error.userMessage : ""}</div>;
   if (!data) return <div className="text-muted">Loading…</div>;
   const part = parts?.find(p => p.id === data.part_id);
@@ -37,7 +37,7 @@ export function LotLayout() {
 
 export function LotInfo() {
   const { lotId } = useParams();
-  const { data } = useQuery({ queryKey: useWsKey("lot", lotId), queryFn: () => api.get<Lot>(`/lots/${lotId}`), enabled: !!lotId });
+  const { data } = useQuery({ queryKey: useWsKey("lot", lotId), queryFn: ({ signal }) => api.get<Lot>(`/lots/${lotId}`, { signal }), enabled: !!lotId });
   if (!data) return null;
   return (
     <div className="card p-4 max-w-2xl space-y-2 text-sm">
@@ -63,7 +63,7 @@ export function LotMove() {
   const nav = useNavigate();
   const qc = useQueryClient();
   const { workspaceId } = useAuth();
-  const { data: storage } = useQuery({ queryKey: useWsKey("storage"), queryFn: () => api.get<StorageLocation[]>("/storage") });
+  const { data: storage } = useQuery({ queryKey: useWsKey("storage"), queryFn: ({ signal }) => api.get<StorageLocation[]>("/storage", { signal }) });
   // The Lot resource itself doesn't carry a single storage_location_id
   // (a lot can be split across bins via prior moves), so we read the
   // part's stock breakdown to discover which bins currently hold this
@@ -71,7 +71,7 @@ export function LotMove() {
   // the source bin's StorageInfo / StorageHistory go stale on success.
   const { data: partStock } = useQuery({
     queryKey: useWsKey("part", lot.part_id, "stock"),
-    queryFn: () => api.get<PartStockResp>(`/parts/${lot.part_id}/stock`),
+    queryFn: ({ signal }) => api.get<PartStockResp>(`/parts/${lot.part_id}/stock`, { signal }),
   });
   const [dest, setDest] = useState("");
   const [qty, setQty] = useState<number>(0);
@@ -144,7 +144,7 @@ export function LotAdjust() {
 
 export function LotHistory() {
   const { lotId } = useParams();
-  const { data, isError, error } = useQuery({ queryKey: useWsKey("lot", lotId, "history"), queryFn: () => api.get<StockEntry[]>(`/lots/${lotId}/history?limit=200`) });
+  const { data, isError, error } = useQuery({ queryKey: useWsKey("lot", lotId, "history"), queryFn: ({ signal }) => api.get<StockEntry[]>(`/lots/${lotId}/history?limit=200`, { signal }) });
   if (isError) return <div className="text-red-600 text-sm p-4">Failed to load history. {error instanceof ApiError ? error.userMessage : ""}</div>;
   return (
     <div className="card overflow-hidden">

--- a/web/src/routes/orders/OrderDetail.tsx
+++ b/web/src/routes/orders/OrderDetail.tsx
@@ -44,11 +44,11 @@ export default function OrderDetail() {
 
   const { data, isError, error } = useQuery({
     queryKey: useWsKey("order", orderId),
-    queryFn: () => api.get<DetailOut>(`/orders/${orderId}`),
+    queryFn: ({ signal }) => api.get<DetailOut>(`/orders/${orderId}`, { signal }),
     enabled: !!orderId,
   });
-  const { data: parts } = useQuery({ queryKey: useWsKey("parts"), queryFn: () => api.get<Part[]>("/parts?limit=200") });
-  const { data: storage } = useQuery({ queryKey: useWsKey("storage"), queryFn: () => api.get<StorageLocation[]>("/storage") });
+  const { data: parts } = useQuery({ queryKey: useWsKey("parts"), queryFn: ({ signal }) => api.get<Part[]>("/parts?limit=200", { signal }) });
+  const { data: storage } = useQuery({ queryKey: useWsKey("storage"), queryFn: ({ signal }) => api.get<StorageLocation[]>("/storage", { signal }) });
 
   const partsById = new Map(parts?.map(p => [p.id, p]) ?? []);
   const storageById = new Map(storage?.map(s => [s.id, s]) ?? []);

--- a/web/src/routes/orders/OrdersList.tsx
+++ b/web/src/routes/orders/OrdersList.tsx
@@ -21,7 +21,7 @@ export default function OrdersList({ archived = false }: { archived?: boolean })
   const nav = useNavigate();
   const query = useQuery({
     queryKey: useWsKey("orders", { archived }),
-    queryFn: () => api.get<Order[]>(`/orders${archived ? "?archived=true" : ""}`),
+    queryFn: ({ signal }) => api.get<Order[]>(`/orders${archived ? "?archived=true" : ""}`, { signal }),
   });
   const { data } = query;
 

--- a/web/src/routes/parts/LotsList.tsx
+++ b/web/src/routes/parts/LotsList.tsx
@@ -11,9 +11,9 @@ import PartsTopNav from "@/components/PartsTopNav";
 import QueryStateBoundary from "@/components/QueryStateBoundary";
 
 export default function LotsList() {
-  const query = useQuery({ queryKey: useWsKey("lots"), queryFn: () => api.get<Lot[]>("/lots") });
+  const query = useQuery({ queryKey: useWsKey("lots"), queryFn: ({ signal }) => api.get<Lot[]>("/lots", { signal }) });
   const { data } = query;
-  const { data: parts } = useQuery({ queryKey: useWsKey("parts"), queryFn: () => api.get<Part[]>("/parts?limit=200") });
+  const { data: parts } = useQuery({ queryKey: useWsKey("parts"), queryFn: ({ signal }) => api.get<Part[]>("/parts?limit=200", { signal }) });
   const partName = new Map(parts?.map(p => [p.id, p.name]) ?? []);
   const nav = useNavigate();
 

--- a/web/src/routes/parts/PartCreate.tsx
+++ b/web/src/routes/parts/PartCreate.tsx
@@ -60,7 +60,7 @@ export default function PartCreate() {
   // an inline banner instead of silently swallowing the error. The part
   // is valid — just missing provider-side fields — so we never DELETE it.
   const [refreshFailed, setRefreshFailed] = useState<{ partId: string } | null>(null);
-  const storageQuery = useQuery({ queryKey: useWsKey("storage"), queryFn: () => api.get<StorageLocation[]>("/storage") });
+  const storageQuery = useQuery({ queryKey: useWsKey("storage"), queryFn: ({ signal }) => api.get<StorageLocation[]>("/storage", { signal }) });
   const { data: storage } = storageQuery;
   const safeDatasheetUrl = isSafeHttpOrSameOriginUrl(datasheetUrl) ? datasheetUrl : null;
   const safeImageUrl = isSafeHttpOrSameOriginUrl(imageUrl) ? imageUrl : null;

--- a/web/src/routes/parts/ScanImport.tsx
+++ b/web/src/routes/parts/ScanImport.tsx
@@ -84,7 +84,7 @@ export default function ScanImport() {
 
   const storagesQuery = useQuery({
     queryKey: useWsKey("storage"),
-    queryFn: () => api.get<StorageLocation[]>("/storage"),
+    queryFn: ({ signal }) => api.get<StorageLocation[]>("/storage", { signal }),
   });
   const { data: storages } = storagesQuery;
 

--- a/web/src/routes/parts/StockHistory.tsx
+++ b/web/src/routes/parts/StockHistory.tsx
@@ -11,12 +11,12 @@ import QueryStateBoundary from "@/components/QueryStateBoundary";
 import { Link } from "react-router-dom";
 
 export default function StockHistory() {
-  const historyQuery = useQuery({ queryKey: useWsKey("stock-history"), queryFn: () => api.get<StockEntry[]>("/stock/history?limit=500") });
+  const historyQuery = useQuery({ queryKey: useWsKey("stock-history"), queryFn: ({ signal }) => api.get<StockEntry[]>("/stock/history?limit=500", { signal }) });
   const { data } = historyQuery;
   // The parts/storage queries hydrate name maps for the table cells; missing
   // them just falls back to UUIDs in the column, so they stay bare.
-  const { data: parts } = useQuery({ queryKey: useWsKey("parts"), queryFn: () => api.get<Part[]>("/parts?limit=200") });
-  const { data: storage } = useQuery({ queryKey: useWsKey("storage"), queryFn: () => api.get<StorageLocation[]>("/storage") });
+  const { data: parts } = useQuery({ queryKey: useWsKey("parts"), queryFn: ({ signal }) => api.get<Part[]>("/parts?limit=200", { signal }) });
+  const { data: storage } = useQuery({ queryKey: useWsKey("storage"), queryFn: ({ signal }) => api.get<StorageLocation[]>("/storage", { signal }) });
   const partName = new Map(parts?.map(p => [p.id, p.name]) ?? []);
   const sName = new Map(storage?.map(s => [s.id, s.name]) ?? []);
   return (

--- a/web/src/routes/parts/detail/AuthorizedSupplyTab.tsx
+++ b/web/src/routes/parts/detail/AuthorizedSupplyTab.tsx
@@ -437,7 +437,7 @@ export function AuthorizedSupplyTab({ partId }: { partId: string }) {
   const { workspaceId } = useAuth();
   const workspaceQuery = useQuery({
     queryKey: useWsKey("ws", "current"),
-    queryFn: () => api.get<SourcingWorkspaceSettings>("/workspaces/current"),
+    queryFn: ({ signal }) => api.get<SourcingWorkspaceSettings>("/workspaces/current", { signal }),
   });
   const workspaceCurrency = workspaceQuery.data?.sourcing_currency_code?.trim().toUpperCase() || null;
   const sourcingPath = workspaceCurrency

--- a/web/src/routes/parts/detail/CreateOrderLineModal.tsx
+++ b/web/src/routes/parts/detail/CreateOrderLineModal.tsx
@@ -82,7 +82,7 @@ export function CreateOrderLineModal({
 
   const ordersQuery = useQuery({
     queryKey: ordersKey,
-    queryFn: () => api.get<Order[]>("/orders?order_status=draft"),
+    queryFn: ({ signal }) => api.get<Order[]>("/orders?order_status=draft", { signal }),
     enabled: open,
   });
 

--- a/web/src/routes/parts/detail/PartAddStock.tsx
+++ b/web/src/routes/parts/detail/PartAddStock.tsx
@@ -36,7 +36,7 @@ export default function PartAddStock() {
   const nav = useNavigate();
   const qc = useQueryClient();
   const { workspaceId } = useAuth();
-  const storageQuery = useQuery({ queryKey: useWsKey("storage"), queryFn: () => api.get<StorageLocation[]>("/storage") });
+  const storageQuery = useQuery({ queryKey: useWsKey("storage"), queryFn: ({ signal }) => api.get<StorageLocation[]>("/storage", { signal }) });
   const { data: storage } = storageQuery;
   const [qty, setQty] = useState<number>(0);
   const [location, setLocation] = useState("");

--- a/web/src/routes/parts/detail/PartHistory.tsx
+++ b/web/src/routes/parts/detail/PartHistory.tsx
@@ -10,13 +10,13 @@ export default function PartHistory() {
   const { partId } = useParams();
   const { data, isError, error } = useQuery({
     queryKey: useWsKey("part", partId, "history"),
-    queryFn: async () => {
+    queryFn: async ({ signal }) => {
       // history endpoint is global; filter client-side by part for now
-      const rows = await api.get<StockEntry[]>("/stock/history?limit=1000");
+      const rows = await api.get<StockEntry[]>("/stock/history?limit=1000", { signal });
       return rows.filter(r => r.part_id === partId);
     },
   });
-  const { data: storage } = useQuery({ queryKey: useWsKey("storage"), queryFn: () => api.get<StorageLocation[]>("/storage") });
+  const { data: storage } = useQuery({ queryKey: useWsKey("storage"), queryFn: ({ signal }) => api.get<StorageLocation[]>("/storage", { signal }) });
   const sName = new Map(storage?.map(s => [s.id, s.name]) ?? []);
   if (isError) return <div className="text-red-600 text-sm p-4">Failed to load history. {error instanceof ApiError ? error.userMessage : ""}</div>;
   return (

--- a/web/src/routes/parts/detail/PartInfo.tsx
+++ b/web/src/routes/parts/detail/PartInfo.tsx
@@ -57,8 +57,8 @@ export default function PartInfo() {
   const { workspaceId } = useAuth();
   const cfQuery = useQuery({
     queryKey: useWsKey("part", part.id, "custom-fields"),
-    queryFn: () =>
-      api.get<CustomFieldRow[]>(`/custom-fields/by-object/part/${part.id}`),
+    queryFn: ({ signal }) =>
+      api.get<CustomFieldRow[]>(`/custom-fields/by-object/part/${part.id}`, { signal }),
   });
   const { data: cf } = cfQuery;
   const lookupBy = (k: string) => cf?.find(r => r.key === k)?.value || null;

--- a/web/src/routes/parts/detail/PartLayout.tsx
+++ b/web/src/routes/parts/detail/PartLayout.tsx
@@ -19,7 +19,7 @@ export default function PartLayout() {
 function PartLayoutQuery({ partId }: { partId: string }) {
   const { data: part, isError, error } = useQuery({
     queryKey: useWsKey("part", partId),
-    queryFn: () => api.get<Part>(`/parts/${partId}`),
+    queryFn: ({ signal }) => api.get<Part>(`/parts/${partId}`, { signal }),
   });
 
   if (isError) return <div className="text-red-600 text-sm p-4">Failed to load part. {error instanceof ApiError ? error.userMessage : ""}</div>;

--- a/web/src/routes/parts/detail/PartLots.tsx
+++ b/web/src/routes/parts/detail/PartLots.tsx
@@ -10,7 +10,7 @@ import QueryStateBoundary from "@/components/QueryStateBoundary";
 export default function PartLots() {
   const { partId } = useParams();
   const nav = useNavigate();
-  const lotsQuery = useQuery({ queryKey: useWsKey("part", partId, "lots"), queryFn: () => api.get<Lot[]>(`/parts/${partId}/lots`) });
+  const lotsQuery = useQuery({ queryKey: useWsKey("part", partId, "lots"), queryFn: ({ signal }) => api.get<Lot[]>(`/parts/${partId}/lots`, { signal }) });
   const { data } = lotsQuery;
   return (
     <QueryStateBoundary query={lotsQuery} resourceLabel="lots">

--- a/web/src/routes/parts/detail/PartMembers.tsx
+++ b/web/src/routes/parts/detail/PartMembers.tsx
@@ -16,10 +16,10 @@ export default function PartMembers() {
   const { workspaceId } = useAuth();
   const membersQuery = useQuery({
     queryKey: useWsKey("part", partId, "members"),
-    queryFn: () => api.get<Member[]>(`/parts/${partId}/members`),
+    queryFn: ({ signal }) => api.get<Member[]>(`/parts/${partId}/members`, { signal }),
   });
   const { data: members } = membersQuery;
-  const { data: parts } = useQuery({ queryKey: useWsKey("parts"), queryFn: () => api.get<Part[]>("/parts?limit=200") });
+  const { data: parts } = useQuery({ queryKey: useWsKey("parts"), queryFn: ({ signal }) => api.get<Part[]>("/parts?limit=200", { signal }) });
   const partsById = new Map(parts?.map(p => [p.id, p]) ?? []);
 
   const [pick, setPick] = useState("");

--- a/web/src/routes/parts/detail/PartMoveStock.tsx
+++ b/web/src/routes/parts/detail/PartMoveStock.tsx
@@ -37,15 +37,15 @@ export default function PartMoveStock() {
   const { workspaceId } = useAuth();
   const storageQuery = useQuery({
     queryKey: useWsKey("storage"),
-    queryFn: () => api.get<StorageLocation[]>("/storage"),
+    queryFn: ({ signal }) => api.get<StorageLocation[]>("/storage", { signal }),
   });
   const stockQuery = useQuery({
     queryKey: useWsKey("part", partId, "stock"),
-    queryFn: () => api.get<StockResp>(`/parts/${partId}/stock`),
+    queryFn: ({ signal }) => api.get<StockResp>(`/parts/${partId}/stock`, { signal }),
   });
   const lotsQuery = useQuery({
     queryKey: useWsKey("part", partId, "lots"),
-    queryFn: () => api.get<Lot[]>(`/parts/${partId}/lots`),
+    queryFn: ({ signal }) => api.get<Lot[]>(`/parts/${partId}/lots`, { signal }),
   });
   const { data: storage } = storageQuery;
   const { data: stock } = stockQuery;

--- a/web/src/routes/parts/detail/PartRemoveStock.tsx
+++ b/web/src/routes/parts/detail/PartRemoveStock.tsx
@@ -41,15 +41,15 @@ export default function PartRemoveStock() {
   const { workspaceId } = useAuth();
   const storageQuery = useQuery({
     queryKey: useWsKey("storage"),
-    queryFn: () => api.get<StorageLocation[]>("/storage"),
+    queryFn: ({ signal }) => api.get<StorageLocation[]>("/storage", { signal }),
   });
   const stockQuery = useQuery({
     queryKey: useWsKey("part", partId, "stock"),
-    queryFn: () => api.get<StockResp>(`/parts/${partId}/stock`),
+    queryFn: ({ signal }) => api.get<StockResp>(`/parts/${partId}/stock`, { signal }),
   });
   const lotsQuery = useQuery({
     queryKey: useWsKey("part", partId, "lots"),
-    queryFn: () => api.get<Lot[]>(`/parts/${partId}/lots`),
+    queryFn: ({ signal }) => api.get<Lot[]>(`/parts/${partId}/lots`, { signal }),
   });
   const { data: storage } = storageQuery;
   const { data: stock } = stockQuery;

--- a/web/src/routes/parts/detail/PartSettings.tsx
+++ b/web/src/routes/parts/detail/PartSettings.tsx
@@ -23,7 +23,7 @@ export default function PartSettings() {
   const { partId } = useParams();
   const qc = useQueryClient();
   const { workspaceId } = useAuth();
-  const storageQuery = useQuery({ queryKey: useWsKey("storage"), queryFn: () => api.get<StorageLocation[]>("/storage") });
+  const storageQuery = useQuery({ queryKey: useWsKey("storage"), queryFn: ({ signal }) => api.get<StorageLocation[]>("/storage", { signal }) });
   const { data: storage } = storageQuery;
   const [low, setLow] = useState(part.low_stock_report_quantity?.toString() ?? "");
   const [attrPct, setAttrPct] = useState(String(part.attrition_percentage));

--- a/web/src/routes/parts/detail/PartSourcing.tsx
+++ b/web/src/routes/parts/detail/PartSourcing.tsx
@@ -40,8 +40,8 @@ export default function PartSourcing() {
 
   const { data, isLoading, isError, error } = useQuery({
     queryKey: useWsKey("part", part.id, "custom-fields"),
-    queryFn: () =>
-      api.get<CustomFieldRow[]>(`/custom-fields/by-object/part/${part.id}`),
+    queryFn: ({ signal }) =>
+      api.get<CustomFieldRow[]>(`/custom-fields/by-object/part/${part.id}`, { signal }),
   });
 
   const rows = (data ?? []).filter(r => isCatalogKey(r.key));

--- a/web/src/routes/parts/detail/PartSpecs.tsx
+++ b/web/src/routes/parts/detail/PartSpecs.tsx
@@ -50,8 +50,8 @@ export default function PartSpecs() {
 
   const { data, isLoading, isError, error } = useQuery({
     queryKey,
-    queryFn: () =>
-      api.get<CustomFieldRow[]>(`/custom-fields/by-object/part/${part.id}`),
+    queryFn: ({ signal }) =>
+      api.get<CustomFieldRow[]>(`/custom-fields/by-object/part/${part.id}`, { signal }),
   });
 
   const [newKey, setNewKey] = useState("");

--- a/web/src/routes/parts/detail/PartStock.tsx
+++ b/web/src/routes/parts/detail/PartStock.tsx
@@ -13,9 +13,9 @@ export default function PartStock() {
   const { partId } = useParams();
   const { data, isError, error } = useQuery({
     queryKey: useWsKey("part", partId, "stock"),
-    queryFn: () => api.get<StockResp>(`/parts/${partId}/stock`),
+    queryFn: ({ signal }) => api.get<StockResp>(`/parts/${partId}/stock`, { signal }),
   });
-  const { data: storage } = useQuery({ queryKey: useWsKey("storage"), queryFn: () => api.get<StorageLocation[]>("/storage") });
+  const { data: storage } = useQuery({ queryKey: useWsKey("storage"), queryFn: ({ signal }) => api.get<StorageLocation[]>("/storage", { signal }) });
   const storageById = new Map(storage?.map(s => [s.id, s.name]) ?? []);
 
   if (isError) return <div className="text-red-600 text-sm p-4">Failed to load stock. {error instanceof ApiError ? error.userMessage : ""}</div>;

--- a/web/src/routes/parts/detail/PartSubstitutes.tsx
+++ b/web/src/routes/parts/detail/PartSubstitutes.tsx
@@ -13,9 +13,9 @@ export default function PartSubstitutes() {
   const { partId } = useParams();
   const qc = useQueryClient();
   const { workspaceId } = useAuth();
-  const subsQuery = useQuery({ queryKey: useWsKey("part", partId, "subs"), queryFn: () => api.get<Sub[]>(`/parts/${partId}/substitutes`) });
+  const subsQuery = useQuery({ queryKey: useWsKey("part", partId, "subs"), queryFn: ({ signal }) => api.get<Sub[]>(`/parts/${partId}/substitutes`, { signal }) });
   const { data: subs } = subsQuery;
-  const { data: parts } = useQuery({ queryKey: useWsKey("parts"), queryFn: () => api.get<Part[]>("/parts?limit=200") });
+  const { data: parts } = useQuery({ queryKey: useWsKey("parts"), queryFn: ({ signal }) => api.get<Part[]>("/parts?limit=200", { signal }) });
   const partsById = new Map(parts?.map(p => [p.id, p]) ?? []);
   const [pick, setPick] = useState("");
 

--- a/web/src/routes/projects/ProjectsList.tsx
+++ b/web/src/routes/projects/ProjectsList.tsx
@@ -13,7 +13,7 @@ export default function ProjectsList({ archived = false }: { archived?: boolean 
   const nav = useNavigate();
   const query = useQuery({
     queryKey: useWsKey("projects", { archived }),
-    queryFn: () => api.get<Project[]>(`/projects${archived ? "?archived=true" : ""}`),
+    queryFn: ({ signal }) => api.get<Project[]>(`/projects${archived ? "?archived=true" : ""}`, { signal }),
   });
   const { data } = query;
   return (

--- a/web/src/routes/projects/detail/AddPartFromLibraryModal.tsx
+++ b/web/src/routes/projects/detail/AddPartFromLibraryModal.tsx
@@ -38,13 +38,13 @@ export default function AddPartFromLibraryModal({ open, projectId, onClose }: Pr
 
   const partsQuery = useQuery({
     queryKey: useWsKey("parts", "library-picker", debouncedSearch),
-    queryFn: () => {
+    queryFn: ({ signal }) => {
       const params = new URLSearchParams({ limit: "20" });
       if (debouncedSearch) {
         params.set("q", debouncedSearch);
         params.set("search", debouncedSearch);
       }
-      return api.get<Part[]>(`/parts?${params.toString()}`);
+      return api.get<Part[]>(`/parts?${params.toString()}`, { signal });
     },
     enabled: open,
   });

--- a/web/src/routes/projects/detail/ProjectBOM.tsx
+++ b/web/src/routes/projects/detail/ProjectBOM.tsx
@@ -47,13 +47,13 @@ export default function ProjectBOM() {
   const { workspaceId } = useAuth();
   const entriesQuery = useQuery({
     queryKey: useWsKey("project", projectId, "entries"),
-    queryFn: () => api.get<ProjectEntry[]>(`/projects/${projectId}/entries`),
+    queryFn: ({ signal }) => api.get<ProjectEntry[]>(`/projects/${projectId}/entries`, { signal }),
   });
   const { data: entries } = entriesQuery;
-  const { data: parts } = useQuery({ queryKey: useWsKey("parts"), queryFn: () => api.get<Part[]>("/parts?limit=200") });
+  const { data: parts } = useQuery({ queryKey: useWsKey("parts"), queryFn: ({ signal }) => api.get<Part[]>("/parts?limit=200", { signal }) });
   const { data: workspace } = useQuery({
     queryKey: useWsKey("ws", "current"),
-    queryFn: () => api.get<WorkspaceProviderSettings>("/workspaces/current"),
+    queryFn: ({ signal }) => api.get<WorkspaceProviderSettings>("/workspaces/current", { signal }),
   });
   const partsById = new Map(parts?.map(p => [p.id, p]) ?? []);
 

--- a/web/src/routes/projects/detail/ProjectBuilds.tsx
+++ b/web/src/routes/projects/detail/ProjectBuilds.tsx
@@ -13,7 +13,7 @@ export default function ProjectBuilds() {
   const { projectId } = useParams<{ projectId: string }>();
   const buildsQuery = useQuery({
     queryKey: useWsKey("builds", { project: projectId }),
-    queryFn: () => api.get<Build[]>(`/builds?project_id=${projectId}`),
+    queryFn: ({ signal }) => api.get<Build[]>(`/builds?project_id=${projectId}`, { signal }),
     enabled: !!projectId,
   });
   const { data } = buildsQuery;

--- a/web/src/routes/projects/detail/ProjectImport.tsx
+++ b/web/src/routes/projects/detail/ProjectImport.tsx
@@ -146,7 +146,7 @@ export default function ProjectImport() {
   });
   const presetsQuery = useQuery({
     queryKey: useWsKey("bom-presets"),
-    queryFn: () => api.get<Preset[]>("/bom-presets"),
+    queryFn: ({ signal }) => api.get<Preset[]>("/bom-presets", { signal }),
   });
   const { data: presets, refetch: refetchPresets } = presetsQuery;
 

--- a/web/src/routes/projects/detail/ProjectLayout.tsx
+++ b/web/src/routes/projects/detail/ProjectLayout.tsx
@@ -9,7 +9,7 @@ import { SourceBomButton } from "@/routes/projects/sourcing/SourceBomButton";
 
 export default function ProjectLayout() {
   const { projectId } = useParams<{ projectId: string }>();
-  const { data, isError, error } = useQuery({ queryKey: useWsKey("project", projectId), queryFn: () => api.get<Project>(`/projects/${projectId}`), enabled: !!projectId });
+  const { data, isError, error } = useQuery({ queryKey: useWsKey("project", projectId), queryFn: ({ signal }) => api.get<Project>(`/projects/${projectId}`, { signal }), enabled: !!projectId });
   if (isError) return <div className="text-red-600 text-sm p-4">Failed to load project. {error instanceof ApiError ? error.userMessage : ""}</div>;
   if (!data) return <div className="text-muted">Loading…</div>;
   const items = [

--- a/web/src/routes/projects/detail/__tests__/AddPartFromLibraryModal.test.tsx
+++ b/web/src/routes/projects/detail/__tests__/AddPartFromLibraryModal.test.tsx
@@ -103,7 +103,7 @@ describe("AddPartFromLibraryModal", () => {
     expect(await screen.findByText("STM32")).toBeDefined();
     expect(screen.getByText("STM32F103C8T6 - ST")).toBeDefined();
     expect(screen.getByText("Regulator")).toBeDefined();
-    expect(api.get).toHaveBeenCalledWith("/parts?limit=20");
+    expect(api.get).toHaveBeenCalledWith("/parts?limit=20", expect.any(Object));
   });
 
   it("uses the debounced search term in the parts request", async () => {
@@ -114,7 +114,7 @@ describe("AddPartFromLibraryModal", () => {
     await user.type(await screen.findByLabelText("Search library"), "STM");
 
     await waitFor(() => {
-      expect(api.get).toHaveBeenCalledWith(expect.stringContaining("search=STM"));
+      expect(api.get).toHaveBeenCalledWith(expect.stringContaining("search=STM"), expect.any(Object));
     });
   });
 

--- a/web/src/routes/projects/sourcing/ProjectSourcingPage.tsx
+++ b/web/src/routes/projects/sourcing/ProjectSourcingPage.tsx
@@ -42,7 +42,7 @@ export default function ProjectSourcingPage() {
   } = useSourcingFilters(budgetDisabledUntil);
   const { data: project } = useQuery({
     queryKey: useWsKey("project", projectId),
-    queryFn: () => api.get<Project>(`/projects/${projectId}`),
+    queryFn: ({ signal }) => api.get<Project>(`/projects/${projectId}`, { signal }),
     enabled: !!projectId,
   });
 

--- a/web/src/routes/projects/sourcing/PurchasePlanReviewPage.tsx
+++ b/web/src/routes/projects/sourcing/PurchasePlanReviewPage.tsx
@@ -42,7 +42,7 @@ export default function PurchasePlanReviewPage() {
   const initialPlan = locationState.plan?.id === planId ? locationState.plan : undefined;
   const planQuery = useQuery({
     queryKey: purchasePlanKey,
-    queryFn: () => api.get<PurchasePlan>(`/projects/${projectId}/purchase-plans/${planId}`),
+    queryFn: ({ signal }) => api.get<PurchasePlan>(`/projects/${projectId}/purchase-plans/${planId}`, { signal }),
     enabled: !!projectId && !!planId,
     initialData: initialPlan,
     staleTime: 5 * 60 * 1000,

--- a/web/src/routes/projects/sourcing/SourceBomButton.tsx
+++ b/web/src/routes/projects/sourcing/SourceBomButton.tsx
@@ -21,7 +21,7 @@ type Props = {
 export function SourceBomButton({ projectId, className }: Props) {
   const { data: workspace } = useQuery({
     queryKey: useWsKey("ws", "current"),
-    queryFn: () => api.get<SourcingWorkspaceSettings>("/workspaces/current"),
+    queryFn: ({ signal }) => api.get<SourcingWorkspaceSettings>("/workspaces/current", { signal }),
   });
   const disabled = workspace?.has_sourcing_api_key === false;
   const classes = className ?? "btn-primary";

--- a/web/src/routes/projects/sourcing/__tests__/PurchasePlanReviewPage.test.tsx
+++ b/web/src/routes/projects/sourcing/__tests__/PurchasePlanReviewPage.test.tsx
@@ -200,7 +200,10 @@ describe("PurchasePlanReviewPage", () => {
     renderPage({ initialPlan: null });
 
     expect(await screen.findByRole("heading", { name: /Purchase plan #\s*plan-123/ })).toBeDefined();
-    expect(api.get).toHaveBeenCalledWith("/projects/project-123/purchase-plans/plan-12345678");
+    expect(api.get).toHaveBeenCalledWith(
+      "/projects/project-123/purchase-plans/plan-12345678",
+      expect.any(Object),
+    );
   });
 
   it("reload preserves the plan view from the fresh query cache", async () => {

--- a/web/src/routes/projects/sourcing/useProjectSourcing.ts
+++ b/web/src/routes/projects/sourcing/useProjectSourcing.ts
@@ -18,7 +18,7 @@ export function useProjectSourcing({
   const sourcingDisplayCacheKey = useWsKey("project-sourcing", projectId);
   const cachedSourcing = useQuery<SourcingBomResponse | null>({
     queryKey: sourcingDisplayCacheKey,
-    queryFn: async () => null,
+    queryFn: async ({ signal: _signal }) => null,
     enabled: false,
     staleTime: Infinity,
     gcTime: SOURCING_BOM_GC_TIME_MS,

--- a/web/src/routes/projects/sourcing/useSourcingFilters.ts
+++ b/web/src/routes/projects/sourcing/useSourcingFilters.ts
@@ -17,7 +17,7 @@ export function useSourcingFilters(budgetDisabledUntil: number | null) {
   const [defaultsApplied, setDefaultsApplied] = useState(false);
   const { data: workspace } = useQuery({
     queryKey: useWsKey("ws", "current"),
-    queryFn: () => api.get<SourcingWorkspaceSettings>("/workspaces/current"),
+    queryFn: ({ signal }) => api.get<SourcingWorkspaceSettings>("/workspaces/current", { signal }),
   });
 
   useEffect(() => {

--- a/web/src/routes/reports/BomBuyabilityReport.tsx
+++ b/web/src/routes/reports/BomBuyabilityReport.tsx
@@ -68,7 +68,7 @@ export default function BomBuyabilityReport() {
 
   const { data, isLoading, isError, error } = useQuery({
     queryKey: useWsKey("report", "bom-buyability", qtyFromUrl),
-    queryFn: () => api.get<BomBuyabilityReportOut>(`/reports/bom-buyability?build_quantity=${qtyFromUrl}`),
+    queryFn: ({ signal }) => api.get<BomBuyabilityReportOut>(`/reports/bom-buyability?build_quantity=${qtyFromUrl}`, { signal }),
   });
 
   const status = statusCopy(data?.sourcing_status ?? "ok");

--- a/web/src/routes/reports/ReplenishmentCostReport.tsx
+++ b/web/src/routes/reports/ReplenishmentCostReport.tsx
@@ -118,7 +118,7 @@ export default function ReplenishmentCostReport() {
   const [sort, setSort] = useState<SortMode>("delta_pct");
   const { data, isError, isLoading, error } = useQuery({
     queryKey: useWsKey("report", "replenishment-cost", sort),
-    queryFn: () => api.get<ReplenishmentCostReport>(`/reports/replenishment-cost?sort=${sort}`),
+    queryFn: ({ signal }) => api.get<ReplenishmentCostReport>(`/reports/replenishment-cost?sort=${sort}`, { signal }),
   });
 
   if (isError) {

--- a/web/src/routes/reports/Reports.tsx
+++ b/web/src/routes/reports/Reports.tsx
@@ -226,15 +226,15 @@ function KpiCard({
 function KpiStrip() {
   const { data: lowStock } = useQuery({
     queryKey: useWsKey("report", "low-stock"),
-    queryFn: () => api.get<LowStockRow[]>("/reports/low-stock"),
+    queryFn: ({ signal }) => api.get<LowStockRow[]>("/reports/low-stock", { signal }),
   });
   const { data: stockValue } = useQuery({
     queryKey: useWsKey("report", "stock-value"),
-    queryFn: () => api.get<StockValue>("/reports/stock-value"),
+    queryFn: ({ signal }) => api.get<StockValue>("/reports/stock-value", { signal }),
   });
   const { data: expiring } = useQuery({
     queryKey: useWsKey("report", "expiring", 30),
-    queryFn: () => api.get<Expiring>("/reports/expiring-lots?days=30"),
+    queryFn: ({ signal }) => api.get<Expiring>("/reports/expiring-lots?days=30", { signal }),
   });
 
   const lowCount = lowStock?.length ?? 0;
@@ -286,10 +286,10 @@ export function LowStockReport() {
   const [orderLineSource, setOrderLineSource] = useState<CreateOrderLineSource | null>(null);
   const { data, isLoading, isError, error } = useQuery<LowStockRow[] | LowStockWithSourcing>({
     queryKey: useWsKey("report", "low-stock", includeSourcing),
-    queryFn: () =>
+    queryFn: ({ signal }) =>
       includeSourcing
-        ? api.get<LowStockWithSourcing>("/reports/low-stock?include_sourcing=true")
-        : api.get<LowStockRow[]>("/reports/low-stock"),
+        ? api.get<LowStockWithSourcing>("/reports/low-stock?include_sourcing=true", { signal })
+        : api.get<LowStockRow[]>("/reports/low-stock", { signal }),
   });
 
   const restockMutation = useApiMutation<void, { name: string; lines: { part_id: string; quantity: number }[] }>({
@@ -463,7 +463,7 @@ export function LowStockReport() {
 export function StockValueReport() {
   const { data, isLoading, isError, error } = useQuery({
     queryKey: useWsKey("report", "stock-value"),
-    queryFn: () => api.get<StockValue>("/reports/stock-value"),
+    queryFn: ({ signal }) => api.get<StockValue>("/reports/stock-value", { signal }),
   });
   if (isError) return <div className="text-red-600 text-sm p-4">Failed to load stock value report. {error instanceof ApiError ? error.userMessage : ""}</div>;
   if (isLoading) return <div className="text-muted">Loading…</div>;
@@ -511,12 +511,12 @@ export function BomShortageReport() {
   const nav = useNavigate();
   const qc = useQueryClient();
   const { workspaceId } = useAuth();
-  const { data: projects } = useQuery({ queryKey: useWsKey("projects"), queryFn: () => api.get<Project[]>("/projects") });
+  const { data: projects } = useQuery({ queryKey: useWsKey("projects"), queryFn: ({ signal }) => api.get<Project[]>("/projects", { signal }) });
   const [projectId, setProjectId] = useState("");
   const [qty, setQty] = useState(1);
   const { data } = useQuery({
     queryKey: useWsKey("report", "bom", projectId, qty),
-    queryFn: () => api.get<Shortage>(`/reports/bom-shortage?project_id=${projectId}&quantity=${qty}`),
+    queryFn: ({ signal }) => api.get<Shortage>(`/reports/bom-shortage?project_id=${projectId}&quantity=${qty}`, { signal }),
     enabled: !!projectId && qty > 0,
   });
 
@@ -601,7 +601,7 @@ export function ExpiringLotsReport() {
   const [days, setDays] = useState(90);
   const { data } = useQuery({
     queryKey: useWsKey("report", "expiring", days),
-    queryFn: () => api.get<Expiring>(`/reports/expiring-lots?days=${days}`),
+    queryFn: ({ signal }) => api.get<Expiring>(`/reports/expiring-lots?days=${days}`, { signal }),
   });
   return (
     <div className="space-y-3">

--- a/web/src/routes/reports/SourcingRiskReport.tsx
+++ b/web/src/routes/reports/SourcingRiskReport.tsx
@@ -136,10 +136,10 @@ export default function SourcingRiskReport() {
   const [selectedFlags, setSelectedFlags] = useState<SourcingRiskFlag[]>([]);
   const { data, isLoading, isError, error } = useQuery({
     queryKey: useWsKey("report", "sourcing-risk", onlyWithFlags),
-    queryFn: () =>
+    queryFn: ({ signal }) =>
       api.get<SourcingRiskReportOut>(
         `/reports/sourcing-risk?only_with_flags=${String(onlyWithFlags)}`
-      ),
+      , { signal }),
   });
 
   const rows = useMemo(

--- a/web/src/routes/reports/__tests__/BomBuyabilityReport.test.tsx
+++ b/web/src/routes/reports/__tests__/BomBuyabilityReport.test.tsx
@@ -112,7 +112,10 @@ describe("BomBuyabilityReport", () => {
     await user.type(input, "5{Enter}");
 
     await waitFor(() => {
-      expect(get).toHaveBeenCalledWith("/reports/bom-buyability?build_quantity=5");
+      expect(get).toHaveBeenCalledWith(
+        "/reports/bom-buyability?build_quantity=5",
+        expect.any(Object),
+      );
     });
     expect(screen.getByTestId("location").textContent).toContain("build_quantity=5");
     const table = screen.getByRole("table");

--- a/web/src/routes/reports/__tests__/ReplenishmentCostReport.test.tsx
+++ b/web/src/routes/reports/__tests__/ReplenishmentCostReport.test.tsx
@@ -125,7 +125,13 @@ describe("ReplenishmentCostReport", () => {
     await user.selectOptions(screen.getByLabelText("Sort"), "name");
 
     expect(await screen.findByText("Name asc")).toBeDefined();
-    expect(getSpy).toHaveBeenCalledWith("/reports/replenishment-cost?sort=delta_pct");
-    expect(getSpy).toHaveBeenCalledWith("/reports/replenishment-cost?sort=name");
+    expect(getSpy).toHaveBeenCalledWith(
+      "/reports/replenishment-cost?sort=delta_pct",
+      expect.any(Object),
+    );
+    expect(getSpy).toHaveBeenCalledWith(
+      "/reports/replenishment-cost?sort=name",
+      expect.any(Object),
+    );
   });
 });

--- a/web/src/routes/reports/__tests__/SourcingRiskReport.test.tsx
+++ b/web/src/routes/reports/__tests__/SourcingRiskReport.test.tsx
@@ -133,7 +133,10 @@ describe("SourcingRiskReport", () => {
     await userEvent.click(screen.getByLabelText("Show only flagged"));
 
     expect(await screen.findByText("Clean")).toBeDefined();
-    expect(get).toHaveBeenCalledWith("/reports/sourcing-risk?only_with_flags=false");
+    expect(get).toHaveBeenCalledWith(
+      "/reports/sourcing-risk?only_with_flags=false",
+      expect.any(Object),
+    );
   });
 
   it("sorts by flag count desc by default", async () => {

--- a/web/src/routes/settings/ActiveListsCard.tsx
+++ b/web/src/routes/settings/ActiveListsCard.tsx
@@ -142,7 +142,7 @@ export function ActiveListsCard({
 
   const masterQuery = useQuery({
     queryKey: ["workspaces", "master-lists"],
-    queryFn: () => api.get<MasterLists>("/workspaces/master-lists"),
+    queryFn: ({ signal }) => api.get<MasterLists>("/workspaces/master-lists", { signal }),
   });
 
   const options = useMemo(() => {

--- a/web/src/routes/settings/Workspace.tsx
+++ b/web/src/routes/settings/Workspace.tsx
@@ -76,18 +76,18 @@ export default function WorkspaceSettings() {
   const confirm = useConfirm();
   const { me, workspaceId, refresh, switchWorkspace } = useAuth();
   const qc = useQueryClient();
-  const curQuery = useQuery({ queryKey: useWsKey("ws", "current"), queryFn: () => api.get<Ws>("/workspaces/current") });
+  const curQuery = useQuery({ queryKey: useWsKey("ws", "current"), queryFn: ({ signal }) => api.get<Ws>("/workspaces/current", { signal }) });
   const membersQuery = useQuery({
     queryKey: useWsKey("ws", "members"),
-    queryFn: () => api.get<Member[]>("/workspaces/members"),
+    queryFn: ({ signal }) => api.get<Member[]>("/workspaces/members", { signal }),
   });
   const invitesQuery = useQuery({
     queryKey: useWsKey("ws", "invitations"),
-    queryFn: () => api.get<Invitation[]>("/invitations"),
+    queryFn: ({ signal }) => api.get<Invitation[]>("/invitations", { signal }),
   });
   const catalogTokensQuery = useQuery({
     queryKey: useWsKey("ws", "catalog-tokens"),
-    queryFn: () => api.get<CatalogToken[]>("/workspaces/current/catalog/tokens"),
+    queryFn: ({ signal }) => api.get<CatalogToken[]>("/workspaces/current/catalog/tokens", { signal }),
   });
   const { data: cur } = curQuery;
   const { data: members, refetch: refetchMembers } = membersQuery;

--- a/web/src/routes/sourcing/alerts/AlertFormModal.tsx
+++ b/web/src/routes/sourcing/alerts/AlertFormModal.tsx
@@ -139,29 +139,29 @@ export default function AlertFormModal({
 
   const workspaceQuery = useQuery({
     queryKey: useWsKey("ws", "current"),
-    queryFn: () => api.get<WorkspaceSourcingSettings>("/workspaces/current"),
+    queryFn: ({ signal }) => api.get<WorkspaceSourcingSettings>("/workspaces/current", { signal }),
     enabled: open,
   });
   const membersQuery = useQuery({
     queryKey: useWsKey("ws", "members"),
-    queryFn: () => api.get<WorkspaceMemberOption[]>("/workspaces/members"),
+    queryFn: ({ signal }) => api.get<WorkspaceMemberOption[]>("/workspaces/members", { signal }),
     enabled: open,
   });
   const partsQuery = useQuery({
     queryKey: useWsKey("parts", "alert-picker", debouncedPartSearch),
-    queryFn: () => {
+    queryFn: ({ signal }) => {
       const params = new URLSearchParams({ limit: "20" });
       if (debouncedPartSearch) {
         params.set("q", debouncedPartSearch);
         params.set("search", debouncedPartSearch);
       }
-      return api.get<Part[]>(`/parts?${params.toString()}`);
+      return api.get<Part[]>(`/parts?${params.toString()}`, { signal });
     },
     enabled: open && !isProjectAlert(alertType),
   });
   const projectsQuery = useQuery({
     queryKey: useWsKey("projects", "alert-picker"),
-    queryFn: () => api.get<Project[]>("/projects?limit=200"),
+    queryFn: ({ signal }) => api.get<Project[]>("/projects?limit=200", { signal }),
     enabled: open && isProjectAlert(alertType),
   });
 

--- a/web/src/routes/sourcing/alerts/AlertsPage.tsx
+++ b/web/src/routes/sourcing/alerts/AlertsPage.tsx
@@ -77,11 +77,11 @@ export default function AlertsPage() {
   });
   const partsQuery = useQuery({
     queryKey: useWsKey("parts", "alert-scope-map"),
-    queryFn: () => api.get<Part[]>("/parts?limit=200"),
+    queryFn: ({ signal }) => api.get<Part[]>("/parts?limit=200", { signal }),
   });
   const projectsQuery = useQuery({
     queryKey: useWsKey("projects", "alert-scope-map"),
-    queryFn: () => api.get<Project[]>("/projects?limit=200"),
+    queryFn: ({ signal }) => api.get<Project[]>("/projects?limit=200", { signal }),
   });
   const partMap = useMemo(() => mapById(partsQuery.data), [partsQuery.data]);
   const projectMap = useMemo(() => mapById(projectsQuery.data), [projectsQuery.data]);

--- a/web/src/routes/storage/StorageDetail.tsx
+++ b/web/src/routes/storage/StorageDetail.tsx
@@ -17,7 +17,7 @@ export function StorageDetailLayout() {
   const { storageId } = useParams<{ storageId: string }>();
   const { data, isError, error } = useQuery({
     queryKey: useWsKey("storage", storageId),
-    queryFn: () => api.get<StorageLocation>(`/storage/${storageId}`),
+    queryFn: ({ signal }) => api.get<StorageLocation>(`/storage/${storageId}`, { signal }),
     enabled: !!storageId,
   });
   if (isError) return <div className="text-red-600 text-sm p-4">Failed to load storage location. {error instanceof ApiError ? error.userMessage : ""}</div>;
@@ -67,9 +67,9 @@ export function StorageInfo() {
   const partsKey = useWsKey("parts");
   const { data: rows, isError, error } = useQuery({
     queryKey: storagePartsKey,
-    queryFn: () => api.get<{ part_id: string; lot_id: string | null; quantity: number }[]>(`/storage/${storageId}/parts`),
+    queryFn: ({ signal }) => api.get<{ part_id: string; lot_id: string | null; quantity: number }[]>(`/storage/${storageId}/parts`, { signal }),
   });
-  const { data: parts } = useQuery({ queryKey: partsKey, queryFn: () => api.get<Part[]>("/parts?limit=200") });
+  const { data: parts } = useQuery({ queryKey: partsKey, queryFn: ({ signal }) => api.get<Part[]>("/parts?limit=200", { signal }) });
   // Derived data — safe to compute even when rows/parts are undefined.
   // Hoisted above the `isError` early-return so the hook count stays
   // stable across renders (Rules of Hooks — see #284).
@@ -102,10 +102,10 @@ export function StorageHistory() {
   const { storageId } = useParams();
   const historyQuery = useQuery({
     queryKey: useWsKey("storage", storageId, "history"),
-    queryFn: () => api.get<StockEntry[]>(`/storage/${storageId}/history?limit=200`),
+    queryFn: ({ signal }) => api.get<StockEntry[]>(`/storage/${storageId}/history?limit=200`, { signal }),
   });
   const { data } = historyQuery;
-  const { data: parts } = useQuery({ queryKey: useWsKey("parts"), queryFn: () => api.get<Part[]>("/parts?limit=200") });
+  const { data: parts } = useQuery({ queryKey: useWsKey("parts"), queryFn: ({ signal }) => api.get<Part[]>("/parts?limit=200", { signal }) });
   const partName = new Map(parts?.map(p => [p.id, p.name]) ?? []);
   return (
     <QueryStateBoundary query={historyQuery} resourceLabel="storage history">
@@ -130,7 +130,7 @@ export function StorageSettings() {
   const { storageId } = useParams();
   const qc = useQueryClient();
   const { workspaceId } = useAuth();
-  const { data } = useQuery({ queryKey: useWsKey("storage", storageId), queryFn: () => api.get<StorageLocation>(`/storage/${storageId}`), enabled: !!storageId });
+  const { data } = useQuery({ queryKey: useWsKey("storage", storageId), queryFn: ({ signal }) => api.get<StorageLocation>(`/storage/${storageId}`, { signal }), enabled: !!storageId });
   if (!data) return null;
   // Patch fields are a finite set on the backend StorageLocationPatch
   // model — boolean flags + a few text fields. `unknown` would be too
@@ -167,7 +167,7 @@ export function StorageOther() {
   const nav = useNavigate();
   const qc = useQueryClient();
   const { workspaceId } = useAuth();
-  const { data } = useQuery({ queryKey: useWsKey("storage", storageId), queryFn: () => api.get<StorageLocation>(`/storage/${storageId}`), enabled: !!storageId });
+  const { data } = useQuery({ queryKey: useWsKey("storage", storageId), queryFn: ({ signal }) => api.get<StorageLocation>(`/storage/${storageId}`, { signal }), enabled: !!storageId });
   const archiveMutation = useApiMutation<unknown, { wasArchived: boolean }>({
     mutationKey: ["storage", storageId, "archive"],
     mutationFn: ({ wasArchived }) =>

--- a/web/src/routes/storage/StorageList.tsx
+++ b/web/src/routes/storage/StorageList.tsx
@@ -12,7 +12,7 @@ export default function StorageList({ archived = false }: { archived?: boolean }
   const nav = useNavigate();
   const storageQuery = useQuery({
     queryKey: useWsKey("storage", { archived }),
-    queryFn: () => api.get<StorageLocation[]>(`/storage${archived ? "?archived=true" : ""}`),
+    queryFn: ({ signal }) => api.get<StorageLocation[]>(`/storage${archived ? "?archived=true" : ""}`, { signal }),
   });
   const { data } = storageQuery;
   return (


### PR DESCRIPTION
## Summary

- Thread TanStack Query's `signal` through every frontend `queryFn` API read.
- Add ESLint `no-restricted-syntax` guards so future `queryFn` callbacks must accept/destructure the query context signal.
- Add `web/src/lib/api.abort.test.ts` covering unmount abort propagation from `useQuery` through `api.get` to `fetch`.

## Validation

- `npm --prefix web run test` passed: 65 files passed, 1 skipped; 471 tests passed, 3 skipped.
- `npm --prefix web run test -- src/lib/api.abort.test.ts` passed.
- Targeted changed-file lint passed: `npm --prefix web exec eslint -- $(git diff --name-only -- 'web/src/**/*.{ts,tsx}' | sed 's#^web/##')`.
- Signal scan passed: no remaining `api.get` calls inside `queryFn` without signal.
- `git diff --check` passed.

## Known validation blocker

`npm --prefix web run lint` is still blocked by existing unrelated errors in `web/src/lib/bagCode.ts` (`no-control-regex` at lines 91 and 164). I left those out of scope for AUD-013.

## Merge notes

Current open PR inspection found no frontend file overlap with open PRs. The requested likely PRs #574 and #579 were not resolvable in `matescb/stockManager` via `gh pr view`, so no merge order is required from the current repository state.

Closes #552
