### PR TITLE
[codex] AUD-004 document universal audit log policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,6 +181,13 @@ them, that's the bug.
 - **No `verify=False` on httpx clients.** CI greps for `verify=False`,
   `trust_env=False`, `ssl=False` under `backend/app/`. Annotate with
   `# noqa: tls-verify` if intentional (e.g. internal test doubles).
+- **Universal `audit_log` for workspace mutations.** Every successful
+  workspace-scoped API mutation writes one row through
+  `domain/audit/service.py::log` in the same transaction as the business
+  change. Include stable target IDs when available and keep comments to
+  low-sensitivity summaries such as changed field names. Never put
+  plaintext credentials, provider API keys, verification tokens, raw bag
+  codes, or other secrets in `audit_log.comment`.
 
 ## Things that have bitten us — don't undo
 

--- a/backend/app/api/routes/lots.py
+++ b/backend/app/api/routes/lots.py
@@ -12,6 +12,7 @@ from app.core.deps import CurrentUser, CurrentWorkspace, DbSession
 from app.core.errors import ErrorCodes, raise_http
 from app.core.pagination import decode_cursor, paginate
 from app.core.responses import ok
+from app.domain.audit.service import log as _audit_log
 from app.domain.lots.models import Lot
 from app.domain.lots.schemas import LotAdjustIn, LotPatch
 from app.domain.stock.models import StockEntry
