### PR TITLE
AUD-076: Fix backend-cron-sessions healthcheck flap

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -320,7 +320,7 @@ services:
       backend:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "test -d /tmp/stockmanager-job-heartbeats && find /tmp/stockmanager-job-heartbeats -name session-purge -mmin +0 -mmin -90 -print -quit | grep -q ."]
+      test: ["CMD-SHELL", "test -d /tmp/stockmanager-job-heartbeats && find /tmp/stockmanager-job-heartbeats -name session-purge -mmin -90 -print -quit | grep -q ."]
       interval: 60s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
## Summary
- Remove the transient `-mmin +0` predicate from the `backend-cron-sessions` heartbeat healthcheck.
- Keep the existing `-mmin -90` freshness window aligned with the peer cron healthchecks.

## Tests
- `docker compose -f docker-compose.prod.yml config -q` could not run because Docker is unavailable in this environment (`docker: command not found`).
- `python3` static YAML validation of `docker-compose.prod.yml`, including assertions that `backend-cron-sessions` no longer contains `-mmin +0` and still contains `-mmin -90`.

## Merge-order / conflict notes
- Scope is limited to `docker-compose.prod.yml` line 323 area.
- No expected conflicts unless another PR edits the `backend-cron-sessions` healthcheck.
- Does not touch digest pins or the #706 deploy SSH/pepper workflow.

Refs #714