### PR TITLE
[codex] HOTFIX deploy with ED25519 host key pin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -781,118 +781,151 @@ jobs:
 
     steps:
       - name: SSH deploy
-        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2  # v1.2.5
-        with:
-          host: ${{ secrets.DEPLOY_HOST }}
-          username: ${{ secrets.DEPLOY_USER }}
-          key: ${{ secrets.DEPLOY_SSH_KEY }}
-          fingerprint: ${{ secrets.DEPLOY_HOST_FINGERPRINT }}
-          script: |
-            set -euo pipefail
-            cd /srv/stockmanager
-            git fetch --quiet origin main
-            git reset --hard origin/main
-            # Tag this deploy with the short SHA — exposed to both the
-            # backend (SENTRY_RELEASE) and the frontend Vite build
-            # (VITE_APP_VERSION) so Sentry groups issues per release
-            # and source-map upload pins maps to it. Exported, not
-            # appended to .env.prod, so the SHA isn't persisted between
-            # deploys.
-            export SENTRY_RELEASE
-            SENTRY_RELEASE=$(git rev-parse --short=12 HEAD)
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          DEPLOY_HOST_FINGERPRINT: ${{ secrets.DEPLOY_HOST_FINGERPRINT }}
+        run: |
+          set -euo pipefail
 
