### PR TITLE
HOTFIX #684 + #693: fail-closed pepper bootstrap and SSH host pinning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -414,6 +414,7 @@ jobs:
           cp deploy/.env.prod.example .env.prod.ci
           sed -i 's|^POSTGRES_PASSWORD=.*|POSTGRES_PASSWORD=stockmgr-prod-ci|' .env.prod.ci
           sed -i 's|^SESSION_SECRET=.*|SESSION_SECRET=ci-prod-smoke-session-secret-2026|' .env.prod.ci
+          sed -i 's|^PASSWORD_PEPPER=.*|PASSWORD_PEPPER=ci-prod-smoke-password-pepper-2026|' .env.prod.ci
           sed -i 's|^CORS_ORIGINS=.*|CORS_ORIGINS=http://127.0.0.1:8091|' .env.prod.ci
           sed -i 's|^WORKSPACE_SECRETS_KEY=.*|WORKSPACE_SECRETS_KEY=ZDZkYjI4NzM0YTQ4MjNhODNhZGFkNzE3ZGVkMGY5YWU=|' .env.prod.ci
           sed -i 's|^SMTP_HOST=.*|SMTP_HOST=smtp.invalid|' .env.prod.ci
@@ -808,8 +809,6 @@ jobs:
           set -euo pipefail
 
           ed25519_known_hosts="${RUNNER_TEMP}/deploy_ed25519_known_hosts"
-          ecdsa_known_hosts="${RUNNER_TEMP}/deploy_ecdsa_known_hosts"
-          trap 'rm -f "${ed25519_known_hosts}" "${ecdsa_known_hosts}"' EXIT
 
           ssh-keyscan -T 10 -t ed25519 "${DEPLOY_HOST}" > "${ed25519_known_hosts}"
           if [ ! -s "${ed25519_known_hosts}" ]; then
@@ -825,130 +824,117 @@ jobs:
             exit 1
           fi
 
-          # drone-ssh negotiates the VPS ECDSA host key. The trusted pin
-          # remains the ED25519 fingerprint above; this value constrains
-          # the following appleboy connection to the scanned ECDSA key.
-          ssh-keyscan -T 10 -t ecdsa "${DEPLOY_HOST}" > "${ecdsa_known_hosts}"
-          if [ ! -s "${ecdsa_known_hosts}" ]; then
-            echo "No ECDSA host key returned for DEPLOY_HOST."
-            exit 1
-          fi
-          ecdsa_fingerprint=$(ssh-keygen -lf "${ecdsa_known_hosts}" | awk 'NR == 1 {print $2}')
-          echo "ecdsa_fingerprint=${ecdsa_fingerprint}" >> "${GITHUB_OUTPUT}"
+          echo "known_hosts=${ed25519_known_hosts}" >> "${GITHUB_OUTPUT}"
 
       - name: SSH deploy
-        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2  # v1.2.5
-        with:
-          host: ${{ secrets.DEPLOY_HOST }}
-          username: ${{ secrets.DEPLOY_USER }}
-          key: ${{ secrets.DEPLOY_SSH_KEY }}
-          fingerprint: ${{ steps.deploy_host_key.outputs.ecdsa_fingerprint }}
-          script: |
-            set -euo pipefail
-            cd /srv/stockmanager
-            git fetch --quiet origin main
-            git reset --hard origin/main
-            # Tag this deploy with the short SHA — exposed to both the
-            # backend (SENTRY_RELEASE) and the frontend Vite build
-            # (VITE_APP_VERSION) so Sentry groups issues per release
-            # and source-map upload pins maps to it. Exported, not
-            # appended to .env.prod, so the SHA isn't persisted between
-            # deploys.
-            export SENTRY_RELEASE
-            SENTRY_RELEASE=$(git rev-parse --short=12 HEAD)
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          DEPLOY_KNOWN_HOSTS: ${{ steps.deploy_host_key.outputs.known_hosts }}
+        run: |
+          set -euo pipefail
 
