### PR TITLE
Fix #707 medium follow-ups

### DIFF
--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -27,8 +27,9 @@ from app.core.auth import (
 from app.core.config import settings
 from app.core.cookies import (
     WORKSPACE_COOKIE_NAME,
+    delete_session_cookie,
+    delete_workspace_cookie,
     session_cookie_attrs,
-    workspace_cookie_attrs,
 )
 from app.core.deps import CurrentUser, DbSession
 from app.core.errors import ErrorCodes, raise_http
@@ -468,8 +469,8 @@ def logout(request: Request, response: Response, db: DbSession) -> Envelope[None
                 request_id=getattr(request.state, "request_id", None),
             )
         revoke_session(db, token)
-    response.delete_cookie(cookie_name, **session_cookie_attrs())
-    response.delete_cookie(WORKSPACE_COOKIE_NAME, **workspace_cookie_attrs())
+    delete_session_cookie(response, cookie_name)
+    delete_workspace_cookie(response)
     log.info("logout")
     return ok(None, "logged out")
 

--- a/backend/app/api/routes/stock.py
+++ b/backend/app/api/routes/stock.py
@@ -5,6 +5,7 @@ from sqlalchemy.exc import IntegrityError
 
 from app.api.routes._stock_integrity import raise_integrity_as_409
 from app.core.deps import CurrentUser, CurrentWorkspace, DbSession
+from app.core.errors import ErrorCodes, raise_http
 from app.core.responses import Envelope, ok
 from app.domain.parts.services.bag_signature import compute_bag_signature
 from app.domain.stock.schemas import (
@@ -24,6 +25,23 @@ from app.domain.stock.service import (
 )
 
 router = APIRouter()
+
+
+def _validate_add_stock_currency(payload: AddStockIn, ws: CurrentWorkspace) -> None:
+    if payload.price is None or payload.price.mode == "none":
+        return
+    currency = (payload.price.currency or "").strip().upper()
+    active_currencies = ws.active_currencies or []
+    if currency not in active_currencies:
+        raise_http(
+            422,
+            ErrorCodes.STOCK_INVALID_CURRENCY,
+            "price.currency must be one of the workspace active currencies",
+            field="price.currency",
+            value=payload.price.currency,
+            active_currencies=active_currencies,
+        )
+    payload.price.currency = currency
 
 
 def _serialize_entry(e):
@@ -67,6 +85,7 @@ def add(
                     )
                 },
             )
+    _validate_add_stock_currency(payload, ws)
     try:
         e = add_stock(db, workspace_id=ws.id, user_id=user.id, payload=payload)
     except StockConflictError as exc:

--- a/backend/app/core/cookies.py
+++ b/backend/app/core/cookies.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+from starlette.responses import Response
+
 from app.core.config import settings
 
+LEGACY_COOKIE_PATH = "/"
 SESSION_COOKIE_PATH = "/api"
 WORKSPACE_COOKIE_NAME = "stockmgr_workspace"
 WORKSPACE_COOKIE_PATH = "/api"
@@ -27,3 +30,15 @@ def workspace_cookie_attrs() -> dict[str, bool | str]:
         "samesite": "strict",
         "path": WORKSPACE_COOKIE_PATH,
     }
+
+
+def delete_session_cookie(response: Response, cookie_name: str) -> None:
+    attrs = session_cookie_attrs()
+    response.delete_cookie(cookie_name, **attrs)
+    response.delete_cookie(cookie_name, **{**attrs, "path": LEGACY_COOKIE_PATH})
+
+
+def delete_workspace_cookie(response: Response) -> None:
+    attrs = workspace_cookie_attrs()
+    response.delete_cookie(WORKSPACE_COOKIE_NAME, **attrs)
+    response.delete_cookie(WORKSPACE_COOKIE_NAME, **{**attrs, "path": LEGACY_COOKIE_PATH})

--- a/backend/app/core/errors.py
+++ b/backend/app/core/errors.py
@@ -162,6 +162,9 @@ class ErrorCodes:
     SOURCING_INVALID_CURRENCY_CODE = "invalid_currency_code"
     SOURCING_GENERIC = "sourcing.error"
 
