### PR TITLE
E2E-6: Settings and reports coverage

### DIFF
--- a/web/e2e/reports.spec.ts
+++ b/web/e2e/reports.spec.ts
@@ -1,0 +1,67 @@
+import type { Locator, Page } from "@playwright/test";
+
+import { test, expect, seedPart } from "./fixtures";
+
+type ReportRoute = {
+  path: string;
+  tab: string;
+  anchor: (page: Page) => Locator;
+};
+
+const reportRoutes: ReportRoute[] = [
+  {
+    path: "/reports/value",
+    tab: "Stock value",
+    anchor: (page) => page.getByRole("heading", { name: "By currency" }),
+  },
+  {
+    path: "/reports/replenishment-cost",
+    tab: "Replenishment cost",
+    anchor: (page) => page.getByLabel("Sort"),
+  },
+  {
+    path: "/reports/bom",
+    tab: "BOM shortage",
+    anchor: (page) => page.getByLabel("Project"),
+  },
+  {
+    path: "/reports/buyability",
+    tab: "BOM buyability",
+    anchor: (page) => page.getByText("No projects", { exact: true }),
+  },
+  {
+    path: "/reports/expiring",
+    tab: "Expiring lots",
+    anchor: (page) => page.getByText("All clear", { exact: true }),
+  },
+  {
+    path: "/reports/sourcing-risk",
+    tab: "Sourcing risk",
+    anchor: (page) => page.getByText("All clear", { exact: true }),
+  },
+];
+
+for (const report of reportRoutes) {
+  test(
+    `${report.path} loads + ${report.tab} tab active`,
+    { tag: ["@core"] },
+    async ({ authedPage }, testInfo) => {
+      const { page, request } = authedPage;
+      const mpnSuffix = testInfo.testId.replace(/[^a-zA-Z0-9]+/g, "-").slice(0, 48);
+
+      await seedPart(request, {
+        name: "E2E Report Part",
+        manufacturer: "E2E Fixtures",
+        mpn: `E2E-REPORT-${mpnSuffix}`,
+      });
+
+      await page.goto(report.path);
+
+      const activeTab = page.getByRole("link", { name: report.tab, exact: true });
+      await expect(activeTab).toBeVisible({ timeout: 5_000 });
+      await expect(activeTab).toHaveAttribute("aria-current", "page");
+      await expect(report.anchor(page)).toBeVisible({ timeout: 5_000 });
+      await expect(page.locator("text=Something went wrong")).toHaveCount(0);
+    },
+  );
+}

--- a/web/e2e/settings.spec.ts
+++ b/web/e2e/settings.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect } from "./fixtures";
+
+test(
+  "settings nav: /settings/account and /settings/workspace both load",
+  { tag: ["@core"] },
+  async ({ authedPage }) => {
+    const { page } = authedPage;
+
+    await page.goto("/settings/account");
+    await expect(page.getByRole("heading", { name: "Account", level: 1 })).toBeVisible({
+      timeout: 5_000,
+    });
+
+    await page.goto("/settings/workspace");
+    await expect(page.getByRole("heading", { name: "Workspace", level: 1 })).toBeVisible({
+      timeout: 5_000,
+    });
+  },
+);
+
+test(
+  "workspace distributor active-list: >=1 option present, selection round-trips",
+  { tag: ["@core"] },
+  async ({ authedPage }) => {
+    const { page } = authedPage;
+
+    await page.goto("/settings/workspace");
+
+    const activeLists = page.locator("form", {
+      has: page.getByRole("heading", {
+        name: "Active currencies / countries / distributors",
+        level: 2,
+      }),
+    });
+    await expect(activeLists).toBeVisible({ timeout: 5_000 });
+    await activeLists.scrollIntoViewIfNeeded();
+
+    const distributorGroup = activeLists.getByRole("group", { name: "Active distributors" });
+    const distributorOptions = distributorGroup.getByRole("checkbox");
+    await expect.poll(async () => distributorOptions.count()).toBeGreaterThan(0);
+
+    const arrow = distributorGroup.getByLabel("Arrow", { exact: true });
+    await expect(arrow).toBeVisible({ timeout: 5_000 });
+    await expect(arrow).not.toBeChecked();
+
+    await arrow.check();
+    await activeLists.getByRole("button", { name: "Save active lists" }).click();
+    await expect(page.getByText("Active lists saved.")).toBeVisible({ timeout: 10_000 });
+
+    await page.reload();
+
+    const reloadedActiveLists = page.locator("form", {
+      has: page.getByRole("heading", {
+        name: "Active currencies / countries / distributors",
+        level: 2,
+      }),
+    });
+    const reloadedArrow = reloadedActiveLists
+      .getByRole("group", { name: "Active distributors" })
+      .getByLabel("Arrow", { exact: true });
+
+    await expect(reloadedArrow).toBeVisible({ timeout: 5_000 });
+    await expect(reloadedArrow).toBeChecked();
+  },
+);
+
+test(
+  "workspace scanner choice: ZXing option is always present",
+  { tag: ["@core"] },
+  async ({ authedPage }) => {
+    const { page } = authedPage;
+
+    await page.goto("/settings/workspace");
+
+    const scannerCard = page.locator(".card", {
+      has: page.getByRole("heading", { name: "Scanner", level: 2 }),
+    });
+    await expect(scannerCard).toBeVisible({ timeout: 5_000 });
+    await scannerCard.scrollIntoViewIfNeeded();
+
+    const scannerSelect = scannerCard.getByRole("combobox");
+    await expect(scannerSelect.locator("option").filter({ hasText: /Open-source.*ZXing/ })).toHaveCount(1);
+  },
+);


### PR DESCRIPTION
## Summary
- Add `web/e2e/settings.spec.ts` with three `@core` settings smoke tests for account/workspace routing, active distributor persistence, and ZXing availability.
- Add `web/e2e/reports.spec.ts` with six `@core` report route smoke tests covering the active tab and stable post-load anchors.
- No `web/src` changes and no new `data-testid` attributes.

## Tests
- `npm ci` (needed because `web/node_modules` was absent; completed with existing engine/audit warnings)
- `npm run typecheck` - pass
- `npx playwright test --project=core --list --reporter=list` - listed 9 tests in 2 files
- `grep -R -n --include='*.spec.ts' waitForTimeout web/e2e` - no matches
- `grep -L "@core" web/e2e/{settings,reports}.spec.ts` - empty output
- `git diff --cached --check` - pass

Discovered `@core` tests:
- `/reports/value loads + Stock value tab active`
- `/reports/replenishment-cost loads + Replenishment cost tab active`
- `/reports/bom loads + BOM shortage tab active`
- `/reports/buyability loads + BOM buyability tab active`
- `/reports/expiring loads + Expiring lots tab active`
- `/reports/sourcing-risk loads + Sourcing risk tab active`
- `settings nav: /settings/account and /settings/workspace both load`
- `workspace distributor active-list: >=1 option present, selection round-trips`
- `workspace scanner choice: ZXing option is always present`

Full Playwright runtime was not run locally because Docker is unavailable here (`docker: command not found`) and no local dev stack is healthy; runtime execution remains CI-only for this environment.

## Merge Order
- Built from `origin/main` after #694 merged; merge after #694.
- Independent of #687, #688, #689, and #690 based on this two-spec scope.

Refs #691
Refs #685
