### PR TITLE
AUD-082: Sentry tunnel accepts same-origin Referer fallback

### DIFF
--- a/backend/app/api/routes/sentry_tunnel.py
+++ b/backend/app/api/routes/sentry_tunnel.py
@@ -9,8 +9,9 @@ Reference: https://docs.sentry.io/platforms/javascript/troubleshooting/#using-th
 
 Security posture:
 * Same-origin browser SDK posts are allowed pre-auth so login-screen errors
-  still reach Sentry. Requests without a trusted Origin must carry a valid
-  session cookie before we do any tunnel work.
+  still reach Sentry. Requests without a trusted Origin (or same-origin
+  Referer when Origin is absent) must carry a valid session cookie before
+  we do any tunnel work.
 * Host allow-list against `SENTRY_DSN` / `VITE_SENTRY_DSN`. Without it,
   this endpoint would be an open egress to anywhere Sentry-shaped — we
   cap it to our own DSN's host + project id.
@@ -105,16 +106,23 @@ def _origin_host(value: str | None) -> str | None:
     return f"{parsed.scheme}://{parsed.netloc}"
 
 
-def _has_trusted_origin(request: Request) -> bool:
-    origin = _origin_host(request.headers.get("origin"))
-    if origin is None:
-        return False
+def _allowed_request_origins() -> set[str]:
     allowed = {
         host
         for host in (_origin_host(candidate) for candidate in settings().cors_origin_list)
         if host
     }
-    return origin in allowed
+    return allowed
+
+
+def _has_trusted_origin(request: Request) -> bool:
+    origin_header = request.headers.get("origin")
+    if origin_header is not None:
+        origin = _origin_host(origin_header)
+        return origin is not None and origin in _allowed_request_origins()
+
+    referer = _origin_host(request.headers.get("referer"))
+    return referer is not None and referer in _allowed_request_origins()
 
 
 def _require_session_or_trusted_origin(request: Request) -> None:

--- a/backend/tests/test_sentry_tunnel_auth.py
+++ b/backend/tests/test_sentry_tunnel_auth.py
@@ -5,6 +5,10 @@ import json
 from app.api.routes import sentry_tunnel as sentry_tunnel_route
 
 
+def _remove_default_origin(client):
+    client.headers.pop("Origin", None)
+
+
 def test_unauthenticated_cross_origin_rejected(client, monkeypatch):
     monkeypatch.setattr(
         sentry_tunnel_route,
@@ -23,3 +27,47 @@ def test_unauthenticated_cross_origin_rejected(client, monkeypatch):
     body = response.json()
     assert body["data"] is None
     assert body["status"]["category"] in {"unauthenticated", "forbidden"}
+
+
+def test_referer_fallback_when_origin_missing(client, monkeypatch):
+    monkeypatch.setattr(sentry_tunnel_route, "ALLOWED_ENDPOINTS", ())
+    _remove_default_origin(client)
+
+    response = client.post(
+        "/api/sentry-tunnel",
+        content=b'{"dsn":"https://abc@o123.ingest.sentry.io/456"}\n{}',
+        headers={"Referer": "http://testserver/login"},
+    )
+
+    assert response.status_code == 204, response.text
+
+
+def test_cross_origin_referer_rejected_when_origin_missing(client, monkeypatch):
+    monkeypatch.setattr(sentry_tunnel_route, "ALLOWED_ENDPOINTS", ())
+    _remove_default_origin(client)
+
+    response = client.post(
+        "/api/sentry-tunnel",
+        content=b'{"dsn":"https://abc@o123.ingest.sentry.io/456"}\n{}',
+        headers={"Referer": "https://evil.example.com/login"},
+    )
+
+    assert response.status_code == 401, response.text
+    body = response.json()
+    assert body["data"] is None
+    assert body["status"]["category"] == "unauthenticated"
+
+
+def test_referer_not_used_when_origin_present(client, monkeypatch):
+    monkeypatch.setattr(sentry_tunnel_route, "ALLOWED_ENDPOINTS", ())
+
+    response = client.post(
+        "/api/sentry-tunnel",
+        content=b'{"dsn":"https://abc@o123.ingest.sentry.io/456"}\n{}',
+        headers={
+            "Origin": "https://evil.example.com",
+            "Referer": "http://testserver/login",
+        },
+    )
+
+    assert response.status_code == 401, response.text


### PR DESCRIPTION
## Summary

- Adds same-origin `Referer` fallback for Sentry tunnel pre-auth requests only when `Origin` is absent.
- Keeps requests with a present but untrusted `Origin` on the session-auth path, even if `Referer` is same-origin.
- Covers same-origin fallback, cross-origin Referer rejection, and no fallback when Origin is present.

## Tests

- `cd backend && uv run python -m pytest tests/test_sentry_tunnel_auth.py -q` (4 passed, 1 Alembic deprecation warning)

Note: plain `python` is not on PATH in this shell, so I used the repo's established backend uv environment. A repo-root attempt with `backend/.venv/bin/python -m pytest backend/tests/test_sentry_tunnel_auth.py -q` hit an Alembic migration setup error (`attachments` table missing during 0033), while the documented backend-root uv command passes.

## Merge Order / Conflicts

- Scope is limited to `backend/app/api/routes/sentry_tunnel.py` and `backend/tests/test_sentry_tunnel_auth.py`.
- No frontend Sentry transaction scrubbing or deployment docs changes.
- Expected conflicts are only with other changes touching Sentry tunnel request authentication or this focused auth test file.

Refs #720