-            if [ ! -f .env.prod ]; then
-              echo ".env.prod is missing on the VPS; aborting before touching containers."
-              exit 1
+          if [ ! -s "${DEPLOY_KNOWN_HOSTS}" ]; then
+            echo "Verified ED25519 known_hosts file is missing."
+            exit 1
+          fi
+
+          key_file="${RUNNER_TEMP}/deploy_ssh_key"
+          umask 077
+          printf '%s\n' "${DEPLOY_SSH_KEY}" > "${key_file}"
+          trap 'rm -f "${key_file}"' EXIT
+
+          ssh -i "${key_file}" \
+            -o BatchMode=yes \
+            -o IdentitiesOnly=yes \
+            -o StrictHostKeyChecking=yes \
+            -o UserKnownHostsFile="${DEPLOY_KNOWN_HOSTS}" \
+            -o GlobalKnownHostsFile=/dev/null \
+            -o HostKeyAlgorithms=ssh-ed25519 \
+            "${DEPLOY_USER}@${DEPLOY_HOST}" 'bash -se' <<'REMOTE_DEPLOY'
+          set -euo pipefail
+          cd /srv/stockmanager
+          git fetch --quiet origin main
+          git reset --hard origin/main
+          # Tag this deploy with the short SHA — exposed to both the
+          # backend (SENTRY_RELEASE) and the frontend Vite build
+          # (VITE_APP_VERSION) so Sentry groups issues per release
+          # and source-map upload pins maps to it. Exported, not
+          # appended to .env.prod, so the SHA isn't persisted between
+          # deploys.
+          export SENTRY_RELEASE
+          SENTRY_RELEASE=$(git rev-parse --short=12 HEAD)
+
+          if [ ! -f .env.prod ]; then
+            echo ".env.prod is missing on the VPS; aborting before touching containers."
+            exit 1
+          fi
+
+          pepper_line=$(grep -E '^PASSWORD_PEPPER=' .env.prod | tail -n 1 || true)
+          pepper_value="${pepper_line#PASSWORD_PEPPER=}"
+          if [ -z "${pepper_line}" ] || [ -z "${pepper_value}" ] || [ "${pepper_value}" = "replace-me-with-the-output-of-openssl-rand-hex-32" ]; then
+            echo "PASSWORD_PEPPER is missing or still the template placeholder in .env.prod."
+            echo "Run 'make bootstrap-pepper' on the VPS as deploy, escrow the generated value, then rerun deploy."
+            exit 1
+          fi
+          echo "PASSWORD_PEPPER present in .env.prod."
+
+          # FB-005: keep users on the static Apache page during the deploy
+          # window. The trap is deliberately registered before the first
+          # deploy-side effect so failed dumps, builds, migrations, or health
+          # gates do not leave maintenance mode enabled indefinitely.
+          disable_maintenance() {
+            sudo -n a2disconf parts-maintenance && sudo -n systemctl reload apache2 || true
+          }
+          trap disable_maintenance EXIT
+          if sudo -n a2enconf parts-maintenance && sudo -n systemctl reload apache2; then
+            echo "Apache maintenance mode enabled for deploy."
+          else
+            echo "WARNING: could not enable Apache maintenance mode; continuing deploy."
+          fi
+
+          # Pre-deploy DB snapshot (INFRA2-001 / Infra CRIT-1).
+          # Runs before `docker compose up` so the pre-migration state
+          # of the running Postgres is captured. Fails loud — if the
+          # dump can't be written, the deploy aborts here and the old
+          # containers keep serving the old code.
+          bash deploy/predeploy-dump.sh "${SENTRY_RELEASE}"
+
+          if ! docker compose -f docker-compose.prod.yml --env-file .env.prod up -d --build; then
+            echo "docker compose up failed — current service state:"
+            docker compose -f docker-compose.prod.yml --env-file .env.prod ps || true
+            echo "--- backend-init logs (tail) ---"
+            docker compose -f docker-compose.prod.yml --env-file .env.prod logs --tail=120 backend-init || true
+            echo "--- backend logs (tail) ---"
+            docker compose -f docker-compose.prod.yml --env-file .env.prod logs --tail=120 backend || true
+            exit 1
+          fi
+          docker image prune -f
+
+          # Post-deploy health gate (INFRA2-002 / Infra HIGH-1/7/8).
+          # Polls the public health endpoint until 200 — covers the
+          # rebuild window plus alembic upgrade plus first-request
+          # warm-up. The 30 × 5s = 150s ceiling is generous for our
+          # one-worker stack; tighten if it routinely takes less.
+          # On failure the SSH script exits non-zero, which fails the
+          # deploy job and surfaces in GitHub Actions instead of
+          # leaving prod broken with a green CI badge.
+          echo "post-deploy health gate"
+          ok=0
+          for i in $(seq 1 30); do
+            if curl -fsS https://parts.matescb.cz/api/health > /dev/null 2>&1; then
+              echo "  /api/health OK after ${i} attempts ($((i*5))s)"
+              ok=1
+              break
             fi