+    # Stock router.
+    STOCK_INVALID_CURRENCY = "stock.invalid_currency"
+
     # Workspace dependency-injection edge cases (deps.py).
     # WORKSPACE_NONE: caller has no active membership in any workspace
     # at all — distinct from WORKSPACE_NOT_FOUND, which is "this id

--- a/backend/tests/test_auth_cookie_attrs.py
+++ b/backend/tests/test_auth_cookie_attrs.py
@@ -9,12 +9,20 @@ from tests._factories import signup_user
 
 
 def _cookie_from(response: Any, name: str) -> Morsel[str]:
+    cookies = _cookies_from(response, name)
+    if cookies:
+        return cookies[0]
+    raise AssertionError(f"missing Set-Cookie for {name}: {response.headers!r}")
+
+
+def _cookies_from(response: Any, name: str) -> list[Morsel[str]]:
+    out: list[Morsel[str]] = []
     for header in response.headers.get_list("set-cookie"):
         parsed = SimpleCookie()
         parsed.load(header)
         if name in parsed:
-            return parsed[name]
-    raise AssertionError(f"missing Set-Cookie for {name}: {response.headers!r}")
+            out.append(parsed[name])
+    return out
 
 
 def _security_attrs(cookie: Morsel[str]) -> dict[str, bool | str]:
@@ -52,12 +60,34 @@ def test_set_and_delete_attributes_match(client):
     logout = client.post("/api/auth/logout")
     assert logout.status_code == 200, logout.text
 
-    session_delete = _cookie_from(logout, session_cookie_name)
+    session_deletes = {cookie["path"]: cookie for cookie in _cookies_from(logout, session_cookie_name)}
+    assert {"/api", "/"}.issubset(session_deletes)
+
+    session_delete = session_deletes["/api"]
     assert session_delete.value == ""
     assert session_delete["max-age"] == "0"
     assert _security_attrs(session_delete) == _security_attrs(session_set)
 
-    workspace_delete = _cookie_from(logout, WORKSPACE_COOKIE_NAME)
+    legacy_session_delete = session_deletes["/"]
+    assert legacy_session_delete.value == ""
+    assert legacy_session_delete["max-age"] == "0"
+    assert _security_attrs(legacy_session_delete) == {
+        **_security_attrs(session_set),
+        "path": "/",
+    }
+
+    workspace_deletes = {cookie["path"]: cookie for cookie in _cookies_from(logout, WORKSPACE_COOKIE_NAME)}
+    assert {"/api", "/"}.issubset(workspace_deletes)
+
+    workspace_delete = workspace_deletes["/api"]
     assert workspace_delete.value == ""
     assert workspace_delete["max-age"] == "0"
     assert _security_attrs(workspace_delete) == _security_attrs(workspace_set)
+
+    legacy_workspace_delete = workspace_deletes["/"]
+    assert legacy_workspace_delete.value == ""
+    assert legacy_workspace_delete["max-age"] == "0"
+    assert _security_attrs(legacy_workspace_delete) == {
+        **_security_attrs(workspace_set),
+        "path": "/",
+    }

