### PR TITLE
[codex] AUD-020 prevent orphan lots on import stock error

### DIFF
--- a/backend/app/api/routes/parts_scan.py
+++ b/backend/app/api/routes/parts_scan.py
@@ -499,27 +499,30 @@ def _import_one_scan_row(
                 serial_number=row.lot_serial,
             )
         try:
-            add_stock(
-                db,
-                workspace_id=ws.id,
-                user_id=user.id,
-                payload=AddStockIn(
-                    part_id=p.id,
-                    quantity=row.quantity,
-                    storage_location_id=row.storage_location_id,
-                    lot=lot_payload,
-                    comments=row.comments,
-                    bag_signature=row.bag_signature,
-                ),
-            )
+            with db.begin_nested():
+                add_stock(
+                    db,
+                    workspace_id=ws.id,
+                    user_id=user.id,
+                    payload=AddStockIn(
+                        part_id=p.id,
+                        quantity=row.quantity,
+                        storage_location_id=row.storage_location_id,
+                        lot=lot_payload,
+                        comments=row.comments,
+                        bag_signature=row.bag_signature,
+                    ),
+                )
             qty_added = row.quantity
         except StockError as exc:
             # Don't fail the whole row — the part is created, but surface
             # the stock issue so the UI can flag it. StockError is
-            # caught here (inside the savepoint) rather than letting it
-            # bubble out, because we don't want a stock-add failure to
-            # roll back the Part + provider specs the operator already
-            # sees as "created" in the response.
+            # caught here rather than letting it bubble out, because we
+            # don't want a stock-add failure to roll back the Part +
+            # provider specs the operator already sees as "created" in
+            # the response. The inner savepoint above still rolls back
+            # any partial stock writes, including a Lot flushed before
+            # the StockEntry fails.
             stock_error = str(exc)
 
     return p, qty_added, stock_error

--- a/backend/tests/test_provider_import_no_orphan_lots.py
+++ b/backend/tests/test_provider_import_no_orphan_lots.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import uuid
+
+from fastapi.testclient import TestClient
+from sqlalchemy import func, select
+
+from app.domain.lots.models import Lot
+from app.domain.stock.models import StockEntry
+from app.domain.stock.service import StockError
+from app.main import app
+
+
+def _signup(c: TestClient) -> None:
+    r = c.post(
+        "/api/auth/signup",
+        json={
+            "email": f"u-{uuid.uuid4().hex[:8]}@x.com",
+            "name": "u",
+            "password": "TestPass-2026-Stronk",
+        },
+    )
+    assert r.status_code == 200, r.text
+
+
+def _stub_mouser_response(mpn: str = "RC0402JR-070R") -> dict:
+    return {
+        "Errors": [],
+        "SearchResults": {
+            "NumberOfResult": 1,
+            "Parts": [
+                {
+                    "Manufacturer": "Yageo",
+                    "ManufacturerPartNumber": mpn,
+                    "Description": "Thick Film Resistors - SMD 0R 1/16W 5% 0402",
+                    "Category": "Resistors",
+                    "DataSheetUrl": "https://example.com/ds.pdf",
+                    "ImagePath": "https://example.com/img.jpg",
+                    "ProductDetailUrl": f"https://www.mouser.com/{mpn}",
+                    "ProductAttributes": [],
+                }
+            ],
+        },
+    }
+
+
+def test_savepoint_rollback_on_stock_error(db, monkeypatch):
+    c = TestClient(app)
+    _signup(c)
+    r = c.patch(
+        "/api/workspaces/current",
+        json={"parts_provider": "mouser", "parts_provider_api_key": "fake-key"},
+    )
+    assert r.status_code == 200, r.text
+
+    monkeypatch.setattr(
+        "app.domain.parts.providers.mouser._post_mouser",
+        lambda url, payload: _stub_mouser_response(
+            mpn=payload["SearchByPartRequest"]["mouserPartNumber"]
+        ),
+    )
+
+    def stock_entry_failure(*args, **kwargs):
+        raise StockError("simulated stock entry failure")
+
+    monkeypatch.setattr("app.domain.stock.service.StockEntry", stock_entry_failure)
+
+    r = c.post(
+        "/api/parts/bulk-import-from-scan",
+        json={
+            "rows": [
+                {
+                    "mpn": "RC0402JR-070R",
+                    "quantity": 1,
+                    "lot_name": "lot-created-before-stock-entry",
+                }
+            ]
+        },
+    )
+
+    assert r.status_code == 200, r.text
+    row = r.json()["data"]["rows"][0]
+    assert row["status"] == "created"
+    assert row["quantity_added"] == 0
+    assert row["stock_error"] == "simulated stock entry failure"
+
+    part_id = uuid.UUID(row["part_id"])
+    lot_count = db.execute(
+        select(func.count()).select_from(Lot).where(Lot.part_id == part_id)
+    ).scalar_one()
+    stock_count = db.execute(
+        select(func.count()).select_from(StockEntry).where(StockEntry.part_id == part_id)
+    ).scalar_one()
+
+    assert lot_count == 0
+    assert stock_count == 0


### PR DESCRIPTION
## Summary
- Wrap provider scan-import initial stock creation in an inner savepoint so caught `StockError` still rolls back partial stock writes.
- Add a regression test that forces a stock-entry failure after the lot path starts and verifies no `Lot` or `StockEntry` remains for the created part.

## Root Cause
`_import_one_scan_row` caught `StockError` inside the caller's per-row savepoint. If `add_stock` had already flushed a `Lot`, the row savepoint exited normally and could commit the partial lot while reporting stock creation failed.

## Validation
- `uv run --project backend --extra dev python -c "import alembic.command; import pytest; raise SystemExit(pytest.main(['backend/tests/test_provider_import_no_orphan_lots.py','-q']))"`
- `uv run --project backend --extra dev python -c "import alembic.command; import pytest; raise SystemExit(pytest.main(['backend/tests/test_bulk_import_from_scan.py','-q']))"`
- `uv run --project backend --extra dev python -c "import alembic.command; import pytest; raise SystemExit(pytest.main(['backend/tests/test_stock_ledger.py','backend/tests/test_stock_null_bucket.py','-q']))"`
- `uv run --project backend --extra dev ruff check backend/app/api/routes/parts_scan.py backend/tests/test_provider_import_no_orphan_lots.py`

## Merge Order / Conflicts
No currently open PR modifies `backend/app/api/routes/parts_scan.py` or `backend/tests/test_provider_import_no_orphan_lots.py` at PR creation time.

Closes #559
