### PR TITLE
E2E-5: Projects + BOM sourcing (mocked providers) — Playwright coverage

### DIFF
--- a/web/e2e/fixtures/mocks.ts
+++ b/web/e2e/fixtures/mocks.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import type { Page, Route } from "@playwright/test";
 
 type Envelope<T> = {
@@ -11,13 +12,12 @@ const SOURCING_REFRESH_ROUTES = [
   "**/api/parts/**/sourcing/refresh",
 ] as const;
 const PROJECT_SOURCING_ROUTE = "**/api/projects/**/sourcing";
+const PROJECT_PURCHASE_PLAN_ROUTE = "**/api/projects/**/purchase-plan";
+const PURCHASE_PLAN_ORDERS_ROUTE = "**/api/sourcing/purchase-plans/**/orders";
 
-function okEnvelope<T>(data: T): Envelope<T> {
-  return {
-    data,
-    status: { category: "ok", message: "OK" },
-  };
-}
+type MockSourcingOptions = {
+  refreshResponse?: "success" | "stale";
+};
 
 async function fulfillJson(route: Route, payload: unknown) {
   await route.fulfill({
@@ -27,21 +27,85 @@ async function fulfillJson(route: Route, payload: unknown) {
   });
 }
 
+function fixture<T>(fileName: string): T {
+  return JSON.parse(
+    readFileSync(new URL(`./responses/${fileName}`, import.meta.url), "utf8"),
+  ) as T;
+}
+
+function runtimeIso(offsetMs = 0): string {
+  return new Date(Date.now() + offsetMs).toISOString();
+}
+
+function withRuntimeFields<T>(payload: T, route?: Route): T {
+  const copy = structuredClone(payload) as T & {
+    data?: {
+      id?: string;
+      project_id?: string;
+      created_at?: string;
+      expires_at?: string;
+      last_refreshed_at?: string | null;
+      fetched_at?: string;
+    };
+  };
+  if (!copy.data) return copy;
+
+  const now = runtimeIso();
+  if ("fetched_at" in copy.data) {
+    copy.data.fetched_at = now;
+  }
+  if ("created_at" in copy.data) {
+    copy.data.created_at = now;
+  }
+  if ("last_refreshed_at" in copy.data) {
+    copy.data.last_refreshed_at = now;
+  }
+  if ("expires_at" in copy.data) {
+    copy.data.expires_at = runtimeIso(7 * 24 * 60 * 60 * 1000);
+  }
+  if (route && "project_id" in copy.data) {
+    const match = route.request().url().match(/\/api\/projects\/([^/]+)\//);
+    if (match) copy.data.project_id = match[1];
+  }
+  return copy;
+}
+
 export async function mockMpnLookup(page: Page, fixture: Envelope<unknown>) {
   await page.route(MPN_LOOKUP_ROUTE, async (route) => {
     await fulfillJson(route, fixture);
   });
 }
 
-export async function mockSourcingProviders(page: Page, { offers }: { offers: unknown }) {
-  const payload = okEnvelope(offers);
+export async function mockSourcingProviders(page: Page, options: MockSourcingOptions = {}) {
+  const sourcingPayload = fixture<Envelope<unknown>>("sourcing.bom.json");
+  const purchasePlanPayload = fixture<Envelope<unknown>>("sourcing.purchase-plan.json");
+  const refreshPayload = fixture<Envelope<unknown>>("sourcing.refresh.json");
+  const ordersPayload = fixture<Envelope<unknown>>("sourcing.orders.json");
+
   for (const pattern of SOURCING_REFRESH_ROUTES) {
     await page.route(pattern, async (route) => {
-      await fulfillJson(route, payload);
+      if (options.refreshResponse === "stale") {
+        await route.fulfill({
+          status: 409,
+          contentType: "application/json",
+          body: JSON.stringify({
+            code: "sourcing.plan_stale",
+            status: { category: "conflict", message: "Prices are stale." },
+          }),
+        });
+        return;
+      }
+      await fulfillJson(route, withRuntimeFields(refreshPayload, route));
     });
   }
   await page.route(PROJECT_SOURCING_ROUTE, async (route) => {
-    await fulfillJson(route, payload);
+    await fulfillJson(route, withRuntimeFields(sourcingPayload, route));
+  });
+  await page.route(PROJECT_PURCHASE_PLAN_ROUTE, async (route) => {
+    await fulfillJson(route, withRuntimeFields(purchasePlanPayload, route));
+  });
+  await page.route(PURCHASE_PLAN_ORDERS_ROUTE, async (route) => {
+    await fulfillJson(route, ordersPayload);
   });
 }
 
@@ -51,4 +115,6 @@ export async function clearProviderMocks(page: Page) {
     await page.unroute(pattern);
   }
   await page.unroute(PROJECT_SOURCING_ROUTE);
+  await page.unroute(PROJECT_PURCHASE_PLAN_ROUTE);
+  await page.unroute(PURCHASE_PLAN_ORDERS_ROUTE);
 }

--- a/web/e2e/fixtures/responses/README.md
+++ b/web/e2e/fixtures/responses/README.md
@@ -7,5 +7,9 @@ Canned provider payloads for Playwright route mocks.
 | File | Source fixture |
 |---|---|
 | `lookup-mpn-success.json` | Stubbed from the `MpnLookupResult` shape in `web/src/types.ts`; E2E-4/E2E-5 replace or extend this with provider-specific integration fixtures. |
+| `sourcing.bom.json` | Lifted from the fake TrustedParts offer shapes and asserted BOM response in `backend/tests/test_sourcing_bom_route.py`; provider URLs sanitized to `example.test`. |
+| `sourcing.purchase-plan.json` | Lifted from `backend/tests/test_purchase_plan_route.py` and `backend/tests/test_purchase_plan_convert_route.py` purchase-plan line/offer assertions; provider URLs sanitized to `example.test`. |
+| `sourcing.refresh.json` | Lifted from `backend/tests/test_purchase_plan_refresh_route.py`; keeps offer identity stable while mutating the second line price for refresh evidence. |
+| `sourcing.orders.json` | Lifted from the order response shape asserted in `backend/tests/test_purchase_plan_convert_route.py`. |
 
 Payloads include the API envelope (`{ data, status }`) because `web/src/lib/api.ts` unwraps `data` and treats malformed responses as failures.

--- a/web/e2e/fixtures/responses/sourcing.bom.json
+++ b/web/e2e/fixtures/responses/sourcing.bom.json
@@ -1,0 +1,210 @@
+{
+  "data": {
+    "rows": [
+      {
+        "project_entry_id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        "part_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        "part_name": "E2E Source MCU",
+        "mpn": "E2E-PLAN-A",
+        "required": 10,
+        "available": 0,
+        "substitute_ids": [],
+        "substitute_available": 0,
+        "short_by": 10,
+        "authorized_stock": 200,
+        "offers": [
+          {
+            "mpn": "E2E-PLAN-A",
+            "distributor": "DigiKey",
+            "sku": "E2E-PLAN-A-DK",
+            "stock": 100,
+            "unit_price": "1.00",
+            "currency": "EUR",
+            "packaging": "Cut tape",
+            "moq": 1,
+            "lead_time_days": 3,
+            "price_breaks": [{ "quantity": 1, "unit_price": "1.00", "currency": "EUR" }],
+            "url": "https://example.test/e2e/plan-a/digikey",
+            "availability_text": "In Stock",
+            "quantity_multiple": 1,
+            "lifecycle_risk": "Low",
+            "supply_chain_risk": "Stable",
+            "is_affected_by_tariff": false,
+            "rohs_compliance": [{ "region": "EU", "is_compliant": true, "description": "RoHS compliant" }]
+          },
+          {
+            "mpn": "E2E-PLAN-A",
+            "distributor": "Mouser",
+            "sku": "E2E-PLAN-A-MO",
+            "stock": 100,
+            "unit_price": "0.95",
+            "currency": "EUR",
+            "packaging": "Reel",
+            "moq": 10,
+            "lead_time_days": 5,
+            "price_breaks": [{ "quantity": 10, "unit_price": "0.95", "currency": "EUR" }],
+            "url": "https://example.test/e2e/plan-a/mouser",
+            "availability_text": "In Stock",
+            "quantity_multiple": 10,
+            "lifecycle_risk": "Low",
+            "supply_chain_risk": "Stable",
+            "is_affected_by_tariff": false,
+            "rohs_compliance": [{ "region": "EU", "is_compliant": true, "description": "RoHS compliant" }]
+          }
+        ],
+        "best_offer": {
+          "mpn": "E2E-PLAN-A",
+          "distributor": "Mouser",
+          "sku": "E2E-PLAN-A-MO",
+          "stock": 100,
+          "unit_price": "0.95",
+          "currency": "EUR",
+          "packaging": "Reel",
+          "moq": 10,
+          "lead_time_days": 5,
+          "price_breaks": [{ "quantity": 10, "unit_price": "0.95", "currency": "EUR" }],
+          "url": "https://example.test/e2e/plan-a/mouser",
+          "availability_text": "In Stock",
+          "quantity_multiple": 10,
+          "lifecycle_risk": "Low",
+          "supply_chain_risk": "Stable",
+          "is_affected_by_tariff": false,
+          "rohs_compliance": [{ "region": "EU", "is_compliant": true, "description": "RoHS compliant" }]
+        },
+        "est_extended_cost": "9.50",
+        "lead_time_days": 5,
+        "cache_hit": false,
+        "reason": "ok",
+        "fx_status": null,
+        "risk_flags": []
+      },
+      {
+        "project_entry_id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+        "part_id": "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+        "part_name": "E2E Source Regulator",
+        "mpn": "E2E-PLAN-B",
+        "required": 8,
+        "available": 0,
+        "substitute_ids": [],
+        "substitute_available": 0,
+        "short_by": 8,
+        "authorized_stock": 150,
+        "offers": [
+          {
+            "mpn": "E2E-PLAN-B",
+            "distributor": "DigiKey",
+            "sku": "E2E-PLAN-B-DK",
+            "stock": 80,
+            "unit_price": "2.00",
+            "currency": "EUR",
+            "packaging": "Cut tape",
+            "moq": 1,
+            "lead_time_days": 4,
+            "price_breaks": [{ "quantity": 1, "unit_price": "2.00", "currency": "EUR" }],
+            "url": "https://example.test/e2e/plan-b/digikey",
+            "availability_text": "In Stock",
+            "quantity_multiple": 1,
+            "lifecycle_risk": "Low",
+            "supply_chain_risk": "Stable",
+            "is_affected_by_tariff": false,
+            "rohs_compliance": [{ "region": "EU", "is_compliant": true, "description": "RoHS compliant" }]
+          },
+          {
+            "mpn": "E2E-PLAN-B",
+            "distributor": "Mouser",
+            "sku": "E2E-PLAN-B-MO",
+            "stock": 70,
+            "unit_price": "2.50",
+            "currency": "EUR",
+            "packaging": "Tray",
+            "moq": 1,
+            "lead_time_days": 6,
+            "price_breaks": [{ "quantity": 1, "unit_price": "2.50", "currency": "EUR" }],
+            "url": "https://example.test/e2e/plan-b/mouser",
+            "availability_text": "In Stock",
+            "quantity_multiple": 1,
+            "lifecycle_risk": "Low",
+            "supply_chain_risk": "Stable",
+            "is_affected_by_tariff": false,
+            "rohs_compliance": [{ "region": "EU", "is_compliant": true, "description": "RoHS compliant" }]
+          }
+        ],
+        "best_offer": {
+          "mpn": "E2E-PLAN-B",
+          "distributor": "DigiKey",
+          "sku": "E2E-PLAN-B-DK",
+          "stock": 80,
+          "unit_price": "2.00",
+          "currency": "EUR",
+          "packaging": "Cut tape",
+          "moq": 1,
+          "lead_time_days": 4,
+          "price_breaks": [{ "quantity": 1, "unit_price": "2.00", "currency": "EUR" }],
+          "url": "https://example.test/e2e/plan-b/digikey",
+          "availability_text": "In Stock",
+          "quantity_multiple": 1,
+          "lifecycle_risk": "Low",
+          "supply_chain_risk": "Stable",
+          "is_affected_by_tariff": false,
+          "rohs_compliance": [{ "region": "EU", "is_compliant": true, "description": "RoHS compliant" }]
+        },
+        "est_extended_cost": "16.00",
+        "lead_time_days": 4,
+        "cache_hit": false,
+        "reason": "ok",
+        "fx_status": null,
+        "risk_flags": []
+      }
+    ],
+    "coverage": {
+      "rows": [
+        {
+          "distributor": "DigiKey",
+          "lines_covered": 2,
+          "lines_uncovered": [],
+          "coverage_pct": 1,
+          "est_total_cost": "26.00",
+          "worst_lead_time_days": 4
+        },
+        {
+          "distributor": "Mouser",
+          "lines_covered": 2,
+          "lines_uncovered": [],
+          "coverage_pct": 1,
+          "est_total_cost": "29.50",
+          "worst_lead_time_days": 6
+        }
+      ],
+      "total_lines": 2,
+      "best_single_distributor": "DigiKey",
+      "best_two_distributor_combo": ["DigiKey", "Mouser"],
+      "lowest_total_price_combo": ["DigiKey"],
+      "lowest_total_price_total": "26.00",
+      "fewest_distributors_combo": ["DigiKey"],
+      "fewest_distributors_total": "26.00",
+      "target_coverage_pct": 1
+    },
+    "capacity": {
+      "can_build_now": 0,
+      "can_build_after_purchase": 1,
+      "total_bom_cost": "25.50",
+      "cost_per_single_bom": "25.50",
+      "purchase_to_pay_cost": "25.50",
+      "blocking_lines_now": [
+        "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        "cccccccc-cccc-4ccc-8ccc-cccccccccccc"
+      ],
+      "blocking_lines_after_purchase": []
+    },
+    "build_quantity": 1,
+    "powered_by": "TrustedParts",
+    "fetched_at": "2026-05-14T12:00:00.000Z",
+    "partial": false,
+    "fx_status": "ok",
+    "links": {
+      "primary": "https://example.test/e2e/sourcing",
+      "attribution": "https://example.test/e2e/about"
+    }
+  },
+  "status": { "category": "ok", "message": "OK" }
+}

--- a/web/e2e/fixtures/responses/sourcing.orders.json
+++ b/web/e2e/fixtures/responses/sourcing.orders.json
@@ -1,0 +1,43 @@
+{
+  "data": {
+    "orders": [
+      {
+        "id": "33333333-3333-4333-8333-333333333333",
+        "name": "PO-E2E-DIGIKEY",
+        "supplier": "DigiKey",
+        "status": "draft",
+        "currency": "EUR",
+        "comments": "E2E mocked purchase plan order",
+        "entries": [
+          {
+            "id": "44444444-4444-4444-8444-444444444444",
+            "part_id": "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+            "quantity_ordered": 8,
+            "unit_price": "1.80",
+            "currency": "EUR",
+            "comments": "E2E mocked purchase plan line"
+          }
+        ]
+      },
+      {
+        "id": "55555555-5555-4555-8555-555555555555",
+        "name": "PO-E2E-MOUSER",
+        "supplier": "Mouser",
+        "status": "draft",
+        "currency": "EUR",
+        "comments": "E2E mocked purchase plan order",
+        "entries": [
+          {
+            "id": "66666666-6666-4666-8666-666666666666",
+            "part_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+            "quantity_ordered": 10,
+            "unit_price": "1.10",
+            "currency": "EUR",
+            "comments": "E2E mocked override line"
+          }
+        ]
+      }
+    ]
+  },
+  "status": { "category": "ok", "message": "OK" }
+}

--- a/web/e2e/fixtures/responses/sourcing.purchase-plan.json
+++ b/web/e2e/fixtures/responses/sourcing.purchase-plan.json
@@ -1,0 +1,113 @@
+{
+  "data": {
+    "id": "00000000-0000-4000-8000-000000000690",
+    "project_id": "99999999-9999-4999-8999-999999999999",
+    "build_quantity": 1,
+    "strategy": "preferred_first",
+    "country_code": "CZ",
+    "currency_code": "EUR",
+    "preferred_distributors": ["DigiKey", "Mouser"],
+    "max_distributors": null,
+    "moq_overbuy_cap": null,
+    "price_tolerance_pct": "5",
+    "status": "refreshed",
+    "created_at": "2026-05-14T12:00:00.000Z",
+    "expires_at": "2026-05-21T12:00:00.000Z",
+    "last_refreshed_at": "2026-05-14T12:00:00.000Z",
+    "lines": [
+      {
+        "id": "11111111-1111-4111-8111-111111111111",
+        "project_entry_id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        "part_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        "mpn_searched": "E2E-PLAN-A",
+        "required_qty": 10,
+        "internal_available_qty": 0,
+        "shortage_qty": 10,
+        "selected_distributor": "DigiKey",
+        "selected_qty": 10,
+        "selected_unit_price": "1.00",
+        "selected_currency": "EUR",
+        "selected_packaging": "Cut tape",
+        "selected_moq": 1,
+        "selected_lead_time_days": 3,
+        "selected_url": "https://example.test/e2e/plan-a/digikey",
+        "available_offers": [
+          {
+            "mpn": "E2E-PLAN-A",
+            "distributor": "DigiKey",
+            "stock": 100,
+            "unit_price": "1.00",
+            "currency": "EUR",
+            "packaging": "Cut tape",
+            "moq": 1,
+            "lead_time_days": 3,
+            "price_breaks": [{ "quantity": 1, "unit_price": "1.00", "currency": "EUR" }],
+            "url": "https://example.test/e2e/plan-a/digikey"
+          },
+          {
+            "mpn": "E2E-PLAN-A",
+            "distributor": "Mouser",
+            "stock": 100,
+            "unit_price": "1.10",
+            "currency": "EUR",
+            "packaging": "Reel",
+            "moq": 10,
+            "lead_time_days": 5,
+            "price_breaks": [{ "quantity": 10, "unit_price": "1.10", "currency": "EUR" }],
+            "url": "https://example.test/e2e/plan-a/mouser"
+          }
+        ],
+        "risk_flags": []
+      },
+      {
+        "id": "22222222-2222-4222-8222-222222222222",
+        "project_entry_id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+        "part_id": "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+        "mpn_searched": "E2E-PLAN-B",
+        "required_qty": 8,
+        "internal_available_qty": 0,
+        "shortage_qty": 8,
+        "selected_distributor": "DigiKey",
+        "selected_qty": 8,
+        "selected_unit_price": "2.00",
+        "selected_currency": "EUR",
+        "selected_packaging": "Cut tape",
+        "selected_moq": 1,
+        "selected_lead_time_days": 4,
+        "selected_url": "https://example.test/e2e/plan-b/digikey",
+        "available_offers": [
+          {
+            "mpn": "E2E-PLAN-B",
+            "distributor": "DigiKey",
+            "stock": 80,
+            "unit_price": "2.00",
+            "currency": "EUR",
+            "packaging": "Cut tape",
+            "moq": 1,
+            "lead_time_days": 4,
+            "price_breaks": [{ "quantity": 1, "unit_price": "2.00", "currency": "EUR" }],
+            "url": "https://example.test/e2e/plan-b/digikey"
+          },
+          {
+            "mpn": "E2E-PLAN-B",
+            "distributor": "Mouser",
+            "stock": 70,
+            "unit_price": "2.50",
+            "currency": "EUR",
+            "packaging": "Tray",
+            "moq": 1,
+            "lead_time_days": 6,
+            "price_breaks": [{ "quantity": 1, "unit_price": "2.50", "currency": "EUR" }],
+            "url": "https://example.test/e2e/plan-b/mouser"
+          }
+        ],
+        "risk_flags": []
+      }
+    ],
+    "distributors_used": ["DigiKey"],
+    "est_total_cost": "26.00",
+    "worst_lead_time_days": 4,
+    "unfilled_count": 0
+  },
+  "status": { "category": "ok", "message": "OK" }
+}

--- a/web/e2e/fixtures/responses/sourcing.refresh.json
+++ b/web/e2e/fixtures/responses/sourcing.refresh.json
@@ -1,0 +1,113 @@
+{
+  "data": {
+    "id": "00000000-0000-4000-8000-000000000690",
+    "project_id": "99999999-9999-4999-8999-999999999999",
+    "build_quantity": 1,
+    "strategy": "preferred_first",
+    "country_code": "CZ",
+    "currency_code": "EUR",
+    "preferred_distributors": ["DigiKey", "Mouser"],
+    "max_distributors": null,
+    "moq_overbuy_cap": null,
+    "price_tolerance_pct": "5",
+    "status": "refreshed",
+    "created_at": "2026-05-14T12:00:00.000Z",
+    "expires_at": "2026-05-21T12:00:00.000Z",
+    "last_refreshed_at": "2026-05-14T12:05:00.000Z",
+    "lines": [
+      {
+        "id": "11111111-1111-4111-8111-111111111111",
+        "project_entry_id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        "part_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        "mpn_searched": "E2E-PLAN-A",
+        "required_qty": 10,
+        "internal_available_qty": 0,
+        "shortage_qty": 10,
+        "selected_distributor": "DigiKey",
+        "selected_qty": 10,
+        "selected_unit_price": "1.00",
+        "selected_currency": "EUR",
+        "selected_packaging": "Cut tape",
+        "selected_moq": 1,
+        "selected_lead_time_days": 3,
+        "selected_url": "https://example.test/e2e/plan-a/digikey",
+        "available_offers": [
+          {
+            "mpn": "E2E-PLAN-A",
+            "distributor": "DigiKey",
+            "stock": 100,
+            "unit_price": "1.00",
+            "currency": "EUR",
+            "packaging": "Cut tape",
+            "moq": 1,
+            "lead_time_days": 3,
+            "price_breaks": [{ "quantity": 1, "unit_price": "1.00", "currency": "EUR" }],
+            "url": "https://example.test/e2e/plan-a/digikey"
+          },
+          {
+            "mpn": "E2E-PLAN-A",
+            "distributor": "Mouser",
+            "stock": 100,
+            "unit_price": "1.10",
+            "currency": "EUR",
+            "packaging": "Reel",
+            "moq": 10,
+            "lead_time_days": 5,
+            "price_breaks": [{ "quantity": 10, "unit_price": "1.10", "currency": "EUR" }],
+            "url": "https://example.test/e2e/plan-a/mouser"
+          }
+        ],
+        "risk_flags": []
+      },
+      {
+        "id": "22222222-2222-4222-8222-222222222222",
+        "project_entry_id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+        "part_id": "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+        "mpn_searched": "E2E-PLAN-B",
+        "required_qty": 8,
+        "internal_available_qty": 0,
+        "shortage_qty": 8,
+        "selected_distributor": "DigiKey",
+        "selected_qty": 8,
+        "selected_unit_price": "1.80",
+        "selected_currency": "EUR",
+        "selected_packaging": "Cut tape",
+        "selected_moq": 1,
+        "selected_lead_time_days": 4,
+        "selected_url": "https://example.test/e2e/plan-b/digikey",
+        "available_offers": [
+          {
+            "mpn": "E2E-PLAN-B",
+            "distributor": "DigiKey",
+            "stock": 80,
+            "unit_price": "1.80",
+            "currency": "EUR",
+            "packaging": "Cut tape",
+            "moq": 1,
+            "lead_time_days": 4,
+            "price_breaks": [{ "quantity": 1, "unit_price": "1.80", "currency": "EUR" }],
+            "url": "https://example.test/e2e/plan-b/digikey"
+          },
+          {
+            "mpn": "E2E-PLAN-B",
+            "distributor": "Mouser",
+            "stock": 70,
+            "unit_price": "2.50",
+            "currency": "EUR",
+            "packaging": "Tray",
+            "moq": 1,
+            "lead_time_days": 6,
+            "price_breaks": [{ "quantity": 1, "unit_price": "2.50", "currency": "EUR" }],
+            "url": "https://example.test/e2e/plan-b/mouser"
+          }
+        ],
+        "risk_flags": []
+      }
+    ],
+    "distributors_used": ["DigiKey"],
+    "est_total_cost": "24.40",
+    "worst_lead_time_days": 4,
+    "unfilled_count": 0
+  },
+  "status": { "category": "ok", "message": "OK" }
+}

--- a/web/e2e/fixtures/seed.ts
+++ b/web/e2e/fixtures/seed.ts
@@ -201,21 +201,32 @@ export async function seedStock(
 }
 
 export async function seedProject(
-  _authedRequest: APIRequestContext,
-  _payload: SeedProjectPayload,
-): Promise<never> {
-  throw new Error(
-    "seedProject is reserved for E2E-3 and is intentionally not implemented in E2E-1.",
+  authedRequest: APIRequestContext,
+  payload: SeedProjectPayload,
+): Promise<{ id: string; name: string; [key: string]: unknown }> {
+  return postJson<{ id: string; name: string; [key: string]: unknown }>(
+    authedRequest,
+    "/api/projects",
+    payload,
+    201,
   );
 }
 
 export async function seedBomLine(
-  _authedRequest: APIRequestContext,
-  _projectId: string,
-  _payload: SeedBomLinePayload,
-): Promise<never> {
-  throw new Error(
-    "seedBomLine is reserved for E2E-3 and is intentionally not implemented in E2E-1.",
+  authedRequest: APIRequestContext,
+  projectId: string,
+  payload: SeedBomLinePayload,
+): Promise<{ id: string; project_id: string; [key: string]: unknown }> {
+  return postJson<{ id: string; project_id: string; [key: string]: unknown }>(
+    authedRequest,
+    `/api/projects/${projectId}/entries`,
+    {
+      entry_type: "part",
+      quantity: 1,
+      designators: [],
+      dnp: false,
+      ...payload,
+    },
   );
 }
 

--- a/web/e2e/projects-sourcing.spec.ts
+++ b/web/e2e/projects-sourcing.spec.ts
@@ -12,7 +12,6 @@ import {
 
 const BASE_URL = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:5173";
 const OVERRIDE_LINE_ID = "11111111-1111-4111-8111-111111111111";
-const OTHER_LINE_ID = "22222222-2222-4222-8222-222222222222";
 
 function uniqueName(prefix: string): string {
   return `${prefix} ${randomUUID().slice(0, 8)}`;
@@ -165,7 +164,7 @@ test(
     });
 
     await page.goto(`/projects/${project.id}/data`);
-    await page.getByRole("link", { name: "BOM" }).click();
+    await page.getByRole("link", { name: "BOM", exact: true }).click();
     await expect(page).toHaveURL(new RegExp(`/projects/${project.id}/bom$`));
     await expect(page.getByText(seededPart.name).first()).toBeVisible();
 
@@ -284,7 +283,7 @@ test(
       });
     });
 
-    await page.getByRole("link", { name: "BOM" }).click();
+    await page.getByRole("link", { name: "BOM", exact: true }).click();
     await expect(page).toHaveURL(new RegExp(`/projects/${project.id}/bom$`));
     await expect(page.getByRole("button", { name: "Add Part" })).toBeVisible();
     await attachScreenshot(testInfo, page, "sa-9-bom-page");

--- a/web/e2e/projects-sourcing.spec.ts
+++ b/web/e2e/projects-sourcing.spec.ts
@@ -1,0 +1,339 @@
+import { randomUUID } from "node:crypto";
+import type { APIRequestContext, Page, TestInfo } from "@playwright/test";
+
+import {
+  expect,
+  mockSourcingProviders,
+  seedBomLine,
+  seedPart,
+  seedProject,
+  test,
+} from "./fixtures";
+
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:5173";
+const OVERRIDE_LINE_ID = "11111111-1111-4111-8111-111111111111";
+const OTHER_LINE_ID = "22222222-2222-4222-8222-222222222222";
+
+function uniqueName(prefix: string): string {
+  return `${prefix} ${randomUUID().slice(0, 8)}`;
+}
+
+function sameOriginHeaders() {
+  return {
+    origin: BASE_URL,
+    referer: `${BASE_URL}/`,
+  };
+}
+
+async function configureSourcingWorkspace(request: APIRequestContext): Promise<void> {
+  const response = await request.patch("/api/workspaces/current", {
+    data: {
+      sourcing_provider: "trustedparts",
+      sourcing_company_id: "e2e-company",
+      sourcing_api_key: "e2e-api-key",
+      sourcing_country_code: "CZ",
+      sourcing_currency_code: "EUR",
+      sourcing_preferred_distributors: ["DigiKey", "Mouser"],
+      active_countries: ["CZ", "US"],
+      active_currencies: ["EUR", "USD"],
+      active_distributors: ["DigiKey", "Mouser"],
+      sourcing_use_cached_for_dashboards: false,
+    },
+    headers: sameOriginHeaders(),
+  });
+  expect(response.ok()).toBe(true);
+}
+
+async function seedTwoLineProject(request: APIRequestContext) {
+  const project = await seedProject(request, {
+    name: uniqueName("E2E Sourcing Project"),
+    description: "Projects + BOM sourcing E2E",
+  });
+  const mcu = await seedPart(request, {
+    name: uniqueName("E2E Source MCU"),
+    manufacturer: "E2E TestCo",
+    mpn: "E2E-PLAN-A",
+  });
+  const regulator = await seedPart(request, {
+    name: uniqueName("E2E Source Regulator"),
+    manufacturer: "E2E TestCo",
+    mpn: "E2E-PLAN-B",
+  });
+  await seedBomLine(request, project.id, {
+    part_id: mcu.id,
+    name: mcu.name,
+    quantity: 10,
+    designators: ["U1"],
+  });
+  await seedBomLine(request, project.id, {
+    part_id: regulator.id,
+    name: regulator.name,
+    quantity: 8,
+    designators: ["U2"],
+  });
+  return { project, mcu, regulator };
+}
+
+async function sourceBom(page: Page, projectId: string): Promise<void> {
+  await page.goto(`/projects/${projectId}/sourcing`);
+  await expect(page.getByRole("heading", { name: "Source BOM" })).toBeVisible();
+  await expect(page.getByRole("button", { name: /^Source$/ })).toBeEnabled();
+  await page.getByRole("button", { name: /^Source$/ }).click();
+  await expect(page.getByRole("heading", { name: "Coverage matrix" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "BOM rows" })).toBeVisible();
+}
+
+async function openPurchasePlan(page: Page, projectId: string): Promise<void> {
+  await sourceBom(page, projectId);
+  await expect(page.getByRole("button", { name: "Generate purchase plan" })).toBeEnabled();
+  await page.getByRole("button", { name: "Generate purchase plan" }).click();
+  const dialog = page.getByRole("dialog", { name: "Generate purchase plan" });
+  await expect(dialog).toBeVisible();
+  await dialog.getByRole("button", { name: /^Generate$/ }).click();
+  await page.waitForURL(new RegExp(`/projects/${projectId}/purchase-plans/[0-9a-f-]+$`));
+  await expect(page.getByTestId("purchase-plan-loaded")).toBeVisible();
+}
+
+function planLine(page: Page, mpn: string) {
+  return page.getByRole("row").filter({ hasText: mpn });
+}
+
+async function selectMouserOverride(page: Page): Promise<void> {
+  await page.getByTestId(`override-button-${OVERRIDE_LINE_ID}`).click();
+  const dialog = page.getByRole("dialog", { name: "Override offer" });
+  await expect(dialog).toBeVisible();
+  await dialog
+    .getByRole("row")
+    .filter({ hasText: "Mouser" })
+    .getByRole("button", { name: "Select" })
+    .click();
+  await expect(dialog).toHaveCount(0);
+  const row = planLine(page, "E2E-PLAN-A");
+  await expect(row).toContainText("Mouser");
+  await expect(row).toContainText("10");
+  await expect(row).toContainText("1.10 EUR");
+}
+
+async function attachScreenshot(testInfo: TestInfo, page: Page, name: string): Promise<void> {
+  await testInfo.attach(name, {
+    body: await page.screenshot(),
+    contentType: "image/png",
+  });
+}
+
+test.beforeEach(async ({ page }) => {
+  await mockSourcingProviders(page, { refreshResponse: "success" });
+});
+
+test(
+  "create project: form submit routes to /projects/<id>/data with name visible",
+  { tag: ["@core"] },
+  async ({ authedPage }) => {
+    const { page } = authedPage;
+    const projectName = uniqueName("E2E Created Project");
+
+    await page.goto("/projects");
+    await page.getByRole("link", { name: "+ Project" }).first().click();
+    await page.getByLabel("Name *").fill(projectName);
+    await page.getByRole("button", { name: /^Create$/ }).click();
+
+    await page.waitForURL(/\/projects\/[0-9a-f-]+\/data$/);
+    await expect(page.getByText(projectName).first()).toBeVisible();
+    await expect(page.getByLabel("Name")).toHaveValue(projectName);
+  },
+);
+
+test(
+  "BOM line add: seeded part + UI add produces two entries",
+  { tag: ["@core"] },
+  async ({ authedPage }) => {
+    const { page, request } = authedPage;
+    const project = await seedProject(request, { name: uniqueName("E2E BOM Project") });
+    const seededPart = await seedPart(request, {
+      name: uniqueName("E2E Seeded BOM Part"),
+      mpn: "E2E-BOM-SEEDED",
+    });
+    const uiPart = await seedPart(request, {
+      name: uniqueName("E2E UI BOM Part"),
+      mpn: "E2E-BOM-UI",
+    });
+    await seedBomLine(request, project.id, {
+      part_id: seededPart.id,
+      name: seededPart.name,
+      quantity: 2,
+      designators: ["R1", "R2"],
+    });
+
+    await page.goto(`/projects/${project.id}/data`);
+    await page.getByRole("link", { name: "BOM" }).click();
+    await expect(page).toHaveURL(new RegExp(`/projects/${project.id}/bom$`));
+    await expect(page.getByText(seededPart.name).first()).toBeVisible();
+
+    await page.getByRole("button", { name: "Add Part" }).click();
+    const dialog = page.getByRole("dialog", { name: "Add part from library" });
+    await expect(dialog).toBeVisible();
+    await dialog.getByLabel("Search library").fill(uiPart.name);
+    await expect(dialog.getByLabel(`Select ${uiPart.name}`)).toBeVisible();
+    await dialog.getByLabel(`Select ${uiPart.name}`).check();
+    await dialog.getByRole("button", { name: "Add 1 part to BOM" }).click();
+
+    await expect(page.getByText("Added 1 part to BOM.")).toBeVisible();
+    await expect(page.getByText(seededPart.name).first()).toBeVisible();
+    await expect(page.getByText(uiPart.name).first()).toBeVisible();
+    await expect(page.getByText("2 rows")).toBeVisible();
+  },
+);
+
+test(
+  "sourcing trigger: mocked providers produce coverage card and offer rows",
+  { tag: ["@core"] },
+  async ({ authedPage }) => {
+    const { page, request } = authedPage;
+    const { project } = await seedTwoLineProject(request);
+    await configureSourcingWorkspace(request);
+
+    await page.goto(`/projects/${project.id}/data`);
+    await page.getByRole("link", { name: "Source BOM" }).click();
+    await expect(page).toHaveURL(new RegExp(`/projects/${project.id}/sourcing$`));
+    await expect(page.getByRole("button", { name: /^Source$/ })).toBeEnabled();
+    await page.getByRole("button", { name: /^Source$/ }).click();
+
+    await expect(page.getByRole("heading", { name: "Coverage matrix" })).toBeVisible();
+    await expect(page.getByText("Lowest total price")).toBeVisible();
+    await expect(planLine(page, "E2E-PLAN-A")).toContainText("Mouser");
+    await expect(planLine(page, "E2E-PLAN-B")).toContainText("DigiKey");
+  },
+);
+
+test(
+  "override offer: selecting an alternate offer persists in plan state",
+  { tag: ["@core"] },
+  async ({ authedPage }) => {
+    const { page, request } = authedPage;
+    const { project } = await seedTwoLineProject(request);
+    await configureSourcingWorkspace(request);
+
+    await openPurchasePlan(page, project.id);
+    await selectMouserOverride(page);
+
+    await expect(page.getByTestId(`override-button-${OVERRIDE_LINE_ID}`)).toHaveClass(/btn-primary/);
+  },
+);
+
+test(
+  "SA-2 invariant: override is preserved across a successful refresh",
+  { tag: ["@core"] },
+  async ({ authedPage }, testInfo) => {
+    const { page, request } = authedPage;
+    const { project } = await seedTwoLineProject(request);
+    await configureSourcingWorkspace(request);
+
+    await openPurchasePlan(page, project.id);
+    await selectMouserOverride(page);
+    await attachScreenshot(testInfo, page, "sa-2-before-refresh");
+
+    await page.getByRole("button", { name: "Refresh prices" }).click();
+    await expect(page.getByText("Prices refreshed")).toBeVisible();
+
+    const overridden = planLine(page, "E2E-PLAN-A");
+    await expect(overridden).toContainText("Mouser");
+    await expect(overridden).toContainText("10");
+    await expect(overridden).toContainText("1.10 EUR");
+    await expect(page.getByTestId(`override-button-${OVERRIDE_LINE_ID}`)).toHaveClass(/btn-primary/);
+    await expect(planLine(page, "E2E-PLAN-B")).toContainText("1.80 EUR");
+    await attachScreenshot(testInfo, page, "sa-2-after-refresh");
+  },
+);
+
+test(
+  "SA-9 invariant: plan view is restored from TanStack cache on back-navigation",
+  { tag: ["@core"] },
+  async ({ authedPage }, testInfo) => {
+    const { page, request } = authedPage;
+    const { project } = await seedTwoLineProject(request);
+    await configureSourcingWorkspace(request);
+
+    await openPurchasePlan(page, project.id);
+    await expect(page.getByText("Est. cost")).toBeVisible();
+    await attachScreenshot(testInfo, page, "sa-9-plan-loaded");
+
+    let purchasePlanGetCount = 0;
+    page.on("request", req => {
+      if (
+        req.method() === "GET" &&
+        req.url().includes(`/api/projects/${project.id}/purchase-plans/`)
+      ) {
+        purchasePlanGetCount += 1;
+      }
+    });
+    await page.evaluate(() => {
+      const target = window as Window & {
+        __e2eSawPlanLoading?: boolean;
+        __e2ePlanLoadingObserver?: MutationObserver;
+      };
+      target.__e2eSawPlanLoading = document.body.innerText.includes("Loading purchase plan...");
+      target.__e2ePlanLoadingObserver = new MutationObserver(() => {
+        if (document.body.innerText.includes("Loading purchase plan...")) {
+          target.__e2eSawPlanLoading = true;
+        }
+      });
+      target.__e2ePlanLoadingObserver.observe(document.body, {
+        childList: true,
+        subtree: true,
+        characterData: true,
+      });
+    });
+
+    await page.getByRole("link", { name: "BOM" }).click();
+    await expect(page).toHaveURL(new RegExp(`/projects/${project.id}/bom$`));
+    await expect(page.getByRole("button", { name: "Add Part" })).toBeVisible();
+    await attachScreenshot(testInfo, page, "sa-9-bom-page");
+
+    const unexpectedRequest = page
+      .waitForRequest(
+        req => req.method() === "GET" &&
+          req.url().includes(`/api/projects/${project.id}/purchase-plans/`),
+        { timeout: 500 },
+      )
+      .catch(() => null);
+    await page.goBack();
+    await expect(page.getByTestId("purchase-plan-loaded")).toBeVisible();
+    await expect(page.getByText("Loading purchase plan...")).toHaveCount(0);
+    expect(await unexpectedRequest).toBeNull();
+    expect(purchasePlanGetCount).toBe(0);
+    expect(await page.evaluate(() => {
+      const target = window as Window & {
+        __e2eSawPlanLoading?: boolean;
+        __e2ePlanLoadingObserver?: MutationObserver;
+      };
+      target.__e2ePlanLoadingObserver?.disconnect();
+      return target.__e2eSawPlanLoading;
+    })).toBe(false);
+    await attachScreenshot(testInfo, page, "sa-9-plan-restored");
+  },
+);
+
+test(
+  "convert plan to orders: confirm flow creates draft orders",
+  { tag: ["@core"] },
+  async ({ authedPage }) => {
+    const { page, request } = authedPage;
+    const { project } = await seedTwoLineProject(request);
+    await configureSourcingWorkspace(request);
+
+    await openPurchasePlan(page, project.id);
+    await selectMouserOverride(page);
+    await page.getByRole("button", { name: "Create draft orders" }).click();
+
+    await expect(page.getByText("Created 2 draft orders")).toBeVisible();
+    await expect(page).toHaveURL(/\/orders$/);
+  },
+);
+
+test.fixme(
+  "real-key sourcing smoke (placeholder)",
+  { tag: ["@nightly"] },
+  async () => {
+    // Follow-up #685: real Mouser/DigiKey/TP key suite.
+  },
+);

--- a/web/src/routes/projects/sourcing/PurchasePlanLinesTable.tsx
+++ b/web/src/routes/projects/sourcing/PurchasePlanLinesTable.tsx
@@ -90,6 +90,7 @@ export default function PurchasePlanLinesTable({
         <button
           type="button"
           className={overrides[line.id] ? "btn-primary" : "btn"}
+          data-testid={`override-button-${line.id}`}
           onClick={() => onOverride(line)}
         >
           Override

--- a/web/src/routes/projects/sourcing/PurchasePlanLinesTable.tsx
+++ b/web/src/routes/projects/sourcing/PurchasePlanLinesTable.tsx
@@ -28,6 +28,7 @@ export default function PurchasePlanLinesTable({
 }: Props) {
   const columns: Column<PurchasePlanLine>[] = [
     { key: "mpn", header: "MPN", accessor: line => line.mpn_searched },
+    { key: "distributor", header: "Distributor", accessor: line => line.selected_distributor ?? "" },
     { key: "required", header: "Required", accessor: line => line.required_qty, align: "right" },
     { key: "internal", header: "Internal", accessor: line => line.internal_available_qty, align: "right" },
     { key: "shortage", header: "Shortage", accessor: line => line.shortage_qty, align: "right" },

--- a/web/src/routes/projects/sourcing/PurchasePlanReviewPage.tsx
+++ b/web/src/routes/projects/sourcing/PurchasePlanReviewPage.tsx
@@ -96,36 +96,58 @@ export default function PurchasePlanReviewPage() {
   }
   const fresh = isRefreshFresh(plan);
   const currency = summaryCurrency(plan);
+  function planWithOverrides(
+    nextPlan: PurchasePlan,
+    retainedOverrides: Record<string, PurchasePlanOrderOverride>,
+  ): PurchasePlan {
+    const nextLines = nextPlan.lines.map(line => {
+      const override = retainedOverrides[line.id];
+      if (!override) return line;
+      const matchingOffer = (line.available_offers ?? []).find(offer =>
+        purchasePlanOverrideMatchesOffer(line, override, offer),
+      );
+      return {
+        ...line,
+        selected_distributor: override.selected_distributor,
+        selected_qty: override.selected_qty,
+        selected_unit_price: override.selected_unit_price,
+        selected_currency: override.selected_currency,
+        selected_packaging: matchingOffer?.packaging ?? null,
+        selected_moq: matchingOffer?.moq ?? null,
+        selected_lead_time_days: matchingOffer?.lead_time_days ?? null,
+        selected_url: matchingOffer?.url ?? null,
+      };
+    });
+    return recomputePlanFromLines(nextPlan, nextLines);
+  }
   async function refresh() {
     if (!plan) return;
     setBusyAction("refresh");
     try {
       const next = await api.post<PurchasePlan>(`/sourcing/purchase-plans/${plan.id}/refresh`);
-      setOverrides(current => {
-        const pruned: typeof current = {};
-        const dropped: string[] = [];
-        const linesById = new Map(next.lines.map(line => [line.id, line]));
-        for (const [lineId, override] of Object.entries(current)) {
-          const refreshedLine = linesById.get(lineId);
-          const stillAvailable = refreshedLine
-            ? (refreshedLine.available_offers ?? []).some(offer =>
-                purchasePlanOverrideMatchesOffer(refreshedLine, override, offer),
-              )
-            : false;
-          if (stillAvailable) {
-            pruned[lineId] = override;
-          } else {
-            dropped.push(lineId);
-          }
+      const pruned: typeof overrides = {};
+      const dropped: string[] = [];
+      const linesById = new Map(next.lines.map(line => [line.id, line]));
+      for (const [lineId, override] of Object.entries(overrides)) {
+        const refreshedLine = linesById.get(lineId);
+        const stillAvailable = refreshedLine
+          ? (refreshedLine.available_offers ?? []).some(offer =>
+              purchasePlanOverrideMatchesOffer(refreshedLine, override, offer),
+            )
+          : false;
+        if (stillAvailable) {
+          pruned[lineId] = override;
+        } else {
+          dropped.push(lineId);
         }
-        if (dropped.length > 0) {
-          toast.info(
-            `Removed ${dropped.length} override${dropped.length === 1 ? "" : "s"} no longer available after refresh.`,
-          );
-        }
-        return pruned;
-      });
-      queryClient.setQueryData(purchasePlanKey, next);
+      }
+      if (dropped.length > 0) {
+        toast.info(
+          `Removed ${dropped.length} override${dropped.length === 1 ? "" : "s"} no longer available after refresh.`,
+        );
+      }
+      setOverrides(pruned);
+      queryClient.setQueryData(purchasePlanKey, planWithOverrides(next, pruned));
       setRefreshAttention(false);
       toast.success("Prices refreshed");
     } catch (err) {
@@ -193,7 +215,7 @@ export default function PurchasePlanReviewPage() {
           <div className="text-sm text-muted">
             Projects / {project?.name ?? "Project"} / Purchase plan
           </div>
-          <div className="mt-1 flex flex-wrap items-center gap-2">
+          <div className="mt-1 flex flex-wrap items-center gap-2" data-testid="purchase-plan-loaded">
             <h1 className="text-xl font-semibold">
               Purchase plan #{plan.id.slice(0, 8)} - {project?.name ?? "Project"} - strategy={plan.strategy}
             </h1>

--- a/web/src/routes/projects/sourcing/__tests__/PurchasePlanReviewPage.test.tsx
+++ b/web/src/routes/projects/sourcing/__tests__/PurchasePlanReviewPage.test.tsx
@@ -248,8 +248,8 @@ describe("PurchasePlanReviewPage", () => {
   it("renders one distributor group per distributor", () => {
     renderPage();
 
-    expect(screen.getByText("DigiKey")).toBeDefined();
-    expect(screen.getByText("Mouser")).toBeDefined();
+    expect(screen.getAllByText("DigiKey").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Mouser").length).toBeGreaterThan(0);
     expect(screen.getAllByLabelText("Source: TrustedParts").length).toBeGreaterThanOrEqual(2);
   });
 
@@ -280,7 +280,7 @@ describe("PurchasePlanReviewPage", () => {
 
     await userEvent.click(screen.getByRole("button", { name: /Refresh prices/ }));
 
-    await waitFor(() => expect(screen.getByText("Arrow")).toBeDefined());
+    await waitFor(() => expect(screen.getAllByText("Arrow").length).toBeGreaterThan(0));
     expect(api.post).toHaveBeenCalledWith("/sourcing/purchase-plans/plan-12345678/refresh");
     expect(toast.success).toHaveBeenCalledWith("Prices refreshed");
   });
@@ -463,7 +463,7 @@ describe("PurchasePlanReviewPage", () => {
     await selectArrowOffer();
 
     await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
-    expect(screen.getByText("Arrow")).toBeDefined();
+    expect(screen.getAllByText("Arrow").length).toBeGreaterThan(0);
     expect(screen.getByText("2.05 USD")).toBeDefined();
     expect(screen.getByText("2 days")).toBeDefined();
 
@@ -494,7 +494,7 @@ describe("PurchasePlanReviewPage", () => {
     await userEvent.click(screen.getByRole("button", { name: /Create draft orders/ }));
 
     await waitFor(() => expect(toast.error).toHaveBeenCalledWith("Could not create draft orders"));
-    expect(screen.getByText("Arrow")).toBeDefined();
+    expect(screen.getAllByText("Arrow").length).toBeGreaterThan(0);
 
     await userEvent.click(screen.getByRole("button", { name: /Create draft orders/ }));
 


### PR DESCRIPTION
## Merge / deploy order

PR #697 has merged to `main` as `a098c45d5503a60e10108ead9f634c4791de53cc`, and this branch is rebased onto `origin/main` after fetching that merge commit. Main deploy run 25868833735 completed successfully after PR #697 merged; public /api/health was validated green. This PR is now unblocked by merge order, pending its own CI.

## Summary

- Adds `web/e2e/projects-sourcing.spec.ts` with 7 `@core` tests covering project creation, BOM add, mocked sourcing, override selection, SA-2 refresh override preservation, SA-9 plan cache restore, and convert-to-draft-orders.
- Adds the `@nightly` real-key sourcing placeholder as `test.fixme`.
- Implements `seedProject()` / `seedBomLine()` and extends `mockSourcingProviders()` for sourcing, purchase-plan, refresh, and orders route responses.
- Adds envelope-wrapped canned sourcing responses under `web/e2e/fixtures/responses/`, derived from backend TrustedParts/purchase-plan route fixture shapes with provider URLs sanitized to `example.test`.
- Reapplies retained purchase-plan overrides to refreshed plan data before updating the TanStack Query cache, so SA-2 is preserved in the visible row state.

## Core test inventory

- LISTED: `create project: form submit routes to /projects/<id>/data with name visible`
- LISTED: `BOM line add: seeded part + UI add produces two entries`
- LISTED: `sourcing trigger: mocked providers produce coverage card and offer rows`
- LISTED: `override offer: selecting an alternate offer persists in plan state`
- LISTED: `SA-2 invariant: override is preserved across a successful refresh`
- LISTED: `SA-9 invariant: plan view is restored from TanStack cache on back-navigation`
- LISTED: `convert plan to orders: confirm flow creates draft orders`

## Screenshots / report

- The SA-2 test attaches `sa-2-before-refresh` and `sa-2-after-refresh` screenshots to the Playwright HTML report.
- The SA-9 test attaches `sa-9-plan-loaded`, `sa-9-bom-page`, and `sa-9-plan-restored` screenshots to the Playwright HTML report.
- CI should upload the Playwright HTML report artifact. A live local report could not be generated in this environment because Docker is unavailable.

## `data-testid` justifications

- `override-button-{line.id}`: the per-line `Override` button repeats once per purchase-plan line, so role/name selectors are ambiguous and row-order `nth()` selectors would be brittle after refresh regrouping.
- `purchase-plan-loaded`: SA-9 needs a stable rendered-from-cache anchor that is independent of plan-id-derived heading copy and avoids class selectors.

## Validation

Passed locally after rebasing onto `origin/main` at `a098c45`:

- `npm run typecheck`
- `npx eslint src/routes/projects/sourcing/PurchasePlanReviewPage.tsx src/routes/projects/sourcing/PurchasePlanLinesTable.tsx`
- `npx vitest run src/routes/projects/sourcing/__tests__/PurchasePlanReviewPage.test.tsx` (16 passed)
- `npx playwright test --grep @core projects-sourcing.spec.ts --list --reporter=list` (listed 7 core tests)
- `npx playwright test --grep @nightly projects-sourcing.spec.ts --reporter=list` (1 skipped/fixme)
- `git -C /mnt/data/WORK/stockManager-1/.codex-worktrees/e2e-5-projects-sourcing diff --check`

Previously passed locally before the rebase and still applicable to unchanged fixture/spec content:

- `npm ci` (completed with dependency engine warnings under local Node v18.19.1)
- `jq empty web/e2e/fixtures/responses/sourcing.bom.json web/e2e/fixtures/responses/sourcing.purchase-plan.json web/e2e/fixtures/responses/sourcing.refresh.json web/e2e/fixtures/responses/sourcing.orders.json`
- `grep -L "@core" web/e2e/projects-sourcing.spec.ts` (empty output)
- `grep -n "waitForTimeout" web/e2e/projects-sourcing.spec.ts` (empty output)
- `grep -E "mouser\.com|digikey\.com|trustedparts\.com" web/e2e/projects-sourcing.spec.ts` (empty output)

Blocked locally:

- `make dev-up` failed because this environment has no `docker` binary (`make: docker: No such file or directory`), so the live `npx playwright test --grep @core projects-sourcing.spec.ts` run against the dev stack could not be executed here.
- Full `npm run lint` is still blocked by existing unrelated errors in `src/lib/bagCode.ts` (`no-control-regex`) plus unrelated warnings; the files touched in this PR lint cleanly.

Refs #690