--- a/backend/tests/test_stock_add_currency_validation.py
+++ b/backend/tests/test_stock_add_currency_validation.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from tests._factories import create_part
+
+
+def _priced_payload(part_id: str, currency: str) -> dict:
+    return {
+        "part_id": part_id,
+        "quantity": 1,
+        "price": {
+            "mode": "per_component",
+            "unit_price": "1.00",
+            "currency": currency,
+        },
+    }
+
+
+def test_add_stock_rejects_currency_outside_workspace_active_list(authed_client):
+    part_id = create_part(authed_client, name="Currency policy part")
+    patch = authed_client.patch("/api/workspaces/current", json={"active_currencies": ["EUR"]})
+    assert patch.status_code == 200, patch.text
+
+    response = authed_client.post("/api/stock/add", json=_priced_payload(part_id, "USD"))
+
+    assert response.status_code == 422, response.text
+    body = response.json()
+    assert body["code"] == "stock.invalid_currency"
+    assert body["field"] == "price.currency"
+    assert body["value"] == "USD"
+    assert body["active_currencies"] == ["EUR"]
+
+    stock = authed_client.get(f"/api/parts/{part_id}/stock")
+    assert stock.status_code == 200, stock.text
+    assert stock.json()["data"]["total_on_hand"] == 0
+
+
+def test_add_stock_rejects_unknown_three_letter_currency(authed_client):
+    part_id = create_part(authed_client, name="Unknown currency part")
+
+    response = authed_client.post("/api/stock/add", json=_priced_payload(part_id, "XYZ"))
+
+    assert response.status_code == 422, response.text
+    body = response.json()
+    assert body["code"] == "stock.invalid_currency"
+    assert body["value"] == "XYZ"
+
+
+def test_add_stock_accepts_active_currency(authed_client):
+    part_id = create_part(authed_client, name="Active currency part")
+    patch = authed_client.patch("/api/workspaces/current", json={"active_currencies": ["EUR"]})
+    assert patch.status_code == 200, patch.text
+
+    response = authed_client.post("/api/stock/add", json=_priced_payload(part_id, "eur"))
+
+    assert response.status_code == 200, response.text
+    body = response.json()["data"]
+    assert body["currency"] == "EUR"
+    assert body["unit_price"] == 1.0

--- a/docs/domain/scan-import.md
+++ b/docs/domain/scan-import.md
@@ -108,7 +108,7 @@ Schema:
 | Column | Notes |
 |---|---|
 | `workspace_id` | FK to `workspaces`, **CASCADE**, part of PK. |
-| `key` | `varchar(64)` part of PK. SHA-256 hex of `(workspace_id + sorted row contents)` or a client-supplied UUID4. |
+| `key` | `varchar(64)` part of PK. SHA-256 hex of `(workspace_id + ordered row contents)` or a client-supplied UUID4. |
 | `result_json` | JSONB. Holds the full API envelope so a cache hit returns verbatim without re-running any logic. |
 | `created_at` | `timestamptz`, `server_default=func.now()`. |
 
@@ -116,13 +116,19 @@ Index: `ix_bulk_import_idempotency_ws_created` for the TTL sweep.
 
 **TTL: 24 hours.** Rows older than `_BULK_IMPORT_IDEMPOTENCY_TTL_H` (24) are swept best-effort at the start of each request — bounded table without a background cron (`backend/app/api/routes/parts_scan.py:59,132-142`).
 
+### Content-key order contract
+
+The implicit content key is **order-sensitive**. `_bulk_import_content_key()` serialises each row in request order and joins those serialised blobs before hashing. Two payloads with the same rows in a different order intentionally produce different fallback keys; `backend/tests/test_bulk_import_idempotency.py::test_distinct_orders_distinct_hashes` pins this contract.
+
+Operationally, the stable retry contract is the explicit frontend-supplied `idempotency_key`. If an operator or support engineer must replay a request body without that key, preserve the exact row order. Shuffling rows changes the fallback content key and can bypass the idempotency cache, so first inspect existing parts / stock entries before retrying a shuffled payload. See [scan-import-retry](../runbooks/scan-import-retry.md).
+
 ## Bulk-import flow
 
 `POST /api/parts/bulk-import-from-scan` — `backend/app/api/routes/parts_scan.py:79-432`.
 
 The full sequence:
 
-1. **Idempotency key derivation** (`:129-130`): explicit FE-supplied `idempotency_key`, or fall back to a SHA-256 content hash of `(ws_id + sorted row JSON)`. Sorting rows by `(bag_signature or "", mpn)` makes the hash order-independent so the operator can re-sort between retries.
+1. **Idempotency key derivation** (`:129-130`): explicit FE-supplied `idempotency_key`, or fall back to a SHA-256 content hash of `(ws_id + request-order row JSON)`. The fallback is order-sensitive; it preserves the submitted sequence rather than sorting rows.
 2. **Best-effort TTL sweep** (`:132-142`): delete rows older than 24h. Failure is swallowed.
 3. **Cache lookup** — only when an explicit key was supplied. Falling back to content-hash for cache HIT would suppress the duplicate-MPN detection path on a second scan of the same MPN (`:149-156`).
 4. **Provider setup** — `make_provider(ws.parts_provider, decrypt(api_key), decrypt(api_secret))`. Returns 400 if not configured.
