### PR TITLE
E2E-1: Foundation: fixtures, tag taxonomy, CI jobs, docs

### DIFF
--- a/.github/actions/playwright-setup/action.yml
+++ b/.github/actions/playwright-setup/action.yml
@@ -1,0 +1,60 @@
+name: Playwright setup
+description: Shared setup for Playwright jobs against the dev compose stack.
+
+inputs:
+  node-version:
+    description: Node.js version for the web toolchain.
+    default: "20"
+  health-timeout-seconds:
+    description: Seconds to wait for /api/health.
+    default: "60"
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: npm
+        cache-dependency-path: web/package-lock.json
+
+    - name: Create dev .env
+      shell: bash
+      run: cp .env.example .env
+
+    - name: Install web deps
+      shell: bash
+      working-directory: web
+      run: npm ci
+
+    - name: Start dev stack
+      shell: bash
+      run: docker compose -f docker-compose.dev.yml up -d --build
+
+    - name: Wait for /api/health
+      shell: bash
+      run: |
+        ok=0
+        deadline=$((SECONDS + ${{ inputs.health-timeout-seconds }}))
+        attempt=0
+        while [ "${SECONDS}" -lt "${deadline}" ]; do
+          attempt=$((attempt + 1))
+          if curl -fsS http://localhost:8000/api/health > /dev/null 2>&1; then
+            echo "/api/health OK after ${attempt} attempt(s)"
+            ok=1
+            break
+          fi
+          sleep 2
+        done
+        if [ "${ok}" -ne 1 ]; then
+          echo "/api/health never became healthy — dumping backend logs:"
+          docker compose -f docker-compose.dev.yml logs --tail=80 backend || true
+          exit 1
+        fi
+
+    - name: Install Playwright + Chromium
+      shell: bash
+      working-directory: web
+      run: npx playwright install --with-deps chromium

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -564,8 +564,9 @@ jobs:
         working-directory: web
         env:
           PLAYWRIGHT_BASE_URL: "http://127.0.0.1:8091"
+          PLAYWRIGHT_PROJECT_SET: "prod-smoke"
           CI: "true"
-        run: npx playwright test prod-smoke.spec.ts --grep @prod-smoke
+        run: npx playwright test prod-smoke.spec.ts --project=prod-smoke
 
       - name: Upload prod Playwright report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
@@ -598,60 +599,71 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
-        with:
-          node-version: "20"
-          cache: npm
-          cache-dependency-path: web/package-lock.json
-
-      # Use .env.example so the dev stack has all required variables.
-      # APP_ENV=dev keeps session cookies working over plain HTTP.
-      - name: Create dev .env
-        run: cp .env.example .env
-
-      # Run npm ci BEFORE docker compose so the dev stack's volume mount
-      # (./web:/app) doesn't create web/node_modules owned by root, which
-      # would cause EACCES when the runner tries to write to it afterwards.
-      - name: Install web deps
-        working-directory: web
-        run: npm ci
-
-      - name: Start dev stack
-        run: docker compose -f docker-compose.dev.yml up -d --build
-
-      - name: Wait for /api/health (30 x 5s)
-        run: |
-          ok=0
-          for i in $(seq 1 30); do
-            if curl -fsS http://localhost:8000/api/health > /dev/null 2>&1; then
-              echo "  /api/health OK after ${i} attempt(s) ($((i*5))s)"
-              ok=1
-              break
-            fi
-            sleep 5
-          done
-          if [ "${ok}" -ne 1 ]; then
-            echo "/api/health never became healthy — dumping backend logs:"
-            docker compose -f docker-compose.dev.yml logs --tail=80 backend || true
-            exit 1
-          fi
-
-      - name: Install Playwright + Chromium
-        working-directory: web
-        run: npx playwright install --with-deps chromium
+      - uses: ./.github/actions/playwright-setup
 
       - name: Run Playwright @smoke suite
         working-directory: web
         env:
           PLAYWRIGHT_BASE_URL: "http://localhost:5173"
           CI: "true"
-        run: npx playwright test --grep @smoke
+        run: npx playwright test --project=smoke
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         if: failure()
         with:
           name: playwright-report
+          path: |
+            web/playwright-report/
+            web/test-results/
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Dump backend logs on failure
+        if: failure()
+        run: docker compose -f docker-compose.dev.yml logs --tail=100 backend || true
+
+      - name: Tear down dev stack
+        if: always()
+        run: docker compose -f docker-compose.dev.yml down -v
+
+  playwright-core:
+    # E2E-1 / issue #686: advisory @core suite. It is label-gated while
+    # coverage grows so deploy remains gated only on the one @smoke walk.
+    if: >
+      github.event_name == 'pull_request' &&
+      (contains(github.event.pull_request.labels.*.name, 'area:frontend') ||
+      contains(github.event.pull_request.labels.*.name, 'area:testing'))
+    needs: [web-build]
+    continue-on-error: true
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - uses: ./.github/actions/playwright-setup
+
+      - name: Forbid waitForTimeout in spec files
+        run: |
+          if grep -rn "waitForTimeout" web/e2e --include="*.spec.ts"; then
+            echo "::error::waitForTimeout is banned in spec files. Use waitFor/expect.poll/route handlers instead."
+            exit 1
+          fi
+
+      - name: Run Playwright @core suite
+        working-directory: web
+        env:
+          PLAYWRIGHT_BASE_URL: "http://localhost:5173"
+          CI: "true"
+        run: npx playwright test --project=core --pass-with-no-tests
+
+      - name: Upload Playwright core report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        if: always()
+        with:
+          name: playwright-core-report
           path: |
             web/playwright-report/
             web/test-results/
