### PR TITLE
[codex] AUD-041 make session idle window configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@ POSTGRES_PASSWORD=stockmgr
 POSTGRES_DB=stockmgr
 DATABASE_URL=postgresql+psycopg://stockmgr:stockmgr@db:5432/stockmgr
 SESSION_SECRET=dev-change-me-locally
+SESSION_IDLE_HOURS=24
 UPLOAD_DIR=/data/uploads
 APP_ENV=dev
 CORS_ORIGINS=http://localhost:5173

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import urllib.parse
 from functools import lru_cache
 
-from pydantic import model_validator
+from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -30,6 +30,9 @@ class Settings(BaseSettings):
     SESSION_SECRET: str = "dev-secret-change-me"
     SESSION_COOKIE_NAME: str = "stockmgr_session"
     SESSION_LIFETIME_DAYS: int = 30
+    # Sliding-expiry idle window. A session idle longer than this is
+    # rejected even when the absolute lifetime has not elapsed.
+    SESSION_IDLE_HOURS: int = Field(default=24, gt=0)
     # Cadence (seconds) of the in-process expired-session purge driven
     # by the FastAPI lifespan hook. DB-007 / issue #98. Knob exists so
     # tests can shorten it; ops should not need to touch it. 0 disables
@@ -156,7 +159,8 @@ class Settings(BaseSettings):
             raise ValueError(
                 "WORKSPACE_SECRETS_KEY is required when APP_ENV=prod. "
                 "Generate one with: "
-                'python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"'
+                'python -c "from cryptography.fernet import Fernet; '
+                'print(Fernet.generate_key().decode())"'
             )
         return self
 

--- a/backend/app/core/deps.py
+++ b/backend/app/core/deps.py
@@ -15,13 +15,13 @@ from app.domain.users.models import User, UserSession
 from app.domain.workspaces.models import Workspace, WorkspaceMember
 from app.infra.db import get_db
 
-# Sliding-expiry idle window (SEC2-015). A session whose `last_used_at`
-# is older than this is rejected even if the absolute `expires_at` is
-# still in the future. Tighter than SESSION_LIFETIME_DAYS so an
-# abandoned tab can't sit logged in for a month.
-_SESSION_IDLE_WINDOW = timedelta(hours=24)
-
 DbSession = Annotated[Session, Depends(get_db)]