@@ -172,3 +178,4 @@ The full sequence:
 - **Never use Python's `str.strip()` on a bag code.** It strips field-separator control chars that are valid bag content.
 - **Never write `bag_signature` on a non-scan path.** The partial index assumes scan-only population; widening that breaks the cardinality assumption.
 - **Never replace the savepoint-per-row pattern with a single transaction.** A single uncaught exception in row N would discard rows 1..N-1's writes — which the operator already saw acknowledged in the per-row outcome list — and the audit trail would diverge from what was actually persisted (Sec CRIT-6).
+- **Never shuffle rows when replaying a scan-import payload without the original `idempotency_key`.** Row order is part of the fallback content key.

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -27,6 +27,7 @@ How to handle ops scenarios. Each runbook follows the template in [STYLE.md](../
 | [incident-response](incident-response.md) | SEV-1/2 | Severity triage, comms cadence, post-mortem template |
 | [smtp-outage](smtp-outage.md) | SEV-2 | Signup verification + invitation emails fail; degraded paths |
 | [provider-outage](provider-outage.md) | SEV-2 | DigiKey or Mouser API unavailable; user-visible impact and mitigation |
+| [scan-import-retry](scan-import-retry.md) | SEV-3 | Retry scan-import safely without bypassing idempotency |
 | [workspace-recovery](workspace-recovery.md) | SEV-2 | Restore a disabled workspace, audit a suspected isolation leak |
 | [analytics-umami](analytics-umami.md) | Routine / SEV-3 | Self-hosted Umami: rotate website ID, disable tracking, debug a missing pageview |
 

--- a/docs/runbooks/scan-import-retry.md
+++ b/docs/runbooks/scan-import-retry.md
@@ -1,0 +1,42 @@
+# Scan-import retry runbook
+
+Audience: engineer / on-call
+
+## When
+
+A user reports that `POST /api/parts/bulk-import-from-scan` timed out, returned a transient provider error, or the browser lost the response after submitting a scan-import queue.
+
+## Severity
+
+Usually SEV-3. Escalate to SEV-2 if multiple workspaces are blocked from importing stock.
+
+## TTR
+
+15-30 minutes for a single workspace once you know whether the original request committed.
+
+## Pre-flight
+
+- Ask whether the retry is from the original browser queue. The frontend sends an explicit `idempotency_key`; retrying from the same queue is the safest path.
+- If support is replaying a captured payload manually, check whether it includes `idempotency_key`.
+- If there is no `idempotency_key`, preserve the exact row order from the original request. The fallback content key is order-sensitive.
+
+## Steps
+
+1. If the original payload has an `idempotency_key`, retry the same payload with the same key.
+2. If the original payload has no `idempotency_key`, do not sort, group, dedupe, or otherwise reorder `rows` before replaying it.
+3. Before replaying a shuffled or edited payload, inspect the affected MPNs and `bag_signature` values in the workspace. A different row order changes the fallback content key and can bypass the idempotency cache.
+4. If the original request likely committed, prefer having the user re-open the scan queue and resolve duplicate / bag-rescan rows instead of manually replaying.
+
+## Verify
+
+- The response summary matches the expected created / duplicate / failed counts.
+- No unexpected duplicate active parts were created for the same workspace MPNs.
+- Re-scanned bags return `bag_rescan` rather than creating new stock rows for the same physical bag.
+
+## Rollback
+
+There is no bulk undo. If a replay double-imported stock, correct it with normal stock removal / adjustment flows so the ledger keeps an auditable trail.
+
+## Post-mortem
+
+Record whether the retry used the explicit `idempotency_key`. If not, include whether row order changed and link to the affected workspace / request id.

--- a/web/src/instrument.test.ts
+++ b/web/src/instrument.test.ts
@@ -104,6 +104,76 @@ describe("Sentry beforeSend", () => {
     );
   });
 