@@ -694,10 +706,17 @@ jobs:
           WORKFLOW = ".github/workflows/ci.yml"
           # Jobs intentionally NOT required to gate deploy:
           #   - deploy itself (it can't depend on itself).
+          #   - advisory or scheduled-only jobs documented in EXCLUDE below.
           # Add a job name here only with a comment explaining why it is
           # not a quality gate. The default — and safe — assumption is
           # that any new top-level job IS a gate.
-          EXCLUDE = {"deploy"}
+          EXCLUDE = {
+              "deploy",
+              # playwright-core is advisory until @core has a 100-run green streak;
+              # promotion to deploy-gating is a one-line change (remove from EXCLUDE,
+              # add to deploy.needs). See E2E epic plan.
+              "playwright-core",
+          }
 
           cfg = yaml.safe_load(pathlib.Path(WORKFLOW).read_text())
           jobs = cfg["jobs"]

--- a/.github/workflows/playwright-nightly.yml
+++ b/.github/workflows/playwright-nightly.yml
@@ -1,0 +1,53 @@
+name: playwright-nightly
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  playwright-nightly:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - uses: ./.github/actions/playwright-setup
+
+      - name: Forbid waitForTimeout in spec files
+        run: |
+          if grep -rn "waitForTimeout" web/e2e --include="*.spec.ts"; then
+            echo "::error::waitForTimeout is banned in spec files. Use waitFor/expect.poll/route handlers instead."
+            exit 1
+          fi
+
+      - name: Run Playwright nightly suite
+        working-directory: web
+        env:
+          PLAYWRIGHT_BASE_URL: "http://localhost:5173"
+          CI: "true"
+        run: npx playwright test --project=nightly --pass-with-no-tests
+
+      - name: Upload Playwright nightly report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        if: always()
+        with:
+          name: playwright-nightly-report
+          path: |
+            web/playwright-report/
+            web/test-results/
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Dump backend logs on failure
+        if: failure()
+        run: docker compose -f docker-compose.dev.yml logs --tail=100 backend || true
+
+      - name: Tear down dev stack
+        if: always()
+        run: docker compose -f docker-compose.dev.yml down -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ the canonical record.
 
 ## 2026-05 — feedback brief fixes
 
+- **E2E-1 / #686** Playwright E2E now has smoke/core/nightly project
+  tiers, shared authenticated fixtures and seed/mock helpers, an advisory
+  label-gated `playwright-core` CI job, and a scheduled nightly workflow.
 - **SA-2b / #538** Refresh now prunes overrides whose target offer disappeared
   upstream; info toast surfaces the count.
 - **SA-10b / #539** Convert-orders route now uses explicit `raise_http` +

--- a/docs/development.md
+++ b/docs/development.md
@@ -160,6 +160,31 @@ The round-trip uses a sibling DB (`<your_test_db>_migration_rt`)
 created on first run so concurrent test runs don't trample each
 other. Override the URL via `MIGRATION_TEST_DATABASE_URL` if needed.
 
