### PR TITLE
[codex] AUD-043 drop redundant polymorphic indexes

### DIFF
--- a/backend/alembic/versions/0052_drop_redundant_polymorphic_indexes.py
+++ b/backend/alembic/versions/0052_drop_redundant_polymorphic_indexes.py
@@ -1,0 +1,47 @@
+"""Drop redundant two-column polymorphic indexes.
+
+Revision ID: 0052
+Revises: 0051
+Create Date: 2026-05-14
+
+The cleanup queries filter by workspace_id, object_type, and object_id, which
+is covered by the existing three-column polymorphic object indexes. The
+two-column workspace_id/object_id indexes from 0033 add write overhead without
+serving a remaining query shape.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+
+revision = "0052"
+down_revision = "0051"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS ix_attachments_ws_objid_only")
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS ix_cf_ws_objid_only")
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS ix_tag_link_ws_objid_only")
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS "
+            "ix_attachments_ws_objid_only "
+            "ON attachments (workspace_id, object_id)"
+        )
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS "
+            "ix_cf_ws_objid_only "
+            "ON custom_fields (workspace_id, object_id)"
+        )
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS "
+            "ix_tag_link_ws_objid_only "
+            "ON tag_links (workspace_id, object_id)"
+        )

--- a/backend/app/domain/attachments/models.py
+++ b/backend/app/domain/attachments/models.py
@@ -19,10 +19,6 @@ class Attachment(WorkspaceOwned, Base):
             "archived_at",
             postgresql_where=text("archived_at IS NULL"),
         ),
-        # (workspace_id, object_id) — added in alembic 0031 (DB-006) to
-        # make orphan-cleanup queries fast (no object_type filter needed
-        # when sweeping a deleted parent's id).
-        Index("ix_attachments_ws_objid_only", "workspace_id", "object_id"),
     )
 
     object_type = Column(String(40), nullable=False)

--- a/backend/app/domain/custom_fields/models.py
+++ b/backend/app/domain/custom_fields/models.py
@@ -20,10 +20,6 @@ class CustomField(WorkspaceOwned, Base):
             "archived_at",
             postgresql_where=text("archived_at IS NULL"),
         ),
-        # (workspace_id, object_id) — added in alembic 0031 (DB-006) to
-        # make orphan-cleanup queries fast (no object_type filter needed
-        # when sweeping a deleted parent's id).
-        Index("ix_cf_ws_objid_only", "workspace_id", "object_id"),
     )
 
     object_type = Column(String(40), nullable=False)

--- a/backend/app/domain/tags/models.py
+++ b/backend/app/domain/tags/models.py
@@ -38,10 +38,6 @@ class TagLink(WorkspaceOwned, Base):
             "archived_at",
             postgresql_where=text("archived_at IS NULL"),
         ),
-        # (workspace_id, object_id) — added in alembic 0031 (DB-006) to
-        # make orphan-cleanup queries fast (no object_type filter needed
-        # when sweeping a deleted parent's id).
-        Index("ix_tag_link_ws_objid_only", "workspace_id", "object_id"),
     )
 
     tag_id = Column(UUID(as_uuid=True), ForeignKey("tags.id", ondelete="CASCADE"), nullable=False)


### PR DESCRIPTION
## Summary
- add Alembic revision 0052 to drop the redundant `(workspace_id, object_id)` polymorphic indexes created by 0033
- remove the same index definitions from ORM metadata for attachments, custom fields, and tag links
- keep the existing `(workspace_id, object_type, object_id)` indexes that cover the cleanup DELETE predicates

Closes #582

## Validation
- `uv run alembic heads`
- `uv run --extra dev ruff check app/domain/attachments/models.py app/domain/custom_fields/models.py app/domain/tags/models.py`
- `DATABASE_URL=postgresql+psycopg://stockmgr:stockmgr@127.0.0.1:5432/stockmgr_aud043_test MIGRATION_TEST_DATABASE_URL=postgresql+psycopg://stockmgr:stockmgr@127.0.0.1:5432/stockmgr_aud043_migration_rt uv run --extra dev python -m pytest tests/test_migrations.py -q -m "slow or not slow"`

## Notes
- Migration 0033 is intentionally unchanged.
- PR #671 migration-test overlap is already merged into `origin/main`; this branch is rebased on top of it.
