### PR TITLE
[codex] AUD-024 remove signup enumeration oracle

### DIFF
--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -33,7 +33,7 @@ from app.core.cookies import (
 from app.core.deps import CurrentUser, DbSession
 from app.core.errors import ErrorCodes, raise_http
 from app.core.logging import get_logger
-from app.core.mail import send_verification_email
+from app.core.mail import send_account_exists_email, send_verification_email
 from app.core.ratelimit import limiter
 from app.core.responses import Envelope, ok
 from app.core.time import utcnow
@@ -58,6 +58,10 @@ def _verify_password_for_login(hash_: str, password: str) -> PasswordVerifyResul
     if verify_password is _verify_password:
         return verify_password_with_rehash(hash_, password)
     return PasswordVerifyResult(valid=verify_password(hash_, password))
+
+
+_SIGNUP_VERIFICATION_DATA = {"status": "verification_sent"}
+_SIGNUP_VERIFICATION_MESSAGE = "verification email sent"
 
 
 def _set_session_cookie(response: Response, token: str) -> None:
@@ -158,9 +162,8 @@ def signup(
             str(exc),
         )
 
-    # Reject if there is already a verified User with this email.
     existing = db.query(User).filter(User.email == payload.email).first()
-    if existing:
+    if existing and not settings().SIGNUP_REQUIRE_EMAIL_VERIFICATION:
         log.warning("signup conflict", extra={"email": payload.email})
         raise_http(
             status.HTTP_409_CONFLICT,
@@ -200,6 +203,19 @@ def signup(
         )
 
     # --- Prod path: email-verification two-step flow ---
+    if existing:
+        try:
+            send_account_exists_email(to=payload.email)
+        except Exception as exc:
+            log.error("failed to send duplicate-signup email to %s: %s", payload.email, exc)
+            raise_http(
+                status.HTTP_503_SERVICE_UNAVAILABLE,
+                "mail.send_failed",
+                "could not send signup email — please try again later",
+            )
+        log.info("signup existing account notice sent", extra={"user_id": str(existing.id)})
+        response.status_code = status.HTTP_202_ACCEPTED
+        return ok(_SIGNUP_VERIFICATION_DATA, _SIGNUP_VERIFICATION_MESSAGE)
 
     # Reap expired pending rows for this email before checking for an
     # active pending one, so old unverified attempts don't block a retry.
@@ -224,10 +240,7 @@ def signup(
     if existing_pending:
         log.info("signup resent existing pending", extra={"email": payload.email})
         response.status_code = status.HTTP_202_ACCEPTED
-        return ok(
-            {"status": "verification_sent"},
-            "verification email sent",
-        )
+        return ok(_SIGNUP_VERIFICATION_DATA, _SIGNUP_VERIFICATION_MESSAGE)
 
     # Mint a verification token, store its HMAC, send the link.
     plaintext_token = secrets.token_urlsafe(32)
@@ -251,15 +264,12 @@ def signup(
         raise_http(
             status.HTTP_503_SERVICE_UNAVAILABLE,
             "mail.send_failed",
-            "could not send verification email — please try again later",
+            "could not send signup email — please try again later",
         )
 
     log.info("signup pending", extra={"pending_id": str(pending.id)})
     response.status_code = status.HTTP_202_ACCEPTED
-    return ok(
-        {"status": "verification_sent"},
-        "verification email sent",
-    )
+    return ok(_SIGNUP_VERIFICATION_DATA, _SIGNUP_VERIFICATION_MESSAGE)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/core/mail.py
+++ b/backend/app/core/mail.py
@@ -15,9 +15,11 @@ Two backends are available:
   are populated.
 
 Call :func:`send_verification_email` from route code — it picks the
-right backend automatically based on the current settings. Background
-jobs that need transactional mail call :func:`send` so they stay on the
-same stdout/dev and SMTP/prod path.
+right backend automatically based on the current settings. Use
+:func:`send_account_exists_email` for duplicate signup attempts so the
+HTTP response can remain non-enumerating while the mailbox owner gets a
+private signal. Background jobs that need transactional mail call
+:func:`send` so they stay on the same stdout/dev and SMTP/prod path.
 
 Design notes:
 - All functions are synchronous; FastAPI routes calling them must use
@@ -135,6 +137,26 @@ def send_verification_email(*, to: str, verification_link: str) -> None:
         _send_smtp(to=to, verification_link=verification_link)
     else:
         _send_stdout(to=to, verification_link=verification_link)
+
+
+def send_account_exists_email(*, to: str) -> None:
+    """Notify an existing user that a signup was attempted for their email."""
+    send(
+        to=to,
+        subject="Stock Manager account already exists",
+        text_body=(
+            "Someone tried to sign up for Stock Manager with this email address.\n\n"
+            "An account already exists for this address, so no new account was created.\n"
+            "If this was you, sign in with your existing account. If you did not try "
+            "to sign up, you can safely ignore this email."
+        ),
+        html_body=(
+            "<p>Someone tried to sign up for Stock Manager with this email address.</p>"
+            "<p>An account already exists for this address, so no new account was created.</p>"
+            "<p>If this was you, sign in with your existing account. If you did not try "
+            "to sign up, you can safely ignore this email.</p>"
+        ),
+    )
 
 
 def _send_stdout(*, to: str, verification_link: str) -> None:

--- a/backend/tests/test_signup_no_enumeration.py
+++ b/backend/tests/test_signup_no_enumeration.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import re
+import uuid
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from app.core.config import settings
+from app.main import app
+
+PASSWORD = "StrongVerify-2026!!"
+
+
+def _signup_and_verify(email: str) -> None:
+    client = TestClient(app)
+    captured: dict[str, str] = {}
+
+    def _capture_link(*, to: str, verification_link: str) -> None:
+        assert to == email
+        captured["link"] = verification_link
+
+    with (
+        patch.object(settings(), "SIGNUP_REQUIRE_EMAIL_VERIFICATION", True),
+        patch("app.api.routes.auth.send_verification_email", side_effect=_capture_link),
+    ):
+        response = client.post(
+            "/api/auth/signup",
+            json={"email": email, "name": "Known", "password": PASSWORD},
+        )
+    assert response.status_code == 202, response.text
+
+    match_id = re.search(r"[?&]id=([^&]+)", captured["link"])
+    match_token = re.search(r"[?&]token=([^&]+)", captured["link"])
+    assert match_id and match_token
+
+    response = client.post(
+        "/api/auth/verify",
+        json={"id": match_id.group(1), "token": match_token.group(1)},
+    )
+    assert response.status_code == 200, response.text
+
+
+def test_response_identical_for_known_and_unknown_email(db):
+    known_email = f"known-{uuid.uuid4().hex[:8]}@example.com"
+    unknown_email = f"unknown-{uuid.uuid4().hex[:8]}@example.com"
+    _signup_and_verify(known_email)
+
+    with (
+        patch.object(settings(), "SIGNUP_REQUIRE_EMAIL_VERIFICATION", True),
+        patch("app.api.routes.auth.send_account_exists_email") as account_exists_email,
+        patch("app.api.routes.auth.send_verification_email") as verification_email,
+    ):
+        known_response = TestClient(app).post(
+            "/api/auth/signup",
+            json={"email": known_email, "name": "Known Again", "password": PASSWORD},
+        )
+        unknown_response = TestClient(app).post(
+            "/api/auth/signup",
+            json={"email": unknown_email, "name": "Unknown", "password": PASSWORD},
+        )
+
+    assert known_response.status_code == unknown_response.status_code == 202
+    assert known_response.json() == unknown_response.json()
+    account_exists_email.assert_called_once_with(to=known_email)
+    verification_email.assert_called_once()

--- a/backend/tests/test_signup_verification.py
+++ b/backend/tests/test_signup_verification.py
@@ -16,7 +16,6 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
-import pytest
 from fastapi.testclient import TestClient
 
 from app.core.config import settings
@@ -24,7 +23,6 @@ from app.domain.users.models import PendingUser, User
 from app.domain.workspaces.models import Workspace, WorkspaceMember
 from app.infra.db import SessionLocal
 from app.main import app
-
 
 PASSWORD = "StrongVerify-2026!!"
 
@@ -227,18 +225,18 @@ def test_duplicate_signup_same_email_returns_202_without_new_row(db):
     )
 
 
-def test_signup_rejects_already_verified_email():
-    """Signing up with an email that already has a verified User returns 409."""
+def test_signup_with_already_verified_email_returns_202():
+    """Signing up with an email that already has a verified User does not enumerate."""
     email = f"v-{uuid.uuid4().hex[:8]}@x.com"
     # First: complete the full verification flow to create a User.
     _full_signup_verify(email=email)
 
-    # Second attempt should 409.
     c2 = TestClient(app)
     with (
         patch.object(settings(), "SIGNUP_REQUIRE_EMAIL_VERIFICATION", True),
-        patch("app.api.routes.auth.send_verification_email"),
+        patch("app.api.routes.auth.send_account_exists_email") as account_exists_email,
     ):
         r = c2.post("/api/auth/signup", json={"email": email, "name": "T2", "password": PASSWORD})
-    assert r.status_code == 409, r.text
-    assert r.json()["code"] == "auth.email_taken"
+    assert r.status_code == 202, r.text
+    assert r.json()["data"]["status"] == "verification_sent"
+    account_exists_email.assert_called_once_with(to=email)


### PR DESCRIPTION
## Summary
- remove the verified-user duplicate signup oracle from the email-verification signup path
- return the same 202 {data,status} envelope for new, pending, and already-verified signup attempts
- send an account-exists email to the mailbox owner when a verified account already exists

Closes #563

## Validation
- `uv run --extra dev python -m pytest tests/test_signup_no_enumeration.py tests/test_signup_verification.py tests/test_error_envelope.py::test_auth_signup_email_taken_envelope -q`
- `uv run --extra dev ruff check app/api/routes/auth.py app/core/mail.py tests/test_signup_no_enumeration.py tests/test_signup_verification.py tests/test_error_envelope.py`
- `git diff --check`

## Merge-order notes
- PR #669 also edits `backend/app/api/routes/auth.py` and `backend/app/core/auth.py`. If #669 merges first, rebase this PR afterward and keep both its password-pepper login/hash changes and this duplicate-signup 202 behavior.
- PR #675 also edits `backend/app/api/routes/auth.py`. If #675 merges first, rebase this PR afterward and keep its verify-session rotation plus this signup anti-enumeration branch.

## Notes
- This intentionally leaves the dev/test immediate-signup duplicate behavior as 409; the anti-enumeration behavior applies to the email-verification path used in prod.
- Preserves the API envelope invariant and does not touch TLS verification, session cookie attributes, or workspace-scoped queries.