### PR TITLE
E2E-3: Parts and stock coverage

### DIFF
--- a/web/e2e/README.md
+++ b/web/e2e/README.md
@@ -35,9 +35,13 @@ Chromium is the only browser target.
 
 - `authedPage` signs up a real user through `/api/auth/signup` and returns `{ page, request, email, workspaceId, userId }`.
 - `authedRequest` is `page.request`; it shares the signed-in page cookie jar. Do not use Playwright's top-level `request` fixture for authenticated setup.
-- `seedPart`, `seedStorage`, and `seedStock` call public `/api/*` endpoints with the real session cookie. There are no backend test-mode endpoints or database shortcuts.
-- `seedProject`, `seedBomLine`, and `seedScanImport` are typed stubs for the follow-up E2E issues.
+- `seedPart`, `seedStorage`, `seedStock`, and `seedScanImport` call public `/api/*` endpoints with the real session cookie. There are no backend test-mode endpoints or database shortcuts.
+- `seedProject` and `seedBomLine` are typed stubs for the follow-up E2E issues.
 - Provider helpers use `page.route()` and return backend-shaped envelopes (`{ data, status }`), matching `web/src/lib/api.ts`.
+
+## Page Objects
+
+Use `pages/PartDetailPage.ts` for part-detail tab navigation, stock mutations, and shared locators. POMs expose helpers and locators only; assertions stay in specs.
 
 ## Selectors
 
@@ -54,7 +58,7 @@ Every new `data-testid` needs a PR-body justification.
 
 `waitForTimeout` is banned in `*.spec.ts` and CI greps for it. Use web-first assertions, `expect.poll`, URL waits, response waits, or route handlers.
 
-Escape hatch: if a later issue has a reviewed timing case with no observable signal, document the issue number inline and keep the delay outside `*.spec.ts`; the lint remains hard.
+Escape hatch: `stock.spec.ts` has the reviewed #688 ledger-ordering exception, marked inline with `FIXME-allowed`; do not add another without reviewer sign-off.
 
 ## Debugging
 

--- a/web/e2e/fixtures/index.ts
+++ b/web/e2e/fixtures/index.ts
@@ -2,3 +2,4 @@ export * from "./auth";
 export * from "./constants";
 export * from "./mocks";
 export * from "./seed";
+export * from "../pages/PartDetailPage";

--- a/web/e2e/fixtures/seed.ts
+++ b/web/e2e/fixtures/seed.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
 import { expect, type APIRequestContext } from "@playwright/test";
 
 const BASE_URL = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:5173";