-            if [ ! -f .env.prod ]; then
-              echo ".env.prod is missing on the VPS; aborting before touching containers."
-              exit 1
+          key_path="${RUNNER_TEMP}/deploy_key"
+          known_hosts="${RUNNER_TEMP}/deploy_known_hosts"
+          trap 'rm -f "${key_path}" "${known_hosts}"' EXIT
+
+          printf '%s\n' "${DEPLOY_SSH_KEY}" | tr -d '\r' > "${key_path}"
+          chmod 600 "${key_path}"
+
+          ssh-keyscan -T 10 -t ed25519 "${DEPLOY_HOST}" > "${known_hosts}"
+          if [ ! -s "${known_hosts}" ]; then
+            echo "No ED25519 host key returned for DEPLOY_HOST."
+            exit 1
+          fi
+
+          actual_fingerprint=$(ssh-keygen -lf "${known_hosts}" | awk 'NR == 1 {print $2}')
+          if [ "${actual_fingerprint}" != "${DEPLOY_HOST_FINGERPRINT}" ]; then
+            echo "DEPLOY_HOST_FINGERPRINT mismatch for DEPLOY_HOST."
+            echo "Expected: ${DEPLOY_HOST_FINGERPRINT}"
+            echo "Actual:   ${actual_fingerprint}"
+            exit 1
+          fi
+
+          ssh \
+            -i "${key_path}" \
+            -o IdentitiesOnly=yes \
+            -o StrictHostKeyChecking=yes \
+            -o UserKnownHostsFile="${known_hosts}" \
+            -o GlobalKnownHostsFile=/dev/null \
+            -o HostKeyAlgorithms=ssh-ed25519 \
+            -o LogLevel=ERROR \
+            "${DEPLOY_USER}@${DEPLOY_HOST}" \
+            'bash -se' <<'REMOTE'
+          set -euo pipefail
+          cd /srv/stockmanager
+          git fetch --quiet origin main
+          git reset --hard origin/main
+          # Tag this deploy with the short SHA — exposed to both the
+          # backend (SENTRY_RELEASE) and the frontend Vite build
+          # (VITE_APP_VERSION) so Sentry groups issues per release
+          # and source-map upload pins maps to it. Exported, not
+          # appended to .env.prod, so the SHA isn't persisted between
+          # deploys.
+          export SENTRY_RELEASE
+          SENTRY_RELEASE=$(git rev-parse --short=12 HEAD)
+
+          if [ ! -f .env.prod ]; then
+            echo ".env.prod is missing on the VPS; aborting before touching containers."
+            exit 1
+          fi
+
+          # AUD-022 introduced mandatory PASSWORD_PEPPER. Older prod env files
+          # predate that setting, so bootstrap it once on the VPS without
+          # logging the value. Legacy unpeppered hashes verify and rehash on
+          # successful login; after this deploy, operators must escrow the
+          # generated value from /srv/stockmanager/.env.prod.
+          python3 - <<'PY'
+          from pathlib import Path
+          import os
+          import secrets
+
+          env_path = Path(".env.prod")
+          lines = env_path.read_text().splitlines()
+          for idx, line in enumerate(lines):
+              if line.startswith("PASSWORD_PEPPER="):
+                  if line.split("=", 1)[1].strip():
+                      print("PASSWORD_PEPPER present in .env.prod.")
+                      raise SystemExit(0)
+                  lines[idx] = f"PASSWORD_PEPPER={secrets.token_hex(32)}"
+                  break
+          else:
+              if lines and lines[-1] != "":
+                  lines.append("")
+              lines.append(f"PASSWORD_PEPPER={secrets.token_hex(32)}")
+
+          env_path.write_text("\n".join(lines) + "\n")
+          os.chmod(env_path, 0o600)
+          print(
+              "PASSWORD_PEPPER was missing in .env.prod; generated and "
+              "stored on the VPS (value not logged). Escrow it from "
+              "/srv/stockmanager/.env.prod."
+          )
+          PY
+
+          # FB-005: keep users on the static Apache page during the deploy
+          # window. The trap is deliberately registered before the first
+          # deploy-side effect so failed dumps, builds, migrations, or health
+          # gates do not leave maintenance mode enabled indefinitely.
+          disable_maintenance() {
+            sudo -n a2disconf parts-maintenance && sudo -n systemctl reload apache2 || true
+          }
+          trap disable_maintenance EXIT
+          if sudo -n a2enconf parts-maintenance && sudo -n systemctl reload apache2; then
+            echo "Apache maintenance mode enabled for deploy."
+          else
+            echo "WARNING: could not enable Apache maintenance mode; continuing deploy."
+          fi
+
+          # Pre-deploy DB snapshot (INFRA2-001 / Infra CRIT-1).
+          # Runs before `docker compose up` so the pre-migration state
+          # of the running Postgres is captured. Fails loud — if the
+          # dump can't be written, the deploy aborts here and the old
+          # containers keep serving the old code.
+          bash deploy/predeploy-dump.sh "${SENTRY_RELEASE}"
+
+          if ! docker compose -f docker-compose.prod.yml --env-file .env.prod up -d --build; then
+            echo "docker compose up failed — current service state:"
+            docker compose -f docker-compose.prod.yml --env-file .env.prod ps || true
+            echo "--- backend-init logs (tail) ---"
+            docker compose -f docker-compose.prod.yml --env-file .env.prod logs --tail=120 backend-init || true
+            echo "--- backend logs (tail) ---"
+            docker compose -f docker-compose.prod.yml --env-file .env.prod logs --tail=120 backend || true
+            exit 1
+          fi
+          docker image prune -f
+
+          # Post-deploy health gate (INFRA2-002 / Infra HIGH-1/7/8).
+          # Polls the public health endpoint until 200 — covers the
+          # rebuild window plus alembic upgrade plus first-request
+          # warm-up. The 30 × 5s = 150s ceiling is generous for our
+          # one-worker stack; tighten if it routinely takes less.
+          # On failure the SSH script exits non-zero, which fails the
+          # deploy job and surfaces in GitHub Actions instead of
+          # leaving prod broken with a green CI badge.
+          echo "post-deploy health gate"
+          ok=0
+          for i in $(seq 1 30); do
+            if curl -fsS https://parts.matescb.cz/api/health > /dev/null 2>&1; then
+              echo "  /api/health OK after ${i} attempts ($((i*5))s)"
+              ok=1
+              break
             fi
