### PR TITLE
[codex] AUD-054 scope part CAD keys by workspace

### DIFF
--- a/backend/alembic/versions/0055_part_cad_keys_workspace_id.py
+++ b/backend/alembic/versions/0055_part_cad_keys_workspace_id.py
@@ -1,0 +1,102 @@
+"""Add workspace_id to part_cad_keys.
+
+Revision ID: 0055
+Revises: 0054
+Create Date: 2026-05-14
+
+AUD-054 / issue #593.
+
+part_cad_keys are part-owned, but BOM matching is workspace-sensitive. Store
+the workspace directly for grep-able query isolation and enforce that it stays
+aligned with the owning part at the database boundary.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision = "0055"
+down_revision = "0054"
+branch_labels = None
+depends_on = None
+
+
+_FUNCTION_SQL = """
+CREATE OR REPLACE FUNCTION check_part_cad_keys_workspace()
+RETURNS trigger AS $$
+BEGIN
+  PERFORM 1 FROM parts
+   WHERE id = NEW.part_id
+     AND workspace_id = NEW.workspace_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'part_cad_keys.part_id (%) not in workspace (%)',
+      NEW.part_id, NEW.workspace_id
+      USING ERRCODE = '23514';
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+"""
+
+
+def upgrade() -> None:
+    op.add_column(
+        "part_cad_keys",
+        sa.Column("workspace_id", postgresql.UUID(as_uuid=True), nullable=True),
+    )
+    op.execute(
+        """
+        UPDATE part_cad_keys pck
+           SET workspace_id = p.workspace_id
+          FROM parts p
+         WHERE pck.part_id = p.id
+        """
+    )
+    op.alter_column("part_cad_keys", "workspace_id", nullable=False)
+    op.create_foreign_key(
+        "fk_part_cad_keys_workspace_id_workspaces",
+        "part_cad_keys",
+        "workspaces",
+        ["workspace_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.create_index(
+        op.f("ix_part_cad_keys_workspace_id"),
+        "part_cad_keys",
+        ["workspace_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_part_cad_keys_ws_cad_key",
+        "part_cad_keys",
+        ["workspace_id", "cad_key"],
+        unique=False,
+    )
+    op.execute(_FUNCTION_SQL)
+    op.execute(
+        """
+        CREATE TRIGGER part_cad_keys_workspace_check
+          BEFORE INSERT OR UPDATE OF workspace_id, part_id
+          ON part_cad_keys
+          FOR EACH ROW
+          EXECUTE FUNCTION check_part_cad_keys_workspace();
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TRIGGER IF EXISTS part_cad_keys_workspace_check ON part_cad_keys;")
+    op.execute("DROP FUNCTION IF EXISTS check_part_cad_keys_workspace();")
+    op.drop_index("ix_part_cad_keys_ws_cad_key", table_name="part_cad_keys")
+    op.drop_index(op.f("ix_part_cad_keys_workspace_id"), table_name="part_cad_keys")
+    op.drop_constraint(
+        "fk_part_cad_keys_workspace_id_workspaces",
+        "part_cad_keys",
+        type_="foreignkey",
+    )
+    op.drop_column("part_cad_keys", "workspace_id")

--- a/backend/app/domain/parts/models.py
+++ b/backend/app/domain/parts/models.py
@@ -56,7 +56,8 @@ class Part(WorkspaceOwned, Base):
         ),
     )
 
-    part_type = Column(String(20), nullable=False, default="local")  # linked|local|meta|sub_assembly
+    # linked|local|meta|sub_assembly
+    part_type = Column(String(20), nullable=False, default="local")
     name = Column(String(300), nullable=False)
     internal_part_number = Column(String(120), nullable=True)
     manufacturer = Column(String(200), nullable=True)
@@ -65,7 +66,11 @@ class Part(WorkspaceOwned, Base):
     notes_markdown = Column(Text, nullable=True)
     footprint = Column(String(120), nullable=True)
     linked_external_id = Column(String(200), nullable=True)
-    project_id = Column(UUID(as_uuid=True), ForeignKey("projects.id", ondelete="SET NULL"), nullable=True)
+    project_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("projects.id", ondelete="SET NULL"),
+        nullable=True,
+    )
     low_stock_report_quantity = Column(Integer, nullable=True)
     attrition_percentage = Column(Numeric(8, 4), nullable=False, default=0)
     attrition_min_quantity = Column(Integer, nullable=False, default=0)
@@ -90,9 +95,23 @@ class Part(WorkspaceOwned, Base):
 
 class PartCadKey(Base):
     __tablename__ = "part_cad_keys"
