### PR TITLE
E2E-3b: manual scan-import entry

### DIFF
--- a/web/e2e/README.md
+++ b/web/e2e/README.md
@@ -38,6 +38,7 @@ Chromium is the only browser target.
 - `seedPart`, `seedStorage`, `seedStock`, and `seedScanImport` call public `/api/*` endpoints with the real session cookie. There are no backend test-mode endpoints or database shortcuts.
 - `seedProject` and `seedBomLine` are typed stubs for the follow-up E2E issues.
 - Provider helpers use `page.route()` and return backend-shaped envelopes (`{ data, status }`), matching `web/src/lib/api.ts`.
+- Scan-import bag flows should use `/parts/scan-import` → `Manual entry` → `Bag code` → `Add bag`; keep those tests on the paste path instead of camera-decoder shims.
 
 ## Page Objects
 

--- a/web/e2e/stock.spec.ts
+++ b/web/e2e/stock.spec.ts
@@ -83,51 +83,10 @@ async function partsByMpn(request: E2ERequest, mpn: string): Promise<Part[]> {
   return apiGet<Part[]>(request, `/api/parts?mpn=${encodeURIComponent(mpn)}`);
 }
 
-async function mockNextZxingScan(page: Page, rawBagCode: string): Promise<void> {
-  await page.route(/.*zxing-wasm_reader.*\.js.*/, async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: "application/javascript",
-      body: `
-let delivered = false;
-export async function prepareZXingModule() {}
-export async function readBarcodes() {
-  if (delivered) return [];
-  const text = globalThis.__E2E_SCAN_CODE;
-  if (!text) return [];
-  delivered = true;
-  return [{ text, format: "DataMatrix" }];
-}
-`,
-    });
-  });
-
-  await page.addInitScript((code: string) => {
-    (globalThis as typeof globalThis & { __E2E_SCAN_CODE?: string }).__E2E_SCAN_CODE = code;
-    Object.defineProperty(navigator, "mediaDevices", {
-      configurable: true,
-      value: {
-        getUserMedia: async () => {
-          const canvas = document.createElement("canvas");
-          canvas.width = 640;
-          canvas.height = 480;
-          const context = canvas.getContext("2d");
-          context?.fillRect(0, 0, canvas.width, canvas.height);
-          const stream = canvas.captureStream(1);
-          const track = stream.getVideoTracks()[0] as MediaStreamTrack & {
-            getCapabilities?: () => MediaTrackCapabilities;
-            getSettings?: () => MediaTrackSettings;
-            applyConstraints?: () => Promise<void>;
-          };
-          track.getCapabilities = () => ({});
-          track.getSettings = () => ({});
-          track.applyConstraints = async () => {};
-          return stream;
-        },
-        enumerateDevices: async () => [],
-      },
-    });
-  }, rawBagCode);
+async function addManualBagScan(page: Page, rawBagCode: string): Promise<void> {
+  await page.getByRole("button", { name: /manual entry/i }).click();
+  await page.getByLabel(/bag code/i).fill(rawBagCode);
+  await page.getByRole("button", { name: /^add bag$/i }).click();
 }
 
 function fixtureBagWithMpn(index = 0) {
@@ -266,9 +225,9 @@ test(
       bag_code: bag.raw,
       qty: 5,
     });
-    await mockNextZxingScan(page, bag.raw);
 
     await page.goto("/parts/scan-import");
+    await addManualBagScan(page, bag.raw);
 
     const rescanRow = page.getByTestId("scan-row-bag-rescan");
     await expect(rescanRow).toBeVisible({ timeout: 15_000 });
@@ -295,9 +254,9 @@ test(
       bag_code: bag.raw,
       qty: 5,
     });
-    await mockNextZxingScan(page, bag.raw);
 
     await page.goto("/parts/scan-import");
+    await addManualBagScan(page, bag.raw);
 
     const rescanRow = page.getByTestId("scan-row-bag-rescan");
     await expect(rescanRow).toBeVisible({ timeout: 15_000 });