-
-            # AUD-022 introduced mandatory PASSWORD_PEPPER. Older prod env files
-            # predate that setting, so bootstrap it once on the VPS without
-            # logging the value. Legacy unpeppered hashes verify and rehash on
-            # successful login; after this deploy, operators must escrow the
-            # generated value from /srv/stockmanager/.env.prod.
-            python3 - <<'PY'
-            from pathlib import Path
-            import os
-            import secrets
-
-            env_path = Path(".env.prod")
-            lines = env_path.read_text().splitlines()
-            for idx, line in enumerate(lines):
-                if line.startswith("PASSWORD_PEPPER="):
-                    if line.split("=", 1)[1].strip():
-                        print("PASSWORD_PEPPER present in .env.prod.")
-                        raise SystemExit(0)
-                    lines[idx] = f"PASSWORD_PEPPER={secrets.token_hex(32)}"
-                    break
-            else:
-                if lines and lines[-1] != "":
-                    lines.append("")
-                lines.append(f"PASSWORD_PEPPER={secrets.token_hex(32)}")
-
-            env_path.write_text("\n".join(lines) + "\n")
-            os.chmod(env_path, 0o600)
-            print(
-                "PASSWORD_PEPPER was missing in .env.prod; generated and "
-                "stored on the VPS (value not logged). Escrow it from "
-                "/srv/stockmanager/.env.prod."
-            )
-            PY
-
-            # FB-005: keep users on the static Apache page during the deploy
-            # window. The trap is deliberately registered before the first
-            # deploy-side effect so failed dumps, builds, migrations, or health
-            # gates do not leave maintenance mode enabled indefinitely.
-            disable_maintenance() {
-              sudo -n a2disconf parts-maintenance && sudo -n systemctl reload apache2 || true
-            }
-            trap disable_maintenance EXIT
-            if sudo -n a2enconf parts-maintenance && sudo -n systemctl reload apache2; then
-              echo "Apache maintenance mode enabled for deploy."
-            else
-              echo "WARNING: could not enable Apache maintenance mode; continuing deploy."
-            fi
-
-            # Pre-deploy DB snapshot (INFRA2-001 / Infra CRIT-1).
-            # Runs before `docker compose up` so the pre-migration state
-            # of the running Postgres is captured. Fails loud — if the
-            # dump can't be written, the deploy aborts here and the old
-            # containers keep serving the old code.
-            bash deploy/predeploy-dump.sh "${SENTRY_RELEASE}"
-
-            if ! docker compose -f docker-compose.prod.yml --env-file .env.prod up -d --build; then
-              echo "docker compose up failed — current service state:"
-              docker compose -f docker-compose.prod.yml --env-file .env.prod ps || true
-              echo "--- backend-init logs (tail) ---"
-              docker compose -f docker-compose.prod.yml --env-file .env.prod logs --tail=120 backend-init || true
-              echo "--- backend logs (tail) ---"
-              docker compose -f docker-compose.prod.yml --env-file .env.prod logs --tail=120 backend || true
-              exit 1
-            fi
-            docker image prune -f
-
-            # Post-deploy health gate (INFRA2-002 / Infra HIGH-1/7/8).
-            # Polls the public health endpoint until 200 — covers the
-            # rebuild window plus alembic upgrade plus first-request
-            # warm-up. The 30 × 5s = 150s ceiling is generous for our
-            # one-worker stack; tighten if it routinely takes less.
-            # On failure the SSH script exits non-zero, which fails the
-            # deploy job and surfaces in GitHub Actions instead of
-            # leaving prod broken with a green CI badge.
-            echo "post-deploy health gate"
-            ok=0
-            for i in $(seq 1 30); do
-              if curl -fsS https://parts.matescb.cz/api/health > /dev/null 2>&1; then
-                echo "  /api/health OK after ${i} attempts ($((i*5))s)"
-                ok=1
-                break
-              fi
-              sleep 5
-            done
-            if [ "${ok}" -ne 1 ]; then
-              echo "post-deploy health gate FAILED — last response:"
-              curl -v https://parts.matescb.cz/api/health || true
-              echo "--- backend logs (tail) ---"
-              docker compose -f docker-compose.prod.yml --env-file .env.prod logs --tail=80 backend || true
-              exit 1
-            fi
+            sleep 5
+          done
+          if [ "${ok}" -ne 1 ]; then
+            echo "post-deploy health gate FAILED — last response:"
+            curl -v https://parts.matescb.cz/api/health || true
+            echo "--- backend logs (tail) ---"
+            docker compose -f docker-compose.prod.yml --env-file .env.prod logs --tail=80 backend || true
+            exit 1
+          fi
+          REMOTE_DEPLOY

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev-up dev-down dev-logs dev-rebuild prod-up prod-logs prod-rebuild refresh-tp-spec regen-tp-models
+.PHONY: dev-up dev-down dev-logs dev-rebuild prod-up prod-logs prod-rebuild bootstrap-pepper refresh-tp-spec regen-tp-models
 
 TP_SPEC_URL := https://api.trustedparts.com/swagger/inventory-api-v2/swagger.json
 TP_SPEC := docs/schemas/trustedparts-v2.json
