### PR TITLE
AUD-080: document workspace trigger naming convention

### DIFF
--- a/backend/alembic/README.md
+++ b/backend/alembic/README.md
@@ -10,3 +10,31 @@ reflected default.
 
 Do not retro-edit merged migrations to fix default drift. Add a new migration
 that moves the live schema back to the intended default.
+
+## Workspace-isolation trigger function names
+
+For new workspace-isolation triggers, name the trigger function with the
+table-first pattern:
+
+```sql
+check_<table>_workspace_<scope>()
+```
+
+Use the plural table name exactly as it appears in the schema. Pick a short
+`<scope>` that describes the checked relationship set, such as `fks`,
+`owner`, or `default_storage`. Keep the trigger name table-first as well, for
+example `<table>_workspace_<scope>_check`.
+
+Merged migrations may keep their existing function names. In particular,
+0036, 0050, 0054, and 0055 introduced these grandfathered names:
+
+- `check_default_storage_workspace()`
+- `check_stock_entries_workspace_fks()`
+- `check_part_substitutes_workspace_fks()`
+- `check_part_meta_members_workspace_fks()`
+- `check_part_cad_keys_workspace()`
+
+Do not add a migration only to rename those functions. Renaming a PostgreSQL
+trigger function requires replacing the function used by existing triggers and
+creates avoidable migration churn; use the convention above for new migrations
+instead.


### PR DESCRIPTION
## Summary
- Documents the forward convention for workspace-isolation trigger function names in `backend/alembic/README.md`.
- Grandfathers the existing merged function names from migrations 0036, 0050, 0054, and 0055 instead of adding a rename migration.

## Tests / Validation
- Manual review of `backend/alembic/README.md` and migrations 0036, 0050, 0054, and 0055.
- `git diff --check`
- Checked for a clearly relevant docs/Markdown lint target; none found for this README.

## Merge Order / Conflict Notes
- Docs-only change; no Alembic migration added, so this should not conflict with active migration PRs #730, #710, #716, or #717.
- If another PR edits `backend/alembic/README.md`, resolve by keeping this workspace trigger naming section and any other README additions.

Refs #718