+  it("test_beforesendtransaction_strips_query_string", async () => {
+    vi.resetModules();
+
+    const Sentry = await import("@sentry/react");
+    vi.mocked(Sentry.init).mockClear();
+
+    await import("./instrument");
+
+    const options = vi.mocked(Sentry.init).mock.calls[0]?.[0];
+    const beforeSendTransaction = options?.beforeSendTransaction;
+    expect(beforeSendTransaction).toBeTypeOf("function");
+    if (!beforeSendTransaction) {
+      throw new Error("Sentry beforeSendTransaction was not configured");
+    }
+
+    const event = {
+      type: "transaction",
+      transaction: "GET /parts/abc?token=secret#stock?tab=lots",
+      tags: {
+        url: "https://parts.matescb.cz/parts/abc?token=secret#stock?tab=lots",
+        route: "/parts/:id",
+      },
+      request: {
+        url: "https://parts.matescb.cz/api/parts?token=secret&workspace_id=ws",
+        query_string: "token=secret&workspace_id=ws",
+        method: "GET",
+        headers: {
+          Referer: "https://parts.matescb.cz/search?q=secret",
+          Cookie: "stockmgr_session=secret",
+        },
+      },
+      contexts: {
+        trace: {
+          data: {
+            "http.url": "https://parts.matescb.cz/api/parts?token=secret",
+            url: "/api/parts?workspace_id=ws",
+          },
+        },
+      },
+      spans: [
+        {
+          trace_id: "a".repeat(32),
+          span_id: "b".repeat(16),
+          start_timestamp: 1,
+          description: "GET /api/parts?token=secret",
+          data: {
+            "http.url": "https://parts.matescb.cz/api/parts?token=secret",
+            url: "/api/parts?workspace_id=ws",
+          },
+        },
+      ],
+    } as unknown as Parameters<typeof beforeSendTransaction>[0];
+
+    const scrubbed = await Promise.resolve(beforeSendTransaction(event, {}));
+
+    expect(scrubbed?.transaction).toBe("GET /parts/abc#stock");
+    expect(scrubbed?.tags?.url).toBe("https://parts.matescb.cz/parts/abc#stock");
+    expect(scrubbed?.request?.url).toBe("https://parts.matescb.cz/api/parts");
+    expect(scrubbed?.request?.query_string).toBeUndefined();
+    expect(scrubbed?.request?.headers?.Referer).toBe("https://parts.matescb.cz/search");
+    expect(scrubbed?.request?.headers?.Cookie).toBeUndefined();
+    expect(scrubbed?.contexts?.trace?.data?.["http.url"]).toBe("https://parts.matescb.cz/api/parts");
+    expect(scrubbed?.contexts?.trace?.data?.url).toBe("/api/parts");
+    expect(scrubbed?.spans?.[0]?.description).toBe("GET /api/parts");
+    expect(scrubbed?.spans?.[0]?.data?.["http.url"]).toBe("https://parts.matescb.cz/api/parts");
+    expect(scrubbed?.spans?.[0]?.data?.url).toBe("/api/parts");
+    expect(JSON.stringify(scrubbed)).not.toContain("secret");
+    expect(JSON.stringify(scrubbed)).not.toContain("?");
+  });
+
   it("test_init_uses_env_traces_rate", async () => {
     vi.resetModules();
     vi.stubEnv("VITE_SENTRY_TRACES_SAMPLE_RATE", "0.05");

--- a/web/src/instrument.ts
+++ b/web/src/instrument.ts
@@ -36,8 +36,17 @@ const replaysOnErrorSampleRate = parseSampleRate(
 const requestHeaderDenylist = new Set(["cookie", "authorization", "x-workspace-id"]);
 const requestUrlHeaders = new Set(["referer", "referrer"]);
 const breadcrumbUrlKeys = new Set(["url", "from", "to"]);
+const transactionUrlKeys = new Set(["url", "from", "to", "http.url"]);
 const sensitiveTextPattern =
   /(["']?\b(?:password|passwd|pass|token|secret|api[_-]?key|authorization|cookie|session(?:[_-]?id)?)["']?\s*[:=]\s*["']?)([^"',&\s;}\]]+)/gi;
+type MutableRequest = {
+  url?: string;
+  query_string?: unknown;
+  headers?: Record<string, unknown>;
+  method?: string;
+  data?: unknown;
+  body_redacted?: boolean;
+};
 
 function parseSampleRate(
   raw: string | undefined,
@@ -76,6 +85,27 @@ function scrubUrlKeys(values: Record<string, unknown>, keys: ReadonlySet<string>
     if (keys.has(key.toLowerCase()) && typeof values[key] === "string") {
       values[key] = stripQueryString(values[key]);
     }
+  }
+}
+
+function scrubRequest(req: MutableRequest | undefined, { redactNonGetBody }: { redactNonGetBody: boolean }) {
+  if (!req) return;
+  if (typeof req.url === "string") {
+    req.url = stripQueryString(req.url);
+  }
+  delete req.query_string;
+  if (req.headers) {
+    for (const k of Object.keys(req.headers)) {
+      if (requestHeaderDenylist.has(k.toLowerCase())) {
+        delete req.headers[k];
+      }
+    }
+    scrubUrlKeys(req.headers, requestUrlHeaders);
+  }
+  const method = (req.method ?? "").toUpperCase();
+  if (redactNonGetBody && method && method !== "GET" && req.data !== undefined) {
+    delete req.data;
+    req.body_redacted = true;
   }
 }
 
@@ -137,31 +167,32 @@ Sentry.init({
   beforeSend(event) {
     scrubEventStrings(event as unknown as Record<string, unknown>);
 
-    const req = event.request;
-    if (req) {
-      if (typeof req.url === "string") {
-        req.url = stripQueryString(req.url);
-      }
-      delete (req as Record<string, unknown>).query_string;
-      if (req.headers) {
-        for (const k of Object.keys(req.headers)) {
-          if (requestHeaderDenylist.has(k.toLowerCase())) {
-            delete (req.headers as Record<string, unknown>)[k];
-          }
-        }
-        scrubUrlKeys(req.headers as Record<string, unknown>, requestUrlHeaders);
-      }
-      const method = (req.method ?? "").toUpperCase();
-      if (method && method !== "GET") {
-        if (req.data !== undefined) {
-          delete req.data;
-          (req as Record<string, unknown>).body_redacted = true;
-        }
-      }
-    }
+    scrubRequest(event.request as MutableRequest | undefined, { redactNonGetBody: true });
     for (const breadcrumb of event.breadcrumbs ?? []) {
       if (breadcrumb.data) {
         scrubUrlKeys(breadcrumb.data, breadcrumbUrlKeys);
+      }
+    }
+    return event;
+  },
+  beforeSendTransaction(event) {
+    if (typeof event.transaction === "string") {
+      event.transaction = stripQueryString(event.transaction);
+    }
+    scrubRequest(event.request as MutableRequest | undefined, { redactNonGetBody: false });
+    if (event.tags) {
+      scrubUrlKeys(event.tags as Record<string, unknown>, transactionUrlKeys);
+    }
+    const trace = event.contexts?.trace as { data?: Record<string, unknown> } | undefined;
+    if (trace?.data) {
+      scrubUrlKeys(trace.data, transactionUrlKeys);
+    }
+    for (const span of event.spans ?? []) {
+      if (span.data) {
+        scrubUrlKeys(span.data as Record<string, unknown>, transactionUrlKeys);
+      }
+      if (typeof span.description === "string") {
+        span.description = stripQueryString(span.description);
       }
     }
     return event;

--- a/web/src/routes/projects/sourcing/PurchasePlanReviewPage.tsx
+++ b/web/src/routes/projects/sourcing/PurchasePlanReviewPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState, type SetStateAction } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 import { RefreshCw, ShoppingCart } from "lucide-react";
@@ -31,6 +31,7 @@ import type {
   PurchasePlanOrderOverride,
 } from "./purchasePlanTypes";
 type LocationState = { plan?: PurchasePlan; project?: Project };
+type OrderOverrides = Record<string, PurchasePlanOrderOverride>;
 
 export default function PurchasePlanReviewPage() {
   const { projectId, planId } = useParams<{ projectId: string; planId: string }>();
@@ -52,7 +53,17 @@ export default function PurchasePlanReviewPage() {
   const [busyAction, setBusyAction] = useState<"refresh" | "convert" | null>(null);
   const [refreshAttention, setRefreshAttention] = useState(false);
   const [overrideLine, setOverrideLine] = useState<PurchasePlanLine | null>(null);
-  const [overrides, setOverrides] = useState<Record<string, PurchasePlanOrderOverride>>({});
+  const [overrides, setOverridesState] = useState<OrderOverrides>({});
+  const overridesRef = useRef(overrides);
+  const setOverrides = useCallback((update: SetStateAction<OrderOverrides>) => {
+    setOverridesState(current => {
+      const next = typeof update === "function"
+        ? (update as (current: OrderOverrides) => OrderOverrides)(current)
+        : update;
+      overridesRef.current = next;
+      return next;
+    });
+  }, []);
   const grouped = useMemo(() => groupLines(plan?.lines ?? []), [plan]);
   const unfilled = useMemo(
     () => (plan?.lines ?? []).filter(line => !line.selected_distributor),
@@ -96,9 +107,31 @@ export default function PurchasePlanReviewPage() {
   }
   const fresh = isRefreshFresh(plan);
   const currency = summaryCurrency(plan);
+  function pruneStaleOverrides(
+    current: OrderOverrides,
+    refreshed: PurchasePlan,
+  ): { retained: OrderOverrides; dropped: string[] } {
+    const retained: OrderOverrides = {};
+    const dropped: string[] = [];
+    const linesById = new Map(refreshed.lines.map(line => [line.id, line]));
+    for (const [lineId, override] of Object.entries(current)) {
+      const refreshedLine = linesById.get(lineId);
+      const stillAvailable = refreshedLine
+        ? (refreshedLine.available_offers ?? []).some(offer =>
+            purchasePlanOverrideMatchesOffer(refreshedLine, override, offer),
+          )
+        : false;
+      if (stillAvailable) {
+        retained[lineId] = override;
+      } else {
+        dropped.push(lineId);
+      }
+    }
+    return { retained, dropped };
+  }
   function planWithOverrides(
     nextPlan: PurchasePlan,
-    retainedOverrides: Record<string, PurchasePlanOrderOverride>,
+    retainedOverrides: OrderOverrides,
   ): PurchasePlan {
     const nextLines = nextPlan.lines.map(line => {
       const override = retainedOverrides[line.id];
@@ -125,28 +158,13 @@ export default function PurchasePlanReviewPage() {
     setBusyAction("refresh");
     try {
       const next = await api.post<PurchasePlan>(`/sourcing/purchase-plans/${plan.id}/refresh`);
-      const pruned: typeof overrides = {};
-      const dropped: string[] = [];
-      const linesById = new Map(next.lines.map(line => [line.id, line]));
-      for (const [lineId, override] of Object.entries(overrides)) {
-        const refreshedLine = linesById.get(lineId);
-        const stillAvailable = refreshedLine
-          ? (refreshedLine.available_offers ?? []).some(offer =>
-              purchasePlanOverrideMatchesOffer(refreshedLine, override, offer),
-            )
-          : false;
-        if (stillAvailable) {
-          pruned[lineId] = override;
-        } else {
-          dropped.push(lineId);
-        }
-      }
+      const { retained: pruned, dropped } = pruneStaleOverrides(overridesRef.current, next);
       if (dropped.length > 0) {
         toast.info(
           `Removed ${dropped.length} override${dropped.length === 1 ? "" : "s"} no longer available after refresh.`,
         );
       }
-      setOverrides(pruned);
+      setOverrides(current => pruneStaleOverrides(current, next).retained);
       queryClient.setQueryData(purchasePlanKey, planWithOverrides(next, pruned));
       setRefreshAttention(false);
       toast.success("Prices refreshed");

--- a/web/src/routes/projects/sourcing/__tests__/PurchasePlanReviewPage.test.tsx
+++ b/web/src/routes/projects/sourcing/__tests__/PurchasePlanReviewPage.test.tsx
@@ -366,6 +366,55 @@ describe("PurchasePlanReviewPage", () => {
     expect(toast.info).not.toHaveBeenCalled();
   });
 
+  it("keeps an override selected while refresh is in flight", async () => {
+    let resolveRefresh!: (value: PurchasePlan) => void;
+    const refreshPromise = new Promise<PurchasePlan>(resolve => {
+      resolveRefresh = resolve;
+    });
+    const refreshed = plan({
+      est_total_cost: "18.40",
+      lines: [
+        {
+          ...plan().lines[0],
+          selected_distributor: "DigiKey",
+          selected_qty: 16,
+          selected_unit_price: "1.15",
+        },
+        plan().lines[1],
+      ],
+      unfilled_count: 0,
+    });
+    const post = vi.spyOn(api, "post")
+      .mockReturnValueOnce(refreshPromise)
+      .mockResolvedValueOnce({
+        orders: [{ id: "order-1", name: "Draft", supplier: "Arrow", status: "draft", entries: [] }],
+      });
+    renderPage();
+
+    await userEvent.click(screen.getByRole("button", { name: /Refresh prices/ }));
+    await waitFor(() => {
+      expect(post).toHaveBeenCalledWith("/sourcing/purchase-plans/plan-12345678/refresh");
+    });
+
+    await selectArrowOffer();
+    resolveRefresh(refreshed);
+
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith("Prices refreshed"));
+    await userEvent.click(screen.getByRole("button", { name: /Create draft orders/ }));
+
+    await waitFor(() => expect(screen.getByTestId("location").textContent).toBe("/orders"));
+    expect(post).toHaveBeenNthCalledWith(2, "/sourcing/purchase-plans/plan-12345678/orders", {
+      overrides: {
+        "line-1": {
+          selected_distributor: "Arrow",
+          selected_qty: 16,
+          selected_unit_price: "2.05",
+          selected_currency: "USD",
+        },
+      },
+    });
+  });
+
   it("does not prune when refresh fails", async () => {
     const apiError = new ApiError(
       502,


### PR DESCRIPTION
## Summary
- Restore purchase-plan refresh pruning to use live functional override state so in-flight manual override changes survive refresh.
- Add frontend Sentry `beforeSendTransaction` URL/query scrubbing for request data, tags, trace data, spans, and URL-bearing headers.
- Emit logout deletion cookies for legacy `path=/` session/workspace cookies while preserving current `path=/api` deletes.
- Document the scan-import content-key order-sensitive contract and add a retry runbook for operators.
- Enforce add-stock price currency against workspace `active_currencies` server-side.

## Tests
- `npm test -- src/routes/projects/sourcing/__tests__/PurchasePlanReviewPage.test.tsx src/instrument.test.ts`
- `npm run typecheck`
- `./.venv/bin/python -m pytest tests/test_auth_cookie_attrs.py tests/test_stock_add_currency_validation.py tests/test_bulk_import_idempotency.py::test_distinct_orders_distinct_hashes -q`

## Merge Order / Conflicts
- Based on current `origin/main` at `18ca06f`, after PR #709.
- Keep separate from #708/#706 secret-rotation and x-api-key denylist work; this PR does not touch the held secret-rotation docs or denylist scope.
- Local worktree still has unrelated untracked workspace files; the pushed branch diff is scoped to #707.

Refs #707