@@ -94,6 +95,15 @@ def patch_lot(lot_id: UUID, payload: LotPatch, db: DbSession, ws: CurrentWorkspa
     for k, v in data.items():
         setattr(l, k, v)
     l.updated_by = user.id
+    _audit_log(
+        db,
+        ws=ws,
+        user=user,
+        action="lot.updated",
+        target_type="lot",
+        target_ids=[l.id],
+        comment="fields=" + ",".join(sorted(data)),
+    )
     q = current_quantity(db, workspace_id=ws.id, part_id=l.part_id, lot_id=l.id)
     return ok(_serialize(l, quantity=q))
 

--- a/backend/app/api/routes/storage.py
+++ b/backend/app/api/routes/storage.py
@@ -11,6 +11,7 @@ from app.core.errors import ErrorCodes, raise_http
 from app.core.pagination import decode_cursor, paginate
 from app.core.responses import ok
 from app.core.time import utcnow
+from app.domain.audit.service import log as _audit_log
 from app.domain.stock.models import StockEntry
 from app.domain.stock.service import (
     StockConflictError,
@@ -69,6 +70,14 @@ def create_storage(payload: StorageIn, db: DbSession, ws: CurrentWorkspace, user
     )
     db.add(s)
     db.flush()
+    _audit_log(
+        db,
+        ws=ws,
+        user=user,
+        action="storage.created",
+        target_type="storage_location",
+        target_ids=[s.id],
+    )
     return ok(_serialize(s))
 
 
@@ -107,6 +116,15 @@ def patch_storage(storage_id: UUID, payload: StoragePatch, db: DbSession, ws: Cu
     for k, v in data.items():
         setattr(s, k, v)
     s.updated_by = user.id
+    _audit_log(
+        db,
+        ws=ws,
+        user=user,
+        action="storage.updated",
+        target_type="storage_location",
+        target_ids=[s.id],
+        comment="fields=" + ",".join(sorted(data)),
+    )
     return ok(_serialize(s))
 
 
@@ -146,6 +164,14 @@ def archive_storage(storage_id: UUID, db: DbSession, ws: CurrentWorkspace, user:
             blocking=blocking,
         )
     s.archived_at = utcnow()
+    _audit_log(
+        db,
+        ws=ws,
+        user=user,
+        action="storage.archived",
+        target_type="storage_location",
+        target_ids=[s.id],
+    )
     return ok(None, "archived")
 
 
@@ -155,6 +181,14 @@ def restore_storage(storage_id: UUID, db: DbSession, ws: CurrentWorkspace, user:
         db, StorageLocation, storage_id, ws=ws, user=user, role="admin", label="storage",
     )
     s.archived_at = None
+    _audit_log(
+        db,
+        ws=ws,
+        user=user,
+        action="storage.restored",
+        target_type="storage_location",
+        target_ids=[s.id],
+    )
     return ok(None, "restored")
 
 

--- a/backend/tests/test_audit_log_coverage.py
+++ b/backend/tests/test_audit_log_coverage.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+import pytest
+from sqlalchemy import select
+
+from app.domain.audit.models import AuditLog
+
+
+def _create_part(client, name: str) -> str:
+    r = client.post("/api/parts", json={"name": name, "part_type": "local"})
+    assert r.status_code == 201, r.text
+    return r.json()["data"]["id"]
+
+
+def _create_storage(client, name: str) -> str:
+    r = client.post("/api/storage", json={"name": name})
+    assert r.status_code == 201, r.text
+    return r.json()["data"]["id"]
+
+
+def _create_lot(client, part_id: str) -> str:
+    r = client.post(
+        "/api/stock/add",
+        json={
+            "part_id": part_id,
+            "quantity": 1,
+            "lot": {"name": "Audit lot"},
+        },
+    )
+    assert r.status_code == 200, r.text
+    return r.json()["data"]["lot_id"]
+
+
+@pytest.mark.parametrize(
+    ("route_name", "setup", "method", "path", "body", "action", "target_type"),
+    [
+        (
+            "lots.patch_lot",
+            lambda client: _create_lot(client, _create_part(client, "Audit Lot Part")),
+            "patch",
+            "/api/lots/{target_id}",
+            {"comments": "cycle counted"},
+            "lot.updated",
+            "lot",
+        ),
+        (
+            "storage.patch_storage",
+            lambda client: _create_storage(client, "Audit Shelf"),
+            "patch",
+            "/api/storage/{target_id}",
+            {"description": "controlled storage"},
+            "storage.updated",
+            "storage_location",
+        ),
+    ],
+)
+def test_each_mutator_writes_audit_row(
+    authed_client,
+    db,
+    route_name,
+    setup,
+    method,
+    path,
+    body,
+    action,
+    target_type,
+):
+    target_id = setup(authed_client)
+
+    r = getattr(authed_client, method)(path.format(target_id=target_id), json=body)
+
+    assert r.status_code == 200, f"{route_name}: {r.text}"
+    row = db.execute(
+        select(AuditLog)
+        .where(AuditLog.action == action)
+        .where(AuditLog.target_type == target_type)
+        .order_by(AuditLog.created_at.desc())
+    ).scalar_one()
+    assert row.target_ids == [UUID(target_id)]
+    assert row.comment == "fields=" + ",".join(sorted(body))

--- a/docs/adr/0025-universal-audit-log-policy.md
+++ b/docs/adr/0025-universal-audit-log-policy.md
@@ -1,0 +1,78 @@
+# ADR-0025: Universal `audit_log` coverage for workspace mutations
+
+Audience: engineer
+
+- **Status**: Accepted
+- **Date**: 2026-05-14
+- **Supersedes**: —
+- **Superseded by**: —
+
+## Context
+
+`audit_log` is the forensic trail for user-facing changes inside a workspace:
+who changed an object, which workspace it belonged to, and which object IDs
+were affected. Before AUD-004, only a few routers wrote audit rows even though
+`CLAUDE.md` already said every mutation should be auditable. That left common
+operator actions such as lot metadata edits and storage-flag changes without a
+queryable trail.
+
+The competing policy options were:
+
+- **Universal**: every successful workspace-scoped mutation writes one
+  `audit_log` row in the same transaction.
+- **Selective**: only specific high-risk routers write rows, and docs plus CI
+  enumerate the covered set.
+
+## Decision
+
+Use the universal policy. Every successful workspace-scoped API mutation must
+write an `audit_log` row through `backend/app/domain/audit/service.py::log` in
+the same database session as the business change. If the business transaction
+rolls back, the audit row rolls back with it.
+
+The row must identify the workspace, acting user when known, action name,
+target type, and affected object IDs when the route has stable IDs. Comments
+may contain low-sensitivity summaries such as changed field names, but must not
+contain plaintext credentials, provider API keys, verification tokens, raw bag
+codes, or other secrets.
+
+## Consequences
+
+- **Good**: Operators and incident responders can query a consistent
+  workspace-scoped trail for successful user-facing mutations.
+- **Good**: The policy is reviewable by convention and regression tests can pin
+  high-risk mutators as they are brought under coverage.
+- **Trade-offs**: Audit volume grows with normal write traffic. The table is
+  indexed for workspace/time queries and target-ID lookup, but retention and
+  export policy may need a separate ADR if volume becomes operationally
+  significant.
+- **What it forbids**:
+  - Do not add a successful workspace-scoped API mutation without an
+    `audit_log` row unless a later ADR narrows this policy.
+  - Do not write audit rows in a separate transaction from the business change.
+  - Do not put secrets or raw credential material in `audit_log.comment`.
+  - Do not treat `audit_log` as the source of truth for current business state;
+    it is evidence of changes, not a replacement for domain tables.
+
+## Alternatives considered
+
+- **Selective coverage by router** — rejected because the product already
+  exposes many equally forensic-relevant mutations across lots, storage,
+  projects, orders, tags, and attachments. A selective list would become a
+  policy exception ledger and make missing rows look intentional.
+- **Database triggers** — rejected because the API has the request context
+  needed for user ID, route-level action name, and safe comment summaries.
+  Trigger-only rows would either omit that context or require fragile session
+  variables.
+- **Use the stock ledger as the audit log for stock routes** — rejected as a
+  general policy because the append-only stock ledger answers inventory state
+  history, while `audit_log` answers user-facing mutation history across all
+  domains. They can reference the same action, but neither replaces the other.
+
+## References
+
+- Source: `backend/app/domain/audit/service.py`
+- Source: `backend/app/api/routes/lots.py`
+- Source: `backend/app/api/routes/storage.py`
+- Test: `backend/tests/test_audit_log_coverage.py`
+- Rule: `CLAUDE.md`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -34,3 +34,4 @@ New ADRs follow the template in [STYLE.md](../STYLE.md#adr-pages-docsadrnnnn-slu
 | 0022 | [TrustedParts schema version pinning](0022-trustedparts-schema-version-pinning.md) |
 | 0023 | [Outbound provider backoff](0023-outbound-provider-backoff.md) |
 | 0024 | [`/api/auth/verify` is CSRF-exempt](0024-auth-verify-csrf-exemption.md) |
+| 0025 | [Universal `audit_log` coverage for workspace mutations](0025-universal-audit-log-policy.md) |


### PR DESCRIPTION
## Summary

- Selects the universal `audit_log` policy for successful workspace-scoped API mutations in ADR-0025 and aligns `CLAUDE.md`.
- Adds audit rows for the explicit AUD-004 acceptance targets: `lots.patch_lot` and `storage.patch_storage`.
- Adds storage create/archive/restore audit rows while touching the storage router, plus focused regression coverage for the named mutators.

Closes #543

## Validation

- `uv run --extra dev python -m py_compile app/api/routes/lots.py app/api/routes/storage.py tests/test_audit_log_coverage.py`
- `uv run --extra dev ruff check tests/test_audit_log_coverage.py`
- `uv run --extra dev python -m pytest tests/test_audit_log_coverage.py -q` currently fails during existing Alembic test bootstrap before these tests run: migration `0020_partial_bag_signature_index.py` attempts `CREATE INDEX CONCURRENTLY ... ON stock_entries`, but `stock_entries` does not exist after the test schema reset in this environment.

## Conflict Risk / Merge Order

- Low direct conflict risk with currently open PRs reviewed before opening this PR.
- No open PR currently touches `CLAUDE.md`, `docs/adr/README.md`, `docs/adr/0025-universal-audit-log-policy.md`, `backend/app/api/routes/lots.py`, `backend/app/api/routes/storage.py`, or `backend/tests/test_audit_log_coverage.py`.
- Can merge independently after CI. If another ADR lands first, renumber this ADR and update the ADR index before merge.
