### PR TITLE
AUD-073: use non-blocking run-job advisory locks

### DIFF
--- a/backend/app/cli/run_job.py
+++ b/backend/app/cli/run_job.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from uuid import uuid4
 
 from sqlalchemy import text
-from sqlalchemy.exc import DBAPIError
 from sqlalchemy.orm import Session
 
 logger = logging.getLogger(__name__)
@@ -19,7 +18,6 @@ logger = logging.getLogger(__name__)
 SessionFactory = Callable[[], Session]
 JobCallable = Callable[[Session], int]
 HEARTBEAT_DIR = Path("/tmp/stockmanager-job-heartbeats")
-LOCK_NOT_AVAILABLE_SQLSTATE = "55P03"
 
 
 @dataclass(frozen=True)
@@ -37,19 +35,12 @@ class UnknownJobError(ValueError):
     """Raised when the requested job name is not registered."""
 
 
-def _is_lock_not_available(exc: DBAPIError) -> bool:
-    orig = getattr(exc, "orig", None)
-    return (
-        getattr(orig, "sqlstate", None) == LOCK_NOT_AVAILABLE_SQLSTATE
-        or getattr(orig, "pgcode", None) == LOCK_NOT_AVAILABLE_SQLSTATE
-    )
-
-
-def _acquire_job_lock(db: Session, job_name: str) -> None:
-    db.execute(
-        text("SELECT pg_advisory_xact_lock(hashtext(:job_name))"),
+def _acquire_job_lock(db: Session, job_name: str) -> bool:
+    result = db.execute(
+        text("SELECT pg_try_advisory_xact_lock(hashtext(:job_name))"),
         {"job_name": job_name},
     )
+    return bool(result.scalar())
 
 
 def _default_session_factory() -> Session:
@@ -121,14 +112,10 @@ def run_job(
 
     db = session_factory()
     try:
-        try:
-            _acquire_job_lock(db, job.name)
-        except DBAPIError as exc:
-            if _is_lock_not_available(exc):
-                db.rollback()
-                logger.info("job=%s status=skipped reason=lock_denied", job.name)
-                return 0
-            raise
+        if not _acquire_job_lock(db, job.name):
+            db.rollback()
+            logger.info("job=%s status=skipped reason=lock_denied", job.name)
+            return 0
         affected = job.run(db)
         db.commit()
     except Exception:

--- a/backend/tests/test_run_job.py
+++ b/backend/tests/test_run_job.py
@@ -4,7 +4,6 @@ import logging
 import uuid
 from datetime import timedelta
 
-from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import Session
 
 from app.cli.run_job import JOBS, JobSpec, UnknownJobError, main, run_job
@@ -12,18 +11,25 @@ from app.core.time import utcnow
 from app.domain.users.models import User, UserSession
 
 
+class _FakeResult:
+    def __init__(self, value: bool) -> None:
+        self.value = value
+
+    def scalar(self) -> bool:
+        return self.value
+
+
 class _FakeSession:
-    def __init__(self, *, execute_error: Exception | None = None) -> None:
+    def __init__(self, *, execute_result: bool = True) -> None:
         self.committed = False
         self.rolled_back = False
         self.closed = False
         self.executed: list[tuple[str, dict[str, object] | None]] = []
-        self.execute_error = execute_error
+        self.execute_result = execute_result
 
-    def execute(self, statement, params=None) -> None:
+    def execute(self, statement, params=None) -> _FakeResult:
         self.executed.append((str(statement), params))
-        if self.execute_error is not None:
-            raise self.execute_error
+        return _FakeResult(self.execute_result)
 
     def commit(self) -> None:
         self.committed = True
@@ -61,7 +67,7 @@ def test_run_job_dispatches_allow_listed_job(tmp_path) -> None:
     assert affected == 4
     assert calls == [session]
     assert session.executed == [
-        ("SELECT pg_advisory_xact_lock(hashtext(:job_name))", {"job_name": "example"})
+        ("SELECT pg_try_advisory_xact_lock(hashtext(:job_name))", {"job_name": "example"})
     ]
     assert session.committed is True
     assert session.rolled_back is False
@@ -174,18 +180,8 @@ def test_sourcing_alerts_evaluate_dispatches_to_module(monkeypatch, tmp_path) ->
     assert (tmp_path / "sourcing-alerts-evaluate").exists()
 
 
-class _FakeLockDenied(Exception):
-    sqlstate = "55P03"
-
-
 def test_run_job_skips_when_advisory_lock_denied(caplog, tmp_path) -> None:
-    session = _FakeSession(
-        execute_error=OperationalError(
-            "SELECT pg_advisory_xact_lock(hashtext(:job_name))",
-            {"job_name": "example"},
-            _FakeLockDenied(),
-        )
-    )
+    session = _FakeSession(execute_result=False)
     calls: list[Session] = []
 
     def _job(db: Session) -> int:

--- a/backend/tests/test_run_job_advisory_lock.py
+++ b/backend/tests/test_run_job_advisory_lock.py
@@ -11,7 +11,7 @@ from app.cli.run_job import JobSpec, run_job
 pytestmark = pytest.mark.real_db
 
 
-def test_concurrent_invocations_serialise(engine, tmp_path) -> None:
+def test_concurrent_same_job_skips(engine, tmp_path) -> None:
     SessionLocal = sessionmaker(
         bind=engine,
         autoflush=False,
@@ -20,12 +20,12 @@ def test_concurrent_invocations_serialise(engine, tmp_path) -> None:
     )
     first_entered = threading.Event()
     release_first = threading.Event()
-    second_attempting = threading.Event()
     state_lock = threading.Lock()
     entered: list[int] = []
     completed: list[int] = []
     errors: list[BaseException] = []
     results: dict[str, int] = {}
+    second_elapsed: list[float] = []
 
     def _job(db: Session) -> int:
         with state_lock:
@@ -53,10 +53,89 @@ def test_concurrent_invocations_serialise(engine, tmp_path) -> None:
 
     def invoke(label: str) -> None:
         try:
+            started = time.monotonic()
             if label == "second":
-                second_attempting.set()
-            results[label] = run_job(
+                started = time.monotonic()
+            result = run_job(
                 "example",
+                jobs=jobs,
+                session_factory=SessionLocal,
+                heartbeat_dir=tmp_path,
+            )
+            if label == "second":
+                second_elapsed.append(time.monotonic() - started)
+            results[label] = result
+        except BaseException as exc:
+            errors.append(exc)
+
+    first = threading.Thread(target=invoke, args=("first",), daemon=True)
+    first.start()
+    assert first_entered.wait(timeout=5)
+
+    second = threading.Thread(target=invoke, args=("second",), daemon=True)
+    second.start()
+    second.join(timeout=1)
+    assert not second.is_alive()
+    with state_lock:
+        assert entered == [1]
+        assert completed == []
+    assert results == {"second": 0}
+    assert second_elapsed and second_elapsed[0] < 1
+
+    release_first.set()
+    first.join(timeout=5)
+
+    assert not first.is_alive()
+    assert errors == []
+    assert results == {"first": 1, "second": 0}
+    assert completed == [1]
+    assert (tmp_path / "example").read_text(encoding="utf-8") == "ok\n"
+
+
+def test_concurrent_different_jobs_do_not_block_each_other(engine, tmp_path) -> None:
+    SessionLocal = sessionmaker(
+        bind=engine,
+        autoflush=False,
+        expire_on_commit=False,
+        future=True,
+    )
+    first_entered = threading.Event()
+    release_first = threading.Event()
+    second_completed = threading.Event()
+    errors: list[BaseException] = []
+    results: dict[str, int] = {}
+
+    def _first_job(db: Session) -> int:
+        first_entered.set()
+        if not release_first.wait(timeout=5):
+            raise AssertionError("timed out waiting to release the first job")
+        return 10
+
+    def _second_job(db: Session) -> int:
+        second_completed.set()
+        return 20
+
+    jobs = {
+        "first": JobSpec(
+            name="first",
+            owner="tests",
+            cadence="manual",
+            idempotency="test-only",
+            run=_first_job,
+        ),
+        "second": JobSpec(
+            name="second",
+            owner="tests",
+            cadence="manual",
+            idempotency="test-only",
+            run=_second_job,
+        ),
+    }
+
+    def invoke(job_name: str) -> None:
+        try:
+            results[job_name] = run_job(
+                job_name,
                 jobs=jobs,
                 session_factory=SessionLocal,
                 heartbeat_dir=tmp_path,
@@ -70,21 +149,16 @@ def test_concurrent_invocations_serialise(engine, tmp_path) -> None:
 
     second = threading.Thread(target=invoke, args=("second",), daemon=True)
     second.start()
-    assert second_attempting.wait(timeout=5)
-
-    time.sleep(0.5)
-    with state_lock:
-        assert entered == [1]
-        assert completed == []
-    assert second.is_alive()
+    second.join(timeout=1)
+    assert second_completed.is_set()
+    assert not second.is_alive()
+    assert results == {"second": 20}
 
     release_first.set()
     first.join(timeout=5)
-    second.join(timeout=5)
 
     assert not first.is_alive()
-    assert not second.is_alive()
     assert errors == []
-    assert results == {"first": 1, "second": 2}
-    assert completed == [1, 2]
-    assert (tmp_path / "example").read_text(encoding="utf-8") == "ok\n"
+    assert results == {"first": 10, "second": 20}
+    assert (tmp_path / "first").read_text(encoding="utf-8") == "ok\n"
+    assert (tmp_path / "second").read_text(encoding="utf-8") == "ok\n"


### PR DESCRIPTION
## Summary

- Switch run-job advisory locking to non-blocking `pg_try_advisory_xact_lock(hashtext(:job_name))`.
- Skip quickly with `status=skipped` when the same job lock is already held.
- Update advisory-lock regression coverage for same-job skip and different-job independence.

## Tests

- `PYTHONPATH=backend uv run --project backend --extra dev python -m pytest backend/tests/test_run_job_advisory_lock.py -q`
- `PYTHONPATH=backend uv run --project backend --extra dev python -m pytest backend/tests/test_run_job.py -q`

## Merge Order / Conflict Notes

- Scoped to `backend/app/cli/run_job.py`, `backend/tests/test_run_job_advisory_lock.py`, and the directly affected `backend/tests/test_run_job.py` unit assertions.
- Should merge after any branch that rewrites the run-job advisory-lock implementation or these two test files; no expected conflicts with auth/signup, Sentry, deploy SSH/pepper, or migration trigger work.

Refs #711
