### PR TITLE
[codex] AUD-007 expire workspace invitations

### DIFF
--- a/backend/alembic/versions/0053_workspace_invitation_expires_at.py
+++ b/backend/alembic/versions/0053_workspace_invitation_expires_at.py
@@ -1,0 +1,31 @@
+"""Add expiry timestamp to workspace invitations.
+
+Revision ID: 0053
+Revises: 0052
+Create Date: 2026-05-14
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "0053"
+down_revision = "0052"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "workspace_invitations",
+        sa.Column(
+            "expires_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now() + INTERVAL '14 days'"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("workspace_invitations", "expires_at")

--- a/backend/app/api/routes/invitations.py
+++ b/backend/app/api/routes/invitations.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hmac as _hmac
 import secrets
+from datetime import timezone
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Query, Request, status
@@ -21,10 +22,23 @@ from app.core.responses import ok
 from app.core.time import utcnow
 from app.domain.audit.service import log as _audit_log
 from app.domain.users.models import User
-from app.domain.workspaces.models import Workspace, WorkspaceInvitation, WorkspaceMember
+from app.domain.workspaces.models import (
+    INVITATION_TTL,
+    Workspace,
+    WorkspaceInvitation,
+    WorkspaceMember,
+)
 from app.domain.workspaces.schemas import AcceptIn, InviteIn
 
 router = APIRouter()
+
+
+def _invitation_expires_at():
+    return utcnow() + INVITATION_TTL
+
+
+def _iso_utc(value):
+    return value.astimezone(timezone.utc).isoformat()
 
 
 def _hmac_token(plaintext: str) -> str:
@@ -66,8 +80,9 @@ def _serialize(inv: WorkspaceInvitation, *, plaintext_token: str | None = None) 
         # Only the create response carries the composite token; all other
         # serialisations return None here.
         "token": composite_token,
-        "created_at": inv.created_at.isoformat(),
-        "accepted_at": inv.accepted_at.isoformat() if inv.accepted_at else None,
+        "created_at": _iso_utc(inv.created_at),
+        "expires_at": _iso_utc(inv.expires_at),
+        "accepted_at": _iso_utc(inv.accepted_at) if inv.accepted_at else None,
     }
 
 
@@ -144,6 +159,7 @@ def create_invitation(
         role=payload.role,
         token_hmac=_hmac_token(plaintext),
         invited_by=user.id,
+        expires_at=_invitation_expires_at(),
     )
     db.add(inv)
     # Wrap in a savepoint so an IntegrityError from concurrent creates
@@ -297,6 +313,12 @@ def accept_invitation(request: Request, payload: AcceptIn, db: DbSession, user: 
             ErrorCodes.INVITATION_NOT_PENDING,
             f"invitation is {inv.status}",
             invitation_status=inv.status,
+        )
+    if inv.expires_at <= utcnow():
+        raise_http(
+            status.HTTP_410_GONE,
+            ErrorCodes.INVITATION_EXPIRED,
+            "invitation has expired",
         )
     if inv.email.lower() != user.email.lower():
         raise_http(

--- a/backend/app/core/errors.py
+++ b/backend/app/core/errors.py
@@ -117,6 +117,7 @@ class ErrorCodes:
     INVITATION_ALREADY_MEMBER = "invitation.already_member"
     INVITATION_NOT_PENDING = "invitation.not_pending"
     INVITATION_EMAIL_MISMATCH = "invitation.email_mismatch"
+    INVITATION_EXPIRED = "invitation.expired"
 
     # Sentry tunnel
     SENTRY_TUNNEL_TOO_LARGE = "sentry_tunnel.too_large"

--- a/backend/app/domain/workspaces/models.py
+++ b/backend/app/domain/workspaces/models.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import uuid
+from datetime import timedelta
 
 import sqlalchemy as sa
 from sqlalchemy import (
@@ -23,6 +24,8 @@ from app.domain.workspaces.master_lists import (
     DEFAULT_ACTIVE_DISTRIBUTORS,
 )
 from app.infra.db import Base
+
+INVITATION_TTL = timedelta(days=14)
 
 
 class Workspace(Base):
@@ -179,6 +182,12 @@ class WorkspaceInvitation(Base):
         nullable=True,
     )
     created_at = Column(DateTime(timezone=True), nullable=False, default=utcnow)
+    expires_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: utcnow() + INVITATION_TTL,
+        server_default=text("now() + INTERVAL '14 days'"),
+    )
     accepted_at = Column(DateTime(timezone=True), nullable=True)
     accepted_by = Column(
         UUID(as_uuid=True),

--- a/backend/tests/test_invitations.py
+++ b/backend/tests/test_invitations.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import uuid
+from datetime import timedelta
 
 import pytest
 from fastapi.testclient import TestClient
@@ -43,6 +44,7 @@ def test_admin_creates_invitation_user_accepts(admin):
     assert r.status_code == 201, r.text
     inv = r.json()["data"]
     assert inv["status"] == "pending"
+    assert inv["expires_at"]
     token = inv["token"]
     assert token
 
@@ -109,6 +111,42 @@ def test_revoke_invitation_blocks_acceptance(admin):
     _do_signup_verify(invitee, email=invitee_email, name="x")
     r = invitee.post("/api/invitations/accept", json={"token": inv["token"]})
     assert r.status_code == 400
+
+
+def test_invite_has_expires_at(admin):
+    invitee_email = f"expiry-{uuid.uuid4().hex[:6]}@x.com"
+    r = admin.post("/api/invitations", json={"email": invitee_email, "role": "member"})
+    assert r.status_code == 201, r.text
+    inv = r.json()["data"]
+    assert inv["expires_at"]
+
+    rows = admin.get("/api/invitations").json()["data"]
+    listed = next(row for row in rows if row["id"] == inv["id"])
+    assert listed["expires_at"] == inv["expires_at"]
+
+
+def test_expired_invite_rejected(admin):
+    from app.core.time import utcnow
+    from app.domain.workspaces.models import WorkspaceInvitation
+    from app.infra.db import SessionLocal
+
+    invitee_email = f"expired-{uuid.uuid4().hex[:6]}@x.com"
+    inv = admin.post(
+        "/api/invitations", json={"email": invitee_email, "role": "member"}
+    ).json()["data"]
+
+    with SessionLocal() as s:
+        row = s.get(WorkspaceInvitation, uuid.UUID(inv["id"]))
+        assert row is not None
+        row.expires_at = utcnow() - timedelta(seconds=1)
+        s.commit()
+
+    invitee = TestClient(app)
+    _do_signup_verify(invitee, email=invitee_email, name="Expired")
+    r = invitee.post("/api/invitations/accept", json={"token": inv["token"]})
+    assert r.status_code == 410, r.text
+    body = r.json()
+    assert body["code"] == "invitation.expired"
 
 
 def test_cannot_demote_last_owner(admin):


### PR DESCRIPTION
## Summary
- Add `workspace_invitations.expires_at` with a 14-day default/backfill migration.
- Populate invitation expiry on create and expose `expires_at` in invitation responses.
- Reject expired invitation tokens with HTTP 410 after token verification and before membership changes.

Closes #546

## Validation
- `uv run --project backend --extra dev python -m pytest backend/tests/test_invitations.py backend/tests/test_migrations.py -q`
- `uv run --project backend --extra dev ruff check backend/app/api/routes/invitations.py backend/app/core/errors.py backend/app/domain/workspaces/models.py backend/tests/test_invitations.py backend/alembic/versions/0053_workspace_invitation_expires_at.py`

Note: a broader `ruff check backend/app ...` still reports existing unrelated lint violations outside this PR scope.

## Merge order / conflict risks
- This branch is rebased on current `origin/main` after #674, so this migration is `0053` and depends on `0052_drop_redundant_polymorphic_indexes.py`.
- If another migration PR lands first, renumber this migration and update `down_revision` before merge.
- Open auth PRs touching `backend/app/api/routes/auth.py` should not conflict with this invitation route change; workspace/auth behavior overlap is limited to invitation acceptance semantics.