### PR TITLE
AUD-081: Make extra weak passwords configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@ POSTGRES_PASSWORD=stockmgr
 POSTGRES_DB=stockmgr
 DATABASE_URL=postgresql+psycopg://stockmgr:stockmgr@db:5432/stockmgr
 SESSION_SECRET=dev-change-me-locally
+EXTRA_WEAK_PASSWORDS=
 SESSION_IDLE_HOURS=24
 UPLOAD_DIR=/data/uploads
 APP_ENV=dev

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -78,6 +78,12 @@ _WEAK_PASSWORDS = frozenset({
 })
 
 
+def _weak_passwords() -> frozenset[str]:
+    return _WEAK_PASSWORDS | frozenset(
+        password.lower() for password in settings().EXTRA_WEAK_PASSWORDS
+    )
+
+
 class WeakPasswordError(ValueError):
     """Raised when a candidate password fails the strength check."""
 
@@ -147,7 +153,7 @@ def validate_password_strength(password: str) -> None:
     """
     if len(password) < 8:
         raise WeakPasswordError("password must be at least 8 characters")
-    if password.lower() in _WEAK_PASSWORDS:
+    if password.lower() in _weak_passwords():
         raise WeakPasswordError(
             "password is on the public breach list — pick something else"
         )

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import urllib.parse
 from functools import lru_cache
+from typing import Annotated
 
 from pydantic import Field, field_validator, model_validator
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
 
 class Settings(BaseSettings):
@@ -29,6 +30,9 @@ class Settings(BaseSettings):
     POSTGRES_PORT: str = "5432"
     SESSION_SECRET: str = "dev-secret-change-me"
     PASSWORD_PEPPER: str = ""
+    # Deployment-specific additions to the local weak-password blocklist.
+    # Comma-separated in env, e.g. "stockmanager,customer-brand,internal-code".
+    EXTRA_WEAK_PASSWORDS: Annotated[list[str], NoDecode] = Field(default_factory=list)
     SESSION_COOKIE_NAME: str = "stockmgr_session"
     SESSION_LIFETIME_DAYS: int = 30
     # Sliding-expiry idle window. A session idle longer than this is
@@ -112,6 +116,15 @@ class Settings(BaseSettings):
     def _blank_sentry_traces_rate_to_none(cls, value):
         if value == "":
             return None
+        return value
+
+    @field_validator("EXTRA_WEAK_PASSWORDS", mode="before")
+    @classmethod
+    def _split_extra_weak_passwords(cls, value):
+        if value is None or value == "":
+            return []
+        if isinstance(value, str):
+            return [part.strip() for part in value.split(",") if part.strip()]
         return value
 
     @property

--- a/backend/tests/test_password_policy.py
+++ b/backend/tests/test_password_policy.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.core.config import settings
+from app.main import app
+
+
+def test_extra_weak_passwords_rejected(monkeypatch):
+    monkeypatch.setenv("EXTRA_WEAK_PASSWORDS", "CustomerBrand2026, internal-code-name")
+    settings.cache_clear()
+
+    try:
+        assert settings().EXTRA_WEAK_PASSWORDS == [
+            "CustomerBrand2026",
+            "internal-code-name",
+        ]
+
+        client = TestClient(app)
+        response = client.post(
+            "/api/auth/signup",
+            json={
+                "email": "extra-weak-password@example.com",
+                "name": "Policy Test",
+                "password": "customerbrand2026",
+            },
+        )
+
+        assert response.status_code == 400
+        assert "password" in response.text.lower()
+    finally:
+        settings.cache_clear()

--- a/deploy/.env.prod.example
+++ b/deploy/.env.prod.example
@@ -53,6 +53,10 @@ SESSION_IDLE_HOURS=24
 # the first boot. The deploy job refuses to generate this automatically.
 PASSWORD_PEPPER=replace-me-with-the-output-of-openssl-rand-hex-32
 
+# Optional comma-separated deployment-specific weak passwords to reject at
+# signup, such as customer brand names, workspace names, or internal jargon.
+EXTRA_WEAK_PASSWORDS=
+
 # Comma-separated list of origins allowed to call the API from a browser.
 # In a typical single-domain prod deploy this is just your public hostname.
 CORS_ORIGINS=https://parts.matescb.cz


### PR DESCRIPTION
## Summary
- add comma-separated EXTRA_WEAK_PASSWORDS settings parsing
- merge deployment-specific weak passwords into signup password validation
- document the env var in dev and prod env templates
- add backend/tests/test_password_policy.py coverage for env-listed signup rejection

## Tests
- cd backend && uv run --extra dev ruff check app/core/config.py app/core/auth.py tests/test_password_policy.py
- cd backend && uv run --extra dev python -m pytest tests/test_password_policy.py -q
- PYTHONPATH=backend backend/.venv/bin/python -m pytest backend/tests/test_password_policy.py -q

## Merge-order / conflicts
- based on origin/main at 71f04ec after PR #730
- touches only EXTRA_WEAK_PASSWORDS settings/auth policy, env documentation, and backend/tests/test_password_policy.py
- no password reset (#721), signup SMTP behavior (#712), or session purge (#713/#730) changes

Refs #719