### PR TITLE
E2E-6b: Trim per-route empty-state anchors in reports.spec.ts

### DIFF
--- a/web/e2e/reports.spec.ts
+++ b/web/e2e/reports.spec.ts
@@ -1,43 +1,34 @@
-import type { Locator, Page } from "@playwright/test";
-
 import { test, expect, seedPart } from "./fixtures";
 
 type ReportRoute = {
   path: string;
   tab: string;
-  anchor: (page: Page) => Locator;
 };
 
 const reportRoutes: ReportRoute[] = [
   {
     path: "/reports/value",
     tab: "Stock value",
-    anchor: (page) => page.getByRole("heading", { name: "By currency" }),
   },
   {
     path: "/reports/replenishment-cost",
     tab: "Replenishment cost",
-    anchor: (page) => page.getByLabel("Sort"),
   },
   {
     path: "/reports/bom",
     tab: "BOM shortage",
-    anchor: (page) => page.getByLabel("Project"),
   },
   {
     path: "/reports/buyability",
     tab: "BOM buyability",
-    anchor: (page) => page.getByText("No projects", { exact: true }),
   },
   {
     path: "/reports/expiring",
     tab: "Expiring lots",
-    anchor: (page) => page.getByText("All clear", { exact: true }),
   },
   {
     path: "/reports/sourcing-risk",
     tab: "Sourcing risk",
-    anchor: (page) => page.getByText("All clear", { exact: true }),
   },
 ];
 
@@ -60,7 +51,7 @@ for (const report of reportRoutes) {
       const activeTab = page.getByRole("link", { name: report.tab, exact: true });
       await expect(activeTab).toBeVisible({ timeout: 5_000 });
       await expect(activeTab).toHaveAttribute("aria-current", "page");
-      await expect(report.anchor(page)).toBeVisible({ timeout: 5_000 });
+      await expect(page.locator('[role="main"], main')).toBeVisible({ timeout: 5_000 });
       await expect(page.locator("text=Something went wrong")).toHaveCount(0);
     },
   );


### PR DESCRIPTION
## Summary

- Removed the per-route `anchor` locator from `reports.spec.ts`.
- Replaced the secondary route-specific assertion with a structural main-landmark visibility check.
- Kept the active `NavLink` `aria-current="page"` assertion and the negative error-boundary check.

## Before / After

Before:

```ts
await expect(activeTab).toBeVisible({ timeout: 5_000 });
await expect(activeTab).toHaveAttribute("aria-current", "page");
await expect(report.anchor(page)).toBeVisible({ timeout: 5_000 });
await expect(page.locator("text=Something went wrong")).toHaveCount(0);
```

After:

```ts
await expect(activeTab).toBeVisible({ timeout: 5_000 });
await expect(activeTab).toHaveAttribute("aria-current", "page");
await expect(page.locator('[role="main"], main')).toBeVisible({ timeout: 5_000 });
await expect(page.locator("text=Something went wrong")).toHaveCount(0);
```

The route table no longer contains `getByText("All clear")` or `getByText("No projects")` anchors.

## Validation

- `npx tsc --noEmit --pretty false --moduleResolution Bundler --module ESNext --target ES2022 --lib ES2022,DOM,DOM.Iterable --types node,@playwright/test e2e/reports.spec.ts`
- `npx eslint e2e/reports.spec.ts`
- `npx playwright test e2e/reports.spec.ts --project=core --list` listed all 6 report tests.
- Attempted `PLAYWRIGHT_BASE_URL=https://localhost:5173 npx playwright test e2e/reports.spec.ts --project=core`; local run failed before page assertions on self-signed certificate during signup.
- Retried with `NODE_TLS_REJECT_UNAUTHORIZED=0 PLAYWRIGHT_BASE_URL=https://localhost:5173 npx playwright test e2e/reports.spec.ts --project=core`; local run reached signup but the local backend/proxy returned `signup failed: 500` for all 6 tests. Docker is unavailable in this environment, so I could not restart the repo dev stack here.

## Merge Order

independent; can merge before/after #699

Refs #685
Refs #701