--- a/web/src/routes/parts/ScanImport/ScanImportSession.tsx
+++ b/web/src/routes/parts/ScanImport/ScanImportSession.tsx
@@ -12,8 +12,9 @@
  *
  * It does NOT own `rows` state — the parent (ScanImport) owns it.
  */
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import type React from "react";
+import { ClipboardPaste, Plus } from "lucide-react";
 import Scanner, { type ScanResult } from "@/components/scanner/Scanner";
 import { api, ApiError } from "@/lib/api";
 import { parseBagCode, bagSignature } from "@/lib/bagCode";
@@ -82,6 +83,10 @@ export default function ScanImportSession({
   onRow,
   onLookupUpdate,
 }: ScanImportSessionProps) {
+  const [manualOpen, setManualOpen] = useState(false);
+  const [manualCode, setManualCode] = useState("");
+  const [manualSubmitting, setManualSubmitting] = useState(false);
+
   const handleScan = useCallback(
     async (s: ScanResult) => {
       const parsed = parseBagCode(s.data);
@@ -147,8 +152,61 @@ export default function ScanImportSession({
     [seenSigs, seenMpns, onRow, onLookupUpdate],
   );
 
+  async function handleManualSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const data = manualCode.trim();
+    if (!data) return;
+    setManualSubmitting(true);
+    try {
+      await handleScan({ data, symbology: "DataMatrix" });
+      setManualCode("");
+    } finally {
+      setManualSubmitting(false);
+    }
+  }
+
   return (
     <div className="card p-3">
+      <div className="mb-3 rounded-md border border-border bg-panel2/40">
+        <button
+          type="button"
+          className="w-full px-3 py-2 text-left text-sm font-medium inline-flex items-center gap-2"
+          aria-expanded={manualOpen}
+          aria-controls="scan-import-manual-entry"
+          onClick={() => setManualOpen(open => !open)}
+        >
+          <ClipboardPaste size={16} className="text-muted" />
+          Manual entry
+        </button>
+        {manualOpen && (
+          <form
+            id="scan-import-manual-entry"
+            className="border-t border-border px-3 py-3 flex flex-col gap-2 sm:flex-row"
+            onSubmit={handleManualSubmit}
+          >
+            <label className="sr-only" htmlFor="scan-import-manual-code">
+              Bag code
+            </label>
+            <input
+              id="scan-import-manual-code"
+              type="text"
+              className="input min-w-0 flex-1"
+              value={manualCode}
+              onChange={e => setManualCode(e.target.value)}
+              placeholder="Paste bag code"
+              required
+            />
+            <button
+              type="submit"
+              className="btn-primary btn-sm inline-flex items-center justify-center gap-1"
+              disabled={manualSubmitting || manualCode.trim().length === 0}
+            >
+              <Plus size={14} />
+              Add bag
+            </button>
+          </form>
+        )}
+      </div>
       <Scanner
         onScan={handleScan}
         symbologies={SCAN_IMPORT_SYMBOLOGIES}


### PR DESCRIPTION
## Option
Option A: added a Manual entry paste/add affordance in ScanImportSession. It submits the pasted bag code to the same handleScan pipeline used by the camera path, so parseBagCode, bagSignature, deduping, bag-rescan detection, duplicate-MPN detection, and provider lookup stay shared.

## stock.spec #6/#7
Before: both bag-rescan tests route-mocked the zxing-wasm_reader chunk and installed a browser camera API shim before navigating.
After: both tests navigate to /parts/scan-import, open Manual entry, fill Bag code, and click Add bag; the decoder route mock and camera shim are removed.

## Validation
- npm run typecheck
- npx eslint src/routes/parts/ScanImport/ScanImportSession.tsx
- npm run lint (blocked by existing src/lib/bagCode.ts no-control-regex errors; unrelated warnings also present)
- npx playwright test stock.spec.ts --project=core --list
- grep -R -n "zxing-wasm_reader\|getUserMedia" web/e2e/ (empty)
- npx playwright test stock.spec.ts --project=core --grep "bag rescan|quick-remove from rescanned bag" (blocked: local stack unavailable; Docker is not installed and localhost:5173 returned socket hang up on /api/auth/signup)

## Merge order
merge before #700 and #689

Refs #685
Refs #699