### PR TITLE
[codex] AUD-050 add backend-init cron dependencies

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -199,6 +199,8 @@ services:
       MAIL_FROM: ${MAIL_FROM}
       APP_BASE_URL: ${APP_BASE_URL}
     depends_on:
+      backend-init:
+        condition: service_completed_successfully
       backend:
         condition: service_healthy
     healthcheck:
@@ -251,6 +253,8 @@ services:
       MAIL_FROM: ${MAIL_FROM}
       APP_BASE_URL: ${APP_BASE_URL}
     depends_on:
+      backend-init:
+        condition: service_completed_successfully
       backend:
         condition: service_healthy
     healthcheck:
@@ -304,6 +308,8 @@ services:
       MAIL_FROM: ${MAIL_FROM}
       APP_BASE_URL: ${APP_BASE_URL}
     depends_on:
+      backend-init:
+        condition: service_completed_successfully
       backend:
         condition: service_healthy
     healthcheck:


### PR DESCRIPTION
## Summary
- Adds a direct `backend-init` dependency to each production cron sidecar (`backend-cron`, `backend-cron-alerts`, `backend-cron-sessions`).
- Keeps the existing scheduler path as backend-cron* sidecars invoking `backend/app/cli/run_job.py`; no new scheduler or topology change.

Closes #589

## Validation
- `python3 - <<PY ... PY` parsed `docker-compose.prod.yml` and asserted all `backend-cron*` services depend on `backend-init: service_completed_successfully` and `backend: service_healthy`.
- `git diff --check`

## Not Run
- `docker compose -f docker-compose.prod.yml config -q` could not run because `docker` is not installed in this environment (`docker: command not found`).

## Open PR Overlap / Merge Order
- Checked current open PRs before editing. PR #669 and PR #667 also modify `docker-compose.prod.yml`; all other open PRs checked had no overlap with this change.
- Merge this PR after any earlier `docker-compose.prod.yml` changes land, or rebase it before merge so the three `backend-cron*` service `depends_on` blocks retain both `backend-init` and `backend` entries.