### PR TITLE
[codex] AUD-044 pool provider httpx clients

### DIFF
--- a/backend/app/domain/sourcing/providers/factory.py
+++ b/backend/app/domain/sourcing/providers/factory.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from contextlib import contextmanager
+from threading import Lock
 
 import httpx
 
@@ -11,6 +12,59 @@ from app.domain.sourcing.providers._retry_transport import RetryingHTTPTransport
 
 CONNECT_TIMEOUT_SECONDS = 2.0
 POOL_TIMEOUT_SECONDS = 2.0
+KEEPALIVE_EXPIRY_SECONDS = 30.0
+MAX_CONNECTIONS = 20
+MAX_KEEPALIVE_CONNECTIONS = 10
+
+_CLIENTS: dict[str, httpx.Client] = {}
+_CLIENTS_LOCK = Lock()
+
+
+def _timeout(timeout: float) -> httpx.Timeout:
+    return httpx.Timeout(
+        connect=CONNECT_TIMEOUT_SECONDS,
+        read=timeout,
+        write=timeout,
+        pool=POOL_TIMEOUT_SECONDS,
+    )
+
+
+def _retry_transport(
+    *,
+    provider_name: str,
+    transport: httpx.BaseTransport | None = None,
+    limits: httpx.Limits | None = None,
+) -> RetryingHTTPTransport:
+    kwargs = {"limits": limits} if limits is not None else {}
+    return RetryingHTTPTransport(
+        verify=True,
+        provider_name=provider_name,
+        inner=transport,
+        **kwargs,
+    )
+
+
+def _limits() -> httpx.Limits:
+    return httpx.Limits(
+        max_connections=MAX_CONNECTIONS,
+        max_keepalive_connections=MAX_KEEPALIVE_CONNECTIONS,
+        keepalive_expiry=KEEPALIVE_EXPIRY_SECONDS,
+    )
+
+
+def _pooled_client(*, provider_name: str, timeout: float) -> httpx.Client:
+    with _CLIENTS_LOCK:
+        client = _CLIENTS.get(provider_name)
+        if client is None or client.is_closed:
+            client = httpx.Client(
+                timeout=_timeout(timeout),
+                transport=_retry_transport(
+                    provider_name=provider_name,
+                    limits=_limits(),
+                ),
+            )
+            _CLIENTS[provider_name] = client
+        return client
 
 
 @contextmanager
@@ -20,17 +74,24 @@ def make_retrying_client(
     timeout: float,
     transport: httpx.BaseTransport | None = None,
 ) -> Iterator[httpx.Client]:
-    """Build a provider HTTP client with the shared retry policy."""
-    split_timeout = httpx.Timeout(
-        connect=CONNECT_TIMEOUT_SECONDS,
-        read=timeout,
-        write=timeout,
-        pool=POOL_TIMEOUT_SECONDS,
-    )
-    retry_transport = RetryingHTTPTransport(
-        verify=True,
-        provider_name=provider_name,
-        inner=transport,
-    )
-    with httpx.Client(timeout=split_timeout, transport=retry_transport) as client:
-        yield client
+    """Return a provider HTTP client with the shared retry policy."""
+    if transport is not None:
+        with httpx.Client(
+            timeout=_timeout(timeout),
+            transport=_retry_transport(
+                provider_name=provider_name,
+                transport=transport,
+            ),
+        ) as client:
+            yield client
+        return
+
+    yield _pooled_client(provider_name=provider_name, timeout=timeout)
+
+
+def _reset_provider_client_pool_for_tests() -> None:
+    with _CLIENTS_LOCK:
+        clients = list(_CLIENTS.values())
+        _CLIENTS.clear()
+    for client in clients:
+        client.close()

--- a/backend/tests/test_provider_pooling.py
+++ b/backend/tests/test_provider_pooling.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from app.domain.sourcing.providers import factory
+
+
+def test_single_client_per_provider(monkeypatch):
+    factory._reset_provider_client_pool_for_tests()
+    created = []
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.is_closed = False
+            created.append(self)
+
+        def close(self):
+            self.is_closed = True
+
+    monkeypatch.setattr(factory.httpx, "Client", FakeClient)
+    try:
+        with factory.make_retrying_client(provider_name="mouser", timeout=8.0) as mouser_1:
+            pass
+        with factory.make_retrying_client(provider_name="mouser", timeout=8.0) as mouser_2:
+            pass
+        with factory.make_retrying_client(provider_name="digikey", timeout=8.0) as digikey:
+            pass
+
+        assert mouser_1 is mouser_2
+        assert mouser_1 is not digikey
+        assert created == [mouser_1, digikey]
+    finally:
+        factory._reset_provider_client_pool_for_tests()


### PR DESCRIPTION
## Summary
- reuse one synchronous httpx client per provider process-wide for outbound provider calls
- keep shared retry transport, split timeouts, verify=True, and explicit keepalive limits
- add the requested provider pooling regression test

## Validation
- `TEST_DATABASE_URL=postgresql+psycopg://stockmgr:stockmgr@127.0.0.1:5432/stockmgr_test_aud044 uv run --project backend --extra dev python -m pytest backend/tests/test_provider_pooling.py backend/tests/test_provider_connect_timeout.py backend/tests/test_sourcing_providers_retry.py -q`
- `uv run --project backend --extra dev ruff check backend/app/domain/sourcing/providers/factory.py backend/tests/test_provider_pooling.py`
- `git diff --check`

## Merge order
No required merge order. Current open PRs do not touch `backend/app/domain/sourcing/providers/factory.py` or `backend/tests/test_provider_pooling.py`.

Closes #583