### PR TITLE
E2E-3c: Fix timestamp race in stock.spec.ts test #8

### DIFF
--- a/web/e2e/stock.spec.ts
+++ b/web/e2e/stock.spec.ts
@@ -283,12 +283,15 @@ test.describe("stock history ordering", () => {
       const part = await seedPart(request, { name: uniqueName("E2E History Order") });
       const detail = new PartDetailPage(page, part.id);
 
-      for (const quantity of [1, 2, 3]) {
+      for (const [index, quantity] of [1, 2, 3].entries()) {
         await seedStock(request, {
           part_id: part.id,
           quantity,
           storage_location_id: storage.id,
         });
+        if (index < 2) {
+          await new Promise((resolve) => setTimeout(resolve, 5));
+        }
       }
 
       await detail.goto("history");


### PR DESCRIPTION
## Summary

- Chose Option A fallback: add a plain 5ms `setTimeout` promise between the three `seedStock` calls in stock.spec.ts test #8.
- Kept the change scoped to `web/e2e/stock.spec.ts`.

## Validation

- `npm run typecheck`
- `npx eslint e2e/stock.spec.ts`
- `npx playwright test stock.spec.ts --project=core --list`
- `npx playwright test stock.spec.ts --project=core --repeat-each=10` could not complete locally because the E2E stack is unavailable: Playwright fails at `POST http://localhost:5173/api/auth/signup` with `apiRequestContext.post: socket hang up`; `curl -i --max-time 5 http://localhost:5173/` returns `Empty reply from server`; `docker compose -f docker-compose.dev.yml ps` fails with `docker: command not found`.

## Merge Order

- After #702.

Refs #685
Refs #700