-
-            # AUD-022 introduced mandatory PASSWORD_PEPPER. Older prod env files
-            # predate that setting, so bootstrap it once on the VPS without
-            # logging the value. Legacy unpeppered hashes verify and rehash on
-            # successful login; after this deploy, operators must escrow the
-            # generated value from /srv/stockmanager/.env.prod.
-            python3 - <<'PY'
-            from pathlib import Path
-            import os
-            import secrets
-
-            env_path = Path(".env.prod")
-            lines = env_path.read_text().splitlines()
-            for idx, line in enumerate(lines):
-                if line.startswith("PASSWORD_PEPPER="):
-                    if line.split("=", 1)[1].strip():
-                        print("PASSWORD_PEPPER present in .env.prod.")
-                        raise SystemExit(0)
-                    lines[idx] = f"PASSWORD_PEPPER={secrets.token_hex(32)}"
-                    break
-            else:
-                if lines and lines[-1] != "":
-                    lines.append("")
-                lines.append(f"PASSWORD_PEPPER={secrets.token_hex(32)}")
-
-            env_path.write_text("\n".join(lines) + "\n")
-            os.chmod(env_path, 0o600)
-            print(
-                "PASSWORD_PEPPER was missing in .env.prod; generated and "
-                "stored on the VPS (value not logged). Escrow it from "
-                "/srv/stockmanager/.env.prod."
-            )
-            PY
-
-            # FB-005: keep users on the static Apache page during the deploy
-            # window. The trap is deliberately registered before the first
-            # deploy-side effect so failed dumps, builds, migrations, or health
-            # gates do not leave maintenance mode enabled indefinitely.
-            disable_maintenance() {
-              sudo -n a2disconf parts-maintenance && sudo -n systemctl reload apache2 || true
-            }
-            trap disable_maintenance EXIT
-            if sudo -n a2enconf parts-maintenance && sudo -n systemctl reload apache2; then
-              echo "Apache maintenance mode enabled for deploy."
-            else
-              echo "WARNING: could not enable Apache maintenance mode; continuing deploy."
-            fi
-
-            # Pre-deploy DB snapshot (INFRA2-001 / Infra CRIT-1).
-            # Runs before `docker compose up` so the pre-migration state
-            # of the running Postgres is captured. Fails loud — if the
-            # dump can't be written, the deploy aborts here and the old
-            # containers keep serving the old code.
-            bash deploy/predeploy-dump.sh "${SENTRY_RELEASE}"
-
-            if ! docker compose -f docker-compose.prod.yml --env-file .env.prod up -d --build; then
-              echo "docker compose up failed — current service state:"
-              docker compose -f docker-compose.prod.yml --env-file .env.prod ps || true
-              echo "--- backend-init logs (tail) ---"
-              docker compose -f docker-compose.prod.yml --env-file .env.prod logs --tail=120 backend-init || true
-              echo "--- backend logs (tail) ---"
-              docker compose -f docker-compose.prod.yml --env-file .env.prod logs --tail=120 backend || true
-              exit 1
-            fi
-            docker image prune -f
-
-            # Post-deploy health gate (INFRA2-002 / Infra HIGH-1/7/8).
-            # Polls the public health endpoint until 200 — covers the
-            # rebuild window plus alembic upgrade plus first-request
-            # warm-up. The 30 × 5s = 150s ceiling is generous for our
-            # one-worker stack; tighten if it routinely takes less.
-            # On failure the SSH script exits non-zero, which fails the
-            # deploy job and surfaces in GitHub Actions instead of
-            # leaving prod broken with a green CI badge.
-            echo "post-deploy health gate"
-            ok=0
-            for i in $(seq 1 30); do
-              if curl -fsS https://parts.matescb.cz/api/health > /dev/null 2>&1; then
-                echo "  /api/health OK after ${i} attempts ($((i*5))s)"
-                ok=1
-                break
-              fi
-              sleep 5
-            done
-            if [ "${ok}" -ne 1 ]; then
-              echo "post-deploy health gate FAILED — last response:"
-              curl -v https://parts.matescb.cz/api/health || true
-              echo "--- backend logs (tail) ---"
-              docker compose -f docker-compose.prod.yml --env-file .env.prod logs --tail=80 backend || true
-              exit 1
-            fi
+            sleep 5
+          done
+          if [ "${ok}" -ne 1 ]; then
+            echo "post-deploy health gate FAILED — last response:"
+            curl -v https://parts.matescb.cz/api/health || true
+            echo "--- backend logs (tail) ---"
+            docker compose -f docker-compose.prod.yml --env-file .env.prod logs --tail=80 backend || true
+            exit 1
+          fi
+          REMOTE

