### PR TITLE
AUD-046 + AUD-069: fix frontend dead-code paths

### DIFF
--- a/web/.eslintrc.cjs
+++ b/web/.eslintrc.cjs
@@ -45,8 +45,9 @@ module.exports = {
           "Do not pass sensitive identifiers to Sentry.logger.*; log a redacted scalar or omit the field.",
       },
       {
-        selector: 'JSXAttribute[name.name="rel"][value.value="noreferrer"]',
-        message: 'External links must use rel="noopener noreferrer".',
+        selector:
+          'JSXOpeningElement:has(JSXAttribute[name.name="target"] Literal[value="_blank"]):matches(:not(:has(JSXAttribute[name.name="rel"] Literal[value=/\\bnoopener\\b/])), :not(:has(JSXAttribute[name.name="rel"] Literal[value=/\\bnoreferrer\\b/])))',
+        message: 'Links with target="_blank" must use rel="noopener noreferrer".',
       },
       {
         selector: "Property[key.name='queryFn'] > ArrowFunctionExpression[params.length=0]",

--- a/web/src/__tests__/targetBlankRelLint.test.ts
+++ b/web/src/__tests__/targetBlankRelLint.test.ts
@@ -1,0 +1,50 @@
+// @ts-expect-error ESLint v8 is installed for tests, but this repo does not carry @types/eslint.
+import { ESLint } from "eslint";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const webRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const targetBlankRelMessage = 'Links with target="_blank" must use rel="noopener noreferrer".';
+
+type LintMessage = {
+  ruleId?: string | null;
+  message: string;
+};
+
+async function restrictedSyntaxMessages(source: string): Promise<string[]> {
+  const eslint = new ESLint({ cwd: webRoot, useEslintrc: true });
+  const [result] = await eslint.lintText(source, {
+    filePath: path.join(webRoot, "src/__tests__/targetBlankRel.fixture.tsx"),
+  });
+
+  return (result.messages as LintMessage[])
+    .filter((message) => message.ruleId === "no-restricted-syntax")
+    .map((message) => message.message);
+}
+
+describe("target=_blank rel lint guard", () => {
+  it('rejects rel="noreferrer" without noopener', async () => {
+    await expect(
+      restrictedSyntaxMessages(
+        'export const Link = () => <a href="https://example.com" target="_blank" rel="noreferrer">open</a>;',
+      ),
+    ).resolves.toContain(targetBlankRelMessage);
+  });
+
+  it("rejects target=_blank links without rel", async () => {
+    await expect(
+      restrictedSyntaxMessages(
+        'export const Link = () => <a href="https://example.com" target="_blank">open</a>;',
+      ),
+    ).resolves.toContain(targetBlankRelMessage);
+  });
+
+  it('allows target=_blank links with rel="noopener noreferrer"', async () => {
+    await expect(
+      restrictedSyntaxMessages(
+        'export const Link = () => <a href="https://example.com" target="_blank" rel="noopener noreferrer">open</a>;',
+      ),
+    ).resolves.not.toContain(targetBlankRelMessage);
+  });
+});

--- a/web/src/routes/auth/Verify.tsx
+++ b/web/src/routes/auth/Verify.tsx
@@ -16,14 +16,17 @@ import AuthShell from "./AuthShell";
 
 type State = "verifying" | "success" | "error";
 
+const AUTH_VERIFICATION_EXPIRED = "auth.verification_expired";
+const AUTH_VERIFICATION_INVALID = "auth.verification_invalid";
+
 function verificationErrorMessage(e: unknown): string {
   if (!(e instanceof ApiError)) {
     return "Verification failed — please try again.";
   }
-  if (e.status === 410) {
+  if (e.code === AUTH_VERIFICATION_EXPIRED) {
     return "Verification link expired.";
   }
-  if (e.status === 404) {
+  if (e.code === AUTH_VERIFICATION_INVALID) {
     return "Verification link not found.";
   }
   return e.userMessage;

--- a/web/src/routes/auth/__dom__/Verify.render.dom.test.tsx
+++ b/web/src/routes/auth/__dom__/Verify.render.dom.test.tsx
@@ -97,11 +97,15 @@ describe("Verify — ApiError render", () => {
     expect(screen.queryByText(new RegExp(RAW_SERVER_MSG))).toBeNull();
   });
 
-  it("shows an expired-link message for 410", async () => {
+  it("shows an expired-link message for the backend verification code", async () => {
     mockPost.mockRejectedValue(
       new ApiError(
-        410,
-        { data: null, status: { category: "not_found", message: "expired" } },
+        400,
+        {
+          data: null,
+          status: { category: "validation_error", message: "expired" },
+          code: "auth.verification_expired",
+        },
         "expired",
       ),
     );
@@ -112,11 +116,15 @@ describe("Verify — ApiError render", () => {
     expect(screen.queryByText("Verification link not found.")).toBeNull();
   });
 
-  it("shows an unknown-link message for 404", async () => {
+  it("shows an unknown-link message for the backend invalid verification code", async () => {
     mockPost.mockRejectedValue(
       new ApiError(
-        404,
-        { data: null, status: { category: "not_found", message: "unknown" } },
+        400,
+        {
+          data: null,
+          status: { category: "validation_error", message: "unknown" },
+          code: "auth.verification_invalid",
+        },
         "unknown",
       ),
     );


### PR DESCRIPTION
## Summary
- Replace the broken JSX rel selector with a target=_blank guard that requires both noopener and noreferrer.
- Add a Vitest lint regression test proving rel="noreferrer" and missing rel are caught.
- Switch the verify-email UI from HTTP status branching to backend auth error codes so the expired-link branch is reachable with the current HTTP 400 envelope.

## Tests
- npm run typecheck
- npx vitest run src/__tests__/targetBlankRelLint.test.ts src/routes/auth/__dom__/Verify.render.dom.test.tsx
- ./node_modules/.bin/eslint src/__tests__/targetBlankRelLint.test.ts src/routes/auth/Verify.tsx src/routes/auth/__dom__/Verify.render.dom.test.tsx src/routes/parts/PartCreate.tsx
- rg -l 'target=("_blank"|\{"_blank"\}|\{\x27_blank\x27\}|\x27_blank\x27)' src | xargs ./node_modules/.bin/eslint

Note: full npm run lint still fails on pre-existing no-control-regex errors in web/src/lib/bagCode.ts, unrelated to this PR.

## Merge order
Independent of #705 because frontend-only auth verification path.

Refs #704