+### E2E tests
+
+Playwright tests live under `web/e2e/`; see
+[`web/e2e/README.md`](../web/e2e/README.md) for fixture and tag rules.
+
+CI has three E2E tiers:
+
+| Tier | CI job | Contract |
+|------|--------|----------|
+| `@smoke` | `playwright-e2e` in `.github/workflows/ci.yml` | Deploy-gating full-stack smoke path. |
+| `@core` | `playwright-core` in `.github/workflows/ci.yml` | Advisory, label-gated on `area:frontend` / `area:testing`. |
+| `@nightly` | `.github/workflows/playwright-nightly.yml` | Scheduled/manual heavy flows with a 30-day report artifact. |
+
+Local smoke loop:
+
+```bash
+make dev-up
+cd web && npx playwright test --project=smoke
+```
+
+E2E seeding goes through public `/api/*` routes with a real session cookie
+from `authedPage`. Do not add backend test-mode endpoints or database
+shortcuts for Playwright setup; the point is to exercise the same API
+envelope, auth, and workspace rules the browser uses.
+
 ## Migrations
 
 The schema is managed by Alembic. Migrations are linear (one chain,

--- a/docs/frontend/testing.md
+++ b/docs/frontend/testing.md
@@ -4,7 +4,7 @@ Audience: engineer
 
 How the FE test suite is organised: vitest with a node default + jsdom
 opt-in convention, the `crypto.subtle` patch, the `__dom__/` boundary,
-and the Playwright smoke spec.
+and the Playwright E2E tiers.
 
 ## Tooling
 
@@ -13,8 +13,8 @@ and the Playwright smoke spec.
 - **@testing-library/react** + **@testing-library/user-event** — DOM
   rendering and synthetic user input.
 - **jsdom** — opt-in environment for tests that render React.
-- **Playwright** (`^1.48.2`) — single E2E smoke spec, opt-in via
-  `npm run test:e2e`.
+- **Playwright** (`^1.48.2`) — E2E smoke/core/nightly tiers under
+  `web/e2e/`, opt-in via `npm run e2e:*`.
 
 ## Running
 
@@ -23,7 +23,9 @@ cd web
 npm test                # vitest run — all unit + DOM tests
 npm run test:watch      # vitest --watch
 npm run test:ui         # vitest UI
-npm run test:e2e        # playwright (assumes docker compose up at :5173)
+npm run e2e:smoke       # deploy-gating Playwright smoke tier
+npm run e2e:core        # advisory Playwright core tier
+npm run e2e:nightly     # scheduled/manual Playwright nightly tier
 ```
 
 CI runs `vitest run --coverage`; output lives in `web/coverage/` and is
@@ -201,18 +203,22 @@ and assert on the listener (line 191-220). `retry: false` is the same
 default as production, so a thrown `ApiError(401)` doesn't fire the
 listener three times.
 
-## Playwright smoke
+## Playwright E2E
 
-`web/playwright.config.ts` + `web/e2e/smoke.spec.ts` cover one
-intentional full-stack dev-compose flow: signup → create part → add
-stock → confirm ledger row. The suite uses one project (`chromium`),
-`fullyParallel: false`, and `workers: 1`. Opt-in via `npm run test:e2e`;
-the default `npm test` (vitest) keeps doing what it does
-(`playwright.config.ts:9-11`).
+`web/playwright.config.ts` exposes three Chromium-only E2E projects:
+`smoke`, `core`, and `nightly`. The smoke project covers one intentional
+full-stack dev-compose flow: signup → create part → add stock → confirm
+ledger row. Use structured Playwright tags (`{ tag: ["@core"] }`) for new
+specs; see `web/e2e/README.md` for the fixture and tag rules. Opt in via
+`npm run e2e:smoke`, `npm run e2e:core`, or `npm run e2e:nightly`; the
+default `npm test` (vitest) keeps doing what it does.
 
 The CI job is `playwright-e2e` (GitHub Actions). It brings up the dev
 docker-compose stack, polls `/api/health`, then invokes
-`npx playwright test --grep @smoke` (`playwright.config.ts:7-13`).
+`npx playwright test --project=smoke`. The advisory `playwright-core` job
+uses the same setup but is label-gated on `area:frontend` or
+`area:testing`; the scheduled `playwright-nightly` workflow runs the
+nightly project at 03:00 UTC and on manual dispatch.
 
 `web/e2e/prod-smoke.spec.ts` is the separate prod-compose smoke used by
 the `prod-validate` job. It boots `docker-compose.prod.yml`, loads the
@@ -222,37 +228,37 @@ through the same origin. It intentionally stays unauthenticated because
 over plain HTTP loopback.
 
 ```ts
-// web/e2e/smoke.spec.ts:18-57 (excerpt)
-test("@smoke signup → create part → add stock → ledger row visible", async ({ page }) => {
-  const email = `e2e-${Date.now()}-${…}@x.com`;     // .test TLD is reserved (RFC 6761),
-                                                      // pydantic EmailStr 422s on it.
-  await page.goto("/signup");
-  await page.getByLabel(/email/i).fill(email);
-  // …
-  await page.waitForURL(/\/parts(\b|$)/, { timeout: 10_000 });
+// web/e2e/smoke.spec.ts (excerpt)
+import { test, expect } from "./fixtures";
 
-  await page.getByRole("link", { name: /\+ part/i }).first().click();
-  await page.getByLabel(/^name$/i).fill("E2E Smoke Resistor");
-  await page.getByRole("button", { name: /^create$/i }).click();
-  await expect(page.getByText("E2E Smoke Resistor").first()).toBeVisible({ timeout: 10_000 });
+test(
+  "signup → create part → add stock → ledger row visible",
+  { tag: ["@smoke"] },
+  async ({ authedPage }) => {
+    const { page } = authedPage;
+    await page.goto("/parts");
+    await page.getByRole("link", { name: /\+ part/i }).first().click();
+    await page.getByLabel(/^name$/i).fill("E2E Smoke Resistor");
+    await page.getByRole("button", { name: /^create$/i }).click();
+    await expect(page.getByText("E2E Smoke Resistor").first()).toBeVisible({ timeout: 10_000 });
 
-  await page.getByRole("link", { name: "Add stock", exact: true }).click();
-  await page.getByLabel(/quantity/i).fill("42");
-  await page.getByRole("button", { name: /^add$/i }).click();
+    await page.getByRole("link", { name: "Add stock", exact: true }).click();
+    await page.getByLabel(/quantity/i).fill("42");
+    await page.getByRole("button", { name: /^add$/i }).click();
 
-  await expect(page.getByText("42").first()).toBeVisible({ timeout: 10_000 });
-});
+    await expect(page.getByText("42").first()).toBeVisible({ timeout: 10_000 });
+  },
+);
 ```
 
 Two E2E gotchas worth pinning here:
 
 - `.test` is a reserved TLD (RFC 6761) and pydantic's `EmailStr` rejects
-  it with 422; use `.com` (`smoke.spec.ts:19-21`).
+  it with 422; shared fixtures use `x.com`.
 - `PartsList` renders a `<Link>` (role=link) "+ Part" — match by link
-  role, not button (`smoke.spec.ts:35-36`).
+  role, not button.
 - The "Add stock" SubNav tab routes to `/parts/{id}/add`, which is where
-  the form lives. The "Stock" tab is read-only
-  (`smoke.spec.ts:48-49`).
+  the form lives. The "Stock" tab is read-only.
 
 The dev-compose suite is intentionally minimal: the v2 plan called out
 page-level component tests as out of scope. This is the one end-to-end
@@ -260,7 +266,7 @@ signal that the routing + API + ledger glue all line up
 (`smoke.spec.ts:11-14`).
 
 `PLAYWRIGHT_BASE_URL` overrides the default `http://localhost:5173`
-(`playwright.config.ts:21`).
+(`web/playwright.config.ts`).
 
 ## Coverage exclusions
 

--- a/web/e2e/README.md
+++ b/web/e2e/README.md
@@ -1,0 +1,74 @@
+# Playwright E2E Tests
+
+Audience: engineer
+
+Authoring guide for the Playwright suite under `web/e2e/`.
+
+## Writing a new test
+
+Import the fixture surface through the local barrel:
+
+```ts
+import { test, expect, seedPart } from "./fixtures";
+
+test("part details render seeded stock", { tag: ["@core"] }, async ({ authedPage }) => {
+  const { page, request } = authedPage;
+  const part = await seedPart(request, { name: "E2E Part" });
+  await page.goto(`/parts/${part.id}/info`);
+  await expect(page.getByText("E2E Part")).toBeVisible();
+});
+```
+
+Use structured tags (`{ tag: ["@core"] }`). Inline title tags still grep, but new specs should not use them.
+
+## Tag Taxonomy
+
+| Tag | Runs | Use when |
+|---|---|---|
+| `@smoke` | `playwright-e2e`, deploy-gating | One minimal full-stack path must stay under the deploy budget. Adding a smoke test requires reviewer sign-off. |
+| `@core` | `playwright-core`, advisory and label-gated | Domain-critical flows that should run on relevant frontend/testing PRs but are not deploy-gating yet. |
+| `@nightly` | `playwright-nightly`, scheduled/manual | Heavy provider-mocked or multi-step flows that are useful signal but too slow or broad for PRs. |
+
+Chromium is the only browser target.
+
+## Seed And Mock Helpers
+
+- `authedPage` signs up a real user through `/api/auth/signup` and returns `{ page, request, email, workspaceId, userId }`.
+- `authedRequest` is `page.request`; it shares the signed-in page cookie jar. Do not use Playwright's top-level `request` fixture for authenticated setup.
+- `seedPart`, `seedStorage`, and `seedStock` call public `/api/*` endpoints with the real session cookie. There are no backend test-mode endpoints or database shortcuts.
+- `seedProject`, `seedBomLine`, and `seedScanImport` are typed stubs for the follow-up E2E issues.
+- Provider helpers use `page.route()` and return backend-shaped envelopes (`{ data, status }`), matching `web/src/lib/api.ts`.
+
+## Selectors
+
+Prefer user-facing locators:
+
+1. `getByRole`
+2. `getByLabel`
+3. `getByText` for stable visible copy
+4. `data-testid` only when the UI has no accessible contract
+
+Every new `data-testid` needs a PR-body justification.
+
+## Waits
+
+`waitForTimeout` is banned in `*.spec.ts` and CI greps for it. Use web-first assertions, `expect.poll`, URL waits, response waits, or route handlers.
+
+Escape hatch: if a later issue has a reviewed timing case with no observable signal, document the issue number inline and keep the delay outside `*.spec.ts`; the lint remains hard.
+
+## Debugging
+
+```bash
+cd web
+npx playwright test --project=smoke --headed --debug
+npx playwright test --project=core --pass-with-no-tests --trace on
+npx playwright show-report
+```
+
+Run against a local stack started with `make dev-up` from the repo root.
+
+## Quarantine
+
+None.
+
+TODO(E2E): nightly failure-opens-issue automation belongs in a follow-up.

--- a/web/e2e/fixtures/auth.ts
+++ b/web/e2e/fixtures/auth.ts
@@ -1,0 +1,62 @@
+import { randomUUID } from "node:crypto";
+import { expect, test as base, type APIRequestContext, type Page } from "@playwright/test";
+
+import { DEFAULT_PASSWORD, EMAIL_DOMAIN, TIMEOUTS } from "./constants";
+
+type SignupEnvelope = {
+  data: {
+    user: { id: string; email: string; name: string };
+    workspace_id: string;
+  };
+  status: { category: string; message: string };
+};
+
+export type AuthedPage = {
+  page: Page;
+  request: APIRequestContext;
+  email: string;
+  workspaceId: string;
+  userId: string;
+};
+
+type Fixtures = {
+  authedPage: AuthedPage;
+  authedRequest: APIRequestContext;
+};
+
+export const test = base.extend<Fixtures>({
+  authedPage: async ({ page }, use, testInfo) => {
+    const email = `e2e-${testInfo.testId}-${randomUUID().slice(0, 8)}@${EMAIL_DOMAIN}`;
+    const response = await page.request.post("/api/auth/signup", {
+      data: {
+        email,
+        name: "e2e",
+        password: DEFAULT_PASSWORD,
+      },
+      timeout: TIMEOUTS.API_REQUEST_MS,
+    });
+
+    if (!response.ok()) {
+      throw new Error(`signup failed: ${response.status()} ${await response.text()}`);
+    }
+
+    const envelope = (await response.json()) as SignupEnvelope;
+    expect(envelope).toHaveProperty("data");
+    expect(envelope).toHaveProperty("status");
+    expect(envelope.data.user.email).toBe(email);
+
+    await use({
+      page,
+      request: page.request,
+      email,
+      workspaceId: envelope.data.workspace_id,
+      userId: envelope.data.user.id,
+    });
+  },
+
+  authedRequest: async ({ authedPage }, use) => {
+    await use(authedPage.request);
+  },
+});
+
+export { expect };

--- a/web/e2e/fixtures/constants.ts
+++ b/web/e2e/fixtures/constants.ts
@@ -1,0 +1,7 @@
+export const DEFAULT_PASSWORD = "TestPass-2026-Stronk";
+export const EMAIL_DOMAIN = "x.com";
+
+export const TIMEOUTS = {
+  HEALTH_POLL_MS: 60_000,
+  API_REQUEST_MS: 15_000,
+} as const;

--- a/web/e2e/fixtures/index.ts
+++ b/web/e2e/fixtures/index.ts
@@ -1,0 +1,4 @@
+export * from "./auth";
+export * from "./constants";
+export * from "./mocks";
+export * from "./seed";

--- a/web/e2e/fixtures/mocks.ts
+++ b/web/e2e/fixtures/mocks.ts
@@ -1,0 +1,54 @@
+import type { Page, Route } from "@playwright/test";
+
+type Envelope<T> = {
+  data: T;
+  status: { category: string; message: string };
+};
+
+const MPN_LOOKUP_ROUTE = "**/api/parts/lookup-mpn**";
+const SOURCING_REFRESH_ROUTES = [
+  "**/api/sourcing/**/refresh",
+  "**/api/parts/**/sourcing/refresh",
+] as const;
+const PROJECT_SOURCING_ROUTE = "**/api/projects/**/sourcing";
+
+function okEnvelope<T>(data: T): Envelope<T> {
+  return {
+    data,
+    status: { category: "ok", message: "OK" },
+  };
+}
+
+async function fulfillJson(route: Route, payload: unknown) {
+  await route.fulfill({
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function mockMpnLookup(page: Page, fixture: Envelope<unknown>) {
+  await page.route(MPN_LOOKUP_ROUTE, async (route) => {
+    await fulfillJson(route, fixture);
+  });
+}
+
+export async function mockSourcingProviders(page: Page, { offers }: { offers: unknown }) {
+  const payload = okEnvelope(offers);
+  for (const pattern of SOURCING_REFRESH_ROUTES) {
+    await page.route(pattern, async (route) => {
+      await fulfillJson(route, payload);
+    });
+  }
+  await page.route(PROJECT_SOURCING_ROUTE, async (route) => {
+    await fulfillJson(route, payload);
+  });
+}
+
+export async function clearProviderMocks(page: Page) {
+  await page.unroute(MPN_LOOKUP_ROUTE);
+  for (const pattern of SOURCING_REFRESH_ROUTES) {
+    await page.unroute(pattern);
+  }
+  await page.unroute(PROJECT_SOURCING_ROUTE);
+}

--- a/web/e2e/fixtures/responses/README.md
+++ b/web/e2e/fixtures/responses/README.md
@@ -1,0 +1,11 @@
+# E2E Fixture Responses
+
+Audience: engineer
+
+Canned provider payloads for Playwright route mocks.
+
+| File | Source fixture |
+|---|---|
+| `lookup-mpn-success.json` | Stubbed from the `MpnLookupResult` shape in `web/src/types.ts`; E2E-4/E2E-5 replace or extend this with provider-specific integration fixtures. |
+
+Payloads include the API envelope (`{ data, status }`) because `web/src/lib/api.ts` unwraps `data` and treats malformed responses as failures.

--- a/web/e2e/fixtures/responses/lookup-mpn-success.json
+++ b/web/e2e/fixtures/responses/lookup-mpn-success.json
@@ -1,0 +1,22 @@
+{
+  "data": {
+    "found": true,
+    "result": {
+      "mpn": "RC0603FR-0710KL",
+      "manufacturer": "Yageo",
+      "description": "RES SMD 10K OHM 1% 1/10W 0603",
+      "category": "Resistors",
+      "footprint": "0603",
+      "datasheet_url": "https://example.invalid/datasheets/rc0603fr-0710kl.pdf",
+      "image_url": "https://example.invalid/images/rc0603fr-0710kl.jpg",
+      "source_url": "https://example.invalid/parts/rc0603fr-0710kl",
+      "specs": [
+        { "key": "Resistance", "value": "10 kOhms" },
+        { "key": "Tolerance", "value": "1%" }
+      ]
+    },
+    "message": null,
+    "provider": "mouser"
+  },
+  "status": { "category": "ok", "message": "OK" }
+}

--- a/web/e2e/fixtures/seed.ts
+++ b/web/e2e/fixtures/seed.ts
@@ -1,0 +1,167 @@
+import { expect, type APIRequestContext } from "@playwright/test";
+
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:5173";
+
+type Envelope<T> = {
+  data: T;
+  status: { category: string; message: string };
+};
+
+export type E2ERequest = APIRequestContext;
+
+export type SeedPartPayload = {
+  name?: string | null;
+  part_type?: "linked" | "local" | "meta" | "sub_assembly";
+  manufacturer?: string | null;
+  mpn?: string | null;
+  internal_part_number?: string | null;
+  description?: string | null;
+  notes_markdown?: string | null;
+  footprint?: string | null;
+  low_stock_report_quantity?: number | null;
+  attrition_percentage?: number;
+  attrition_min_quantity?: number;
+  default_storage_location_id?: string | null;
+  default_storage_mandatory?: boolean;
+  serialized?: boolean;
+};
+
+export type SeedStoragePayload = {
+  name?: string;
+  description?: string | null;
+  single_part_only?: boolean;
+  existing_parts_only?: boolean;
+  is_full?: boolean;
+};
+
+export type SeedStockPayload = {
+  part_id: string;
+  quantity: number;
+  storage_location_id?: string | null;
+  lot?: {
+    name?: string | null;
+    comments?: string | null;
+    expiration_date?: string | null;
+    serial_number?: string | null;
+  };
+  comments?: string | null;
+  bag_signature?: string | null;
+  raw_bag_code?: string | null;
+};
+
+export type SeedProjectPayload = {
+  name: string;
+  description?: string | null;
+  notes_markdown?: string | null;
+  associated_subassembly_part_id?: string | null;
+};
+
+export type SeedBomLinePayload = {
+  entry_type?: "part" | "meta_part" | "non_part" | "unmatched";
+  part_id?: string | null;
+  meta_part_id?: string | null;
+  name?: string | null;
+  quantity?: number;
+  comments?: string | null;
+  designators?: string[];
+  cad_footprint?: string | null;
+  cad_key?: string | null;
+  dnp?: boolean;
+};
+
+export type SeedScanImportPayload = {
+  rows: Array<Record<string, unknown>>;
+  idempotency_key?: string | null;
+};
+
+export type SeededPart = { id: string; name: string; [key: string]: unknown };
+export type SeededStorage = { id: string; name: string; [key: string]: unknown };
+export type SeededStockEntry = {
+  id: string;
+  part_id: string | null;
+  quantity_delta: number;
+  [key: string]: unknown;
+};
+
+function sameOriginHeaders() {
+  return {
+    origin: BASE_URL,
+    referer: `${BASE_URL}/`,
+  };
+}
+
+async function postJson<T>(
+  request: APIRequestContext,
+  path: string,
+  payload: unknown,
+  expectedStatus: number | number[] = [200, 201],
+): Promise<T> {
+  const response = await request.post(path, {
+    data: payload,
+    headers: sameOriginHeaders(),
+  });
+  const expected = Array.isArray(expectedStatus) ? expectedStatus : [expectedStatus];
+  if (!expected.includes(response.status())) {
+    throw new Error(`POST ${path} failed: ${response.status()} ${await response.text()}`);
+  }
+  const envelope = (await response.json()) as Envelope<T>;
+  expect(envelope).toHaveProperty("data");
+  expect(envelope).toHaveProperty("status");
+  return envelope.data;
+}
+
+export async function seedPart(
+  authedRequest: APIRequestContext,
+  payload: SeedPartPayload = {},
+): Promise<SeededPart> {
+  return postJson<SeededPart>(authedRequest, "/api/parts", {
+    name: "E2E Seed Part",
+    part_type: "local",
+    ...payload,
+  });
+}
+
+export async function seedStorage(
+  authedRequest: APIRequestContext,
+  payload: SeedStoragePayload = {},
+): Promise<SeededStorage> {
+  return postJson<SeededStorage>(authedRequest, "/api/storage", {
+    name: "E2E Seed Bin",
+    ...payload,
+  });
+}
+
+export async function seedStock(
+  authedRequest: APIRequestContext,
+  payload: SeedStockPayload,
+): Promise<SeededStockEntry> {
+  return postJson<SeededStockEntry>(authedRequest, "/api/stock/add", payload, 200);
+}
+
+export async function seedProject(
+  _authedRequest: APIRequestContext,
+  _payload: SeedProjectPayload,
+): Promise<never> {
+  throw new Error(
+    "seedProject is reserved for E2E-3 and is intentionally not implemented in E2E-1.",
+  );
+}
+
+export async function seedBomLine(
+  _authedRequest: APIRequestContext,
+  _projectId: string,
+  _payload: SeedBomLinePayload,
+): Promise<never> {
+  throw new Error(
+    "seedBomLine is reserved for E2E-3 and is intentionally not implemented in E2E-1.",
+  );
+}
+
+export async function seedScanImport(
+  _authedRequest: APIRequestContext,
+  _payload: SeedScanImportPayload,
+): Promise<never> {
+  throw new Error(
+    "seedScanImport is reserved for E2E-5 and is intentionally not implemented in E2E-1.",
+  );
+}

--- a/web/e2e/smoke.spec.ts
+++ b/web/e2e/smoke.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./fixtures";
 
 /**
  * Smoke E2E (TEST-004 / @smoke).
@@ -6,52 +6,43 @@ import { test, expect } from "@playwright/test";
  * Walks the canonical happy path: signup → create part → add stock →
  * see the ledger row. Assumes a running docker-compose stack at
  * `PLAYWRIGHT_BASE_URL` (default: http://localhost:5173). Opt in via
- * `npm run test:e2e`.
+ * `npm run e2e:smoke`.
  *
  * The suite is intentionally minimal — the v2 plan calls out that
  * page-level component tests are out of scope here. This is the one
  * end-to-end signal that the routing + API + ledger glue all line up.
  */
 
-const STRONG_PW = "TestPass-2026-Stronk";
+test(
+  "signup → create part → add stock → ledger row visible",
+  { tag: ["@smoke"] },
+  async ({ authedPage }) => {
+    const { page } = authedPage;
+    // -------------------- create part --------------------
+    await page.goto("/parts");
 
-test("@smoke signup → create part → add stock → ledger row visible", async ({ page }) => {
-  // `.test` is a reserved special-use TLD (RFC 6761) and pydantic's
-  // EmailStr (via email-validator) rejects it with 422; use `.com`.
-  const email = `e2e-${Date.now()}-${Math.random().toString(36).slice(2, 8)}@x.com`;
+    // PartsList renders a `<Link>` (role=link) "+ Part" → /parts/create,
+    // not a button — match by link role.
+    await page.getByRole("link", { name: /\+ part/i }).first().click();
+    await page.getByLabel(/^name$/i).fill("E2E Smoke Resistor");
+    await page.getByRole("button", { name: /^create$/i }).click();
 
-  // -------------------- signup --------------------
-  await page.goto("/signup");
-  await page.getByLabel(/email/i).fill(email);
-  await page.getByLabel(/^name$/i).fill("e2e");
-  await page.getByLabel(/password/i).fill(STRONG_PW);
-  await page.getByRole("button", { name: /create account/i }).click();
+    // After create the app routes to /parts/{id}/info, which renders the
+    // part name in the EntityHeader.
+    await expect(page.getByText("E2E Smoke Resistor").first()).toBeVisible({
+      timeout: 10_000,
+    });
 
-  // After signup the app routes into the workspace at /parts.
-  await page.waitForURL(/\/parts(\b|$)/, { timeout: 10_000 });
+    // -------------------- add stock --------------------
+    // The "Add stock" SubNav tab (role=link) routes to /parts/{id}/add,
+    // which is where the form lives — the "Stock" tab is read-only.
+    await page.getByRole("link", { name: "Add stock", exact: true }).click();
+    await page.getByLabel(/quantity/i).fill("42");
+    await page.getByRole("button", { name: /^add$/i }).click();
 
-  // -------------------- create part --------------------
-  // PartsList renders a `<Link>` (role=link) "+ Part" → /parts/create,
-  // not a button — match by link role.
-  await page.getByRole("link", { name: /\+ part/i }).first().click();
-  await page.getByLabel(/^name$/i).fill("E2E Smoke Resistor");
-  await page.getByRole("button", { name: /^create$/i }).click();
-
-  // After create the app routes to /parts/{id}/info, which renders the
-  // part name in the EntityHeader.
-  await expect(page.getByText("E2E Smoke Resistor").first()).toBeVisible({
-    timeout: 10_000,
-  });
-
-  // -------------------- add stock --------------------
-  // The "Add stock" SubNav tab (role=link) routes to /parts/{id}/add,
-  // which is where the form lives — the "Stock" tab is read-only.
-  await page.getByRole("link", { name: "Add stock", exact: true }).click();
-  await page.getByLabel(/quantity/i).fill("42");
-  await page.getByRole("button", { name: /^add$/i }).click();
-
-  // -------------------- ledger row visible --------------------
-  // The success path navigates to /parts/{id}/stock; the on-hand stat
-  // and the ledger row both render the new quantity.
-  await expect(page.getByText("42").first()).toBeVisible({ timeout: 10_000 });
-});
+    // -------------------- ledger row visible --------------------
+    // The success path navigates to /parts/{id}/stock; the on-hand stat
+    // and the ledger row both render the new quantity.
+    await expect(page.getByText("42").first()).toBeVisible({ timeout: 10_000 });
+  },
+);

--- a/web/package.json
+++ b/web/package.json
@@ -13,6 +13,11 @@
     "test:watch": "vitest",
     "test:ui": "vitest --ui",
     "test:e2e": "playwright test",
+    "e2e": "playwright test",
+    "e2e:smoke": "playwright test --project=smoke",
+    "e2e:core": "playwright test --project=core --pass-with-no-tests",
+    "e2e:nightly": "playwright test --project=nightly --pass-with-no-tests",
+    "e2e:ui": "playwright test --ui",
     "typecheck": "tsc -b",
     "lint": "eslint src"
   },

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -1,31 +1,40 @@
 import { defineConfig, devices } from "@playwright/test";
 
 /**
- * Playwright config for the smoke E2E suite (TEST-004).
+ * Playwright config for the E2E suite.
  *
  * Local: assumes `docker compose up` is running on
- * http://localhost:5173. Use `npm run test:e2e` to run.
+ * http://localhost:5173. Use `npm run e2e:smoke` to run the deploy-gating
+ * smoke walk.
  *
- * CI: runs `@smoke` in the `playwright-e2e` job against dev compose, and
- * `@prod-smoke` in `prod-validate` against docker-compose.prod.yml.
- * The suite is opt-in via `npm run test:e2e` so the default
- * `npm test` (vitest) keeps doing what it does.
+ * CI: runs `@smoke` in the `playwright-e2e` job against dev compose.
+ * The separate prod compose validation sets PLAYWRIGHT_PROJECT_SET=prod-smoke
+ * so its legacy unauthenticated check does not join the smoke/core/nightly
+ * taxonomy.
  */
+const desktopChrome = { ...devices["Desktop Chrome"] };
+const e2eProjects = [
+  { name: "smoke", grep: /@smoke/, use: desktopChrome },
+  { name: "core", grep: /@core/, grepInvert: /@nightly/, use: desktopChrome },
+  { name: "nightly", grep: /@nightly/, use: desktopChrome },
+];
+
+const prodSmokeProjects = [
+  { name: "prod-smoke", grep: /@prod-smoke/, use: desktopChrome },
+];
+
 export default defineConfig({
   testDir: "./e2e",
-  fullyParallel: false,
+  fullyParallel: true,
   forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 1 : 0,
-  workers: 1,
-  reporter: "list",
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 2 : 1,
+  reporter: [["list"], ["html", { open: "never" }]],
   use: {
     baseURL: process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:5173",
     trace: "on-first-retry",
   },
-  projects: [
-    {
-      name: "chromium",
-      use: { ...devices["Desktop Chrome"] },
-    },
-  ],
+  projects: process.env.PLAYWRIGHT_PROJECT_SET === "prod-smoke"
+    ? prodSmokeProjects
+    : e2eProjects,
 });


### PR DESCRIPTION
## Summary

- Adds the shared Playwright fixture surface for E2E children: `authedPage`, `authedRequest`, seed helpers, provider route mocks, and canned envelope response fixtures.
- Splits normal Playwright runs into `smoke`, `core`, and `nightly` projects with structured tags; keeps existing prod compose smoke isolated behind `PLAYWRIGHT_PROJECT_SET=prod-smoke`.
- Extracts the dev-stack Playwright setup into `.github/actions/playwright-setup`, rebases the smoke spec onto the fixture, adds advisory `playwright-core`, and adds the scheduled nightly workflow.
- Documents the authoring rules in `web/e2e/README.md`, `docs/development.md`, `docs/frontend/testing.md`, and `CHANGELOG.md`.

## Before / after

`web/playwright.config.ts`:
- Before: one `chromium` project, `fullyParallel: false`, `workers: 1`, CI retries `1`.
- After: `smoke` (`@smoke`), `core` (`@core` minus `@nightly`), and `nightly` (`@nightly`) projects, `fullyParallel: true`, CI workers `2`, CI retries `2`; prod smoke remains a separate env-selected project for `prod-validate`.

`.github/workflows/ci.yml`:
- Before: `playwright-e2e` inlined checkout/setup-node/npm/compose/health/install and ran `npx playwright test --grep @smoke`.
- After: `playwright-e2e` uses `.github/actions/playwright-setup` and runs `npx playwright test --project=smoke`; `playwright-core` is advisory, label-gated on `area:frontend`/`area:testing`, uploads reports on every run, and is explicitly excluded from `ci-policy` deploy gating.

## Validation

- `npm ci` — passed; local Node 18 emitted engine warnings for packages that prefer Node 20, while CI uses Node 20.
- `npm run typecheck` — passed.
- `npm run build` — passed.
- `npm test -- --coverage` — passed: 66 files passed, 1 skipped; 477 tests passed, 3 skipped.
- `npx playwright test --project=smoke --list` — passed; listed exactly 1 smoke test.
- `npx playwright test --project=core --pass-with-no-tests` — passed; no `@core` tests yet.
- `npx playwright test --project=nightly --pass-with-no-tests` — passed; no `@nightly` tests yet.
- `PLAYWRIGHT_PROJECT_SET=prod-smoke npx playwright test prod-smoke.spec.ts --project=prod-smoke --list` — passed; listed exactly 1 prod smoke test.
- `grep -rn "waitForTimeout" web/e2e --include="*.spec.ts"` — empty.
- Scratch `waitForTimeout` spec check — grep fired on the deliberate violation; scratch file removed.
- YAML parsed for `.github/workflows/ci.yml`, `.github/workflows/playwright-nightly.yml`, and `.github/actions/playwright-setup/action.yml`.
- `ci-policy` sanity script against the edited workflow — passed; `playwright-core` is excluded and all deploy gates remain wired.
- `git diff --check origin/main...HEAD` — passed.

Not run locally: full `npx playwright test --project=smoke`, because `make dev-up` cannot start here: the environment has no `docker` CLI (`make: docker: No such file or directory`). `act` is also unavailable, so workflow syntax validation used local YAML parsing instead.

Note: Playwright 1.48 exits 1 for empty grep projects unless `--pass-with-no-tests` is set. The core/nightly CI commands use that flag so the skeleton tiers stay green until the follow-up E2E specs land.

## Merge order

Merge this first. It blocks #687, #688, #689, #690, and #691 because those PRs should import from the fixture barrel and use the new project/tag topology.

Refs #686
Refs #685
