### PR TITLE
[codex] AUD-063 guard archive against reserved stock

### DIFF
--- a/backend/app/api/routes/storage.py
+++ b/backend/app/api/routes/storage.py
@@ -123,14 +123,19 @@ def archive_storage(storage_id: UUID, db: DbSession, ws: CurrentWorkspace, user:
     # 409 listing what's still inside so the operator can move it first.
     # Runs after the auth gate so an attacker probing for ws-membership
     # doesn't learn whether a foreign storage has stock.
+    # AUD-063: reservations do not carry storage_location_id today, but if
+    # that changes, archiving must not hide a location with reserved stock.
     on_hand = stock_for_storage(db, workspace_id=ws.id, storage_location_id=s.id)
+    reserved = stock_for_storage(
+        db, workspace_id=ws.id, storage_location_id=s.id, status="reserved"
+    )
     blocking = [
         {
             "part_id": str(r["part_id"]),
             "lot_id": str(r["lot_id"]) if r["lot_id"] else None,
             "quantity": int(r["quantity"]),
         }
-        for r in on_hand
+        for r in [*on_hand, *reserved]
         if int(r["quantity"]) > 0
     ]
     if blocking:

--- a/backend/tests/test_archive_storage.py
+++ b/backend/tests/test_archive_storage.py
@@ -15,6 +15,7 @@ import uuid
 import pytest
 from fastapi.testclient import TestClient
 
+from app.domain.stock.models import StockEntry
 from app.main import app
 
 
@@ -44,6 +45,12 @@ def _create_storage(c: TestClient, name: str) -> str:
     r = c.post("/api/storage", json={"name": name})
     assert r.status_code in (200, 201), r.text
     return r.json()["data"]["id"]
+
+
+def _current_workspace_id(c: TestClient) -> uuid.UUID:
+    r = c.get("/api/workspaces/current")
+    assert r.status_code == 200, r.text
+    return uuid.UUID(r.json()["data"]["id"])
 
 
 def test_archive_empty_storage_succeeds(authed):
@@ -99,3 +106,28 @@ def test_archive_after_full_consume_succeeds(authed):
 
     r = authed.post(f"/api/storage/{sid_a}/archive")
     assert r.status_code == 200, r.text
+
+
+def test_archive_blocked_when_reserved_present(authed_client, db):
+    """Future-proof reserved rows if reservations gain storage locations."""
+    pid = _create_part(authed_client, "Reserved Cap")
+    sid = _create_storage(authed_client, "Reserved Shelf")
+    workspace_id = _current_workspace_id(authed_client)
+
+    db.add(
+        StockEntry(
+            workspace_id=workspace_id,
+            part_id=uuid.UUID(pid),
+            storage_location_id=uuid.UUID(sid),
+            quantity_delta=4,
+            status="reserved",
+            operation_type="reserve",
+        )
+    )
+    db.flush()
+
+    r = authed_client.post(f"/api/storage/{sid}/archive")
+    assert r.status_code == 409, r.text
+    body = r.json()
+    assert body["status"]["category"] == "conflict"
+    assert body["blocking"] == [{"part_id": pid, "lot_id": None, "quantity": 4}]


### PR DESCRIPTION
Closes #602

## Summary
- Checks both on-hand and reserved stock balances before archiving a storage location.
- Documents the decision in the archive guard: reservations do not currently carry storage_location_id, but the guard is future-proof if they do.
- Adds the focused reserved-stock regression test requested by the issue.

## Validation
- `uv run --extra dev pytest tests/test_archive_storage.py -q`
- `WORK_DIR=. LINT_CMD="uv run --extra dev ruff check app --output-format=concise" BASELINE_FILE="../.ruff-baseline.txt" bash ../scripts/lint-delta.sh`

## Open PR overlap / merge order
- I inspected open PR file lists before editing. No open PR touched `backend/app/api/routes/storage.py` or `backend/tests/test_archive_storage.py`, so no required merge order is expected.
