### PR TITLE
[codex] AUD-051 add workspace checks to part links

### DIFF
--- a/backend/alembic/versions/0054_part_link_workspace_triggers.py
+++ b/backend/alembic/versions/0054_part_link_workspace_triggers.py
@@ -1,0 +1,210 @@
+"""Add workspace columns and triggers to part link tables.
+
+Revision ID: 0054
+Revises: 0053
+Create Date: 2026-05-14
+
+AUD-051 / issue #590.
+
+part_substitutes and part_meta_members only referenced parts by UUID. The
+application checked workspace ownership, but direct SQL could still create a
+cross-workspace link. Store the owning workspace explicitly and enforce that
+all referenced parts belong to it.
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0054"
+down_revision = "0053"
+branch_labels = None
+depends_on = None
+
+
+_PART_SUBSTITUTES_FUNCTION = """
+CREATE OR REPLACE FUNCTION check_part_substitutes_workspace_fks()
+RETURNS trigger AS $$
+BEGIN
+  PERFORM 1 FROM parts
+   WHERE id = NEW.part_id
+     AND workspace_id = NEW.workspace_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'part_substitutes.part_id (%) not in workspace (%)',
+      NEW.part_id, NEW.workspace_id
+      USING ERRCODE = '23514';
+  END IF;
+
+  PERFORM 1 FROM parts
+   WHERE id = NEW.substitute_part_id
+     AND workspace_id = NEW.workspace_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'part_substitutes.substitute_part_id (%) not in workspace (%)',
+      NEW.substitute_part_id, NEW.workspace_id
+      USING ERRCODE = '23514';
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+"""
+
+
+_PART_META_MEMBERS_FUNCTION = """
+CREATE OR REPLACE FUNCTION check_part_meta_members_workspace_fks()
+RETURNS trigger AS $$
+BEGIN
+  PERFORM 1 FROM parts
+   WHERE id = NEW.meta_part_id
+     AND workspace_id = NEW.workspace_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'part_meta_members.meta_part_id (%) not in workspace (%)',
+      NEW.meta_part_id, NEW.workspace_id
+      USING ERRCODE = '23514';
+  END IF;
+
+  PERFORM 1 FROM parts
+   WHERE id = NEW.part_id
+     AND workspace_id = NEW.workspace_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'part_meta_members.part_id (%) not in workspace (%)',
+      NEW.part_id, NEW.workspace_id
+      USING ERRCODE = '23514';
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+"""
+
+
+def upgrade() -> None:
+    uuid_type = postgresql.UUID(as_uuid=True)
+
+    op.add_column("part_substitutes", sa.Column("workspace_id", uuid_type, nullable=True))
+    op.add_column("part_meta_members", sa.Column("workspace_id", uuid_type, nullable=True))
+
+    op.execute("""
+    DO $$
+    BEGIN
+      IF EXISTS (
+        SELECT 1
+        FROM part_substitutes ps
+        JOIN parts p ON p.id = ps.part_id
+        JOIN parts sub ON sub.id = ps.substitute_part_id
+        WHERE p.workspace_id <> sub.workspace_id
+      ) THEN
+        RAISE EXCEPTION 'part_substitutes contains cross-workspace rows'
+          USING ERRCODE = '23514';
+      END IF;
+
+      IF EXISTS (
+        SELECT 1
+        FROM part_meta_members pmm
+        JOIN parts meta ON meta.id = pmm.meta_part_id
+        JOIN parts member ON member.id = pmm.part_id
+        WHERE meta.workspace_id <> member.workspace_id
+      ) THEN
+        RAISE EXCEPTION 'part_meta_members contains cross-workspace rows'
+          USING ERRCODE = '23514';
+      END IF;
+    END
+    $$;
+    """)
+
+    op.execute("""
+    UPDATE part_substitutes ps
+       SET workspace_id = p.workspace_id
+      FROM parts p
+     WHERE p.id = ps.part_id
+    """)
+    op.execute("""
+    UPDATE part_meta_members pmm
+       SET workspace_id = p.workspace_id
+      FROM parts p
+     WHERE p.id = pmm.meta_part_id
+    """)
+
+    op.alter_column("part_substitutes", "workspace_id", nullable=False)
+    op.alter_column("part_meta_members", "workspace_id", nullable=False)
+
+    op.create_foreign_key(
+        "fk_part_substitutes_workspace_id",
+        "part_substitutes",
+        "workspaces",
+        ["workspace_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.create_foreign_key(
+        "fk_part_meta_members_workspace_id",
+        "part_meta_members",
+        "workspaces",
+        ["workspace_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+    op.create_index(
+        "ix_part_substitutes_workspace_id",
+        "part_substitutes",
+        ["workspace_id"],
+    )
+    op.create_index(
+        "ix_part_substitutes_ws_part",
+        "part_substitutes",
+        ["workspace_id", "part_id"],
+    )
+    op.create_index(
+        "ix_part_meta_members_workspace_id",
+        "part_meta_members",
+        ["workspace_id"],
+    )
+    op.create_index(
+        "ix_part_meta_members_ws_meta",
+        "part_meta_members",
+        ["workspace_id", "meta_part_id"],
+    )
+
+    op.execute(_PART_SUBSTITUTES_FUNCTION)
+    op.execute("""
+    CREATE TRIGGER part_substitutes_workspace_fk_check
+      BEFORE INSERT OR UPDATE OF workspace_id, part_id, substitute_part_id
+      ON part_substitutes
+      FOR EACH ROW
+      EXECUTE FUNCTION check_part_substitutes_workspace_fks();
+    """)
+    op.execute(_PART_META_MEMBERS_FUNCTION)
+    op.execute("""
+    CREATE TRIGGER part_meta_members_workspace_fk_check
+      BEFORE INSERT OR UPDATE OF workspace_id, meta_part_id, part_id
+      ON part_meta_members
+      FOR EACH ROW
+      EXECUTE FUNCTION check_part_meta_members_workspace_fks();
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP TRIGGER IF EXISTS part_meta_members_workspace_fk_check ON part_meta_members;")
+    op.execute("DROP FUNCTION IF EXISTS check_part_meta_members_workspace_fks();")
+    op.execute("DROP TRIGGER IF EXISTS part_substitutes_workspace_fk_check ON part_substitutes;")
+    op.execute("DROP FUNCTION IF EXISTS check_part_substitutes_workspace_fks();")
+
+    op.drop_index("ix_part_meta_members_ws_meta", table_name="part_meta_members")
+    op.drop_index("ix_part_meta_members_workspace_id", table_name="part_meta_members")
+    op.drop_index("ix_part_substitutes_ws_part", table_name="part_substitutes")
+    op.drop_index("ix_part_substitutes_workspace_id", table_name="part_substitutes")
+
+    op.drop_constraint(
+        "fk_part_meta_members_workspace_id",
+        "part_meta_members",
+        type_="foreignkey",
+    )
+    op.drop_constraint(
+        "fk_part_substitutes_workspace_id",
+        "part_substitutes",
+        type_="foreignkey",
+    )
+
+    op.drop_column("part_meta_members", "workspace_id")
+    op.drop_column("part_substitutes", "workspace_id")