@@ -24,6 +24,9 @@ prod-logs:
 
 prod-rebuild:
 	docker compose -f docker-compose.prod.yml --env-file .env.prod up -d --build --force-recreate
+
+bootstrap-pepper:
+	deploy/bootstrap-pepper.sh .env.prod
 
 refresh-tp-spec:
 	mkdir -p "$(dir $(TP_SPEC))"

--- a/backend/tests/test_ci_workflow.py
+++ b/backend/tests/test_ci_workflow.py
@@ -89,23 +89,31 @@ def _deploy_ssh_step() -> dict:
     return _deploy_step_by_name("SSH deploy")
 
 
-def test_deploy_bootstraps_missing_password_pepper_before_compose_up():
+def test_deploy_fails_closed_when_password_pepper_missing_before_compose_up():
     step = _deploy_ssh_step()
-    script = step["with"]["script"]
+    script = step["run"]
 
-    assert "PASSWORD_PEPPER was missing in .env.prod" in script
-    assert "secrets.token_hex(32)" in script
+    assert "PASSWORD_PEPPER is missing or still the template placeholder" in script
+    assert "make bootstrap-pepper" in script
+    assert "secrets.token_hex" not in script
     assert script.index("PASSWORD_PEPPER") < script.index("docker compose")
     assert "logs --tail=120 backend" in script
 
 
-def test_deploy_does_not_use_ignored_ssh_action_script_stop():
+def test_deploy_uses_raw_ssh_instead_of_appleboy():
     step = _deploy_ssh_step()
-    assert "appleboy/ssh-action" in step.get("uses", "")
+    script = step["run"]
+
+    assert "uses" not in step
+    assert "appleboy/ssh-action" not in str(step)
     assert "script_stop" not in step.get("with", {})
+    assert "ssh -i" in script
+    assert "-o StrictHostKeyChecking=yes" in script
+    assert '-o UserKnownHostsFile="${DEPLOY_KNOWN_HOSTS}"' in script
+    assert "-o HostKeyAlgorithms=ssh-ed25519" in script
 
 
-def test_deploy_verifies_ed25519_host_fingerprint_before_ssh_action():
+def test_deploy_verifies_ed25519_host_fingerprint_before_raw_ssh():
     precheck = _deploy_host_key_step()
     deploy = _deploy_ssh_step()
     env = precheck.get("env", {})
