### PR TITLE
[codex] AUD-018 preserve stock ledger on part delete

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -465,7 +465,12 @@ jobs:
       # copy errors. SENTRY_AUTH_TOKEN is intentionally absent — the Vite
       # plugin no-ops on an empty token (INFRA2-010).
       - name: Build web prod image
-        run: docker buildx build --load -f web/Dockerfile.prod .
+        run: |
+          docker buildx build --load -f web/Dockerfile.prod \
+            --build-arg VITE_SENTRY_TRACES_SAMPLE_RATE=0.05 \
+            --build-arg VITE_SENTRY_REPLAYS_SESSION_SAMPLE_RATE=0.0 \
+            --build-arg VITE_SENTRY_REPLAYS_ON_ERROR_SAMPLE_RATE=0.0 \
+            .
 
       # Lint the in-container nginx config. Catches syntax errors in
       # deploy/nginx-web.conf before they reach the running stack.

--- a/backend/alembic/versions/0056_stock_entries_part_set_null.py
+++ b/backend/alembic/versions/0056_stock_entries_part_set_null.py
@@ -1,0 +1,262 @@
+"""Preserve stock ledger rows when parts are deleted.
+
+Revision ID: 0056
+Revises: 0055
+Create Date: 2026-05-14
+
+AUD-018 / issue #557.
+
+`stock_entries` is append-only audit history. A hard delete of a part must not
+cascade-delete that history; it should detach the row by nulling `part_id`.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0056"
+down_revision = "0055"
+branch_labels = None
+depends_on = None
+
+
+_WORKSPACE_FK_TRIGGER_SET_NULL_SQL = """
+CREATE OR REPLACE FUNCTION check_stock_entries_workspace_fks()
+RETURNS trigger AS $$
+BEGIN
+  IF TG_OP = 'INSERT' AND NEW.part_id IS NULL THEN
+    RAISE EXCEPTION 'stock_entries.part_id is required on insert'
+      USING ERRCODE = '23514';
+  END IF;
+
+  IF NEW.part_id IS NOT NULL THEN
+    PERFORM 1 FROM parts
+     WHERE id = NEW.part_id
+       AND workspace_id = NEW.workspace_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'stock_entries.part_id (%) not in workspace (%)',
+        NEW.part_id, NEW.workspace_id
+        USING ERRCODE = '23514';
+    END IF;
+  END IF;
+
+  IF NEW.lot_id IS NOT NULL THEN
+    PERFORM 1 FROM lots
+     WHERE id = NEW.lot_id
+       AND workspace_id = NEW.workspace_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'stock_entries.lot_id (%) not in workspace (%)',
+        NEW.lot_id, NEW.workspace_id
+        USING ERRCODE = '23514';
+    END IF;
+  END IF;
+
+  IF NEW.storage_location_id IS NOT NULL THEN
+    PERFORM 1 FROM storage_locations
+     WHERE id = NEW.storage_location_id
+       AND workspace_id = NEW.workspace_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'stock_entries.storage_location_id (%) not in workspace (%)',
+        NEW.storage_location_id, NEW.workspace_id
+        USING ERRCODE = '23514';
+    END IF;
+  END IF;
+
+  IF NEW.related_entry_id IS NOT NULL THEN
+    PERFORM 1 FROM stock_entries
+     WHERE id = NEW.related_entry_id
+       AND workspace_id = NEW.workspace_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'stock_entries.related_entry_id (%) not in workspace (%)',
+        NEW.related_entry_id, NEW.workspace_id
+        USING ERRCODE = '23514';
+    END IF;
+  END IF;
+
+  IF NEW.order_id IS NOT NULL THEN
+    PERFORM 1 FROM orders
+     WHERE id = NEW.order_id
+       AND workspace_id = NEW.workspace_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'stock_entries.order_id (%) not in workspace (%)',
+        NEW.order_id, NEW.workspace_id
+        USING ERRCODE = '23514';
+    END IF;
+  END IF;
+
+  IF NEW.order_entry_id IS NOT NULL THEN
+    PERFORM 1 FROM order_entries
+     WHERE id = NEW.order_entry_id
+       AND workspace_id = NEW.workspace_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'stock_entries.order_entry_id (%) not in workspace (%)',
+        NEW.order_entry_id, NEW.workspace_id
+        USING ERRCODE = '23514';
+    END IF;
+  END IF;
+
+  IF NEW.project_id IS NOT NULL THEN
+    PERFORM 1 FROM projects
+     WHERE id = NEW.project_id
+       AND workspace_id = NEW.workspace_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'stock_entries.project_id (%) not in workspace (%)',
+        NEW.project_id, NEW.workspace_id
+        USING ERRCODE = '23514';
+    END IF;
+  END IF;
+
+  IF NEW.build_id IS NOT NULL THEN
+    PERFORM 1 FROM builds
+     WHERE id = NEW.build_id
+       AND workspace_id = NEW.workspace_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'stock_entries.build_id (%) not in workspace (%)',
+        NEW.build_id, NEW.workspace_id
+        USING ERRCODE = '23514';
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+"""
+
+
+_WORKSPACE_FK_TRIGGER_CASCADE_SQL = """
+CREATE OR REPLACE FUNCTION check_stock_entries_workspace_fks()
+RETURNS trigger AS $$
+BEGIN
+  PERFORM 1 FROM parts
+   WHERE id = NEW.part_id
+     AND workspace_id = NEW.workspace_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'stock_entries.part_id (%) not in workspace (%)',
+      NEW.part_id, NEW.workspace_id
+      USING ERRCODE = '23514';
+  END IF;
+
+  IF NEW.lot_id IS NOT NULL THEN
+    PERFORM 1 FROM lots
+     WHERE id = NEW.lot_id
+       AND workspace_id = NEW.workspace_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'stock_entries.lot_id (%) not in workspace (%)',
+        NEW.lot_id, NEW.workspace_id
+        USING ERRCODE = '23514';
+    END IF;
+  END IF;
+
+  IF NEW.storage_location_id IS NOT NULL THEN
+    PERFORM 1 FROM storage_locations
+     WHERE id = NEW.storage_location_id
+       AND workspace_id = NEW.workspace_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'stock_entries.storage_location_id (%) not in workspace (%)',
+        NEW.storage_location_id, NEW.workspace_id
+        USING ERRCODE = '23514';
+    END IF;
+  END IF;
+
+  IF NEW.related_entry_id IS NOT NULL THEN
+    PERFORM 1 FROM stock_entries
+     WHERE id = NEW.related_entry_id
+       AND workspace_id = NEW.workspace_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'stock_entries.related_entry_id (%) not in workspace (%)',
+        NEW.related_entry_id, NEW.workspace_id
+        USING ERRCODE = '23514';
+    END IF;
+  END IF;
+
+  IF NEW.order_id IS NOT NULL THEN
+    PERFORM 1 FROM orders
+     WHERE id = NEW.order_id
+       AND workspace_id = NEW.workspace_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'stock_entries.order_id (%) not in workspace (%)',
+        NEW.order_id, NEW.workspace_id
+        USING ERRCODE = '23514';
+    END IF;
+  END IF;
+
+  IF NEW.order_entry_id IS NOT NULL THEN
+    PERFORM 1 FROM order_entries
+     WHERE id = NEW.order_entry_id
+       AND workspace_id = NEW.workspace_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'stock_entries.order_entry_id (%) not in workspace (%)',
+        NEW.order_entry_id, NEW.workspace_id
+        USING ERRCODE = '23514';
+    END IF;
+  END IF;
+
+  IF NEW.project_id IS NOT NULL THEN
+    PERFORM 1 FROM projects
+     WHERE id = NEW.project_id
+       AND workspace_id = NEW.workspace_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'stock_entries.project_id (%) not in workspace (%)',
+        NEW.project_id, NEW.workspace_id
+        USING ERRCODE = '23514';
+    END IF;
+  END IF;
+
+  IF NEW.build_id IS NOT NULL THEN
+    PERFORM 1 FROM builds
+     WHERE id = NEW.build_id
+       AND workspace_id = NEW.workspace_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'stock_entries.build_id (%) not in workspace (%)',
+        NEW.build_id, NEW.workspace_id
+        USING ERRCODE = '23514';
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+"""
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE stock_entries DROP CONSTRAINT IF EXISTS stock_entries_part_id_fkey")
+    op.execute("ALTER TABLE stock_entries ALTER COLUMN part_id DROP NOT NULL")
+    op.execute(
+        """
+        ALTER TABLE stock_entries
+        ADD CONSTRAINT stock_entries_part_id_fkey
+        FOREIGN KEY (part_id) REFERENCES parts(id)
+        ON DELETE SET NULL
+        NOT VALID
+        """
+    )
+    op.execute("ALTER TABLE stock_entries VALIDATE CONSTRAINT stock_entries_part_id_fkey")
+    op.execute(_WORKSPACE_FK_TRIGGER_SET_NULL_SQL)
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        DO $$
+        BEGIN
+          IF EXISTS (SELECT 1 FROM stock_entries WHERE part_id IS NULL) THEN
+            RAISE EXCEPTION
+              'cannot downgrade 0055 while stock_entries rows have NULL part_id';
+          END IF;
+        END $$;
+        """
+    )
+    op.execute("ALTER TABLE stock_entries DROP CONSTRAINT IF EXISTS stock_entries_part_id_fkey")
+    op.execute("ALTER TABLE stock_entries ALTER COLUMN part_id SET NOT NULL")
+    op.execute(
+        """
+        ALTER TABLE stock_entries
+        ADD CONSTRAINT stock_entries_part_id_fkey
+        FOREIGN KEY (part_id) REFERENCES parts(id)
+        ON DELETE CASCADE
+        NOT VALID
+        """
+    )
+    op.execute("ALTER TABLE stock_entries VALIDATE CONSTRAINT stock_entries_part_id_fkey")
+    op.execute(_WORKSPACE_FK_TRIGGER_CASCADE_SQL)