+    __table_args__ = (
+        Index("ix_part_cad_keys_ws_cad_key", "workspace_id", "cad_key"),
+    )
 
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    part_id = Column(UUID(as_uuid=True), ForeignKey("parts.id", ondelete="CASCADE"), nullable=False, index=True)
+    workspace_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("workspaces.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    part_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("parts.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
     cad_key = Column(String(300), nullable=False, index=True)
     source = Column(String(40), nullable=False, default="manual")
 

--- a/backend/app/domain/projects/bom_import.py
+++ b/backend/app/domain/projects/bom_import.py
@@ -255,6 +255,7 @@ def _match_part(db: Session, *, workspace_id: UUID, row: ParsedRow) -> Part | No
         cad = db.execute(
             select(Part)
             .join(PartCadKey, PartCadKey.part_id == Part.id)
+            .where(PartCadKey.workspace_id == workspace_id)
             .where(Part.workspace_id == workspace_id)
             .where(PartCadKey.cad_key == row.cad_key)
             .limit(1)

--- a/backend/tests/test_workspace_isolation.py
+++ b/backend/tests/test_workspace_isolation.py
@@ -10,7 +10,8 @@ from app.api._helpers import _polymorphic_resolvers, assert_polymorphic_in_works
 from app.domain.builds.models import Build
 from app.domain.lots.models import Lot
 from app.domain.orders.models import Order
-from app.domain.parts.models import Part, PartMetaMember, PartSubstitute
+from app.domain.parts.models import Part, PartCadKey, PartMetaMember, PartSubstitute
+from app.domain.projects.bom_import import ParsedRow, _match_part
 from app.domain.projects.models import Project
 from app.domain.sourcing.budget import BUDGET
 from app.domain.sourcing.models import SourcingCache
@@ -149,6 +150,76 @@ def test_project_entry_rejects_cross_workspace_part_id():
     # pin — it was already correct, this asserts it stays that way).
     r = a.post(f"/api/projects/{proj}/entries/{entry}/match", json={"part_id": secret})
     assert r.status_code == 404, r.text
+
+
+def test_part_cad_keys_ws(db):
+    """CAD-key matching must use the caller workspace, not just cad_key."""
+    a = TestClient(app)
+    b = TestClient(app)
+    ws_a = uuid.UUID(_signup(a, f"a-{uuid.uuid4().hex[:6]}@x.com"))
+    ws_b = uuid.UUID(_signup(b, f"b-{uuid.uuid4().hex[:6]}@x.com"))
+
+    part_a = uuid.UUID(_create_part(a, "A-cad-key-part"))
+    part_b = uuid.UUID(_create_part(b, "B-cad-key-part"))
+    db.add_all(
+        [
+            PartCadKey(workspace_id=ws_a, part_id=part_a, cad_key="SHARED-CAD-KEY"),
+            PartCadKey(workspace_id=ws_b, part_id=part_b, cad_key="SHARED-CAD-KEY"),
+            PartCadKey(workspace_id=ws_a, part_id=part_a, cad_key="A-ONLY-CAD-KEY"),
+        ]
+    )
+    db.flush()
+
+    matched_b = _match_part(
+        db,
+        workspace_id=ws_b,
+        row=ParsedRow(cad_key="SHARED-CAD-KEY"),
+    )
+
+    assert matched_b is not None
+    assert matched_b.id == part_b
+    assert _match_part(
+        db,
+        workspace_id=ws_b,
+        row=ParsedRow(cad_key="A-ONLY-CAD-KEY"),
+    ) is None
+    assert _match_part(
+        db,
+        workspace_id=ws_a,
+        row=ParsedRow(cad_key="A-ONLY-CAD-KEY"),
+    ).id == part_a
+
+
+def test_part_cad_keys_workspace_trigger_rejects_mismatch():
+    """migration 0055: direct SQL cannot desync part_cad_keys.workspace_id."""
+    from sqlalchemy import text
+    from sqlalchemy.exc import DBAPIError, IntegrityError, ProgrammingError
+
+    from app.infra.db import SessionLocal
+
+    a = TestClient(app)
+    b = TestClient(app)
+    ws_b = _signup(b, f"b-{uuid.uuid4().hex[:6]}@x.com")
+    _signup(a, f"a-{uuid.uuid4().hex[:6]}@x.com")
+    part_a = _create_part(a, "A-cad-trigger-part")
+
+    with SessionLocal() as s:
+        with pytest.raises((IntegrityError, ProgrammingError, DBAPIError)):
+            s.execute(
+                text(
+                    "INSERT INTO part_cad_keys ("
+                    "id, workspace_id, part_id, cad_key, source"
+                    ") VALUES ("
+                    ":id, :workspace_id, :part_id, 'CAD-X', 'manual'"
+                    ")"
+                ),
+                {
+                    "id": str(uuid.uuid4()),
+                    "workspace_id": ws_b,
+                    "part_id": part_a,
+                },
+            )
+            s.commit()
 
 
 # ---------------------------------------------------------------------------

--- a/docs/domain/parts.md
+++ b/docs/domain/parts.md
@@ -84,7 +84,7 @@ Hard-delete is not exposed; FKs use `SET NULL` so a hypothetical hard-delete wou
 
 ## Adjacent tables
 
-`part_cad_keys` (`backend/app/domain/parts/models.py:91`) — secondary CAD-footprint identifiers per part. `source` distinguishes manual vs imported. CASCADE on `part_id`.
+`part_cad_keys` (`backend/app/domain/parts/models.py:91`) — secondary CAD-footprint identifiers per part. `source` distinguishes manual vs imported. The table carries `workspace_id` for direct isolation filtering, and migration `0054` adds a trigger so `workspace_id` must match the owning `part_id`. CASCADE on `workspace_id` and `part_id`. See [workspace-isolation](workspace-isolation.md).
 
 `part_meta_members` (`backend/app/domain/parts/models.py:100`) — a meta-part's registered concrete members. Composite unique `(meta_part_id, part_id)`. CASCADE on either side. See [builds-and-bom](builds-and-bom.md) for how members are used during consume.
 

--- a/docs/domain/workspace-isolation.md
+++ b/docs/domain/workspace-isolation.md
@@ -38,9 +38,13 @@ The active leak this prevents — `adjust_stock` validates caller-supplied `lot_
 
 The same defence-in-depth pattern is replicated in `remove_stock` (`backend/app/domain/stock/service.py:508-515`), `move_stock` (`backend/app/domain/stock/service.py:563-576`), `builds.consume` (`backend/app/domain/builds/service.py:367-380`), and `orders.receive` (`backend/app/domain/orders/service.py:103,118-119`).
 
-## The one DB-enforced exception
+## DB-enforced exceptions
 
-`parts.default_storage_location_id` is *additionally* enforced by a Postgres BEFORE trigger.
+Most workspace isolation is enforced in code. Two part-domain edges are
+additionally enforced by Postgres BEFORE triggers because direct SQL could
+otherwise persist a cross-workspace reference.
+
+### `parts.default_storage_location_id`
 
 - Migration: `backend/alembic/versions/0036_parts_default_storage_ws_trigger.py`.
 - Trigger name: `parts_default_storage_workspace_check`.
@@ -54,16 +58,29 @@ Why this column gets the trigger and others don't (`backend/alembic/versions/003
 
 This is the single column that's a known foot-gun for migration-time data manipulation (it was added late, has fan-out implications for stock-add validation via `default_storage_mandatory`), so it earned the belt-and-braces.
 
-## Tables that are *not* workspace-scoped
+### `part_cad_keys.workspace_id`
 
-Three tables intentionally lack a `workspace_id` column. The model docstrings carry the rationale in case a well-meaning refactor tries to "fix" them:
+- Migration: `backend/alembic/versions/0054_part_cad_keys_workspace_id.py`.
+- Trigger name: `part_cad_keys_workspace_check`.
+- Function: `check_part_cad_keys_workspace()`.
+- Fires: `BEFORE INSERT OR UPDATE OF workspace_id, part_id ON part_cad_keys`.
+- Behaviour: checks that `part_cad_keys.part_id` points at a `parts` row in
+  `part_cad_keys.workspace_id`; mismatches raise `ERRCODE = '23514'`.
+
+The table stores `workspace_id` directly so BOM CAD-key matching can filter
+`part_cad_keys.workspace_id` before joining to `parts`. The trigger keeps that
+stored workspace aligned with the owning part for migration/admin writes.
+
+## Tables without `workspace_id`
+
+These tables intentionally lack a `workspace_id` column. The model docstrings carry the rationale in case a well-meaning refactor tries to "fix" them:
 
 - `users` — predates workspaces. Login is pre-workspace.
 - `pending_users` — created by signup before any workspace exists (`backend/app/domain/users/models.py:91-95`).
 - `user_login_failures` — protects the user credential, not a workspace resource (`backend/app/domain/users/models.py:62-64`).
 - `user_sessions` — keyed by token hash; user-scoped, not workspace-scoped.
 
-Everything else inherits `WorkspaceOwned` (`backend/app/domain/_mixins.py:11-21`) which means `workspace_id` is `nullable=False` with `ON DELETE CASCADE`.
+Everything else either inherits `WorkspaceOwned` (`backend/app/domain/_mixins.py:11-21`) which means `workspace_id` is `nullable=False` with `ON DELETE CASCADE`, or is an explicit child table whose workspace contract is documented here.
 
 ## Polymorphic tables
 


### PR DESCRIPTION
## Summary
- add `workspace_id` to `part_cad_keys` with a backfill migration and DB trigger enforcing alignment with the owning part
- filter BOM CAD-key matching by `PartCadKey.workspace_id` as well as `Part.workspace_id`
- document the decision and add workspace-isolation regression coverage

Closes #593

## Validation
- `uv run --project backend --extra dev ruff check backend/app/domain/parts/models.py backend/app/domain/projects/bom_import.py backend/tests/test_workspace_isolation.py backend/alembic/versions/0054_part_cad_keys_workspace_id.py`
- `DATABASE_URL=postgresql+psycopg://stockmgr:stockmgr@127.0.0.1:5432/stockmgr_test_aud054 uv run --project backend --extra dev python -m pytest backend/tests/test_workspace_isolation.py -q`

## Conflict Risk / Merge Order
- Open PR #678 adds `backend/alembic/versions/0053_workspace_invitation_expires_at.py`. Merge #678 before this PR, then rebase this branch and update `0054_part_cad_keys_workspace_id.py` to depend on #678's `0053` revision before merging.