@@ -117,10 +125,11 @@ def test_deploy_verifies_ed25519_host_fingerprint_before_ssh_action():
     assert 'ssh-keyscan -T 10 -t ed25519 "${DEPLOY_HOST}"' in script
     assert 'actual_fingerprint=$(ssh-keygen -lf "${ed25519_known_hosts}"' in script
     assert '"${actual_fingerprint}" != "${DEPLOY_HOST_FINGERPRINT}"' in script
-    assert 'ssh-keyscan -T 10 -t ecdsa "${DEPLOY_HOST}"' in script
-    assert "ecdsa_fingerprint=" in script
-    assert deploy["with"]["fingerprint"] == (
-        "${{ steps.deploy_host_key.outputs.ecdsa_fingerprint }}"
+    assert 'ssh-keyscan -T 10 -t ecdsa "${DEPLOY_HOST}"' not in script
+    assert "ecdsa_fingerprint" not in script
+    assert 'echo "known_hosts=${ed25519_known_hosts}"' in script
+    assert deploy["env"]["DEPLOY_KNOWN_HOSTS"] == (
+        "${{ steps.deploy_host_key.outputs.known_hosts }}"
     )
 
 

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -15,6 +15,19 @@ def _set_required_prod_env(monkeypatch):
     monkeypatch.setenv("APP_BASE_URL", "https://parts.example.com")
 
 
+def test_password_pepper_required_in_prod(monkeypatch):
+    _set_required_prod_env(monkeypatch)
+    monkeypatch.setenv("SENTRY_TRACES_SAMPLE_RATE", "0.05")
+    monkeypatch.delenv("PASSWORD_PEPPER", raising=False)
+
+    try:
+        Settings(_env_file=None)
+    except ValidationError as exc:
+        assert "PASSWORD_PEPPER is required" in str(exc)
+    else:
+        raise AssertionError("prod Settings accepted missing PASSWORD_PEPPER")
+
+
 def test_sentry_traces_rate_required_in_prod(monkeypatch):
     _set_required_prod_env(monkeypatch)
     monkeypatch.delenv("SENTRY_TRACES_SAMPLE_RATE", raising=False)

--- a/deploy/.env.prod.example
+++ b/deploy/.env.prod.example
@@ -47,8 +47,10 @@ SESSION_IDLE_HOURS=24
 #
 # REQUIRED in prod: the backend's Settings validator raises on an empty value
 # when APP_ENV=prod.
-# Generate with:
-#   openssl rand -hex 32
+# First prod bootstrap:
+#   make bootstrap-pepper
+# Run this on the VPS as the deploy user, then escrow the printed value before
+# the first boot. The deploy job refuses to generate this automatically.
 PASSWORD_PEPPER=replace-me-with-the-output-of-openssl-rand-hex-32
 
 # Comma-separated list of origins allowed to call the API from a browser.

--- a/deploy/bootstrap-pepper.sh
+++ b/deploy/bootstrap-pepper.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+env_file="${1:-.env.prod}"
+placeholder="replace-me-with-the-output-of-openssl-rand-hex-32"
+confirm_phrase="I HAVE ESCROWED PASSWORD_PEPPER"
+
+die() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+if [ ! -t 0 ] || [ ! -t 1 ]; then
+  die "bootstrap-pepper must be run interactively on the VPS, not from CI."
+fi
+
+if [ ! -f "${env_file}" ]; then
+  die "${env_file} does not exist. Copy deploy/.env.prod.example first."
+fi
+
+if [ ! -w "${env_file}" ]; then
+  die "${env_file} is not writable by the current user."
+fi
+
+pepper_count=$(grep -Ec '^PASSWORD_PEPPER=' "${env_file}" || true)
+if [ "${pepper_count}" -gt 1 ]; then
+  die "multiple PASSWORD_PEPPER entries found in ${env_file}; resolve manually."
+fi
+
+pepper_line=$(grep -E '^PASSWORD_PEPPER=' "${env_file}" | tail -n 1 || true)
+pepper_value="${pepper_line#PASSWORD_PEPPER=}"
+
+if [ -n "${pepper_line}" ] && [ -n "${pepper_value}" ] && [ "${pepper_value}" != "${placeholder}" ]; then
+  echo "PASSWORD_PEPPER is already set in ${env_file}; refusing to overwrite it."
+  exit 0
+fi
+
+if command -v openssl >/dev/null 2>&1; then
+  new_pepper=$(openssl rand -hex 32)
+else
+  new_pepper=$(python3 -c 'import secrets; print(secrets.token_hex(32))')
+fi
+
+cat <<EOF
+This will bootstrap PASSWORD_PEPPER in ${env_file}.
+
+Changing this value after users have logged in prevents peppered password
+hashes from verifying. Store the value below in the operator password manager
+alongside SESSION_SECRET before continuing.
+
+PASSWORD_PEPPER=${new_pepper}
+EOF
+
+printf "\nAfter escrow, type '%s' to write it: " "${confirm_phrase}"
+IFS= read -r confirmation
+if [ "${confirmation}" != "${confirm_phrase}" ]; then
+  die "confirmation did not match; ${env_file} was not changed."
+fi
+
+tmp_file=$(mktemp "${env_file}.XXXXXX")
+trap 'rm -f "${tmp_file}"' EXIT
+
+python3 - "${env_file}" "${tmp_file}" "${new_pepper}" "${placeholder}" <<'PY'
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+env_path = Path(sys.argv[1])
+tmp_path = Path(sys.argv[2])
+new_pepper = sys.argv[3]
+placeholder = sys.argv[4]
+
+lines = env_path.read_text().splitlines()
+pepper_indexes = [
+    idx for idx, line in enumerate(lines) if line.startswith("PASSWORD_PEPPER=")
+]
+
+if len(pepper_indexes) > 1:
+    raise SystemExit(
+        "multiple PASSWORD_PEPPER entries found; resolve the ambiguity manually"
+    )
+
+if pepper_indexes:
+    idx = pepper_indexes[0]
+    current = lines[idx].split("=", 1)[1].strip()
+    if current and current != placeholder:
+        raise SystemExit("PASSWORD_PEPPER is already set; refusing to overwrite")
+    lines[idx] = f"PASSWORD_PEPPER={new_pepper}"
+else:
+    if lines and lines[-1] != "":
+        lines.append("")
+    lines.append(f"PASSWORD_PEPPER={new_pepper}")
+
+tmp_path.write_text("\n".join(lines) + "\n")
+PY
+
+chmod 600 "${tmp_file}"
+mv "${tmp_file}" "${env_file}"
+trap - EXIT
+
+echo "PASSWORD_PEPPER written to ${env_file}; keep the escrowed copy off the VPS."

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -170,6 +170,13 @@ unless you're rebuilding the host, or migrating to a fresh VPS.
    # CORS_ORIGINS is preset to https://parts.matescb.cz.
    ```
 
+   Bootstrap `PASSWORD_PEPPER` exactly once and escrow the printed value
+   alongside `SESSION_SECRET` before the first prod boot:
+
+   ```bash
+   sudo -u deploy make -C /srv/stockmanager bootstrap-pepper
+   ```
+
 5. **Bring up the stack.** The backend container's entrypoint runs
    `alembic upgrade head`, so a fresh DB migrates itself.
 
@@ -244,31 +251,36 @@ The next push to `main` triggers the first end-to-end automated deploy.
 - **`backend-tests`** — postgres:16-alpine service container, `pip install -e ".[dev]"`, `pytest -q --tb=short`. Runs on every push and PR.
 - **`web-build`** — `npm ci && npm run build`, followed on `push` to `main` by a Sentry sourcemap upload step (`npx @sentry/cli sourcemaps upload`). The build's `tsc -b` step also catches TypeScript errors. Runs on every push and PR; the sourcemap upload is gated on push to `main` only. `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, and `SENTRY_PROJECT` are GitHub Actions secrets used by the upload step — they must **not** appear in `.env.prod` or `docker-compose.prod.yml` build args (INFRA2-010).
 - **`prod-validate`** (INFRA2-012) — validates the prod artefacts that the two test jobs above don't exercise: (1) `docker compose -f docker-compose.prod.yml config -q` catches YAML/schema/variable errors in `docker-compose.prod.yml` (including the single-line JSON-array `command:` form that previously broke in production); (2) `docker buildx build` of `backend/Dockerfile` and `web/Dockerfile.prod` catches Dockerfile regressions; (3) `docker run nginx:alpine nginx -t` lints `deploy/nginx-web.conf`. Uses a throw-away CI env file derived from `deploy/.env.prod.example` — no real secrets are required. Runs on every push and PR.
-- **`deploy`** — gated on `github.event_name == 'push' && github.ref == 'refs/heads/main'` and `needs: [backend-tests, web-build, prod-validate]`. Verifies the VPS ED25519 host-key fingerprint, then uses `appleboy/ssh-action@v1.2.5` to SSH in and run the pull/up/prune script. Concurrency-grouped on `ci-refs/heads/main` with `cancel-in-progress: false` so consecutive pushes queue rather than abort an in-flight `docker compose up --build`.
+- **`deploy`** — gated on `github.event_name == 'push' && github.ref == 'refs/heads/main'` and the quality gates listed in `deploy.needs`. Verifies the VPS ED25519 host-key fingerprint, then uses raw `ssh` with strict ED25519 host-key checking to run the deploy script. Concurrency-grouped on `ci-refs/heads/main` with `cancel-in-progress: false` so consecutive pushes queue rather than abort an in-flight `docker compose up --build`.
 
-The deploy script body is intentionally tiny:
+At the start of the remote deploy script, before maintenance mode, the
+pre-deploy dump, or container changes, the job hard-resets to `origin/main` and
+fail-closes if `.env.prod` or `PASSWORD_PEPPER` is missing:
 
 ```bash
 set -euo pipefail
 cd /srv/stockmanager
 git fetch --quiet origin main
 git reset --hard origin/main
-docker compose -f docker-compose.prod.yml --env-file .env.prod up -d --build
-docker image prune -f
+test -f .env.prod
+# PASSWORD_PEPPER must be set and must not be the template placeholder.
 ```
 
 `git reset --hard` (rather than `pull`) means the deploy is always exactly
 the tip of `origin/main`, even if some prior failed deploy left the working
-tree dirty. `image prune -f` keeps disk usage in check across rebuilds.
+tree dirty. The later deploy steps enable maintenance mode, take the
+pre-deploy backup, run `docker compose up -d --build`, prune images, and poll
+the public health endpoint.
 
 The deploy job pins the VPS ED25519 host key with the
 `DEPLOY_HOST_FINGERPRINT` GitHub Actions secret. It scans only the ED25519 host
 key and verifies the scanned `SHA256:...` fingerprint against the secret before
-authentication. `appleboy/drone-ssh` negotiates the VPS ECDSA host key on the
-current server, so the workflow derives that ECDSA fingerprint only after the
-trusted ED25519 check passes and feeds it to the action for the actual SSH
-connection. If the VPS host key rotates (rebuild, key regeneration), capture the
-new ED25519 value on the host with
+authentication. The actual deploy connection then uses that verified
+`known_hosts` file with `StrictHostKeyChecking=yes`,
+`GlobalKnownHostsFile=/dev/null`, and `HostKeyAlgorithms=ssh-ed25519`. No ECDSA
+host key is scanned or passed through a second trust path. If the VPS host key
+rotates (rebuild, key regeneration), capture the new ED25519 value on the host
+with
 `ssh-keygen -lf /etc/ssh/ssh_host_ed25519_key.pub`, verify it from a separate
 trusted network, and update the secret before the next deploy. See
 [`docs/runbooks/secret-rotation.md`](runbooks/secret-rotation.md).
@@ -282,7 +294,6 @@ the human-readable tag the SHA was resolved from. Bump them with:
 gh api repos/actions/checkout/git/refs/tags/v4 --jq .object.sha
 gh api repos/actions/setup-python/git/refs/tags/v5 --jq .object.sha
 gh api repos/actions/setup-node/git/refs/tags/v4 --jq .object.sha
-gh api repos/appleboy/ssh-action/git/refs/tags/v1.2.5 --jq .object.sha
 ```
 
 Replace the SHA in the `uses:` line; keep the tag in the trailing comment.

--- a/docs/runbooks/secret-rotation.md
+++ b/docs/runbooks/secret-rotation.md
@@ -65,6 +65,13 @@ every logged-in user is logged out.  No data loss.
 
 ### 2.2 `PASSWORD_PEPPER`
 
+**Initial bootstrap:** run `make bootstrap-pepper` once on the VPS after
+`.env.prod` exists and before the first prod boot. The command prints the
+generated value and requires an explicit escrow confirmation before writing it
+to `.env.prod`. Store it in the operator password manager alongside
+`SESSION_SECRET`. CI deploys fail closed if this value is missing or still set
+to the template placeholder.
+
 **Effect of rotation:** passwords already rehashed with the old pepper will no
 longer verify. Do not rotate this like a routine stateless secret unless you are
 also running a planned password-reset campaign or a purpose-built migration.
@@ -232,8 +239,9 @@ push to `main`.
 ### 2.7 `DEPLOY_HOST_FINGERPRINT`
 
 **Effect of rotation:** CI deploys fail until GitHub Actions has the new
-fingerprint.  Update the secret immediately after a planned VPS host-key
-rotation, and before the first deploy to a migrated VPS.
+fingerprint. The deploy job uses raw SSH pinned to the verified ED25519
+`known_hosts` entry, so update the secret immediately after a planned VPS
+host-key rotation, and before the first deploy to a migrated VPS.
 
 **Steps:**
 


### PR DESCRIPTION
## Summary
- Remove silent deploy-time `PASSWORD_PEPPER` generation and fail closed when prod `.env.prod` is missing a real value.
- Add `make bootstrap-pepper` / `deploy/bootstrap-pepper.sh` as the explicit one-shot operator bootstrap with escrow confirmation.
- Replace the appleboy ECDSA fingerprint handoff with raw `ssh` pinned to the verified ED25519 `known_hosts` entry.

## Operator Impact
- Existing prod must have a real `PASSWORD_PEPPER` in `/srv/stockmanager/.env.prod`; if it is absent, blank, or still the template placeholder, deploy aborts before maintenance mode, backup, or container changes.
- To seed it, run `sudo -u deploy make -C /srv/stockmanager bootstrap-pepper` on the VPS and escrow the printed value alongside `SESSION_SECRET`.
- No new GitHub Actions secret is required; deploy continues to trust `DEPLOY_HOST_FINGERPRINT` as the ED25519 host-key pin.

## Tests
- `python3` parsed `.github/workflows/ci.yml` successfully.
- `bash -n` on extracted deploy host-key and raw-SSH workflow scripts.
- `bash -n deploy/bootstrap-pepper.sh`.
- Grep guard: no `appleboy/ssh-action`, ECDSA scan/output, old pepper-generation message, or deploy `secrets.token_hex` remains in `ci.yml`.
- TTY smoke of `deploy/bootstrap-pepper.sh` against a temp `.env.prod` verified a 64-hex pepper and mode `600`.
- `make -n bootstrap-pepper`.
- `uv run --extra dev pytest -q tests/test_ci_workflow.py tests/test_config.py` (19 passed, 1 warning).
- Not run locally: `shellcheck` is not installed; Docker is not installed, so full prod compose validation was not feasible here.

## Merge Order
- Based on current `origin/main` after merged PR #709 (`18ca06f`).
- Merge after the prod VPS has been seeded and the pepper has been escrowed, or expect the next main deploy to fail closed until that bootstrap is completed.
- Independent of held secret-rotation follow-up #708.

Refs #706