--- a/backend/app/api/routes/parts_core.py
+++ b/backend/app/api/routes/parts_core.py
@@ -560,14 +560,18 @@ def add_substitute(part_id: UUID, payload: SubstituteIn, db: DbSession, ws: Curr
     # can't ever resolve usefully.
     p = _get_part(db, ws.id, part_id)
     sub = _get_part(db, ws.id, payload.substitute_part_id)
-    db.add(PartSubstitute(part_id=p.id, substitute_part_id=sub.id, direction=payload.direction))
+    row = PartSubstitute(
+        workspace_id=ws.id, part_id=p.id,
+        substitute_part_id=sub.id, direction=payload.direction,
+    )
+    db.add(row)
     return ok(None)
 
 
 @router.get("/{part_id}/substitutes")
 def list_substitutes(part_id: UUID, db: DbSession, ws: CurrentWorkspace):
     p = _get_part(db, ws.id, part_id, include_archived=True)
-    rows = list(db.execute(select(PartSubstitute).where(PartSubstitute.part_id == p.id)).scalars())
+    rows = db.query(PartSubstitute).filter_by(workspace_id=ws.id, part_id=p.id).all()
     return ok([{"part_id": str(r.substitute_part_id), "direction": r.direction} for r in rows])
 
 
@@ -576,8 +580,8 @@ def del_substitute(part_id: UUID, substitute_id: UUID, db: DbSession, ws: Curren
     # Removal allowed even on archived rows — operators should be able
     # to clean up dead bindings.
     p = _get_part(db, ws.id, part_id, include_archived=True)
-    db.query(PartSubstitute).filter(
-        PartSubstitute.part_id == p.id, PartSubstitute.substitute_part_id == substitute_id
+    db.query(PartSubstitute).filter_by(
+        workspace_id=ws.id, part_id=p.id, substitute_part_id=substitute_id
     ).delete()
     return ok(None)
 
@@ -588,11 +592,7 @@ def del_substitute(part_id: UUID, substitute_id: UUID, db: DbSession, ws: Curren
 @router.get("/{meta_id}/members")
 def list_members(meta_id: UUID, db: DbSession, ws: CurrentWorkspace):
     meta = _get_part(db, ws.id, meta_id, include_archived=True)
-    rows = list(
-        db.execute(
-            select(PartMetaMember).where(PartMetaMember.meta_part_id == meta.id)
-        ).scalars()
-    )
+    rows = db.query(PartMetaMember).filter_by(workspace_id=ws.id, meta_part_id=meta.id).all()
     return ok([{"id": str(r.id), "member_part_id": str(r.part_id)} for r in rows])
 
 
@@ -606,18 +606,12 @@ def add_member(meta_id: UUID, payload: MetaMemberIn, db: DbSession, ws: CurrentW
         raise HTTPException(status_code=400, detail="meta-part cannot include itself")
     if member.part_type == "meta":
         raise HTTPException(status_code=400, detail="meta-part members cannot themselves be meta")
-    existing = (
-        db.execute(
-            select(PartMetaMember)
-            .where(PartMetaMember.meta_part_id == meta.id)
-            .where(PartMetaMember.part_id == member.id)
-        )
-        .scalars()
-        .first()
-    )
+    existing = db.query(PartMetaMember).filter_by(
+        workspace_id=ws.id, meta_part_id=meta.id, part_id=member.id
+    ).first()
     if existing:
         return ok({"id": str(existing.id), "member_part_id": str(existing.part_id)})
-    row = PartMetaMember(meta_part_id=meta.id, part_id=member.id)
+    row = PartMetaMember(workspace_id=ws.id, meta_part_id=meta.id, part_id=member.id)
     db.add(row)
     db.flush()
     return ok({"id": str(row.id), "member_part_id": str(row.part_id)})
@@ -627,8 +621,8 @@ def add_member(meta_id: UUID, payload: MetaMemberIn, db: DbSession, ws: CurrentW
 def del_member(meta_id: UUID, member_id: UUID, db: DbSession, ws: CurrentWorkspace):
     # Removal — allowed even on archived meta.
     meta = _get_part(db, ws.id, meta_id, include_archived=True)
-    db.query(PartMetaMember).filter(
-        PartMetaMember.meta_part_id == meta.id, PartMetaMember.part_id == member_id
+    db.query(PartMetaMember).filter_by(
+        workspace_id=ws.id, meta_part_id=meta.id, part_id=member_id
     ).delete()
     return ok(None, "deleted")
 

--- a/backend/app/domain/builds/service.py
+++ b/backend/app/domain/builds/service.py
@@ -54,14 +54,18 @@ def _candidate_part_ids(db: Session, *, part: Part) -> list[UUID]:
     if part.part_type == "meta":
         rows = list(
             db.execute(
-                select(PartMetaMember.part_id).where(PartMetaMember.meta_part_id == part.id)
+                select(PartMetaMember.part_id)
+                .where(PartMetaMember.workspace_id == part.workspace_id)
+                .where(PartMetaMember.meta_part_id == part.id)
             ).scalars()
         )
         return [r for r in rows if r != part.id]
 
     sub_rows = list(
         db.execute(
-            select(PartSubstitute).where(
+            select(PartSubstitute)
+            .where(PartSubstitute.workspace_id == part.workspace_id)
+            .where(
                 (PartSubstitute.part_id == part.id)
                 | (
                     (PartSubstitute.substitute_part_id == part.id)

--- a/backend/app/domain/parts/models.py
+++ b/backend/app/domain/parts/models.py
@@ -101,22 +101,56 @@ class PartMetaMember(Base):
     __tablename__ = "part_meta_members"
     __table_args__ = (
         UniqueConstraint("meta_part_id", "part_id", name="uq_meta_member"),
+        Index("ix_part_meta_members_ws_meta", "workspace_id", "meta_part_id"),
     )
 
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    meta_part_id = Column(UUID(as_uuid=True), ForeignKey("parts.id", ondelete="CASCADE"), nullable=False, index=True)
-    part_id = Column(UUID(as_uuid=True), ForeignKey("parts.id", ondelete="CASCADE"), nullable=False, index=True)
+    workspace_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("workspaces.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    meta_part_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("parts.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    part_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("parts.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
 
 
 class PartSubstitute(Base):
     __tablename__ = "part_substitutes"
     __table_args__ = (
         UniqueConstraint("part_id", "substitute_part_id", name="uq_part_sub"),
+        Index("ix_part_substitutes_ws_part", "workspace_id", "part_id"),
     )
 
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    part_id = Column(UUID(as_uuid=True), ForeignKey("parts.id", ondelete="CASCADE"), nullable=False, index=True)
-    substitute_part_id = Column(UUID(as_uuid=True), ForeignKey("parts.id", ondelete="CASCADE"), nullable=False, index=True)
+    workspace_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("workspaces.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    part_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("parts.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    substitute_part_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("parts.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
     direction = Column(String(20), nullable=False, default="bidirectional")
 
 

--- a/backend/tests/test_workspace_isolation.py
+++ b/backend/tests/test_workspace_isolation.py
@@ -10,7 +10,7 @@ from app.api._helpers import _polymorphic_resolvers, assert_polymorphic_in_works
 from app.domain.builds.models import Build
 from app.domain.lots.models import Lot
 from app.domain.orders.models import Order
-from app.domain.parts.models import Part
+from app.domain.parts.models import Part, PartMetaMember, PartSubstitute
 from app.domain.projects.models import Project
 from app.domain.sourcing.budget import BUDGET
 from app.domain.sourcing.models import SourcingCache
@@ -1017,6 +1017,116 @@ def test_stock_entries_ws_trigger():
     for overrides in cross_workspace_refs:
         with pytest.raises((IntegrityError, ProgrammingError, DBAPIError)):
             insert_stock_entry(**overrides)
+
+
+def test_part_substitute_cross_workspace_db_trigger(db):
+    """AUD-051 / migration 0053. Direct SQL cannot link substitute parts
+    across workspaces, even when the route layer is bypassed."""
+    from sqlalchemy import text
+    from sqlalchemy.exc import DBAPIError, IntegrityError, ProgrammingError
+
+    from app.infra.db import SessionLocal
+
+    a = TestClient(app)
+    b = TestClient(app)
+    _signup(a, f"a-{uuid.uuid4().hex[:6]}@x.com")
+    ws_b = _signup(b, f"b-{uuid.uuid4().hex[:6]}@x.com")
+
+    part_a = _create_part(a, "A-substitute-trigger-part")
+    part_b = _create_part(b, "B-substitute-trigger-part")
+    substitute_b = _create_part(b, "B-substitute-trigger-alt")
+
+    row = PartSubstitute(
+        workspace_id=uuid.UUID(ws_b),
+        part_id=uuid.UUID(part_b),
+        substitute_part_id=uuid.UUID(substitute_b),
+    )
+    db.add(row)
+    db.flush()
+
+    with SessionLocal() as s:
+        with pytest.raises((IntegrityError, ProgrammingError, DBAPIError)):
+            s.execute(
+                text(
+                    "INSERT INTO part_substitutes "
+                    "(id, workspace_id, part_id, substitute_part_id, direction) "
+                    "VALUES (:id, :workspace_id, :part_id, :substitute_part_id, "
+                    "'bidirectional')"
+                ),
+                {
+                    "id": str(uuid.uuid4()),
+                    "workspace_id": ws_b,
+                    "part_id": part_b,
+                    "substitute_part_id": part_a,
+                },
+            )
+            s.commit()
+
+    with SessionLocal() as s:
+        with pytest.raises((IntegrityError, ProgrammingError, DBAPIError)):
+            s.execute(
+                text(
+                    "UPDATE part_substitutes "
+                    "SET substitute_part_id = :substitute_part_id "
+                    "WHERE id = :id"
+                ),
+                {"id": row.id, "substitute_part_id": part_a},
+            )
+            s.commit()
+
+
+def test_part_meta_member_cross_workspace_db_trigger(db):
+    """AUD-051 / migration 0053. Direct SQL cannot attach a meta-part member
+    from another workspace."""
+    from sqlalchemy import text
+    from sqlalchemy.exc import DBAPIError, IntegrityError, ProgrammingError
+
+    from app.infra.db import SessionLocal
+
+    a = TestClient(app)
+    b = TestClient(app)
+    _signup(a, f"a-{uuid.uuid4().hex[:6]}@x.com")
+    ws_b = _signup(b, f"b-{uuid.uuid4().hex[:6]}@x.com")
+
+    member_a = _create_part(a, "A-meta-trigger-member")
+    meta_b = _create_part(b, "B-meta-trigger-meta", part_type="meta")
+    member_b = _create_part(b, "B-meta-trigger-member")
+
+    row = PartMetaMember(
+        workspace_id=uuid.UUID(ws_b),
+        meta_part_id=uuid.UUID(meta_b),
+        part_id=uuid.UUID(member_b),
+    )
+    db.add(row)
+    db.flush()
+
+    with SessionLocal() as s:
+        with pytest.raises((IntegrityError, ProgrammingError, DBAPIError)):
+            s.execute(
+                text(
+                    "INSERT INTO part_meta_members "
+                    "(id, workspace_id, meta_part_id, part_id) "
+                    "VALUES (:id, :workspace_id, :meta_part_id, :part_id)"
+                ),
+                {
+                    "id": str(uuid.uuid4()),
+                    "workspace_id": ws_b,
+                    "meta_part_id": meta_b,
+                    "part_id": member_a,
+                },
+            )
+            s.commit()
+
+    with SessionLocal() as s:
+        with pytest.raises((IntegrityError, ProgrammingError, DBAPIError)):
+            s.execute(
+                text(
+                    "UPDATE part_meta_members SET part_id = :part_id "
+                    "WHERE id = :id"
+                ),
+                {"id": row.id, "part_id": member_a},
+            )
+            s.commit()
 
 
 def test_parts_bulk_import_rejects_foreign_storage():


### PR DESCRIPTION
## Summary
- Add `workspace_id` to `part_substitutes` and `part_meta_members`.
- Backfill and enforce same-workspace part links with DB triggers in migration `0053`.
- Store/filter `workspace_id` in part substitute/meta-member routes and build candidate lookup.
- Add raw SQL trigger regression tests for cross-workspace substitutes and meta members.

Closes #590

## Validation
- `TEST_DATABASE_URL=postgresql+psycopg://stockmgr:stockmgr@127.0.0.1:5432/stockmgr_test_aud051_full uv run python -m pytest tests/test_workspace_isolation.py -q`
- `TEST_DATABASE_URL=postgresql+psycopg://stockmgr:stockmgr@127.0.0.1:5432/stockmgr_test_aud051_schema uv run python -m pytest tests/test_all_models.py tests/test_db_schema.py -q`
- `uv run python -m alembic heads --resolve-dependencies` -> `0053 (head)`
- `git diff --check`

## Conflict Risk / Merge Order
- Based on `origin/main` after #674 merged (`0052_drop_redundant_polymorphic_indexes`), so this migration is `0053` and should merge after #674.
- #593 and #557 are not open at PR creation time; if either reopens with Alembic revisions, rebase whichever PR is older so the revision chain stays linear.
- Current open PRs checked before publish (#679, #678, #677, #675, #611, #483, #482) do not appear to add backend Alembic migrations.
