### PR TITLE
AUD-077: Configure workspace invitation TTL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@ POSTGRES_DB=stockmgr
 DATABASE_URL=postgresql+psycopg://stockmgr:stockmgr@db:5432/stockmgr
 SESSION_SECRET=dev-change-me-locally
 SESSION_IDLE_HOURS=24
+INVITATION_TTL_DAYS=14
 UPLOAD_DIR=/data/uploads
 APP_ENV=dev
 CORS_ORIGINS=http://localhost:5173

--- a/backend/app/api/routes/invitations.py
+++ b/backend/app/api/routes/invitations.py
@@ -23,18 +23,14 @@ from app.core.time import utcnow
 from app.domain.audit.service import log as _audit_log
 from app.domain.users.models import User
 from app.domain.workspaces.models import (
-    INVITATION_TTL,
     Workspace,
     WorkspaceInvitation,
     WorkspaceMember,
+    invitation_expires_at,
 )
 from app.domain.workspaces.schemas import AcceptIn, InviteIn
 
 router = APIRouter()
-
-
-def _invitation_expires_at():
-    return utcnow() + INVITATION_TTL
 
 
 def _iso_utc(value):
@@ -159,7 +155,7 @@ def create_invitation(
         role=payload.role,
         token_hmac=_hmac_token(plaintext),
         invited_by=user.id,
-        expires_at=_invitation_expires_at(),
+        expires_at=invitation_expires_at(),
     )
     db.add(inv)
     # Wrap in a savepoint so an IntegrityError from concurrent creates

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -34,6 +34,10 @@ class Settings(BaseSettings):
     # Sliding-expiry idle window. A session idle longer than this is
     # rejected even when the absolute lifetime has not elapsed.
     SESSION_IDLE_HOURS: int = Field(default=24, gt=0)
+    # Workspace invitations expire after this many days. Operators may
+    # tune this without a release; restart the backend for the env
+    # override to be picked up by the cached Settings instance.
+    INVITATION_TTL_DAYS: int = Field(default=14, gt=0)
     # Cadence (seconds) of the in-process expired-session purge driven
     # by the FastAPI lifespan hook. DB-007 / issue #98. Knob exists so
     # tests can shorten it; ops should not need to touch it. 0 disables

--- a/backend/app/domain/workspaces/models.py
+++ b/backend/app/domain/workspaces/models.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import uuid
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 import sqlalchemy as sa
 from sqlalchemy import (
@@ -17,6 +17,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 
+from app.core.config import settings
 from app.core.time import utcnow
 from app.domain.workspaces.master_lists import (
     DEFAULT_ACTIVE_COUNTRIES,
@@ -25,7 +26,9 @@ from app.domain.workspaces.master_lists import (
 )
 from app.infra.db import Base
 
-INVITATION_TTL = timedelta(days=14)
+
+def invitation_expires_at() -> datetime:
+    return utcnow() + timedelta(days=settings().INVITATION_TTL_DAYS)
 
 
 class Workspace(Base):
@@ -185,7 +188,7 @@ class WorkspaceInvitation(Base):
     expires_at = Column(
         DateTime(timezone=True),
         nullable=False,
-        default=lambda: utcnow() + INVITATION_TTL,
+        default=invitation_expires_at,
         server_default=text("now() + INTERVAL '14 days'"),
     )
     accepted_at = Column(DateTime(timezone=True), nullable=True)

--- a/backend/tests/test_invitations.py
+++ b/backend/tests/test_invitations.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import uuid
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from fastapi.testclient import TestClient
@@ -123,6 +123,31 @@ def test_invite_has_expires_at(admin):
     rows = admin.get("/api/invitations").json()["data"]
     listed = next(row for row in rows if row["id"] == inv["id"])
     assert listed["expires_at"] == inv["expires_at"]
+
+
+def test_ttl_env_overrides_default(admin, monkeypatch):
+    from app.core.config import Settings, settings
+
+    monkeypatch.delenv("INVITATION_TTL_DAYS", raising=False)
+    assert Settings(_env_file=None).INVITATION_TTL_DAYS == 14
+
+    monkeypatch.setenv("INVITATION_TTL_DAYS", "3")
+    settings.cache_clear()
+    try:
+        assert settings().INVITATION_TTL_DAYS == 3
+
+        before = datetime.now(timezone.utc)
+        invitee_email = f"ttl-{uuid.uuid4().hex[:6]}@x.com"
+        response = admin.post(
+            "/api/invitations", json={"email": invitee_email, "role": "member"}
+        )
+        after = datetime.now(timezone.utc)
+
+        assert response.status_code == 201, response.text
+        expires_at = datetime.fromisoformat(response.json()["data"]["expires_at"])
+        assert before + timedelta(days=3) <= expires_at <= after + timedelta(days=3)
+    finally:
+        settings.cache_clear()
 
 
 def test_expired_invite_rejected(admin):


### PR DESCRIPTION
## Summary
- Add `INVITATION_TTL_DAYS` to backend Settings with the existing 14-day default.
- Use the setting through the shared workspace invitation expiry helper used by invitation creation and the model fallback.
- Document the env var in `.env.example` and add the AUD-077 regression test.

## Tests
- `cd /mnt/data/WORK/stockManager-715/backend && uv run --extra dev python -m pytest tests/test_invitations.py -q`
- `cd /mnt/data/WORK/stockManager-715 && . backend/.venv/bin/activate && python -m pytest backend/tests/test_invitations.py -q`
- `cd /mnt/data/WORK/stockManager-715/backend && uv run --extra dev ruff check app/core/config.py app/domain/workspaces/models.py app/api/routes/invitations.py tests/test_invitations.py`

## Merge Order / Conflicts
- Isolated worktree: `/mnt/data/WORK/stockManager-715`.
- Narrow scope: settings/env example, invitation expiry computation, and invitation tests only.
- Potential conflicts only with other PRs touching `backend/app/core/config.py`, `backend/app/domain/workspaces/models.py`, `backend/app/api/routes/invitations.py`, `.env.example`, or `backend/tests/test_invitations.py`.
- Does not include stale-invite backfill (#716), signup SMTP handling (#712), or password reset (#721).

Refs #715
