### PR TITLE
AUD-074: Hide signup SMTP failures from enumeration

### DIFF
--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -65,6 +65,19 @@ _SIGNUP_VERIFICATION_DATA = {"status": "verification_sent"}
 _SIGNUP_VERIFICATION_MESSAGE = "verification email sent"
 
 
+def _record_signup_mail_failure(kind: str, exc: Exception) -> None:
+    log.exception(
+        "signup mail send failed",
+        extra={"mail_kind": kind, "error_code": "mail.send_failed"},
+    )
+    try:
+        import sentry_sdk
+
+        sentry_sdk.capture_exception(exc)
+    except Exception:
+        pass
+
+
 def _reap_expired_pending_signup(db: DbSession, email: str) -> None:
     cutoff = utcnow() - timedelta(hours=_VERIFY_TTL_HOURS)
     db.query(PendingUser).filter(
@@ -245,12 +258,7 @@ def signup(
         try:
             send_account_exists_email(to=payload.email)
         except Exception as exc:
-            log.error("failed to send duplicate-signup email to %s: %s", payload.email, exc)
-            raise_http(
-                status.HTTP_503_SERVICE_UNAVAILABLE,
-                "mail.send_failed",
-                "could not send signup email — please try again later",
-            )
+            _record_signup_mail_failure("duplicate_signup", exc)
         log.info("signup existing account notice sent", extra={"user_id": str(existing.id)})
         response.status_code = status.HTTP_202_ACCEPTED
         return ok(_SIGNUP_VERIFICATION_DATA, _SIGNUP_VERIFICATION_MESSAGE)
@@ -283,12 +291,7 @@ def signup(
     try:
         send_verification_email(to=payload.email, verification_link=link)
     except Exception as exc:
-        log.error("failed to send verification email to %s: %s", payload.email, exc)
-        raise_http(
-            status.HTTP_503_SERVICE_UNAVAILABLE,
-            "mail.send_failed",
-            "could not send signup email — please try again later",
-        )
+        _record_signup_mail_failure("verification", exc)
 
     log.info("signup pending", extra={"pending_id": str(pending.id)})
     response.status_code = status.HTTP_202_ACCEPTED

--- a/backend/tests/test_signup_no_enumeration.py
+++ b/backend/tests/test_signup_no_enumeration.py
@@ -4,7 +4,7 @@ import re
 import statistics
 import time
 import uuid
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 from fastapi.testclient import TestClient
 
@@ -66,6 +66,44 @@ def test_response_identical_for_known_and_unknown_email(db):
     assert known_response.json() == unknown_response.json()
     account_exists_email.assert_called_once_with(to=known_email)
     verification_email.assert_called_once()
+
+
+def test_smtp_failure_does_not_diverge(db):
+    known_email = f"known-smtp-{uuid.uuid4().hex[:8]}@example.com"
+    unknown_email = f"unknown-smtp-{uuid.uuid4().hex[:8]}@example.com"
+    _signup_and_verify(known_email)
+
+    duplicate_failure = RuntimeError("duplicate signup SMTP down")
+    verification_failure = RuntimeError("verification SMTP down")
+    with (
+        patch.object(settings(), "SIGNUP_REQUIRE_EMAIL_VERIFICATION", True),
+        patch(
+            "app.api.routes.auth.send_account_exists_email",
+            side_effect=duplicate_failure,
+        ) as account_exists_email,
+        patch(
+            "app.api.routes.auth.send_verification_email",
+            side_effect=verification_failure,
+        ) as verification_email,
+        patch("sentry_sdk.capture_exception") as capture_exception,
+    ):
+        known_response = TestClient(app).post(
+            "/api/auth/signup",
+            json={"email": known_email, "name": "Known Again", "password": PASSWORD},
+        )
+        unknown_response = TestClient(app).post(
+            "/api/auth/signup",
+            json={"email": unknown_email, "name": "Unknown", "password": PASSWORD},
+        )
+
+    assert known_response.status_code == unknown_response.status_code == 202
+    assert known_response.json() == unknown_response.json()
+    account_exists_email.assert_called_once_with(to=known_email)
+    verification_email.assert_called_once()
+    assert capture_exception.call_args_list == [
+        call(duplicate_failure),
+        call(verification_failure),
+    ]
 
 
 def test_timing_similar_for_known_and_unknown_email(db):


### PR DESCRIPTION
## Summary
- Keep duplicate-email signup SMTP failures behind the generic 202 verification envelope.
- Keep unknown-email verification SMTP failures behind the same 202 envelope after the existing pending-row insert.
- Record signup mail-send failures through structured logging and Sentry capture for operator visibility.

## Tests
- `backend/.venv/bin/python -m pytest backend/tests/test_signup_no_enumeration.py -q` from the repo root: 3 passed, 1 Alembic deprecation warning.
- `cd backend && uv run --extra dev python -m pytest tests/test_signup_no_enumeration.py -q`: 3 passed, 1 Alembic deprecation warning.

Note: the literal `python -m pytest backend/tests/test_signup_no_enumeration.py -q` could not run in this shell because `python` is not on PATH, so validation used the repo's backend `uv` environment and its created Python executable.

## Merge Order / Conflicts
- Based on current `origin/main` at `71f04ec`, which includes PR #722/#723/#725/#732 per the issue instructions.
- Scope is limited to `backend/app/api/routes/auth.py` and `backend/tests/test_signup_no_enumeration.py`.
- Expected conflict risk is low unless another active PR edits the signup email-verification exception paths or this focused no-enumeration test file.

Refs #712
