### PR TITLE
[codex] HOTFIX bootstrap prod PASSWORD_PEPPER

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -788,7 +788,6 @@ jobs:
           key: ${{ secrets.DEPLOY_SSH_KEY }}
           # If the VPS's host key ever rotates, pin it via `fingerprint:` here
           # (SHA256 form, captured with `ssh-keygen -lf /etc/ssh/ssh_host_ed25519_key.pub`).
-          script_stop: true
           script: |
             set -euo pipefail
             cd /srv/stockmanager
@@ -803,12 +802,57 @@ jobs:
             export SENTRY_RELEASE
             SENTRY_RELEASE=$(git rev-parse --short=12 HEAD)
 
+            if [ ! -f .env.prod ]; then
+              echo ".env.prod is missing on the VPS; aborting before touching containers."
+              exit 1
+            fi
+
+            # AUD-022 introduced mandatory PASSWORD_PEPPER. Older prod env files
+            # predate that setting, so bootstrap it once on the VPS without
+            # logging the value. Legacy unpeppered hashes verify and rehash on
+            # successful login; after this deploy, operators must escrow the
+            # generated value from /srv/stockmanager/.env.prod.
+            python3 - <<'PY'
+            from pathlib import Path
+            import os
+            import secrets
+
+            env_path = Path(".env.prod")
+            lines = env_path.read_text().splitlines()
+            for idx, line in enumerate(lines):
+                if line.startswith("PASSWORD_PEPPER="):
+                    if line.split("=", 1)[1].strip():
+                        print("PASSWORD_PEPPER present in .env.prod.")
+                        raise SystemExit(0)
+                    lines[idx] = f"PASSWORD_PEPPER={secrets.token_hex(32)}"
+                    break
+            else:
+                if lines and lines[-1] != "":
+                    lines.append("")
+                lines.append(f"PASSWORD_PEPPER={secrets.token_hex(32)}")
+
+            env_path.write_text("\n".join(lines) + "\n")
+            os.chmod(env_path, 0o600)
+            print(
+                "PASSWORD_PEPPER was missing in .env.prod; generated and "
+                "stored on the VPS (value not logged). Escrow it from "
+                "/srv/stockmanager/.env.prod."
+            )
+            PY
+
             # FB-005: keep users on the static Apache page during the deploy
             # window. The trap is deliberately registered before the first
             # deploy-side effect so failed dumps, builds, migrations, or health
             # gates do not leave maintenance mode enabled indefinitely.
-            trap 'sudo a2disconf parts-maintenance && sudo systemctl reload apache2 || true' EXIT
-            sudo a2enconf parts-maintenance && sudo systemctl reload apache2
+            disable_maintenance() {
+              sudo -n a2disconf parts-maintenance && sudo -n systemctl reload apache2 || true
+            }
+            trap disable_maintenance EXIT
+            if sudo -n a2enconf parts-maintenance && sudo -n systemctl reload apache2; then
+              echo "Apache maintenance mode enabled for deploy."
+            else
+              echo "WARNING: could not enable Apache maintenance mode; continuing deploy."
+            fi
 
             # Pre-deploy DB snapshot (INFRA2-001 / Infra CRIT-1).
             # Runs before `docker compose up` so the pre-migration state
@@ -817,7 +861,15 @@ jobs:
             # containers keep serving the old code.
             bash deploy/predeploy-dump.sh "${SENTRY_RELEASE}"
 
-            docker compose -f docker-compose.prod.yml --env-file .env.prod up -d --build
+            if ! docker compose -f docker-compose.prod.yml --env-file .env.prod up -d --build; then
+              echo "docker compose up failed — current service state:"
+              docker compose -f docker-compose.prod.yml --env-file .env.prod ps || true
+              echo "--- backend-init logs (tail) ---"
+              docker compose -f docker-compose.prod.yml --env-file .env.prod logs --tail=120 backend-init || true
+              echo "--- backend logs (tail) ---"
+              docker compose -f docker-compose.prod.yml --env-file .env.prod logs --tail=120 backend || true
+              exit 1
+            fi
             docker image prune -f
 
             # Post-deploy health gate (INFRA2-002 / Infra HIGH-1/7/8).

--- a/backend/tests/test_ci_workflow.py
+++ b/backend/tests/test_ci_workflow.py
@@ -72,6 +72,30 @@ def test_deploy_gates_on_green_main():
     assert "web-build" in needs, "deploy does not depend on web-build"
 
 
+def _deploy_ssh_step() -> dict:
+    data = _load()
+    deploy = data["jobs"]["deploy"]
+    for step in deploy["steps"]:
+        if "appleboy/ssh-action" in step.get("uses", ""):
+            return step
+    raise AssertionError("deploy job does not use appleboy/ssh-action")
+
+
+def test_deploy_bootstraps_missing_password_pepper_before_compose_up():
+    step = _deploy_ssh_step()
+    script = step["with"]["script"]
+
+    assert "PASSWORD_PEPPER was missing in .env.prod" in script
+    assert "secrets.token_hex(32)" in script
+    assert script.index("PASSWORD_PEPPER") < script.index("docker compose")
+    assert "logs --tail=120 backend" in script
+
+
+def test_deploy_does_not_use_ignored_ssh_action_script_stop():
+    step = _deploy_ssh_step()
+    assert "script_stop" not in step.get("with", {})
+
+
 # ── INFRA-004: reproducible backend builds via uv lockfile ──────────────────
 
 


### PR DESCRIPTION
## Summary
- bootstrap a missing PASSWORD_PEPPER in /srv/stockmanager/.env.prod without logging the generated value
- remove the ignored appleboy/ssh-action script_stop input
- make maintenance sudo best-effort and dump backend logs when compose up fails before the post-deploy health gate

## Context
The main deploy for PR #683 failed because production .env.prod predates AUD-022 and has no PASSWORD_PEPPER. The app now correctly refuses to boot in prod without that secret. Legacy unpeppered password hashes verify and rehash on successful login once the pepper exists.

## Validation
- cd backend && uv run --extra dev python -m pytest tests/test_ci_workflow.py -q
- cd backend && uv run --extra dev ruff check tests/test_ci_workflow.py
- git diff --check

## Merge Order / Conflict Notes
- Hotfix should merge before PR #611. PR #611 also edits .github/workflows/ci.yml and will need a rebase afterward.
- After deploy succeeds, escrow the generated PASSWORD_PEPPER from /srv/stockmanager/.env.prod into the operator password manager.