### PR TITLE
AUD-024 + AUD-063: equalize signup timing and guard part archive

### DIFF
--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -64,6 +64,33 @@ _SIGNUP_VERIFICATION_DATA = {"status": "verification_sent"}
 _SIGNUP_VERIFICATION_MESSAGE = "verification email sent"
 
 
+def _reap_expired_pending_signup(db: DbSession, email: str) -> None:
+    cutoff = utcnow() - timedelta(hours=_VERIFY_TTL_HOURS)
+    db.query(PendingUser).filter(
+        PendingUser.email == email,
+        PendingUser.created_at < cutoff,
+        PendingUser.verified_at.is_(None),
+    ).delete(synchronize_session=False)
+
+
+def _active_pending_signup(db: DbSession, email: str) -> PendingUser | None:
+    return (
+        db.query(PendingUser)
+        .filter(
+            PendingUser.email == email,
+            PendingUser.verified_at.is_(None),
+        )
+        .first()
+    )
+
+
+def _mint_signup_verification_material(password: str) -> tuple[str, str, str]:
+    plaintext_token = secrets.token_urlsafe(32)
+    password_hash = hash_password(password)
+    verification_token_hmac = _hmac_token(plaintext_token)
+    return plaintext_token, password_hash, verification_token_hmac
+
+
 def _set_session_cookie(response: Response, token: str) -> None:
     response.set_cookie(
         key=settings().SESSION_COOKIE_NAME,
@@ -203,7 +230,17 @@ def signup(
         )
 
     # --- Prod path: email-verification two-step flow ---
+    # Keep the known-email and fresh unknown-email compute paths close
+    # enough that the response timing does not become the enumeration
+    # signal after the response body was equalised. Both branches do the
+    # pending-row maintenance and Argon2/HMAC token work; only the fresh
+    # unknown-email branch persists the PendingUser and sends the verify
+    # link.
+    _reap_expired_pending_signup(db, payload.email)
+    existing_pending = _active_pending_signup(db, payload.email)
+
     if existing:
+        _mint_signup_verification_material(payload.password)
         try:
             send_account_exists_email(to=payload.email)
         except Exception as exc:
@@ -217,39 +254,24 @@ def signup(
         response.status_code = status.HTTP_202_ACCEPTED
         return ok(_SIGNUP_VERIFICATION_DATA, _SIGNUP_VERIFICATION_MESSAGE)
 
-    # Reap expired pending rows for this email before checking for an
-    # active pending one, so old unverified attempts don't block a retry.
-    cutoff = utcnow() - timedelta(hours=_VERIFY_TTL_HOURS)
-    db.query(PendingUser).filter(
-        PendingUser.email == payload.email,
-        PendingUser.created_at < cutoff,
-        PendingUser.verified_at.is_(None),
-    ).delete(synchronize_session=False)
-
     # If there's already a non-expired pending row, return 202 again
     # without creating a duplicate row. The user may click the first
     # link or wait for it to expire and re-sign-up.
-    existing_pending = (
-        db.query(PendingUser)
-        .filter(
-            PendingUser.email == payload.email,
-            PendingUser.verified_at.is_(None),
-        )
-        .first()
-    )
     if existing_pending:
         log.info("signup resent existing pending", extra={"email": payload.email})
         response.status_code = status.HTTP_202_ACCEPTED
         return ok(_SIGNUP_VERIFICATION_DATA, _SIGNUP_VERIFICATION_MESSAGE)
 
     # Mint a verification token, store its HMAC, send the link.
-    plaintext_token = secrets.token_urlsafe(32)
+    plaintext_token, password_hash, verification_token_hmac = _mint_signup_verification_material(
+        payload.password
+    )
     pending = PendingUser(
         email=payload.email,
         name=payload.name,
-        password_hash=hash_password(payload.password),
+        password_hash=password_hash,
         workspace_name=payload.workspace_name,
-        verification_token_hmac=_hmac_token(plaintext_token),
+        verification_token_hmac=verification_token_hmac,
         ip=request.client.host if request.client else None,
     )
     db.add(pending)

--- a/backend/app/api/routes/parts_core.py
+++ b/backend/app/api/routes/parts_core.py
@@ -26,6 +26,7 @@ from app.api.routes._parts_shared import (
     serialize_part as _serialize,
 )
 from app.core.deps import CurrentUser, CurrentWorkspace, DbSession, require_role
+from app.core.errors import ErrorCodes, raise_http
 from app.core.pagination import decode_cursor, paginate
 from app.core.ratelimit import limiter, workspace_key
 from app.core.responses import Envelope, ok
@@ -334,6 +335,15 @@ def archive_part(
     from app.domain.tags.models import TagLink
 
     p = require_resource_access(db, Part, part_id, ws=ws, user=user, role="admin", label="part")
+    reserved = total_for_part(db, workspace_id=ws.id, part_id=p.id, status="reserved")
+    if reserved > 0:
+        raise_http(
+            status.HTTP_409_CONFLICT,
+            code=ErrorCodes.PART_HAS_RESERVED_STOCK,
+            message="part has reserved stock; release reservations first",
+            blocking=[{"part_id": str(p.id), "quantity": reserved}],
+        )
+
     p.archived_at = utcnow()
 
     # Observability: log how many polymorphic rows are associated with the

--- a/backend/app/core/errors.py
+++ b/backend/app/core/errors.py
@@ -197,6 +197,7 @@ class ErrorCodes:
 
     # Parts shared helpers.
     PART_NOT_FOUND = "part.not_found"
+    PART_HAS_RESERVED_STOCK = "part.has_reserved_stock"
 
     # Projects router.
     PROJECT_NOT_FOUND = "project.not_found"

--- a/backend/tests/test_archive_part_reserved.py
+++ b/backend/tests/test_archive_part_reserved.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import uuid
+
+from app.domain.stock.models import StockEntry
+from tests._factories import create_part
+
+
+def _current_workspace_id(client) -> uuid.UUID:
+    response = client.get("/api/workspaces/current")
+    assert response.status_code == 200, response.text
+    return uuid.UUID(response.json()["data"]["id"])
+
+
+def _add_reserved_entry(db, *, workspace_id: uuid.UUID, part_id: uuid.UUID, quantity: int) -> None:
+    db.add(
+        StockEntry(
+            workspace_id=workspace_id,
+            part_id=part_id,
+            quantity_delta=quantity,
+            status="reserved",
+            operation_type="reserve" if quantity > 0 else "release_reservation",
+        )
+    )
+    db.flush()
+
+
+def test_archive_part_blocked_when_reserved_stock_present(authed_client, db):
+    part_id = create_part(authed_client, "Reserved IC")
+    workspace_id = _current_workspace_id(authed_client)
+
+    _add_reserved_entry(
+        db,
+        workspace_id=workspace_id,
+        part_id=uuid.UUID(part_id),
+        quantity=6,
+    )
+
+    response = authed_client.post(f"/api/parts/{part_id}/archive")
+
+    assert response.status_code == 409, response.text
+    body = response.json()
+    assert body["code"] == "part.has_reserved_stock"
+    assert body["status"]["category"] == "conflict"
+    assert body["blocking"] == [{"part_id": part_id, "quantity": 6}]
+
+    current = authed_client.get(f"/api/parts/{part_id}")
+    assert current.status_code == 200, current.text
+    assert current.json()["data"]["archived_at"] is None
+
+
+def test_archive_part_succeeds_after_reserved_stock_released(authed_client, db):
+    part_id = create_part(authed_client, "Released Reservation IC")
+    workspace_id = _current_workspace_id(authed_client)
+
+    _add_reserved_entry(
+        db,
+        workspace_id=workspace_id,
+        part_id=uuid.UUID(part_id),
+        quantity=6,
+    )
+    _add_reserved_entry(
+        db,
+        workspace_id=workspace_id,
+        part_id=uuid.UUID(part_id),
+        quantity=-6,
+    )
+
+    response = authed_client.post(f"/api/parts/{part_id}/archive")
+
+    assert response.status_code == 200, response.text
+    current = authed_client.get(f"/api/parts/{part_id}")
+    assert current.status_code == 200, current.text
+    assert current.json()["data"]["archived_at"] is not None

--- a/backend/tests/test_signup_no_enumeration.py
+++ b/backend/tests/test_signup_no_enumeration.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import re
+import statistics
+import time
 import uuid
 from unittest.mock import patch
 
@@ -64,3 +66,56 @@ def test_response_identical_for_known_and_unknown_email(db):
     assert known_response.json() == unknown_response.json()
     account_exists_email.assert_called_once_with(to=known_email)
     verification_email.assert_called_once()
+
+
+def test_timing_similar_for_known_and_unknown_email(db):
+    known_email = f"known-timing-{uuid.uuid4().hex[:8]}@example.com"
+    _signup_and_verify(known_email)
+    client = TestClient(app)
+    samples = 4
+
+    def _delayed_hash(password: str) -> str:
+        assert password == PASSWORD
+        time.sleep(0.075)
+        return "timing-test-password-hash"
+
+    def _timed_signup(email: str) -> tuple[int, dict, float]:
+        start = time.perf_counter()
+        response = client.post(
+            "/api/auth/signup",
+            json={"email": email, "name": "Timing", "password": PASSWORD},
+        )
+        return response.status_code, response.json(), time.perf_counter() - start
+
+    known_times: list[float] = []
+    unknown_times: list[float] = []
+    with (
+        patch.object(settings(), "SIGNUP_REQUIRE_EMAIL_VERIFICATION", True),
+        patch("app.api.routes.auth.hash_password", side_effect=_delayed_hash) as hash_password,
+        patch("app.api.routes.auth.send_account_exists_email") as account_exists_email,
+        patch("app.api.routes.auth.send_verification_email") as verification_email,
+    ):
+        for _ in range(samples):
+            known_status, known_body, known_elapsed = _timed_signup(known_email)
+            unknown_status, unknown_body, unknown_elapsed = _timed_signup(
+                f"unknown-timing-{uuid.uuid4().hex[:8]}@example.com"
+            )
+
+            assert known_status == unknown_status == 202
+            assert known_body == unknown_body
+            known_times.append(known_elapsed)
+            unknown_times.append(unknown_elapsed)
+
+    assert hash_password.call_count == samples * 2
+    assert account_exists_email.call_count == samples
+    assert verification_email.call_count == samples
+
+    known_mean = statistics.fmean(known_times)
+    unknown_mean = statistics.fmean(unknown_times)
+    slower_times = known_times if known_mean >= unknown_mean else unknown_times
+    tolerance = max(0.050, 2 * statistics.pstdev(slower_times))
+    delta = abs(known_mean - unknown_mean)
+    assert delta <= tolerance, (
+        f"signup timing diverged: known_mean={known_mean:.4f}s "
+        f"unknown_mean={unknown_mean:.4f}s tolerance={tolerance:.4f}s"
+    )


### PR DESCRIPTION
## Summary
- Equalize the signup email-verification path so known-email attempts perform the same pending-row maintenance and Argon2/HMAC token work as fresh unknown-email attempts before returning the uniform 202 response.
- Block part archive when the part has positive reserved stock, using the stock domain service path via `total_for_part(..., status="reserved")`.
- Add regression coverage for signup timing parity and part archive reserved-stock handling, including net-zero released reservations.

## Tests
- PASS `uv run --extra dev pytest tests/test_signup_no_enumeration.py tests/test_archive_part_reserved.py`
- PASS `uv run --extra dev ruff check app/api/routes/parts_core.py --select F,I`
- PASS `uv run --extra dev ruff check app/api/routes/auth.py app/core/errors.py tests/test_signup_no_enumeration.py tests/test_archive_part_reserved.py`
- NOTE full-file Ruff including `parts_core.py` still reports pre-existing E501/E741 issues on legacy lines outside this PR.

## Merge Order
- Based on current `origin/main` at `18ca06f`, which includes PR #709.
- Independent of #704 frontend verification work; this PR does not touch frontend verification code.

Refs #705