+
+
+def _session_idle_window() -> timedelta:
+    # Sliding-expiry idle window (SEC2-015). Kept in Settings so ops can
+    # tune it without changing the session model.
+    return timedelta(hours=settings().SESSION_IDLE_HOURS)
 
 
 def get_current_user(
@@ -60,7 +60,7 @@ def get_current_user(
             ErrorCodes.AUTH_SESSION_EXPIRED,
             "session expired",
         )
-    if sess.last_used_at and sess.last_used_at < now - _SESSION_IDLE_WINDOW:
+    if sess.last_used_at and sess.last_used_at < now - _session_idle_window():
         # SEC2-015: idle longer than the sliding window. Drop the row
         # so a re-login mints a fresh credential rather than reviving
         # this one.

--- a/backend/tests/test_session_hashing.py
+++ b/backend/tests/test_session_hashing.py
@@ -2,7 +2,7 @@
 
 The DB only ever holds the SHA-256 digest of the cookie; the plaintext
 lives only on the client cookie. A session idle past
-core/deps._SESSION_IDLE_WINDOW (24h) is rejected even when its
+Settings.SESSION_IDLE_HOURS (24h by default) is rejected even when its
 absolute `expires_at` is still in the future.
 """
 from __future__ import annotations

--- a/backend/tests/test_session_idle_window.py
+++ b/backend/tests/test_session_idle_window.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from fastapi.testclient import TestClient
+
+from app.core.config import Settings, settings
+from app.core.errors import ErrorCodes
+from app.domain.users.models import UserSession
+from app.main import app
+from tests._factories import signup_user
+
+
+def test_env_overrides_default(db, monkeypatch):
+    monkeypatch.setenv("APP_ENV", "dev")
+    monkeypatch.delenv("SESSION_IDLE_HOURS", raising=False)
+    assert Settings(_env_file=None).SESSION_IDLE_HOURS == 24
+
+    monkeypatch.setenv("SESSION_IDLE_HOURS", "1")
+    settings.cache_clear()
+    try:
+        assert settings().SESSION_IDLE_HOURS == 1
+
+        client = TestClient(app)
+        signup_user(client)
+
+        rows = db.query(UserSession).all()
+        assert rows
+        for row in rows:
+            row.last_used_at = datetime.now(timezone.utc) - timedelta(hours=2)
+        db.commit()
+
+        response = client.get("/api/auth/me")
+
+        assert response.status_code == 401, response.text
+        assert response.json()["code"] == ErrorCodes.AUTH_SESSION_IDLE_TIMEOUT
+    finally:
+        settings.cache_clear()

--- a/deploy/.env.prod.example
+++ b/deploy/.env.prod.example
@@ -37,6 +37,10 @@ POSTGRES_PASSWORD=replace-me-with-a-strong-random-password
 #   openssl rand -hex 32
 SESSION_SECRET=replace-me-with-the-output-of-openssl-rand-hex-32
 
+# Sliding session idle timeout. Sessions idle longer than this are rejected;
+# keep at 24 unless your deployment policy requires a shorter window.
+SESSION_IDLE_HOURS=24
+
 # Comma-separated list of origins allowed to call the API from a browser.
 # In a typical single-domain prod deploy this is just your public hostname.
 CORS_ORIGINS=https://parts.matescb.cz

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -22,6 +22,7 @@ services:
     environment:
       DATABASE_URL: postgresql+psycopg://${POSTGRES_USER:-stockmgr}:${POSTGRES_PASSWORD:-stockmgr}@db:5432/${POSTGRES_DB:-stockmgr}
       SESSION_SECRET: ${SESSION_SECRET:?SESSION_SECRET is required — copy .env.example to .env and set a value}
+      SESSION_IDLE_HOURS: ${SESSION_IDLE_HOURS:-24}
       UPLOAD_DIR: /data/uploads
       APP_ENV: ${APP_ENV:-dev}
       CORS_ORIGINS: ${CORS_ORIGINS:-http://localhost:5173}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -80,6 +80,7 @@ services:
       POSTGRES_HOST: db
       POSTGRES_PORT: "5432"
       SESSION_SECRET: ${SESSION_SECRET}
+      SESSION_IDLE_HOURS: ${SESSION_IDLE_HOURS:-24}
       UPLOAD_DIR: /data/uploads
       APP_ENV: prod
       CORS_ORIGINS: ${CORS_ORIGINS}
@@ -184,6 +185,7 @@ services:
       POSTGRES_HOST: db
       POSTGRES_PORT: "5432"
       SESSION_SECRET: ${SESSION_SECRET}
+      SESSION_IDLE_HOURS: ${SESSION_IDLE_HOURS:-24}
       UPLOAD_DIR: /data/uploads
       APP_ENV: prod
       CORS_ORIGINS: ${CORS_ORIGINS}
@@ -236,6 +238,7 @@ services:
       POSTGRES_HOST: db
       POSTGRES_PORT: "5432"
       SESSION_SECRET: ${SESSION_SECRET}
+      SESSION_IDLE_HOURS: ${SESSION_IDLE_HOURS:-24}
       UPLOAD_DIR: /data/uploads
       APP_ENV: prod
       CORS_ORIGINS: ${CORS_ORIGINS}


### PR DESCRIPTION
## Summary
- add `SESSION_IDLE_HOURS` to backend Settings with a 24-hour default and positive-value validation
- use the setting for the auth dependency sliding idle timeout
- expose the env var in dev/prod Compose examples and add a regression test for env override behavior

## Validation
- `PATH=/mnt/data/WORK/stockManager-1/.codex-worktrees/aud-041-session-idle-settings/backend/.venv/bin:$PATH python -m pytest backend/tests/test_session_idle_window.py -q`
- `DATABASE_URL=postgresql+psycopg://stockmgr:stockmgr@127.0.0.1:5432/stockmgr_test_aud041 TEST_DATABASE_URL=postgresql+psycopg://stockmgr:stockmgr@127.0.0.1:5432/stockmgr_test_aud041 uv run --extra dev python -m pytest tests/test_session_idle_window.py tests/test_session_hashing.py -q`
- `uv run --extra dev ruff check app/core/config.py app/core/deps.py tests/test_session_idle_window.py tests/test_session_hashing.py`
- `git diff --check`

Closes #580