### PR TITLE
HOTFIX: normalize deploy SSH key secret

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -842,7 +842,21 @@ jobs:
 
           key_file="${RUNNER_TEMP}/deploy_ssh_key"
           umask 077
-          printf '%s\n' "${DEPLOY_SSH_KEY}" > "${key_file}"
+          python3 - "${key_file}" <<'PY'
+          import os
+          import sys
+
+          key = os.environ.get("DEPLOY_SSH_KEY", "")
+          key = key.replace("\\n", "\n").replace("\r\n", "\n").replace("\r", "\n")
+          key = key.strip()
+          if not key:
+              raise SystemExit("DEPLOY_SSH_KEY is empty.")
+
+          with open(sys.argv[1], "w", encoding="utf-8") as fh:
+              fh.write(key + "\n")
+          PY
+          chmod 600 "${key_file}"
+          ssh-keygen -y -f "${key_file}" > /dev/null
           trap 'rm -f "${key_file}"' EXIT
 
           ssh -i "${key_file}" \

--- a/backend/tests/test_ci_workflow.py
+++ b/backend/tests/test_ci_workflow.py
@@ -111,6 +111,8 @@ def test_deploy_uses_raw_ssh_instead_of_appleboy():
     assert "-o StrictHostKeyChecking=yes" in script
     assert '-o UserKnownHostsFile="${DEPLOY_KNOWN_HOSTS}"' in script
     assert "-o HostKeyAlgorithms=ssh-ed25519" in script
+    assert 'key.replace("\\\\n", "\\n")' in script
+    assert 'ssh-keygen -y -f "${key_file}" > /dev/null' in script
 
 
 def test_deploy_verifies_ed25519_host_fingerprint_before_raw_ssh():


### PR DESCRIPTION
## Summary
- Normalize the `DEPLOY_SSH_KEY` secret before raw ssh so secrets stored with literal `\n` or CRLF become a valid private-key file.
- Validate the generated key with `ssh-keygen -y` before trying to connect, keeping the failure explicit and secret-safe.
- Add CI workflow regression coverage for the normalization step.

## Root cause
- Main deploy run 25917316554 failed after PR #723 with `Load key ... error in libcrypto`, then `Permission denied`. The raw OpenSSH path wrote the GitHub secret as-is; the previous action tolerated the stored formatting.

## Tests
- `uv run --project backend --extra dev python -m pytest backend/tests/test_ci_workflow.py -q`
- Parsed `.github/workflows/ci.yml` with Python/YAML and ran `bash -n` on the extracted `SSH deploy` script.

## Merge Order / Conflicts
- Merge immediately after PR #723; it is a direct deploy unbreaker.
- Scoped to `.github/workflows/ci.yml` and `backend/tests/test_ci_workflow.py`.

Refs #706