@@ -24,6 +26,9 @@ export type SeedPartPayload = {
   default_storage_location_id?: string | null;
   default_storage_mandatory?: boolean;
   serialized?: boolean;
+  archived?: boolean;
+  initial_qty?: number;
+  storage_location_id?: string | null;
 };
 
 export type SeedStoragePayload = {
@@ -70,8 +75,14 @@ export type SeedBomLinePayload = {
 };
 
 export type SeedScanImportPayload = {
-  rows: Array<Record<string, unknown>>;
-  idempotency_key?: string | null;
+  bag_code: string;
+  qty?: number;
+  storage_location_id?: string | null;
+  part_id?: string;
+  part?: SeedPartPayload;
+  mpn?: string;
+  bag_signature?: string;
+  raw_bag_code?: string | null;
 };
 
 export type SeededPart = { id: string; name: string; [key: string]: unknown };
@@ -82,6 +93,27 @@ export type SeededStockEntry = {
   quantity_delta: number;
   [key: string]: unknown;
 };
+
+type BagSignatureFixture = {
+  bags: Array<{
+    expected_signature: string;
+    expected_mpn?: string;
+    expected_quantity?: number;
+    raws: string[];
+  }>;
+};
+
+const bagSignatureFixture = JSON.parse(
+  readFileSync(new URL("../../src/lib/__fixtures__/bagSignatures.json", import.meta.url), "utf8"),
+) as BagSignatureFixture;
+
+function randomSuffix(): string {
+  return randomUUID().slice(0, 8);
+}
+
+function fixtureForRawBag(rawBagCode: string) {
+  return bagSignatureFixture.bags.find((bag) => bag.raws.includes(rawBagCode));
+}
 
 function sameOriginHeaders() {
   return {
@@ -114,11 +146,41 @@ export async function seedPart(
   authedRequest: APIRequestContext,
   payload: SeedPartPayload = {},
 ): Promise<SeededPart> {
-  return postJson<SeededPart>(authedRequest, "/api/parts", {
-    name: "E2E Seed Part",
+  const {
+    archived = false,
+    initial_qty,
+    storage_location_id,
+    ...partPayload
+  } = payload;
+  const part = await postJson<SeededPart>(authedRequest, "/api/parts", {
+    name: `E2E Seed Part ${randomSuffix()}`,
     part_type: "local",
-    ...payload,
+    ...partPayload,
   });
+
+  if (initial_qty !== undefined) {
+    if (initial_qty <= 0) {
+      throw new Error("seedPart initial_qty must be greater than zero when provided.");
+    }
+    if (!storage_location_id) {
+      throw new Error("seedPart initial_qty requires storage_location_id.");
+    }
+    await seedStock(authedRequest, {
+      part_id: part.id,
+      quantity: initial_qty,
+      storage_location_id,
+    });
+  }
+
+  if (archived) {
+    await postJson<{
+      archived_ids: string[];
+      already_archived_ids: string[];
+      not_found_ids: string[];
+    }>(authedRequest, "/api/parts/bulk-delete", { part_ids: [part.id] });
+  }
+
+  return part;
 }
 
 export async function seedStorage(
@@ -126,7 +188,7 @@ export async function seedStorage(
   payload: SeedStoragePayload = {},
 ): Promise<SeededStorage> {
   return postJson<SeededStorage>(authedRequest, "/api/storage", {
-    name: "E2E Seed Bin",
+    name: `E2E Seed Bin ${randomSuffix()}`,
     ...payload,
   });
 }
@@ -158,10 +220,26 @@ export async function seedBomLine(
 }
 
 export async function seedScanImport(
-  _authedRequest: APIRequestContext,
-  _payload: SeedScanImportPayload,
-): Promise<never> {
-  throw new Error(
-    "seedScanImport is reserved for E2E-5 and is intentionally not implemented in E2E-1.",
-  );
+  authedRequest: APIRequestContext,
+  payload: SeedScanImportPayload,
+): Promise<SeededStockEntry> {
+  const fixture = fixtureForRawBag(payload.bag_code);
+  const bagSignature = payload.bag_signature ?? fixture?.expected_signature;
+  if (!bagSignature) {
+    throw new Error("seedScanImport requires bag_signature or a bag_code from bagSignatures.json.");
+  }
+
+  const partId = payload.part_id ?? (await seedPart(authedRequest, {
+    name: `E2E Bag Part ${randomSuffix()}`,
+    mpn: payload.mpn ?? fixture?.expected_mpn ?? `E2E-BAG-${randomSuffix()}`,
+    ...payload.part,
+  })).id;
+
+  return seedStock(authedRequest, {
+    part_id: partId,
+    quantity: payload.qty ?? fixture?.expected_quantity ?? 1,
+    storage_location_id: payload.storage_location_id ?? null,
+    bag_signature: bagSignature,
+    raw_bag_code: payload.raw_bag_code === undefined ? payload.bag_code : payload.raw_bag_code,
+  });
 }

--- a/web/e2e/pages/PartDetailPage.ts
+++ b/web/e2e/pages/PartDetailPage.ts
@@ -1,0 +1,78 @@
+import type { AuthedPage } from "../fixtures";
+
+type Page = AuthedPage["page"];
+type Locator = ReturnType<Page["locator"]>;
+
+export type PartTab =
+  | "info"
+  | "specs"
+  | "stock"
+  | "add"
+  | "move"
+  | "remove"
+  | "history"
+  | "settings";
+
+export type PartTabLabel =
+  | "Part info"
+  | "Specs"
+  | "Stock"
+  | "Add stock"
+  | "Move stock"
+  | "Remove stock"
+  | "History"
+  | "Settings";
+
+export class PartDetailPage {
+  constructor(readonly page: Page, readonly partId: string) {}
+
+  async goto(tab: PartTab = "info"): Promise<void> {
+    await this.page.goto(`/parts/${this.partId}/${tab}`);
+  }
+
+  async openTab(label: PartTabLabel): Promise<void> {
+    await this.page.getByRole("link", { name: label, exact: true }).click();
+  }
+
+  async addStock(qty: number, storageName?: string): Promise<void> {
+    await this.openTab("Add stock");
+    await this.page.getByLabel(/quantity/i).fill(String(qty));
+    if (storageName) {
+      await this.page.getByLabel(/storage/i).selectOption({ label: storageName });
+    }
+    await this.page.getByRole("button", { name: /^add$/i }).click();
+  }
+
+  async moveStock(qty: number, fromStorageName: string, toStorageName: string): Promise<void> {
+    await this.openTab("Move stock");
+    const sourceSelect = this.page.locator("#move-stock-from");
+    const sourceValue = await sourceSelect
+      .locator("option", { hasText: fromStorageName })
+      .first()
+      .getAttribute("value");
+    await sourceSelect.selectOption(sourceValue ?? "");
+    await this.page.getByLabel(/to storage/i).selectOption({ label: toStorageName });
+    await this.page.getByLabel(/quantity/i).fill(String(qty));
+    await this.page.getByRole("button", { name: /^move$/i }).click();
+  }
+
+  get onHandValue(): Locator {
+    return this.page.getByTestId("part-stock-on-hand");
+  }
+
+  get historyRows(): Locator {
+    return this.page.locator("table tbody tr");
+  }
+
+  get stockRows(): Locator {
+    return this.page.locator("table tbody tr");
+  }
+
+  get header(): Locator {
+    return this.page.locator(".card").first();
+  }
+
+  subNav(label: PartTabLabel): Locator {
+    return this.page.getByRole("link", { name: label, exact: true });
+  }
+}

--- a/web/e2e/parts.spec.ts
+++ b/web/e2e/parts.spec.ts
@@ -36,7 +36,8 @@ async function createLocalPart(page: Page, name: string, mpn?: string): Promise<
 }
 
 async function signupNewWorkspace(page: Page): Promise<SignupEnvelope["data"]> {
-  await page.request.post("/api/auth/logout");
+  await page.context().clearCookies();
+  await page.goto("/login");
   await page.evaluate(() => {
     localStorage.clear();
     sessionStorage.clear();

--- a/web/e2e/parts.spec.ts
+++ b/web/e2e/parts.spec.ts
@@ -1,0 +1,262 @@
+import { randomUUID } from "node:crypto";
+
+import {
+  DEFAULT_PASSWORD,
+  EMAIL_DOMAIN,
+  expect,
+  PartDetailPage,
+  seedPart,
+  seedStorage,
+  test,
+  type AuthedPage,
+} from "./fixtures";
+
+type Page = AuthedPage["page"];
+
+type SignupEnvelope = {
+  data: {
+    user: { id: string; email: string; name: string };
+    workspace_id: string;
+  };
+  status: { category: string; message: string };
+};
+
+function uniqueName(prefix: string): string {
+  return `${prefix} ${randomUUID().slice(0, 8)}`;
+}
+
+async function createLocalPart(page: Page, name: string, mpn?: string): Promise<void> {
+  await page.goto("/parts/create");
+  await page.getByLabel(/^type$/i).selectOption("local");
+  await page.getByLabel(/^name$/i).fill(name);
+  if (mpn) {
+    await page.getByLabel(/mpn/i).fill(mpn);
+  }
+  await page.getByRole("button", { name: /^create$/i }).click();
+}
+
+async function signupNewWorkspace(page: Page): Promise<SignupEnvelope["data"]> {
+  await page.request.post("/api/auth/logout");
+  await page.evaluate(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+  const email = `e2e-cross-${randomUUID().slice(0, 10)}@${EMAIL_DOMAIN}`;
+  const response = await page.request.post("/api/auth/signup", {
+    data: {
+      email,
+      name: "e2e cross workspace",
+      password: DEFAULT_PASSWORD,
+    },
+  });
+  expect(response.ok()).toBe(true);
+  const envelope = (await response.json()) as SignupEnvelope;
+  expect(envelope).toHaveProperty("data");
+  expect(envelope).toHaveProperty("status");
+  return envelope.data;
+}
+
+test(
+  'empty parts list shows "+ Part" CTA on fresh workspace',
+  { tag: ["@core"] },
+  async ({ authedPage }) => {
+    const { page } = authedPage;
+    await page.goto("/parts");
+
+    await expect(page.getByText("No parts yet")).toBeVisible();
+    const emptyStateCell = page.locator("td", { hasText: "No parts yet" });
+    const emptyStateCta = emptyStateCell.getByRole("link", { name: /\+ part/i });
+    await expect(emptyStateCta).toHaveCount(1);
+    await expect(emptyStateCta).toBeVisible();
+    await expect(emptyStateCta).toHaveAttribute("href", "/parts/create");
+  },
+);
+
+test(
+  '"+ Part" link routes to /parts/create and renders form',
+  { tag: ["@core"] },
+  async ({ authedPage }) => {
+    const { page } = authedPage;
+    await page.goto("/parts");
+
+    const emptyStateCell = page.locator("td", { hasText: "No parts yet" });
+    await emptyStateCell.getByRole("link", { name: /\+ part/i }).click();
+
+    await page.waitForURL(/\/parts\/create$/);
+    await expect(page.getByLabel(/^name$/i)).toBeVisible();
+    await expect(page.getByLabel(/mpn/i)).toBeVisible();
+    await expect(page.getByRole("button", { name: /^create$/i })).toBeEnabled();
+  },
+);
+
+test(
+  "created part appears in list with on_hand=0",
+  { tag: ["@core"] },
+  async ({ authedPage }) => {
+    const { page } = authedPage;
+    const name = uniqueName("E2E Part List");
+
+    await createLocalPart(page, name);
+    await page.waitForURL(/\/parts\/[0-9a-f-]+\/info$/);
+    await page.goto("/parts");
+
+    const row = page.getByRole("row").filter({ hasText: name });
+    await expect(row).toBeVisible();
+    await expect(row.locator("td").last()).toHaveText("0");
+  },
+);
+
+test(
+  "row click navigates to /info tab",
+  { tag: ["@core"] },
+  async ({ authedPage }) => {
+    const { page, request } = authedPage;
+    const name = uniqueName("E2E Row Click");
+    await seedPart(request, { name });
+
+    await page.goto("/parts");
+    const row = page.getByRole("row").filter({ hasText: name });
+    await row.getByText(name).click();
+
+    await page.waitForURL(/\/parts\/[0-9a-f-]+\/info$/);
+    await expect(page.getByText(name).first()).toBeVisible();
+    await expect(page.getByRole("link", { name: "Part info", exact: true })).toHaveClass(/bg-panel/);
+  },
+);
+
+test(
+  'name-only (no MPN) creates a "local" part',
+  { tag: ["@core"] },
+  async ({ authedPage }) => {
+    const { page } = authedPage;
+    const name = uniqueName("E2E Local Only");
+
+    await createLocalPart(page, name);
+
+    await page.waitForURL(/\/parts\/[0-9a-f-]+\/info$/);
+    await expect(page.getByText(name).first()).toBeVisible();
+    await expect(page.locator(".pill").filter({ hasText: "local" })).toBeVisible();
+  },
+);
+
+test(
+  "MPN collision returns 409 and renders mpn-conflict-banner with link to existing part",
+  { tag: ["@core"] },
+  async ({ authedPage }) => {
+    const { page, request } = authedPage;
+    const originalName = uniqueName("Original Part");
+    const original = await seedPart(request, {
+      name: originalName,
+      mpn: "STM32F103C8T6",
+    });
+
+    await page.goto("/parts/create");
+    await page.getByLabel(/^name$/i).fill("Dupe Attempt");
+    await page.getByLabel(/mpn/i).fill("STM32F103C8T6");
+    await page.getByRole("button", { name: /^create$/i }).click();
+
+    const banner = page.getByTestId("mpn-conflict-banner");
+    await expect(banner).toBeVisible();
+    await expect(banner).toContainText(originalName);
+    await expect(banner.getByRole("link", { name: /open existing part/i }))
+      .toHaveAttribute("href", `/parts/${original.id}/info`);
+    await expect(page).toHaveURL(/\/parts\/create$/);
+  },
+);
+
+test(
+  "archived part's MPN is reusable — no conflict banner",
+  { tag: ["@core"] },
+  async ({ authedPage }) => {
+    const { page, request } = authedPage;
+    await seedPart(request, {
+      name: uniqueName("Archived One"),
+      mpn: "STM32F103C8T6",
+      archived: true,
+    });
+
+    await page.goto("/parts/create");
+    await page.getByLabel(/^name$/i).fill("Reused MPN");
+    await page.getByLabel(/mpn/i).fill("STM32F103C8T6");
+    await page.getByRole("button", { name: /^create$/i }).click();
+
+    await page.waitForURL(/\/parts\/[0-9a-f-]+\/info$/);
+    await expect(page.getByTestId("mpn-conflict-banner")).toHaveCount(0);
+    await expect(page.getByText("Reused MPN").first()).toBeVisible();
+  },
+);
+
+test(
+  "cross-workspace navigation returns 404 / redirects",
+  { tag: ["@core"] },
+  async ({ authedPage }) => {
+    const { page, request } = authedPage;
+    const name = uniqueName("E2E Workspace A Part");
+    const partA = await seedPart(request, { name });
+
+    await signupNewWorkspace(page);
+    await page.goto(`/parts/${partA.id}/info`);
+
+    const notFound = page.getByText("Failed to load part. Not found.");
+    const emptyParts = page.getByText("No parts yet");
+    await expect(notFound.or(emptyParts)).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText(name)).toHaveCount(0);
+  },
+);
+
+test(
+  "tab nav (info → specs → stock → history) does not full-reload",
+  { tag: ["@core"] },
+  async ({ authedPage }) => {
+    const { page, request } = authedPage;
+    const storage = await seedStorage(request, { name: uniqueName("E2E Tab Bin") });
+    const part = await seedPart(request, {
+      name: uniqueName("E2E Tab Part"),
+      initial_qty: 5,
+      storage_location_id: storage.id,
+    });
+    const detail = new PartDetailPage(page, part.id);
+
+    await detail.goto("info");
+    const navigationStart = await page.evaluate(() => performance.timing.navigationStart);
+
+    await detail.openTab("Specs");
+    await expect(page).toHaveURL(new RegExp(`/parts/${part.id}/specs$`));
+    expect(await page.evaluate(() => performance.timing.navigationStart)).toBe(navigationStart);
+
+    await detail.openTab("Stock");
+    await expect(page).toHaveURL(new RegExp(`/parts/${part.id}/stock$`));
+    expect(await page.evaluate(() => performance.timing.navigationStart)).toBe(navigationStart);
+    await expect(detail.onHandValue).toHaveText("5");
+
+    await detail.openTab("History");
+    await expect(page).toHaveURL(new RegExp(`/parts/${part.id}/history$`));
+    expect(await page.evaluate(() => performance.timing.navigationStart)).toBe(navigationStart);
+  },
+);
+
+test(
+  "Settings save round-trips low_stock_report_quantity",
+  { tag: ["@core"] },
+  async ({ authedPage }) => {
+    const { page, request } = authedPage;
+    const part = await seedPart(request, { name: uniqueName("E2E Threshold Part") });
+    const detail = new PartDetailPage(page, part.id);
+
+    await detail.goto("settings");
+    await page.getByLabel(/low[- ]stock/i).fill("7");
+    const saved = page.waitForResponse((response) =>
+      response.url().includes(`/api/parts/${part.id}`) &&
+      response.request().method() === "PATCH" &&
+      response.ok()
+    );
+    await page.getByRole("button", { name: /^save$/i }).click();
+    await saved;
+
+    await page.goto("/parts");
+    await detail.goto("info");
+    const threshold = page.getByText("Threshold", { exact: true });
+    await expect(threshold).toBeVisible();
+    await expect(threshold.locator("xpath=..").getByText("7", { exact: true })).toBeVisible();
+  },
+);

--- a/web/e2e/settings.spec.ts
+++ b/web/e2e/settings.spec.ts
@@ -7,12 +7,12 @@ test(
     const { page } = authedPage;
 
     await page.goto("/settings/account");
-    await expect(page.getByRole("heading", { name: "Account", level: 1 })).toBeVisible({
+    await expect(page.getByRole("main").getByRole("heading", { name: "Account", level: 1 })).toBeVisible({
       timeout: 5_000,
     });
 
     await page.goto("/settings/workspace");
-    await expect(page.getByRole("heading", { name: "Workspace", level: 1 })).toBeVisible({
+    await expect(page.getByRole("main").getByRole("heading", { name: "Workspace", level: 1 })).toBeVisible({
       timeout: 5_000,
     });
   },

--- a/web/e2e/stock.spec.ts
+++ b/web/e2e/stock.spec.ts
@@ -325,9 +325,6 @@ test.describe("stock history ordering", () => {
       const detail = new PartDetailPage(page, part.id);
 
       for (const quantity of [1, 2, 3]) {
-        if (quantity > 1) {
-          await page.waitForTimeout(5); // FIXME-allowed: #688 needs distinct ledger timestamps for ordering.
-        }
         await seedStock(request, {
           part_id: part.id,
           quantity,

--- a/web/e2e/stock.spec.ts
+++ b/web/e2e/stock.spec.ts
@@ -1,0 +1,346 @@
+import { randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
+
+import {
+  expect,
+  PartDetailPage,
+  seedPart,
+  seedScanImport,
+  seedStock,
+  seedStorage,
+  test,
+  type AuthedPage,
+  type E2ERequest,
+} from "./fixtures";
+
+type Page = AuthedPage["page"];
+
+type Envelope<T> = {
+  data: T;
+  status: { category: string; message: string };
+};
+
+type Part = {
+  id: string;
+  name: string;
+  mpn: string | null;
+};
+
+type PartStock = {
+  total_on_hand: number;
+  rows: Array<{
+    storage_location_id: string | null;
+    lot_id: string | null;
+    quantity: number;
+  }>;
+};
+
+type StockEntry = {
+  id: string;
+  part_id: string | null;
+  storage_location_id: string | null;
+  quantity_delta: number;
+  operation_type: string;
+  occurred_at: string;
+};
+
+type BagSignatureFixture = {
+  bags: Array<{
+    expected_signature: string;
+    expected_mpn?: string;
+    expected_quantity?: number;
+    raws: string[];
+  }>;
+};
+
+const bagFixture = JSON.parse(
+  readFileSync(new URL("../src/lib/__fixtures__/bagSignatures.json", import.meta.url), "utf8"),
+) as BagSignatureFixture;
+
+function uniqueName(prefix: string): string {
+  return `${prefix} ${randomUUID().slice(0, 8)}`;
+}
+
+async function apiGet<T>(request: E2ERequest, path: string): Promise<T> {
+  const response = await request.get(path);
+  expect(response.ok()).toBe(true);
+  const envelope = (await response.json()) as Envelope<T>;
+  expect(envelope).toHaveProperty("data");
+  expect(envelope).toHaveProperty("status");
+  return envelope.data;
+}
+
+async function stockHistory(request: E2ERequest, partId: string): Promise<StockEntry[]> {
+  const rows = await apiGet<StockEntry[]>(request, "/api/stock/history?limit=1000");
+  return rows.filter((row) => row.part_id === partId);
+}
+
+async function partStock(request: E2ERequest, partId: string): Promise<PartStock> {
+  return apiGet<PartStock>(request, `/api/parts/${partId}/stock`);
+}
+
+async function partsByMpn(request: E2ERequest, mpn: string): Promise<Part[]> {
+  return apiGet<Part[]>(request, `/api/parts?mpn=${encodeURIComponent(mpn)}`);
+}
+
+async function mockNextZxingScan(page: Page, rawBagCode: string): Promise<void> {
+  await page.route(/.*zxing-wasm_reader.*\.js.*/, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/javascript",
+      body: `
+let delivered = false;
+export async function prepareZXingModule() {}
+export async function readBarcodes() {
+  if (delivered) return [];
+  const text = globalThis.__E2E_SCAN_CODE;
+  if (!text) return [];
+  delivered = true;
+  return [{ text, format: "DataMatrix" }];
+}
+`,
+    });
+  });
+
+  await page.addInitScript((code: string) => {
+    (globalThis as typeof globalThis & { __E2E_SCAN_CODE?: string }).__E2E_SCAN_CODE = code;
+    Object.defineProperty(navigator, "mediaDevices", {
+      configurable: true,
+      value: {
+        getUserMedia: async () => {
+          const canvas = document.createElement("canvas");
+          canvas.width = 640;
+          canvas.height = 480;
+          const context = canvas.getContext("2d");
+          context?.fillRect(0, 0, canvas.width, canvas.height);
+          const stream = canvas.captureStream(1);
+          const track = stream.getVideoTracks()[0] as MediaStreamTrack & {
+            getCapabilities?: () => MediaTrackCapabilities;
+            getSettings?: () => MediaTrackSettings;
+            applyConstraints?: () => Promise<void>;
+          };
+          track.getCapabilities = () => ({});
+          track.getSettings = () => ({});
+          track.applyConstraints = async () => {};
+          return stream;
+        },
+        enumerateDevices: async () => [],
+      },
+    });
+  }, rawBagCode);
+}
+
+function fixtureBagWithMpn(index = 0) {
+  const bag = bagFixture.bags[index];
+  if (!bag?.expected_mpn) {
+    throw new Error("Expected bagSignatures.json fixture entry with expected_mpn.");
+  }
+  return { raw: bag.raws[0], mpn: bag.expected_mpn };
+}
+
+test(
+  "add stock writes ledger row and bumps on_hand",
+  { tag: ["@core"] },
+  async ({ authedPage }) => {
+    const { page, request } = authedPage;
+    const storage = await seedStorage(request, { name: uniqueName("A") });
+    const part = await seedPart(request, { name: uniqueName("E2E Add Stock") });
+    const detail = new PartDetailPage(page, part.id);
+
+    await detail.goto("info");
+    await detail.addStock(10, storage.name);
+    await page.waitForURL(new RegExp(`/parts/${part.id}/stock$`));
+    await expect(detail.onHandValue).toHaveText("10");
+
+    await detail.openTab("History");
+    await expect(detail.historyRows).toHaveCount(1);
+    await expect(detail.historyRows.first()).toContainText("+10");
+    await expect(detail.historyRows.first()).toContainText(storage.name);
+  },
+);
+
+test(
+  "second add appends a row; on_hand is the sum",
+  { tag: ["@core"] },
+  async ({ authedPage }) => {
+    const { page, request } = authedPage;
+    const storage = await seedStorage(request, { name: uniqueName("A") });
+    const part = await seedPart(request, { name: uniqueName("E2E Add Twice") });
+    const detail = new PartDetailPage(page, part.id);
+
+    await detail.goto("info");
+    await detail.addStock(4, storage.name);
+    await page.waitForURL(new RegExp(`/parts/${part.id}/stock$`));
+    await detail.addStock(6, storage.name);
+    await page.waitForURL(new RegExp(`/parts/${part.id}/stock$`));
+
+    await expect(detail.onHandValue).toHaveText("10");
+    await detail.openTab("History");
+    await expect(detail.historyRows).toHaveCount(2);
+    await expect(detail.historyRows.filter({ hasText: "+4" })).toHaveCount(1);
+    await expect(detail.historyRows.filter({ hasText: "+6" })).toHaveCount(1);
+  },
+);
+
+test(
+  "zero / negative quantity is rejected by HTML5 min=1",
+  { tag: ["@core"] },
+  async ({ authedPage }) => {
+    const { page, request } = authedPage;
+    await seedStorage(request, { name: uniqueName("A") });
+    const part = await seedPart(request, { name: uniqueName("E2E Invalid Qty") });
+    const detail = new PartDetailPage(page, part.id);
+
+    await detail.goto("add");
+    const form = page.locator("form");
+    await page.getByLabel(/quantity/i).fill("0");
+    await page.getByRole("button", { name: /^add$/i }).click();
+    expect(await form.evaluate((node) => (node as HTMLFormElement).checkValidity())).toBe(false);
+    await expect(page).toHaveURL(new RegExp(`/parts/${part.id}/add$`));
+
+    await page.getByLabel(/quantity/i).fill("-3");
+    await page.getByRole("button", { name: /^add$/i }).click();
+    expect(await form.evaluate((node) => (node as HTMLFormElement).checkValidity())).toBe(false);
+    await expect(page).toHaveURL(new RegExp(`/parts/${part.id}/add$`));
+
+    await detail.openTab("Stock");
+    await expect(detail.onHandValue).toHaveText("0");
+  },
+);
+
+test(
+  "move between locations writes a +/- ledger pair",
+  { tag: ["@core"] },
+  async ({ authedPage }) => {
+    const { page, request } = authedPage;
+    const source = await seedStorage(request, { name: uniqueName("A") });
+    const destination = await seedStorage(request, { name: uniqueName("B") });
+    const part = await seedPart(request, { name: uniqueName("E2E Move Stock") });
+    await seedStock(request, {
+      part_id: part.id,
+      quantity: 5,
+      storage_location_id: source.id,
+    });
+    const detail = new PartDetailPage(page, part.id);
+
+    await detail.goto("info");
+    await detail.moveStock(3, source.name, destination.name);
+    await page.waitForURL(new RegExp(`/parts/${part.id}/stock$`));
+    await expect(detail.onHandValue).toHaveText("5");
+
+    await detail.openTab("History");
+    await expect(detail.historyRows).toHaveCount(3);
+    await expect(detail.historyRows.filter({ hasText: "-3" }).filter({ hasText: source.name })).toHaveCount(1);
+    await expect(detail.historyRows.filter({ hasText: "+3" }).filter({ hasText: destination.name })).toHaveCount(1);
+  },
+);
+
+test(
+  "From-location dropdown is empty when no on-hand stock",
+  { tag: ["@core"] },
+  async ({ authedPage }) => {
+    const { page, request } = authedPage;
+    await seedStorage(request, { name: uniqueName("A") });
+    const part = await seedPart(request, { name: uniqueName("E2E Empty Move") });
+    const detail = new PartDetailPage(page, part.id);
+
+    await detail.goto("move");
+
+    await expect(page.getByText("Nothing on hand for this part.")).toBeVisible();
+    await expect(page.locator("#move-stock-from")).toHaveCount(0);
+  },
+);
+
+test(
+  'bag rescan shows "Found bag" UI, does not create a new part',
+  { tag: ["@core"] },
+  async ({ authedPage }) => {
+    const { page, request } = authedPage;
+    const bag = fixtureBagWithMpn();
+    const part = await seedPart(request, {
+      name: uniqueName("E2E Bag Rescan"),
+      mpn: bag.mpn,
+    });
+    await seedScanImport(request, {
+      part_id: part.id,
+      bag_code: bag.raw,
+      qty: 5,
+    });
+    await mockNextZxingScan(page, bag.raw);
+
+    await page.goto("/parts/scan-import");
+
+    const rescanRow = page.getByTestId("scan-row-bag-rescan");
+    await expect(rescanRow).toBeVisible({ timeout: 15_000 });
+    await expect(rescanRow).toContainText("Recognised");
+    await expect(rescanRow).toContainText("5");
+    await expect(rescanRow.getByRole("button", { name: /open part/i })).toBeVisible();
+    expect(await stockHistory(request, part.id)).toHaveLength(1);
+    expect(await partsByMpn(request, bag.mpn)).toHaveLength(1);
+  },
+);
+
+test(
+  "quick-remove from rescanned bag decrements the existing entry",
+  { tag: ["@core"] },
+  async ({ authedPage }) => {
+    const { page, request } = authedPage;
+    const bag = fixtureBagWithMpn();
+    const part = await seedPart(request, {
+      name: uniqueName("E2E Bag Quick Remove"),
+      mpn: bag.mpn,
+    });
+    await seedScanImport(request, {
+      part_id: part.id,
+      bag_code: bag.raw,
+      qty: 5,
+    });
+    await mockNextZxingScan(page, bag.raw);
+
+    await page.goto("/parts/scan-import");
+
+    const rescanRow = page.getByTestId("scan-row-bag-rescan");
+    await expect(rescanRow).toBeVisible({ timeout: 15_000 });
+    await rescanRow.getByRole("spinbutton").fill("5");
+    await rescanRow.getByRole("button", { name: /^remove 5$/i }).click();
+
+    await expect(page.getByText("Removed 5 from this bag.").first()).toBeVisible({ timeout: 10_000 });
+    await expect.poll(async () => (await partStock(request, part.id)).total_on_hand).toBe(0);
+    const rows = await stockHistory(request, part.id);
+    expect(rows).toHaveLength(2);
+    expect(rows.map((row) => row.quantity_delta).sort((a, b) => a - b)).toEqual([-5, 5]);
+  },
+);
+
+test.describe("stock history ordering", () => {
+  test.describe.configure({ mode: "serial" });
+
+  test(
+    "stock history per-part filter renders rows in newest-first order",
+    { tag: ["@core"] },
+    async ({ authedPage }) => {
+      const { page, request } = authedPage;
+      const storage = await seedStorage(request, { name: uniqueName("A") });
+      const part = await seedPart(request, { name: uniqueName("E2E History Order") });
+      const detail = new PartDetailPage(page, part.id);
+
+      for (const quantity of [1, 2, 3]) {
+        if (quantity > 1) {
+          await page.waitForTimeout(5); // FIXME-allowed: #688 needs distinct ledger timestamps for ordering.
+        }
+        await seedStock(request, {
+          part_id: part.id,
+          quantity,
+          storage_location_id: storage.id,
+        });
+      }
+
+      await detail.goto("history");
+
+      await expect(detail.historyRows).toHaveCount(3);
+      await expect(detail.historyRows.nth(0)).toContainText("+3");
+      await expect(detail.historyRows.nth(1)).toContainText("+2");
+      await expect(detail.historyRows.nth(2)).toContainText("+1");
+    },
+  );
+});

--- a/web/src/routes/parts/PartCreate.tsx
+++ b/web/src/routes/parts/PartCreate.tsx
@@ -175,7 +175,7 @@ export default function PartCreate() {
         </div>
       )}
       {conflict && (
-        <div className="rounded-md border border-warning/40 bg-warning/10 p-3 text-sm">
+        <div data-testid="mpn-conflict-banner" className="rounded-md border border-warning/40 bg-warning/10 p-3 text-sm">
           MPN <span className="font-mono">{form.mpn}</span> is already used
           by part <strong>{conflict.name}</strong>.{" "}
           <Link to={`/parts/${conflict.id}/info`} className="text-accent underline">

--- a/web/src/routes/parts/ScanImport/ScanImportQueue.tsx
+++ b/web/src/routes/parts/ScanImport/ScanImportQueue.tsx
@@ -258,7 +258,7 @@ function ScanCard({
   onQuickRemove: (qty: number) => void;
 }) {
   return (
-    <div className="rounded-md border border-border bg-panel2/40 p-3">
+    <div data-testid={row.state.kind === "bag_rescan" ? "scan-row-bag-rescan" : undefined} className="rounded-md border border-border bg-panel2/40 p-3">
       <div className="flex items-start justify-between gap-2">
         <div className="font-mono text-sm">{row.bag.mpn}</div>
         <button

--- a/web/src/routes/parts/detail/PartStock.tsx
+++ b/web/src/routes/parts/detail/PartStock.tsx
@@ -24,7 +24,7 @@ export default function PartStock() {
     <div>
       <div className="card p-4 mb-4">
         <div className="text-sm text-muted">Total on hand</div>
-        <div className="text-2xl font-semibold tabular-nums">{data.total_on_hand}</div>
+        <div data-testid="part-stock-on-hand" className="text-2xl font-semibold tabular-nums">{data.total_on_hand}</div>
       </div>
       <div className="card overflow-hidden">
         <table className="table">


### PR DESCRIPTION
## Summary

- Adds 18 structured `@core` Playwright tests: 10 in `web/e2e/parts.spec.ts` and 8 in `web/e2e/stock.spec.ts`.
- Adds `PartDetailPage` for part-detail navigation, stock actions, and shared locators with assertions kept in specs.
- Extends E2E seed helpers for #688: archived parts via `/api/parts/bulk-delete`, initial stock, storage defaults, and scan-import seeding through public stock APIs using `bagSignatures.json`.
- Adds only the three approved FE testids.

## Tests

- `npm run typecheck` passed.
- `npx playwright test parts.spec.ts stock.spec.ts --project=core --list --reporter=list` passed and listed 18 tests.
- `rg -n "waitForTimeout" web/e2e -g '*.spec.ts'` returned no matches.
- `grep -c "expect(" web/e2e/pages/PartDetailPage.ts` outputs `0`.
- `grep -L "@core" web/e2e/parts.spec.ts web/e2e/stock.spec.ts` outputs nothing.
- `git diff --stat origin/main -- backend/` outputs nothing.
- Docker is unavailable in this environment (`docker: command not found`), so the live core spec and smoke tier were not run against `make dev-up` here.

## Testid Justifications

- `mpn-conflict-banner`: the 409 conflict banner is a styled div with no accessible role or label, and the invariant needs a stable selector.
- `part-stock-on-hand`: the total on-hand number collides with other numeric table values on the stock surface.
- `scan-row-bag-rescan`: rescan rows need an unambiguous row wrapper so quick-remove targets the correct scan state.

## Notes

- Merge order: after #694; before #689 and before any #690 changes that touch seed.ts.
- The current `origin/main` scan-import UI is camera-only, with no paste/add control. The bag-rescan E2Es drive the existing scan path with a mocked ZXing module and fixture raw bag code, while keeping FE source edits limited to the approved testid.

Refs #688
Refs #685