### PR TITLE
[codex] AUD-060 redact Mouser apiKey from Sentry

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -35,6 +35,22 @@ _SENTRY_SENSITIVE_TEXT_RE = re.compile(
 )
 
 
+def _strip_query_string(raw_url: str) -> str:
+    fragment_index = raw_url.find("#")
+    before_fragment = raw_url if fragment_index == -1 else raw_url[:fragment_index]
+    fragment = "" if fragment_index == -1 else raw_url[fragment_index:]
+    query_index = before_fragment.find("?")
+    fragment_query_index = fragment.find("?")
+
+    clean_before_fragment = (
+        before_fragment if query_index == -1 else before_fragment[:query_index]
+    )
+    clean_fragment = (
+        fragment if fragment_query_index == -1 else fragment[:fragment_query_index]
+    )
+    return f"{clean_before_fragment}{clean_fragment}"
+
+
 def _scrub_sensitive_text(value: str) -> str:
     return _SENTRY_SENSITIVE_TEXT_RE.sub(r"\g<prefix>[Filtered]", value)
 
@@ -86,12 +102,19 @@ def _scrub_event(event, _hint):
     request = event.get("request")
     if not isinstance(request, dict):
         return event
+    if isinstance(request.get("url"), str):
+        request["url"] = _strip_query_string(request["url"])
+    request.pop("query_string", None)
     headers = request.get("headers")
     if isinstance(headers, dict):
         drop = {"cookie", "authorization", "x-workspace-id"}
         for k in list(headers.keys()):
             if k.lower() in drop:
                 headers.pop(k, None)
+            elif k.lower() in {"referer", "referrer"} and isinstance(
+                headers.get(k), str
+            ):
+                headers[k] = _strip_query_string(headers[k])
     method = (request.get("method") or "").upper()
     if method and method != "GET":
         if request.pop("data", None) is not None:

--- a/backend/tests/test_sentry_scrubber.py
+++ b/backend/tests/test_sentry_scrubber.py
@@ -138,6 +138,48 @@ def test_scrubber_strips_sensitive_headers_on_post():
     assert "data" not in out["request"]
 
 
+def test_strips_apikey_query():
+    event = _event(
+        "POST",
+        "https://api.mouser.com/api/v1/search/partnumber?apiKey=MOUSER-SECRET#frag?tab=x",
+        data={"mpn": "RC0402JR-070R"},
+        headers={
+            "Referer": (
+                "https://api.mouser.com/api/v1/search/partnumber"
+                "?apiKey=HEADER-SECRET"
+            ),
+        },
+    )
+    event["request"]["query_string"] = "apiKey=MOUSER-SECRET"
+    event["message"] = "Mouser failed url=https://api.mouser.com/search?apiKey=MSG-SECRET"
+    event["exception"] = {
+        "values": [
+            {
+                "type": "HTTPStatusError",
+                "value": (
+                    "Server error for url "
+                    "https://api.mouser.com/api/v1/search/partnumber?apiKey=EXC-SECRET"
+                ),
+            }
+        ]
+    }
+
+    out = _scrub_event(event, None)
+    serialized = str(out)
+
+    assert out["request"]["url"] == "https://api.mouser.com/api/v1/search/partnumber#frag"
+    assert "query_string" not in out["request"]
+    assert out["request"]["headers"]["Referer"] == (
+        "https://api.mouser.com/api/v1/search/partnumber"
+    )
+    assert "MOUSER-SECRET" not in serialized
+    assert "HEADER-SECRET" not in serialized
+    assert "MSG-SECRET" not in serialized
+    assert "EXC-SECRET" not in serialized
+    assert "apiKey=[Filtered]" in out["message"]
+    assert "apiKey=[Filtered]" in out["exception"]["values"][0]["value"]
+
+
 # ---------------------------------------------------------------------------
 # Edge cases
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What changed

- Strip query strings from backend Sentry `request.url` values and remove Sentry `request.query_string`.
- Strip query strings from backend Sentry `Referer`/`Referrer` headers.
- Add regression coverage for Mouser `apiKey` in request URL/query string, referer, message, and exception values.

## Why

Mouser requests currently include the API key as an `apiKey` URL query parameter. Retry provider logs already record only the host, but Sentry events could retain request query fields or exception text containing the upstream URL.

## Overlap / merge order

PR #663 has already merged into `origin/main`; this branch is rebased on top of it and preserves its generic Sentry exception-value scrubber. Current open PRs inspected before publishing do not touch `backend/app/main.py` or `backend/tests/test_sentry_scrubber.py`, so no special merge order is required.

## Validation

- `uv run pytest tests/test_sentry_scrubber.py -q`
- `uv run ruff check --select F,I app/main.py tests/test_sentry_scrubber.py`
- `uv run ruff check tests/test_sentry_scrubber.py`

Closes #599