--- a/backend/tests/test_ci_workflow.py
+++ b/backend/tests/test_ci_workflow.py
@@ -76,14 +76,14 @@ def _deploy_ssh_step() -> dict:
     data = _load()
     deploy = data["jobs"]["deploy"]
     for step in deploy["steps"]:
-        if "appleboy/ssh-action" in step.get("uses", ""):
+        if step.get("name") == "SSH deploy":
             return step
-    raise AssertionError("deploy job does not use appleboy/ssh-action")
+    raise AssertionError("deploy job does not define the SSH deploy step")
 
 
 def test_deploy_bootstraps_missing_password_pepper_before_compose_up():
     step = _deploy_ssh_step()
-    script = step["with"]["script"]
+    script = step["run"]
 
     assert "PASSWORD_PEPPER was missing in .env.prod" in script
     assert "secrets.token_hex(32)" in script
@@ -93,16 +93,25 @@ def test_deploy_bootstraps_missing_password_pepper_before_compose_up():
 
 def test_deploy_does_not_use_ignored_ssh_action_script_stop():
     step = _deploy_ssh_step()
-    assert "script_stop" not in step.get("with", {})
+    assert "appleboy/ssh-action" not in step.get("uses", "")
+    assert "script_stop" not in step
+    assert "script_stop" not in step.get("run", "")
 
 
-def test_deploy_ssh_action_pins_host_fingerprint():
+def test_deploy_uses_openssh_with_ed25519_host_fingerprint_pin():
     step = _deploy_ssh_step()