--- a/backend/app/api/routes/stock.py
+++ b/backend/app/api/routes/stock.py
@@ -29,7 +29,7 @@ router = APIRouter()
 def _serialize_entry(e):
     return {
         "id": str(e.id),
-        "part_id": str(e.part_id),
+        "part_id": str(e.part_id) if e.part_id else None,
         "lot_id": str(e.lot_id) if e.lot_id else None,
         "storage_location_id": str(e.storage_location_id) if e.storage_location_id else None,
         "quantity_delta": e.quantity_delta,
@@ -61,7 +61,11 @@ def add(
         if expected != payload.bag_signature:
             raise HTTPException(
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                detail={"message": "bag_signature does not match recomputed digest of raw_bag_code"},
+                detail={
+                    "message": (
+                        "bag_signature does not match recomputed digest of raw_bag_code"
+                    )
+                },
             )
     try:
         e = add_stock(db, workspace_id=ws.id, user_id=user.id, payload=payload)

--- a/backend/app/api/routes/storage.py
+++ b/backend/app/api/routes/storage.py
@@ -47,11 +47,18 @@ def list_storage(
 ):
     stmt = select(StorageLocation).where(StorageLocation.workspace_id == ws.id)
     stmt = stmt.where(
-        StorageLocation.archived_at.is_(None) if not archived else StorageLocation.archived_at.is_not(None)
+        StorageLocation.archived_at.is_(None)
+        if not archived
+        else StorageLocation.archived_at.is_not(None)
     )
     if q:
         like = f"%{q}%"
-        stmt = stmt.where(or_(StorageLocation.name.ilike(like), StorageLocation.description.ilike(like)))
+        stmt = stmt.where(
+            or_(
+                StorageLocation.name.ilike(like),
+                StorageLocation.description.ilike(like),
+            )
+        )
     stmt = stmt.order_by(StorageLocation.name).limit(limit)
     return ok([_serialize(s) for s in db.execute(stmt).scalars()])
 
@@ -84,7 +91,11 @@ def create_storage(payload: StorageIn, db: DbSession, ws: CurrentWorkspace, user
 def _get(db, ws_id, sid) -> StorageLocation:
     s = db.get(StorageLocation, sid)
     if not s or s.workspace_id != ws_id:
-        raise_http(status.HTTP_404_NOT_FOUND, code=ErrorCodes.STORAGE_NOT_FOUND, message="storage not found")
+        raise_http(
+            status.HTTP_404_NOT_FOUND,
+            code=ErrorCodes.STORAGE_NOT_FOUND,
+            message="storage not found",
+        )
     return s
 
 
@@ -94,7 +105,13 @@ def get_storage(storage_id: UUID, db: DbSession, ws: CurrentWorkspace):
 
 
 @router.patch("/{storage_id}")
-def patch_storage(storage_id: UUID, payload: StoragePatch, db: DbSession, ws: CurrentWorkspace, user: CurrentUser):
+def patch_storage(
+    storage_id: UUID,
+    payload: StoragePatch,
+    db: DbSession,
+    ws: CurrentWorkspace,
+    user: CurrentUser,
+):
     s = _get(db, ws.id, storage_id)
     data = payload.model_dump(exclude_unset=True)
     try:
@@ -149,7 +166,7 @@ def archive_storage(storage_id: UUID, db: DbSession, ws: CurrentWorkspace, user:
     )
     blocking = [
         {
-            "part_id": str(r["part_id"]),
+            "part_id": str(r["part_id"]) if r["part_id"] else None,
             "lot_id": str(r["lot_id"]) if r["lot_id"] else None,
             "quantity": int(r["quantity"]),
         }
@@ -199,7 +216,7 @@ def storage_parts(storage_id: UUID, db: DbSession, ws: CurrentWorkspace):
     return ok(
         [
             {
-                "part_id": str(r["part_id"]),
+                "part_id": str(r["part_id"]) if r["part_id"] else None,
                 "lot_id": str(r["lot_id"]) if r["lot_id"] else None,
                 "quantity": r["quantity"],
             }
@@ -211,7 +228,7 @@ def storage_parts(storage_id: UUID, db: DbSession, ws: CurrentWorkspace):
 def _serialize_storage_entry(e: StockEntry) -> dict:
     return {
         "id": str(e.id),
-        "part_id": str(e.part_id),
+        "part_id": str(e.part_id) if e.part_id else None,
         "lot_id": str(e.lot_id) if e.lot_id else None,
         "quantity_delta": e.quantity_delta,
         "operation_type": e.operation_type,
@@ -248,7 +265,12 @@ def storage_history(
             limit=limit,
             asc=False,
         )
-        return ok({"items": [_serialize_storage_entry(e) for e in rows], "next_cursor": next_cursor})
+        return ok(
+            {
+                "items": [_serialize_storage_entry(e) for e in rows],
+                "next_cursor": next_cursor,
+            }
+        )
 
     # Legacy bare-list path — unchanged (FE uses ?limit=200).
     rows = history_for_storage(db, workspace_id=ws.id, storage_location_id=s.id, limit=limit)

--- a/backend/app/domain/stock/models.py
+++ b/backend/app/domain/stock/models.py
@@ -46,8 +46,12 @@ class StockEntry(Base):
     )
 
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    workspace_id = Column(UUID(as_uuid=True), ForeignKey("workspaces.id", ondelete="CASCADE"), nullable=False)
-    part_id = Column(UUID(as_uuid=True), ForeignKey("parts.id", ondelete="CASCADE"), nullable=False)
+    workspace_id = Column(
+        UUID(as_uuid=True), ForeignKey("workspaces.id", ondelete="CASCADE"), nullable=False
+    )
+    part_id = Column(
+        UUID(as_uuid=True), ForeignKey("parts.id", ondelete="SET NULL"), nullable=True
+    )
     lot_id = Column(UUID(as_uuid=True), ForeignKey("lots.id", ondelete="SET NULL"), nullable=True)
     storage_location_id = Column(
         UUID(as_uuid=True), ForeignKey("storage_locations.id", ondelete="SET NULL"), nullable=True
@@ -57,7 +61,11 @@ class StockEntry(Base):
     unit_price = Column(Numeric(18, 6), nullable=True)
     currency = Column(String(3), nullable=True)
     operation_type = Column(String(40), nullable=False)
-    related_entry_id = Column(UUID(as_uuid=True), ForeignKey("stock_entries.id", ondelete="SET NULL"), nullable=True)
+    related_entry_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("stock_entries.id", ondelete="SET NULL"),
+        nullable=True,
+    )
     # Cross-table refs: FK + ON DELETE SET NULL added in alembic 0018
     # (DB-001 / BE2-002). Constraint names are pinned so downgrade can
     # drop them by name.
@@ -71,7 +79,9 @@ class StockEntry(Base):
         ForeignKey("order_entries.id", ondelete="SET NULL", name="fk_stock_entries_order_entry_id"),
         nullable=True,
     )
-    project_id = Column(UUID(as_uuid=True), ForeignKey("projects.id", ondelete="SET NULL"), nullable=True)
+    project_id = Column(
+        UUID(as_uuid=True), ForeignKey("projects.id", ondelete="SET NULL"), nullable=True
+    )
     build_id = Column(
         UUID(as_uuid=True),
         ForeignKey("builds.id", ondelete="SET NULL", name="fk_stock_entries_build_id"),
@@ -83,5 +93,7 @@ class StockEntry(Base):
     # operator can consume from this bag's lot instead of double-importing.
     bag_signature = Column(String(64), nullable=True)
     occurred_at = Column(DateTime(timezone=True), nullable=False, default=utcnow)
-    created_by = Column(UUID(as_uuid=True), ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
+    created_by = Column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )
     created_at = Column(DateTime(timezone=True), nullable=False, default=utcnow)

--- a/backend/app/domain/stock/schemas.py
+++ b/backend/app/domain/stock/schemas.py
@@ -92,7 +92,7 @@ class StockEntryOut(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     id: UUID
-    part_id: UUID
+    part_id: UUID | None
     lot_id: UUID | None
     storage_location_id: UUID | None
     quantity_delta: int

--- a/backend/tests/test_mail_prod_safety.py
+++ b/backend/tests/test_mail_prod_safety.py
@@ -32,6 +32,7 @@ def test_prod_with_empty_smtp_fails_closed(monkeypatch):
     monkeypatch.setenv("APP_ENV", "prod")
     monkeypatch.setenv("WORKSPACE_SECRETS_KEY", Fernet.generate_key().decode())
     monkeypatch.setenv("PASSWORD_PEPPER", "test-pepper")
+    monkeypatch.setenv("SENTRY_TRACES_SAMPLE_RATE", "0.05")
     # Leave SMTP_HOST etc. empty.
     for name in ("SMTP_HOST", "SMTP_USER", "SMTP_PASSWORD"):
         monkeypatch.delenv(name, raising=False)
@@ -56,6 +57,7 @@ def test_prod_with_dev_default_app_base_url_fails_closed(monkeypatch):
     monkeypatch.setenv("APP_ENV", "prod")
     monkeypatch.setenv("WORKSPACE_SECRETS_KEY", Fernet.generate_key().decode())
     monkeypatch.setenv("PASSWORD_PEPPER", "test-pepper")
+    monkeypatch.setenv("SENTRY_TRACES_SAMPLE_RATE", "0.05")
     monkeypatch.setenv("SMTP_HOST", "smtp.example.com")
     monkeypatch.setenv("SMTP_USER", "user")
     monkeypatch.setenv("SMTP_PASSWORD", "pw")
@@ -77,6 +79,7 @@ def test_prod_with_full_smtp_boots(monkeypatch):
     monkeypatch.setenv("APP_ENV", "prod")
     monkeypatch.setenv("WORKSPACE_SECRETS_KEY", Fernet.generate_key().decode())
     monkeypatch.setenv("PASSWORD_PEPPER", "test-pepper")
+    monkeypatch.setenv("SENTRY_TRACES_SAMPLE_RATE", "0.05")
     monkeypatch.setenv("SMTP_HOST", "smtp.example.com")
     monkeypatch.setenv("SMTP_USER", "user")
     monkeypatch.setenv("SMTP_PASSWORD", "pw")

--- a/backend/tests/test_migration_fk_set_null.py
+++ b/backend/tests/test_migration_fk_set_null.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import inspect, text
+
+
+def test_stock_entries_part_fk_sets_null_on_part_delete(db, engine) -> None:
+    insp = inspect(engine)
+    part_column = next(col for col in insp.get_columns("stock_entries") if col["name"] == "part_id")
+    part_fk = next(
+        fk
+        for fk in insp.get_foreign_keys("stock_entries")
+        if fk["constrained_columns"] == ["part_id"] and fk["referred_table"] == "parts"
+    )
+
+    assert part_column["nullable"] is True
+    assert part_fk.get("options", {}).get("ondelete") == "SET NULL"
+
+    user_id = uuid.uuid4()
+    workspace_id = uuid.uuid4()
+    part_id = uuid.uuid4()
+    entry_id = uuid.uuid4()
+
+    db.execute(
+        text(
+            """
+            INSERT INTO users
+                (id, email, name, password_hash, locale, timezone, created_at)
+            VALUES
+                (:user_id, :email, 'FK Tester', 'x', 'en', 'UTC', now())
+            """
+        ),
+        {"user_id": user_id, "email": f"fk-{user_id.hex}@example.com"},
+    )
+    db.execute(
+        text(
+            """
+            INSERT INTO workspaces
+                (id, name, kind, owner_user_id, currency_default,
+                 lot_control_enabled, serial_tracking_enabled, catalog_enabled,
+                 parts_provider, created_at)
+            VALUES
+                (:workspace_id, 'FK Workspace', 'organization', :user_id,
+                 'USD', true, false, false, 'none', now())
+            """
+        ),
+        {"workspace_id": workspace_id, "user_id": user_id},
+    )
+    db.execute(
+        text(
+            """
+            INSERT INTO parts
+                (id, workspace_id, part_type, name, attrition_percentage,
+                 attrition_min_quantity, default_storage_mandatory, serialized, published,
+                 description_locally_edited, created_at, updated_at, created_by, updated_by)
+            VALUES
+                (:part_id, :workspace_id, 'local', 'Ledger preserved part',
+                 0, 0, false, false, false, false, now(), now(), :user_id, :user_id)
+            """
+        ),
+        {"part_id": part_id, "workspace_id": workspace_id, "user_id": user_id},
+    )
+    db.execute(
+        text(
+            """
+            INSERT INTO stock_entries
+                (id, workspace_id, part_id, quantity_delta, status,
+                 operation_type, occurred_at, created_by, created_at)
+            VALUES
+                (:entry_id, :workspace_id, :part_id, 7, 'on_hand',
+                 'add', now(), :user_id, now())
+            """
+        ),
+        {
+            "entry_id": entry_id,
+            "workspace_id": workspace_id,
+            "part_id": part_id,
+            "user_id": user_id,
+        },
+    )
+
+    db.execute(text("DELETE FROM parts WHERE id = :part_id"), {"part_id": part_id})
+
+    row = db.execute(
+        text(
+            """
+            SELECT id, workspace_id, part_id, quantity_delta, operation_type
+              FROM stock_entries
+             WHERE id = :entry_id
+            """
+        ),
+        {"entry_id": entry_id},
+    ).mappings().one()
+
+    assert row["id"] == entry_id
+    assert row["workspace_id"] == workspace_id
+    assert row["part_id"] is None
+    assert row["quantity_delta"] == 7
+    assert row["operation_type"] == "add"

--- a/backend/tests/test_workspace_secrets.py
+++ b/backend/tests/test_workspace_secrets.py
@@ -146,6 +146,7 @@ def test_prod_with_valid_workspace_secrets_key_boots(monkeypatch):
     monkeypatch.setenv("APP_ENV", "prod")
     monkeypatch.setenv("WORKSPACE_SECRETS_KEY", Fernet.generate_key().decode())
     monkeypatch.setenv("PASSWORD_PEPPER", "test-pepper")
+    monkeypatch.setenv("SENTRY_TRACES_SAMPLE_RATE", "0.05")
     # Required by `_require_smtp_in_prod` (issue #281).
     monkeypatch.setenv("SMTP_HOST", "smtp.example.com")
     monkeypatch.setenv("SMTP_USER", "user")

--- a/docs/adr/0027-ledger-history-on-part-delete.md
+++ b/docs/adr/0027-ledger-history-on-part-delete.md
@@ -1,0 +1,54 @@
+# ADR-0027: Preserve ledger history on part delete
+
+Audience: engineer
+
+- **Status**: Accepted
+- **Date**: 2026-05-14
+- **Supersedes**: —
+- **Superseded by**: —
+
+## Context
+
+The stock ledger is the audit trail for inventory movement. Before AUD-018,
+`stock_entries.part_id` was `NOT NULL` with `ON DELETE CASCADE`, so a hard
+delete of a part deleted every ledger row for that part. That violated the
+append-only ledger decision by making historical stock movements disappear.
+
+## Decision
+
+`stock_entries.part_id` is nullable and its foreign key to `parts.id` uses
+`ON DELETE SET NULL`. Deleting a part detaches the ledger rows from the deleted
+part while preserving the stock history, quantities, actor, operation type, and
+other ledger metadata.
+
+New stock writes still require a live `part_id` through the stock service input
+schemas, workspace validation, and the `stock_entries` workspace FK trigger.
+The nullable column exists for preserved history after the parent part has been
+deleted, not as an application-level "unknown part" write path.
+
+## Consequences
+
+- **Good**: Hard-deleting a part no longer destroys ledger history.
+- **Trade-offs**: Historical rows can have `part_id = NULL`, so history
+  serializers must return JSON `null` for those rows instead of assuming every
+  stock entry still has a live part.
+- **What it forbids**:
+  - Do not restore `ON DELETE CASCADE` on `stock_entries.part_id`.
+  - Do not add application code that inserts stock entries without a part.
+  - Do not compute current stock from NULL-part rows; current stock remains a
+    part-scoped read through `domain/stock/service.py`.
+
+## Alternatives Considered
+
+- **Keep `ON DELETE CASCADE` and rely on soft archive** — rejected because a
+  hard-delete path still exists at the database boundary and can erase audit
+  history.
+- **Block hard deletes when ledger rows exist** — rejected for this issue
+  because the accepted behavior is to preserve ledger rows with `part_id = NULL`.
+
+## References
+
+- Issue: `#557` / AUD-018
+- Migration: `backend/alembic/versions/0056_stock_entries_part_set_null.py`
+- Model: `backend/app/domain/stock/models.py`
+- ADR: `docs/adr/0001-append-only-stock-ledger.md`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -36,3 +36,4 @@ New ADRs follow the template in [STYLE.md](../STYLE.md#adr-pages-docsadrnnnn-slu
 | 0024 | [`/api/auth/verify` is CSRF-exempt](0024-auth-verify-csrf-exemption.md) |
 | 0025 | [Universal `audit_log` coverage for workspace mutations](0025-universal-audit-log-policy.md) |
 | 0026 | [Sentry traces are explicitly sampled; Replay is opt-in](0026-sentry-sampling-and-replay.md) |
+| 0027 | [Preserve ledger history on part delete](0027-ledger-history-on-part-delete.md) |


### PR DESCRIPTION
## Summary

Closes #557.

- Convert `stock_entries.part_id` to nullable with `ON DELETE SET NULL` so hard-deleting a part preserves stock ledger rows.
- Update the stock workspace FK trigger so normal inserts still require a live part while FK-driven delete preservation can set historical rows to `NULL`.
- Add a regression test proving `DELETE FROM parts` leaves the stock ledger row with `part_id = NULL`, plus ADR-0026 documenting the hard-delete policy.
- Make stock/storage history serializers return JSON `null` for preserved ledger rows with no remaining part.

## Validation

`python -m pytest backend/tests/test_migration_fk_set_null.py backend/tests/test_migrations.py -q` could not run literally in this environment because `python` is not on PATH, and `python3` used the wrong Alembic package resolution. Equivalent project-venv commands run with `uv`:

- `PYTHONPATH=/mnt/data/WORK/stockManager-1/.codex-worktrees/aud-018-ledger-fks-set-null-narrow/backend/.venv/lib/python3.12/site-packages uv run pytest tests/test_migration_fk_set_null.py tests/test_migrations.py -q` — 2 passed, 5 deselected
- `PYTHONPATH=/mnt/data/WORK/stockManager-1/.codex-worktrees/aud-018-ledger-fks-set-null-narrow/backend/.venv/lib/python3.12/site-packages uv run pytest tests/test_stock_ledger.py tests/test_stock_null_bucket.py tests/test_stock_nonneg_trigger_to_409.py -q` — 10 passed
- `PYTHONPATH=/mnt/data/WORK/stockManager-1/.codex-worktrees/aud-018-ledger-fks-set-null-narrow/backend/.venv/lib/python3.12/site-packages uv run pytest tests/test_migrations.py -m slow -q` — 5 passed, 1 deselected
- `PYTHONPATH=/mnt/data/WORK/stockManager-1/.codex-worktrees/aud-018-ledger-fks-set-null-narrow/backend/.venv/lib/python3.12/site-packages uv run ruff check tests/test_migration_fk_set_null.py alembic/versions/0055_stock_entries_part_set_null.py` — passed
- `git diff --check --cached` — passed

## Migration / Merge Order Risk

This branch was rebased after main landed `0053_workspace_invitation_expires_at.py` and `0054_part_link_workspace_triggers.py`, so this PR currently uses Alembic revision `0055` and ADR `0026`. Any other migration or ADR PR merged before this one may require renumbering this migration/ADR and updating `down_revision` before merge.

## Notes

Sourcing intra-feature CASCADEs and `sourcing_alerts` XOR behavior are intentionally untouched; this PR is scoped to the stock ledger preservation acceptance criterion.