-    fingerprint = step.get("with", {}).get("fingerprint")
-    assert fingerprint == "${{ secrets.DEPLOY_HOST_FINGERPRINT }}", (
-        "deploy SSH action must pin the VPS host key fingerprint via "
-        "`secrets.DEPLOY_HOST_FINGERPRINT`"
+    env = step.get("env", {})
+    script = step["run"]
+
+    assert env.get("DEPLOY_HOST_FINGERPRINT") == (
+        "${{ secrets.DEPLOY_HOST_FINGERPRINT }}"
     )
+    assert 'ssh-keyscan -T 10 -t ed25519 "${DEPLOY_HOST}"' in script
+    assert 'actual_fingerprint=$(ssh-keygen -lf "${known_hosts}"' in script
+    assert '"${actual_fingerprint}" != "${DEPLOY_HOST_FINGERPRINT}"' in script
+    assert "-o StrictHostKeyChecking=yes" in script
+    assert '-o UserKnownHostsFile="${known_hosts}"' in script
+    assert "-o HostKeyAlgorithms=ssh-ed25519" in script
 
 
 # ── INFRA-004: reproducible backend builds via uv lockfile ──────────────────

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -244,7 +244,7 @@ The next push to `main` triggers the first end-to-end automated deploy.
 - **`backend-tests`** — postgres:16-alpine service container, `pip install -e ".[dev]"`, `pytest -q --tb=short`. Runs on every push and PR.
 - **`web-build`** — `npm ci && npm run build`, followed on `push` to `main` by a Sentry sourcemap upload step (`npx @sentry/cli sourcemaps upload`). The build's `tsc -b` step also catches TypeScript errors. Runs on every push and PR; the sourcemap upload is gated on push to `main` only. `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, and `SENTRY_PROJECT` are GitHub Actions secrets used by the upload step — they must **not** appear in `.env.prod` or `docker-compose.prod.yml` build args (INFRA2-010).
 - **`prod-validate`** (INFRA2-012) — validates the prod artefacts that the two test jobs above don't exercise: (1) `docker compose -f docker-compose.prod.yml config -q` catches YAML/schema/variable errors in `docker-compose.prod.yml` (including the single-line JSON-array `command:` form that previously broke in production); (2) `docker buildx build` of `backend/Dockerfile` and `web/Dockerfile.prod` catches Dockerfile regressions; (3) `docker run nginx:alpine nginx -t` lints `deploy/nginx-web.conf`. Uses a throw-away CI env file derived from `deploy/.env.prod.example` — no real secrets are required. Runs on every push and PR.
-- **`deploy`** — gated on `github.event_name == 'push' && github.ref == 'refs/heads/main'` and `needs: [backend-tests, web-build, prod-validate]`. Uses `appleboy/ssh-action@v1.0.3` to SSH in and run the pull/up/prune script. Concurrency-grouped on `ci-refs/heads/main` with `cancel-in-progress: false` so consecutive pushes queue rather than abort an in-flight `docker compose up --build`.
+- **`deploy`** — gated on `github.event_name == 'push' && github.ref == 'refs/heads/main'` and `needs: [backend-tests, web-build, prod-validate]`. Uses OpenSSH on the GitHub runner to SSH in and run the pull/up/prune script. Concurrency-grouped on `ci-refs/heads/main` with `cancel-in-progress: false` so consecutive pushes queue rather than abort an in-flight `docker compose up --build`.
 
 The deploy script body is intentionally tiny:
 
@@ -261,9 +261,12 @@ docker image prune -f
 the tip of `origin/main`, even if some prior failed deploy left the working
 tree dirty. `image prune -f` keeps disk usage in check across rebuilds.
 
-The deploy action pins the VPS host key with the `DEPLOY_HOST_FINGERPRINT`
-GitHub Actions secret. If the VPS host key rotates (rebuild, key regeneration),
-capture the new `SHA256:...` value on the host with
+The deploy job pins the VPS ED25519 host key with the
+`DEPLOY_HOST_FINGERPRINT` GitHub Actions secret. It scans only the ED25519 host
+key, verifies the scanned `SHA256:...` fingerprint against the secret, writes a
+temporary `known_hosts` file, and then connects with `StrictHostKeyChecking=yes`
+and `HostKeyAlgorithms=ssh-ed25519`. If the VPS host key rotates (rebuild, key
+regeneration), capture the new value on the host with
 `ssh-keygen -lf /etc/ssh/ssh_host_ed25519_key.pub`, verify it from a separate
 trusted network, and update the secret before the next deploy. See
 [`docs/runbooks/secret-rotation.md`](runbooks/secret-rotation.md).
@@ -277,7 +280,6 @@ the human-readable tag the SHA was resolved from. Bump them with:
 gh api repos/actions/checkout/git/refs/tags/v4 --jq .object.sha
 gh api repos/actions/setup-python/git/refs/tags/v5 --jq .object.sha
 gh api repos/actions/setup-node/git/refs/tags/v4 --jq .object.sha
-gh api repos/appleboy/ssh-action/git/refs/tags/v1.0.3 --jq .object.sha
 ```
 
 Replace the SHA in the `uses:` line; keep the tag in the trailing comment.

--- a/docs/runbooks/secret-rotation.md
+++ b/docs/runbooks/secret-rotation.md
@@ -258,7 +258,9 @@ rotation, and before the first deploy to a migrated VPS.
    git push origin main
    ```
 7. Confirm the `deploy` CI job reaches the remote script.  A host-key mismatch
-   fails before any deploy command runs on the VPS.
+   fails before any deploy command runs on the VPS.  The workflow intentionally
+   forces `HostKeyAlgorithms=ssh-ed25519`, so this secret must stay tied to
+   `/etc/ssh/ssh_host_ed25519_key.pub`; see `docs/deployment.md`.
 
 ---
 


### PR DESCRIPTION
## Summary
- replace appleboy/drone-ssh deploy transport with OpenSSH strict known-hosts verification
- verify DEPLOY_HOST_FINGERPRINT against an ED25519 ssh-keyscan result before auth
- keep the existing remote deploy script body intact and update CI workflow tests/docs

## Merge order
- Based on main at e6dd9c6 after PR #611.
- Merge immediately after #611; this is the deploy recovery follow-up for the fingerprint mismatch on main run 25861654898.
- No sibling PR dependencies.

## Validation
- uv run --extra dev python -m pytest tests/test_ci_workflow.py -q
- uv run --extra dev ruff check tests/test_ci_workflow.py
- git diff --check
- extracted deploy run script | bash -n

Refs #556