### PR TITLE
AUD-072: preserve lots on part delete and gate workspace triggers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,6 +270,10 @@ them, that's the bug.
 - **Maintenance mode is toggled by the deploy script via
   `a2enconf parts-maintenance`.** Do not bypass the deploy path without
   also disabling it with `a2disconf parts-maintenance`.
+- **Hard deletes preserve independent stock history.** Parts use
+  `ON DELETE SET NULL` for both `stock_entries.part_id` and `lots.part_id`;
+  workspace FK triggers validate all parent refs on INSERT but only changed
+  refs on UPDATE. Full policy: `docs/adr/0028-hard-delete-policy-and-workspace-trigger-contract.md`.
 
 ## Frontend conventions worth preserving
 

--- a/backend/alembic/versions/0058_lots_part_set_null_trigger_update_gates.py
+++ b/backend/alembic/versions/0058_lots_part_set_null_trigger_update_gates.py
@@ -1,0 +1,595 @@
+"""Preserve lots on part delete and gate workspace trigger updates.
+
+Revision ID: 0058
+Revises: 0057
+Create Date: 2026-05-15
+
+AUD-072 / issue #710.
+
+`lots` are historical receiving/serial records and should survive a hard part
+delete just like `stock_entries`. The workspace FK triggers remain strict on
+INSERT, but UPDATEs only re-check a reference when that reference column
+changes.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0058"
+down_revision = "0057"
+branch_labels = None
+depends_on = None
+
+
+_STOCK_ENTRIES_UPDATE_GATED_SQL = """
+CREATE OR REPLACE FUNCTION check_stock_entries_workspace_fks()
+RETURNS trigger AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    IF NEW.part_id IS NULL THEN
+      RAISE EXCEPTION 'stock_entries.part_id is required on insert'
+        USING ERRCODE = '23514';
+    END IF;
+
+    PERFORM 1 FROM parts
+     WHERE id = NEW.part_id
+       AND workspace_id = NEW.workspace_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'stock_entries.part_id (%) not in workspace (%)',
+        NEW.part_id, NEW.workspace_id
+        USING ERRCODE = '23514';
+    END IF;
+
+    IF NEW.lot_id IS NOT NULL THEN
+      PERFORM 1 FROM lots
+       WHERE id = NEW.lot_id
+         AND workspace_id = NEW.workspace_id;
+      IF NOT FOUND THEN
+        RAISE EXCEPTION 'stock_entries.lot_id (%) not in workspace (%)',
+          NEW.lot_id, NEW.workspace_id
+          USING ERRCODE = '23514';
+      END IF;
+    END IF;
+
+    IF NEW.storage_location_id IS NOT NULL THEN
+      PERFORM 1 FROM storage_locations
+       WHERE id = NEW.storage_location_id
+         AND workspace_id = NEW.workspace_id;
+      IF NOT FOUND THEN
+        RAISE EXCEPTION 'stock_entries.storage_location_id (%) not in workspace (%)',
+          NEW.storage_location_id, NEW.workspace_id
+          USING ERRCODE = '23514';
+      END IF;
+    END IF;
+
+    IF NEW.related_entry_id IS NOT NULL THEN
+      PERFORM 1 FROM stock_entries
+       WHERE id = NEW.related_entry_id
+         AND workspace_id = NEW.workspace_id;
+      IF NOT FOUND THEN
+        RAISE EXCEPTION 'stock_entries.related_entry_id (%) not in workspace (%)',
+          NEW.related_entry_id, NEW.workspace_id
+          USING ERRCODE = '23514';
+      END IF;
+    END IF;
+
+    IF NEW.order_id IS NOT NULL THEN
+      PERFORM 1 FROM orders
+       WHERE id = NEW.order_id
+         AND workspace_id = NEW.workspace_id;
+      IF NOT FOUND THEN
+        RAISE EXCEPTION 'stock_entries.order_id (%) not in workspace (%)',
+          NEW.order_id, NEW.workspace_id
+          USING ERRCODE = '23514';
+      END IF;
+    END IF;
+
+    IF NEW.order_entry_id IS NOT NULL THEN
+      PERFORM 1 FROM order_entries
+       WHERE id = NEW.order_entry_id
+         AND workspace_id = NEW.workspace_id;
+      IF NOT FOUND THEN
+        RAISE EXCEPTION 'stock_entries.order_entry_id (%) not in workspace (%)',
+          NEW.order_entry_id, NEW.workspace_id
+          USING ERRCODE = '23514';
+      END IF;
+    END IF;
+
+    IF NEW.project_id IS NOT NULL THEN
+      PERFORM 1 FROM projects
+       WHERE id = NEW.project_id
+         AND workspace_id = NEW.workspace_id;
+      IF NOT FOUND THEN
+        RAISE EXCEPTION 'stock_entries.project_id (%) not in workspace (%)',
+          NEW.project_id, NEW.workspace_id
+          USING ERRCODE = '23514';
+      END IF;
+    END IF;
+
+    IF NEW.build_id IS NOT NULL THEN
+      PERFORM 1 FROM builds
+       WHERE id = NEW.build_id
+         AND workspace_id = NEW.workspace_id;
+      IF NOT FOUND THEN
+        RAISE EXCEPTION 'stock_entries.build_id (%) not in workspace (%)',
+          NEW.build_id, NEW.workspace_id
+          USING ERRCODE = '23514';
+      END IF;
+    END IF;
+
+    RETURN NEW;
+  END IF;
+
+  IF NEW.part_id IS DISTINCT FROM OLD.part_id AND NEW.part_id IS NOT NULL THEN
+    PERFORM 1 FROM parts
+     WHERE id = NEW.part_id
+       AND workspace_id = NEW.workspace_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'stock_entries.part_id (%) not in workspace (%)',
+        NEW.part_id, NEW.workspace_id
+        USING ERRCODE = '23514';
+    END IF;
+  END IF;
+
+  IF NEW.lot_id IS DISTINCT FROM OLD.lot_id AND NEW.lot_id IS NOT NULL THEN
+    PERFORM 1 FROM lots
+     WHERE id = NEW.lot_id
+       AND workspace_id = NEW.workspace_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'stock_entries.lot_id (%) not in workspace (%)',
+        NEW.lot_id, NEW.workspace_id
+        USING ERRCODE = '23514';
+    END IF;
+  END IF;
+
+  IF NEW.storage_location_id IS DISTINCT FROM OLD.storage_location_id
+     AND NEW.storage_location_id IS NOT NULL THEN
+    PERFORM 1 FROM storage_locations
+     WHERE id = NEW.storage_location_id
+       AND workspace_id = NEW.workspace_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'stock_entries.storage_location_id (%) not in workspace (%)',
+        NEW.storage_location_id, NEW.workspace_id
+        USING ERRCODE = '23514';
+    END IF;
+  END IF;
+
+  IF NEW.related_entry_id IS DISTINCT FROM OLD.related_entry_id
+     AND NEW.related_entry_id IS NOT NULL THEN
+    PERFORM 1 FROM stock_entries
+     WHERE id = NEW.related_entry_id
+       AND workspace_id = NEW.workspace_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'stock_entries.related_entry_id (%) not in workspace (%)',
+        NEW.related_entry_id, NEW.workspace_id
+        USING ERRCODE = '23514';
+    END IF;
+  END IF;
+
+  IF NEW.order_id IS DISTINCT FROM OLD.order_id AND NEW.order_id IS NOT NULL THEN
+    PERFORM 1 FROM orders
+     WHERE id = NEW.order_id
+       AND workspace_id = NEW.workspace_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'stock_entries.order_id (%) not in workspace (%)',
+        NEW.order_id, NEW.workspace_id
+        USING ERRCODE = '23514';
+    END IF;
+  END IF;
+
+  IF NEW.order_entry_id IS DISTINCT FROM OLD.order_entry_id
+     AND NEW.order_entry_id IS NOT NULL THEN
+    PERFORM 1 FROM order_entries
+     WHERE id = NEW.order_entry_id
+       AND workspace_id = NEW.workspace_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'stock_entries.order_entry_id (%) not in workspace (%)',
+        NEW.order_entry_id, NEW.workspace_id
+        USING ERRCODE = '23514';
+    END IF;
+  END IF;
+
+  IF NEW.project_id IS DISTINCT FROM OLD.project_id AND NEW.project_id IS NOT NULL THEN
+    PERFORM 1 FROM projects
+     WHERE id = NEW.project_id
+       AND workspace_id = NEW.workspace_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'stock_entries.project_id (%) not in workspace (%)',
+        NEW.project_id, NEW.workspace_id
+        USING ERRCODE = '23514';
+    END IF;
+  END IF;
+
+  IF NEW.build_id IS DISTINCT FROM OLD.build_id AND NEW.build_id IS NOT NULL THEN
+    PERFORM 1 FROM builds
+     WHERE id = NEW.build_id
+       AND workspace_id = NEW.workspace_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'stock_entries.build_id (%) not in workspace (%)',
+        NEW.build_id, NEW.workspace_id
+        USING ERRCODE = '23514';
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+"""
+
+
+_STOCK_ENTRIES_FULL_RECHECK_SQL = """
+CREATE OR REPLACE FUNCTION check_stock_entries_workspace_fks()
+RETURNS trigger AS $$
+BEGIN
+  IF TG_OP = 'INSERT' AND NEW.part_id IS NULL THEN
+    RAISE EXCEPTION 'stock_entries.part_id is required on insert'
+      USING ERRCODE = '23514';
+  END IF;
+
+  IF NEW.part_id IS NOT NULL THEN
+    PERFORM 1 FROM parts
+     WHERE id = NEW.part_id
+       AND workspace_id = NEW.workspace_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'stock_entries.part_id (%) not in workspace (%)',
+        NEW.part_id, NEW.workspace_id
+        USING ERRCODE = '23514';
+    END IF;
+  END IF;
+
+  IF NEW.lot_id IS NOT NULL THEN
+    PERFORM 1 FROM lots
+     WHERE id = NEW.lot_id
+       AND workspace_id = NEW.workspace_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'stock_entries.lot_id (%) not in workspace (%)',
+        NEW.lot_id, NEW.workspace_id
+        USING ERRCODE = '23514';
+    END IF;
+  END IF;
+
+  IF NEW.storage_location_id IS NOT NULL THEN
+    PERFORM 1 FROM storage_locations
+     WHERE id = NEW.storage_location_id
+       AND workspace_id = NEW.workspace_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'stock_entries.storage_location_id (%) not in workspace (%)',
+        NEW.storage_location_id, NEW.workspace_id
+        USING ERRCODE = '23514';
+    END IF;
+  END IF;
+
+  IF NEW.related_entry_id IS NOT NULL THEN
+    PERFORM 1 FROM stock_entries
+     WHERE id = NEW.related_entry_id
+       AND workspace_id = NEW.workspace_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'stock_entries.related_entry_id (%) not in workspace (%)',
+        NEW.related_entry_id, NEW.workspace_id
+        USING ERRCODE = '23514';
+    END IF;
+  END IF;
+
+  IF NEW.order_id IS NOT NULL THEN
+    PERFORM 1 FROM orders
+     WHERE id = NEW.order_id
+       AND workspace_id = NEW.workspace_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'stock_entries.order_id (%) not in workspace (%)',
+        NEW.order_id, NEW.workspace_id
+        USING ERRCODE = '23514';
+    END IF;
+  END IF;
+
+  IF NEW.order_entry_id IS NOT NULL THEN
+    PERFORM 1 FROM order_entries
+     WHERE id = NEW.order_entry_id
+       AND workspace_id = NEW.workspace_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'stock_entries.order_entry_id (%) not in workspace (%)',
+        NEW.order_entry_id, NEW.workspace_id
+        USING ERRCODE = '23514';
+    END IF;
+  END IF;
+
+  IF NEW.project_id IS NOT NULL THEN
+    PERFORM 1 FROM projects
+     WHERE id = NEW.project_id
+       AND workspace_id = NEW.workspace_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'stock_entries.project_id (%) not in workspace (%)',
+        NEW.project_id, NEW.workspace_id
+        USING ERRCODE = '23514';
+    END IF;
+  END IF;
+
+  IF NEW.build_id IS NOT NULL THEN
+    PERFORM 1 FROM builds
+     WHERE id = NEW.build_id
+       AND workspace_id = NEW.workspace_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'stock_entries.build_id (%) not in workspace (%)',
+        NEW.build_id, NEW.workspace_id
+        USING ERRCODE = '23514';
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+"""
+
+
+_PART_SUBSTITUTES_UPDATE_GATED_SQL = """
+CREATE OR REPLACE FUNCTION check_part_substitutes_workspace_fks()
+RETURNS trigger AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    PERFORM 1 FROM parts
+     WHERE id = NEW.part_id
+       AND workspace_id = NEW.workspace_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'part_substitutes.part_id (%) not in workspace (%)',
+        NEW.part_id, NEW.workspace_id
+        USING ERRCODE = '23514';
+    END IF;
+
+    PERFORM 1 FROM parts
+     WHERE id = NEW.substitute_part_id
+       AND workspace_id = NEW.workspace_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'part_substitutes.substitute_part_id (%) not in workspace (%)',
+        NEW.substitute_part_id, NEW.workspace_id
+        USING ERRCODE = '23514';
+    END IF;
+
+    RETURN NEW;
+  END IF;
+
+  IF NEW.part_id IS DISTINCT FROM OLD.part_id THEN
+    PERFORM 1 FROM parts
+     WHERE id = NEW.part_id
+       AND workspace_id = NEW.workspace_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'part_substitutes.part_id (%) not in workspace (%)',
+        NEW.part_id, NEW.workspace_id
+        USING ERRCODE = '23514';
+    END IF;
+  END IF;
+
+  IF NEW.substitute_part_id IS DISTINCT FROM OLD.substitute_part_id THEN
+    PERFORM 1 FROM parts
+     WHERE id = NEW.substitute_part_id
+       AND workspace_id = NEW.workspace_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'part_substitutes.substitute_part_id (%) not in workspace (%)',
+        NEW.substitute_part_id, NEW.workspace_id
+        USING ERRCODE = '23514';
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+"""
+
+
+_PART_SUBSTITUTES_FULL_RECHECK_SQL = """
+CREATE OR REPLACE FUNCTION check_part_substitutes_workspace_fks()
+RETURNS trigger AS $$
+BEGIN
+  PERFORM 1 FROM parts
+   WHERE id = NEW.part_id
+     AND workspace_id = NEW.workspace_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'part_substitutes.part_id (%) not in workspace (%)',
+      NEW.part_id, NEW.workspace_id
+      USING ERRCODE = '23514';
+  END IF;
+
+  PERFORM 1 FROM parts
+   WHERE id = NEW.substitute_part_id
+     AND workspace_id = NEW.workspace_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'part_substitutes.substitute_part_id (%) not in workspace (%)',
+      NEW.substitute_part_id, NEW.workspace_id
+      USING ERRCODE = '23514';
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+"""
+
+
+_PART_META_MEMBERS_UPDATE_GATED_SQL = """
+CREATE OR REPLACE FUNCTION check_part_meta_members_workspace_fks()
+RETURNS trigger AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    PERFORM 1 FROM parts
+     WHERE id = NEW.meta_part_id
+       AND workspace_id = NEW.workspace_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'part_meta_members.meta_part_id (%) not in workspace (%)',
+        NEW.meta_part_id, NEW.workspace_id
+        USING ERRCODE = '23514';
+    END IF;
+
+    PERFORM 1 FROM parts
+     WHERE id = NEW.part_id
+       AND workspace_id = NEW.workspace_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'part_meta_members.part_id (%) not in workspace (%)',
+        NEW.part_id, NEW.workspace_id
+        USING ERRCODE = '23514';
+    END IF;
+
+    RETURN NEW;
+  END IF;
+
+  IF NEW.meta_part_id IS DISTINCT FROM OLD.meta_part_id THEN
+    PERFORM 1 FROM parts
+     WHERE id = NEW.meta_part_id
+       AND workspace_id = NEW.workspace_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'part_meta_members.meta_part_id (%) not in workspace (%)',
+        NEW.meta_part_id, NEW.workspace_id
+        USING ERRCODE = '23514';
+    END IF;
+  END IF;
+
+  IF NEW.part_id IS DISTINCT FROM OLD.part_id THEN
+    PERFORM 1 FROM parts
+     WHERE id = NEW.part_id
+       AND workspace_id = NEW.workspace_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'part_meta_members.part_id (%) not in workspace (%)',
+        NEW.part_id, NEW.workspace_id
+        USING ERRCODE = '23514';
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+"""
+
+
+_PART_META_MEMBERS_FULL_RECHECK_SQL = """
+CREATE OR REPLACE FUNCTION check_part_meta_members_workspace_fks()
+RETURNS trigger AS $$
+BEGIN
+  PERFORM 1 FROM parts
+   WHERE id = NEW.meta_part_id
+     AND workspace_id = NEW.workspace_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'part_meta_members.meta_part_id (%) not in workspace (%)',
+      NEW.meta_part_id, NEW.workspace_id
+      USING ERRCODE = '23514';
+  END IF;
+
+  PERFORM 1 FROM parts
+   WHERE id = NEW.part_id
+     AND workspace_id = NEW.workspace_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'part_meta_members.part_id (%) not in workspace (%)',
+      NEW.part_id, NEW.workspace_id
+      USING ERRCODE = '23514';
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+"""
+
+
+_PART_CAD_KEYS_UPDATE_GATED_SQL = """
+CREATE OR REPLACE FUNCTION check_part_cad_keys_workspace()
+RETURNS trigger AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    PERFORM 1 FROM parts
+     WHERE id = NEW.part_id
+       AND workspace_id = NEW.workspace_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'part_cad_keys.part_id (%) not in workspace (%)',
+        NEW.part_id, NEW.workspace_id
+        USING ERRCODE = '23514';
+    END IF;
+
+    RETURN NEW;
+  END IF;
+
+  IF NEW.part_id IS DISTINCT FROM OLD.part_id THEN
+    PERFORM 1 FROM parts
+     WHERE id = NEW.part_id
+       AND workspace_id = NEW.workspace_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'part_cad_keys.part_id (%) not in workspace (%)',
+        NEW.part_id, NEW.workspace_id
+        USING ERRCODE = '23514';
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+"""
+
+
+_PART_CAD_KEYS_FULL_RECHECK_SQL = """
+CREATE OR REPLACE FUNCTION check_part_cad_keys_workspace()
+RETURNS trigger AS $$
+BEGIN
+  PERFORM 1 FROM parts
+   WHERE id = NEW.part_id
+     AND workspace_id = NEW.workspace_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'part_cad_keys.part_id (%) not in workspace (%)',
+      NEW.part_id, NEW.workspace_id
+      USING ERRCODE = '23514';
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+"""
+
+
+def _set_lots_part_set_null() -> None:
+    op.execute("ALTER TABLE lots DROP CONSTRAINT IF EXISTS lots_part_id_fkey")
+    op.execute("ALTER TABLE lots ALTER COLUMN part_id DROP NOT NULL")
+    op.execute(
+        """
+        ALTER TABLE lots
+        ADD CONSTRAINT lots_part_id_fkey
+        FOREIGN KEY (part_id) REFERENCES parts(id)
+        ON DELETE SET NULL
+        NOT VALID
+        """
+    )
+    op.execute("ALTER TABLE lots VALIDATE CONSTRAINT lots_part_id_fkey")
+
+
+def _set_lots_part_cascade() -> None:
+    op.execute(
+        """
+        DO $$
+        BEGIN
+          IF EXISTS (SELECT 1 FROM lots WHERE part_id IS NULL) THEN
+            RAISE EXCEPTION
+              'cannot downgrade 0058 while lots rows have NULL part_id';
+          END IF;
+        END $$;
+        """
+    )
+    op.execute("ALTER TABLE lots DROP CONSTRAINT IF EXISTS lots_part_id_fkey")
+    op.execute("ALTER TABLE lots ALTER COLUMN part_id SET NOT NULL")
+    op.execute(
+        """
+        ALTER TABLE lots
+        ADD CONSTRAINT lots_part_id_fkey
+        FOREIGN KEY (part_id) REFERENCES parts(id)
+        ON DELETE CASCADE
+        NOT VALID
+        """
+    )
+    op.execute("ALTER TABLE lots VALIDATE CONSTRAINT lots_part_id_fkey")
+
+
+def upgrade() -> None:
+    _set_lots_part_set_null()
+    op.execute(_STOCK_ENTRIES_UPDATE_GATED_SQL)
+    op.execute(_PART_SUBSTITUTES_UPDATE_GATED_SQL)
+    op.execute(_PART_META_MEMBERS_UPDATE_GATED_SQL)
+    op.execute(_PART_CAD_KEYS_UPDATE_GATED_SQL)
+
+
+def downgrade() -> None:
+    op.execute(_PART_CAD_KEYS_FULL_RECHECK_SQL)
+    op.execute(_PART_META_MEMBERS_FULL_RECHECK_SQL)
+    op.execute(_PART_SUBSTITUTES_FULL_RECHECK_SQL)
+    op.execute(_STOCK_ENTRIES_FULL_RECHECK_SQL)
+    _set_lots_part_cascade()

--- a/backend/app/domain/lots/models.py
+++ b/backend/app/domain/lots/models.py
@@ -21,10 +21,19 @@ class Lot(WorkspaceOwned, Base):
         ),
     )
 
-    part_id = Column(UUID(as_uuid=True), ForeignKey("parts.id", ondelete="CASCADE"), nullable=False, index=True)
+    part_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("parts.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
     name = Column(String(200), nullable=True)
     serial_number = Column(String(200), nullable=True, index=True)
-    parent_lot_id = Column(UUID(as_uuid=True), ForeignKey("lots.id", ondelete="SET NULL"), nullable=True)
+    parent_lot_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("lots.id", ondelete="SET NULL"),
+        nullable=True,
+    )
     description = Column(Text, nullable=True)
     comments = Column(Text, nullable=True)
     expiration_date = Column(Date, nullable=True)

--- a/backend/tests/test_migration_lots_part_set_null.py
+++ b/backend/tests/test_migration_lots_part_set_null.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import inspect, text
+
+
+def test_part_hard_delete_preserves_lots_history(db, engine) -> None:
+    insp = inspect(engine)
+    part_column = next(col for col in insp.get_columns("lots") if col["name"] == "part_id")
+    part_fk = next(
+        fk
+        for fk in insp.get_foreign_keys("lots")
+        if fk["constrained_columns"] == ["part_id"] and fk["referred_table"] == "parts"
+    )
+
+    assert part_column["nullable"] is True
+    assert part_fk.get("options", {}).get("ondelete") == "SET NULL"
+
+    user_id = uuid.uuid4()
+    workspace_id = uuid.uuid4()
+    part_id = uuid.uuid4()
+    lot_id = uuid.uuid4()
+    entry_id = uuid.uuid4()
+
+    db.execute(
+        text(
+            """
+            INSERT INTO users
+                (id, email, name, password_hash, locale, timezone, created_at)
+            VALUES
+                (:user_id, :email, 'Lot FK Tester', 'x', 'en', 'UTC', now())
+            """
+        ),
+        {"user_id": user_id, "email": f"lot-fk-{user_id.hex}@example.com"},
+    )
+    db.execute(
+        text(
+            """
+            INSERT INTO workspaces
+                (id, name, kind, owner_user_id, currency_default,
+                 lot_control_enabled, serial_tracking_enabled, catalog_enabled,
+                 parts_provider, created_at)
+            VALUES
+                (:workspace_id, 'Lot FK Workspace', 'organization', :user_id,
+                 'USD', true, false, false, 'none', now())
+            """
+        ),
+        {"workspace_id": workspace_id, "user_id": user_id},
+    )
+    db.execute(
+        text(
+            """
+            INSERT INTO parts
+                (id, workspace_id, part_type, name, attrition_percentage,
+                 attrition_min_quantity, default_storage_mandatory, serialized,
+                 published, description_locally_edited, created_at, updated_at,
+                 created_by, updated_by)
+            VALUES
+                (:part_id, :workspace_id, 'local', 'Lot preserved part',
+                 0, 0, false, false, false, false, now(), now(), :user_id,
+                 :user_id)
+            """
+        ),
+        {"part_id": part_id, "workspace_id": workspace_id, "user_id": user_id},
+    )
+    db.execute(
+        text(
+            """
+            INSERT INTO lots
+                (id, workspace_id, part_id, name, source_type, created_at,
+                 updated_at, created_by, updated_by)
+            VALUES
+                (:lot_id, :workspace_id, :part_id, 'Lot survives',
+                 'manual', now(), now(), :user_id, :user_id)
+            """
+        ),
+        {
+            "lot_id": lot_id,
+            "workspace_id": workspace_id,
+            "part_id": part_id,
+            "user_id": user_id,
+        },
+    )
+    db.execute(
+        text(
+            """
+            INSERT INTO stock_entries
+                (id, workspace_id, part_id, lot_id, quantity_delta, status,
+                 operation_type, occurred_at, created_by, created_at)
+            VALUES
+                (:entry_id, :workspace_id, :part_id, :lot_id, 3, 'on_hand',
+                 'add', now(), :user_id, now())
+            """
+        ),
+        {
+            "entry_id": entry_id,
+            "workspace_id": workspace_id,
+            "part_id": part_id,
+            "lot_id": lot_id,
+            "user_id": user_id,
+        },
+    )
+
+    db.execute(text("DELETE FROM parts WHERE id = :part_id"), {"part_id": part_id})
+
+    lot = db.execute(
+        text(
+            """
+            SELECT id, workspace_id, part_id, name
+              FROM lots
+             WHERE id = :lot_id
+            """
+        ),
+        {"lot_id": lot_id},
+    ).mappings().one()
+    entry = db.execute(
+        text(
+            """
+            SELECT id, workspace_id, part_id, lot_id, quantity_delta
+              FROM stock_entries
+             WHERE id = :entry_id
+            """
+        ),
+        {"entry_id": entry_id},
+    ).mappings().one()
+
+    assert lot["id"] == lot_id
+    assert lot["workspace_id"] == workspace_id
+    assert lot["part_id"] is None
+    assert lot["name"] == "Lot survives"
+    assert entry["id"] == entry_id
+    assert entry["workspace_id"] == workspace_id
+    assert entry["part_id"] is None
+    assert entry["lot_id"] == lot_id
+    assert entry["quantity_delta"] == 3

--- a/backend/tests/test_workspace_triggers_tgop.py
+++ b/backend/tests/test_workspace_triggers_tgop.py
@@ -1,0 +1,316 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import DBAPIError, IntegrityError, ProgrammingError
+
+
+def _insert_workspace(db, label: str) -> tuple[uuid.UUID, uuid.UUID]:
+    user_id = uuid.uuid4()
+    workspace_id = uuid.uuid4()
+    db.execute(
+        text(
+            """
+            INSERT INTO users
+                (id, email, name, password_hash, locale, timezone, created_at)
+            VALUES
+                (:user_id, :email, :name, 'x', 'en', 'UTC', now())
+            """
+        ),
+        {
+            "user_id": user_id,
+            "email": f"{label}-{user_id.hex}@example.com",
+            "name": f"{label} tester",
+        },
+    )
+    db.execute(
+        text(
+            """
+            INSERT INTO workspaces
+                (id, name, kind, owner_user_id, currency_default,
+                 lot_control_enabled, serial_tracking_enabled, catalog_enabled,
+                 parts_provider, created_at)
+            VALUES
+                (:workspace_id, :name, 'organization', :user_id,
+                 'USD', true, false, false, 'none', now())
+            """
+        ),
+        {"workspace_id": workspace_id, "name": f"{label} workspace", "user_id": user_id},
+    )
+    return user_id, workspace_id
+
+
+def _insert_part(db, workspace_id: uuid.UUID, user_id: uuid.UUID, label: str) -> uuid.UUID:
+    part_id = uuid.uuid4()
+    db.execute(
+        text(
+            """
+            INSERT INTO parts
+                (id, workspace_id, part_type, name, attrition_percentage,
+                 attrition_min_quantity, default_storage_mandatory, serialized,
+                 published, description_locally_edited, created_at, updated_at,
+                 created_by, updated_by)
+            VALUES
+                (:part_id, :workspace_id, 'local', :name, 0, 0, false, false,
+                 false, false, now(), now(), :user_id, :user_id)
+            """
+        ),
+        {
+            "part_id": part_id,
+            "workspace_id": workspace_id,
+            "name": f"{label} part",
+            "user_id": user_id,
+        },
+    )
+    return part_id
+
+
+def _insert_storage(db, workspace_id: uuid.UUID, user_id: uuid.UUID) -> uuid.UUID:
+    storage_id = uuid.uuid4()
+    db.execute(
+        text(
+            """
+            INSERT INTO storage_locations
+                (id, workspace_id, name, single_part_only, existing_parts_only,
+                 is_full, created_at, updated_at, created_by, updated_by)
+            VALUES
+                (:storage_id, :workspace_id, 'Foreign bin', false, false,
+                 false, now(), now(), :user_id, :user_id)
+            """
+        ),
+        {"storage_id": storage_id, "workspace_id": workspace_id, "user_id": user_id},
+    )
+    return storage_id
+
+
+def _insert_lot(
+    db,
+    workspace_id: uuid.UUID,
+    user_id: uuid.UUID,
+    part_id: uuid.UUID,
+) -> uuid.UUID:
+    lot_id = uuid.uuid4()
+    db.execute(
+        text(
+            """
+            INSERT INTO lots
+                (id, workspace_id, part_id, name, source_type, created_at,
+                 updated_at, created_by, updated_by)
+            VALUES
+                (:lot_id, :workspace_id, :part_id, 'Foreign lot', 'manual',
+                 now(), now(), :user_id, :user_id)
+            """
+        ),
+        {
+            "lot_id": lot_id,
+            "workspace_id": workspace_id,
+            "part_id": part_id,
+            "user_id": user_id,
+        },
+    )
+    return lot_id
+
+
+def _insert_project_build_order(
+    db,
+    workspace_id: uuid.UUID,
+    user_id: uuid.UUID,
+    part_id: uuid.UUID,
+) -> tuple[uuid.UUID, uuid.UUID, uuid.UUID, uuid.UUID]:
+    project_id = uuid.uuid4()
+    build_id = uuid.uuid4()
+    order_id = uuid.uuid4()
+    order_entry_id = uuid.uuid4()
+    db.execute(
+        text(
+            """
+            INSERT INTO projects
+                (id, workspace_id, name, created_at, updated_at,
+                 created_by, updated_by)
+            VALUES
+                (:project_id, :workspace_id, 'Foreign project', now(), now(),
+                 :user_id, :user_id)
+            """
+        ),
+        {"project_id": project_id, "workspace_id": workspace_id, "user_id": user_id},
+    )
+    db.execute(
+        text(
+            """
+            INSERT INTO builds
+                (id, workspace_id, project_id, name, quantity, status,
+                 created_at, updated_at, created_by, updated_by)
+            VALUES
+                (:build_id, :workspace_id, :project_id, 'Foreign build', 1,
+                 'planned', now(), now(), :user_id, :user_id)
+            """
+        ),
+        {
+            "build_id": build_id,
+            "workspace_id": workspace_id,
+            "project_id": project_id,
+            "user_id": user_id,
+        },
+    )
+    db.execute(
+        text(
+            """
+            INSERT INTO orders
+                (id, workspace_id, name, order_type, status, created_at,
+                 updated_at, created_by, updated_by)
+            VALUES
+                (:order_id, :workspace_id, 'Foreign order', 'purchase',
+                 'draft', now(), now(), :user_id, :user_id)
+            """
+        ),
+        {"order_id": order_id, "workspace_id": workspace_id, "user_id": user_id},
+    )
+    db.execute(
+        text(
+            """
+            INSERT INTO order_entries
+                (id, workspace_id, order_id, part_id, quantity_ordered,
+                 quantity_received, order_index, created_at, updated_at,
+                 created_by, updated_by)
+            VALUES
+                (:order_entry_id, :workspace_id, :order_id, :part_id, 1, 0,
+                 0, now(), now(), :user_id, :user_id)
+            """
+        ),
+        {
+            "order_entry_id": order_entry_id,
+            "workspace_id": workspace_id,
+            "order_id": order_id,
+            "part_id": part_id,
+            "user_id": user_id,
+        },
+    )
+    return project_id, build_id, order_id, order_entry_id
+
+
+def _insert_stock_entry(
+    db,
+    workspace_id: uuid.UUID,
+    user_id: uuid.UUID,
+    part_id: uuid.UUID,
+) -> uuid.UUID:
+    entry_id = uuid.uuid4()
+    db.execute(
+        text(
+            """
+            INSERT INTO stock_entries
+                (id, workspace_id, part_id, quantity_delta, status,
+                 operation_type, occurred_at, created_by, created_at)
+            VALUES
+                (:entry_id, :workspace_id, :part_id, 1, 'on_hand',
+                 'audit_probe', now(), :user_id, now())
+            """
+        ),
+        {
+            "entry_id": entry_id,
+            "workspace_id": workspace_id,
+            "part_id": part_id,
+            "user_id": user_id,
+        },
+    )
+    return entry_id
+
+
+def test_unrelated_update_skips_fk_revalidation(db) -> None:
+    user_a, workspace_a = _insert_workspace(db, "a")
+    user_b, workspace_b = _insert_workspace(db, "b")
+    part_a = _insert_part(db, workspace_a, user_a, "a")
+    part_b = _insert_part(db, workspace_b, user_b, "b")
+    storage_a = _insert_storage(db, workspace_a, user_a)
+    lot_a = _insert_lot(db, workspace_a, user_a, part_a)
+    project_a, build_a, order_a, order_entry_a = _insert_project_build_order(
+        db,
+        workspace_a,
+        user_a,
+        part_a,
+    )
+    entry_id = _insert_stock_entry(db, workspace_b, user_b, part_b)
+    changed_fk_entry_id = _insert_stock_entry(db, workspace_b, user_b, part_b)
+
+    try:
+        db.execute(
+            text(
+                "ALTER TABLE stock_entries "
+                "DISABLE TRIGGER stock_entries_workspace_fk_check"
+            )
+        )
+        db.execute(
+            text(
+                """
+                UPDATE stock_entries
+                   SET lot_id = :lot_id,
+                       storage_location_id = :storage_id,
+                       project_id = :project_id,
+                       build_id = :build_id,
+                       order_id = :order_id,
+                       order_entry_id = :order_entry_id
+                 WHERE id = :entry_id
+                """
+            ),
+            {
+                "entry_id": entry_id,
+                "lot_id": lot_a,
+                "storage_id": storage_a,
+                "project_id": project_a,
+                "build_id": build_a,
+                "order_id": order_a,
+                "order_entry_id": order_entry_a,
+            },
+        )
+    finally:
+        db.execute(
+            text(
+                "ALTER TABLE stock_entries "
+                "ENABLE TRIGGER stock_entries_workspace_fk_check"
+            )
+        )
+
+    db.execute(
+        text(
+            """
+            UPDATE stock_entries
+               SET workspace_id = :workspace_id
+             WHERE id = :entry_id
+            """
+        ),
+        {"workspace_id": workspace_b, "entry_id": entry_id},
+    )
+
+    row = db.execute(
+        text(
+            """
+            SELECT workspace_id, lot_id, storage_location_id, project_id,
+                   build_id, order_id, order_entry_id
+              FROM stock_entries
+             WHERE id = :entry_id
+            """
+        ),
+        {"entry_id": entry_id},
+    ).mappings().one()
+    assert row["workspace_id"] == workspace_b
+    assert row["lot_id"] == lot_a
+    assert row["storage_location_id"] == storage_a
+    assert row["project_id"] == project_a
+    assert row["build_id"] == build_a
+    assert row["order_id"] == order_a
+    assert row["order_entry_id"] == order_entry_a
+
+    with pytest.raises((IntegrityError, ProgrammingError, DBAPIError)):
+        db.execute(
+            text(
+                """
+                UPDATE stock_entries
+                   SET lot_id = :lot_id
+                 WHERE id = :entry_id
+                """
+            ),
+            {"lot_id": lot_a, "entry_id": changed_fk_entry_id},
+        )
+        db.flush()

--- a/docs/adr/0028-hard-delete-policy-and-workspace-trigger-contract.md
+++ b/docs/adr/0028-hard-delete-policy-and-workspace-trigger-contract.md
@@ -1,0 +1,83 @@
+# ADR-0028: Hard-delete policy and workspace trigger contract
+
+Audience: engineer
+
+- **Status**: Accepted
+- **Date**: 2026-05-15
+- **Supersedes**: —
+- **Superseded by**: —
+
+## Context
+
+Most user-facing deletion in StockManager is archive/restore, but hard deletes
+still exist at the database boundary through admin scripts, tests, future data
+retention work, and ordinary foreign-key actions. AUD-018 changed
+`stock_entries.part_id` to `ON DELETE SET NULL` so part deletion preserves the
+append-only stock ledger, but `lots.part_id` still cascaded and could delete
+receiving/serial history.
+
+Workspace FK triggers also re-validated every parent reference on any UPDATE
+that mentioned `workspace_id` or a reference column. That was stricter than the
+original AUD-052 goal, which was direct-SQL insert defense, and it made
+operational UPDATEs depend on unrelated reference state.
+
+## Decision
+
+User-facing deletion of `parts`, `projects`, `orders`, and `builds` remains
+archive-first. Hard deletes are reserved for explicit operational workflows and
+must preserve independent history instead of erasing audit-relevant rows.
+
+`parts` hard deletes detach historical `stock_entries` and `lots` by setting
+their `part_id` to `NULL`. Feature-local part metadata such as substitutes,
+meta-members, CAD keys, and provider/sourcing cache rows may cascade because
+they are derived from the deleted part rather than inventory history.
+
+`projects`, `orders`, and `builds` do not have public hard-delete endpoints.
+If an operational hard delete removes one, direct child rows owned by that
+aggregate may cascade, while cross-domain history keeps `ON DELETE SET NULL`
+references where the row still has meaning without the parent.
+
+Workspace FK triggers enforce parent workspace membership on INSERT. On UPDATE,
+they validate only the reference column that changed. A workspace-only UPDATE
+must not re-check unrelated references such as `lot_id`, `storage_location_id`,
+`order_id`, or `build_id`.
+
+## Consequences
+
+- **Good**: Hard part deletes no longer erase stock ledger rows or lot history.
+- **Good**: Direct SQL INSERTs still cannot create cross-workspace references.
+- **Good**: Operational UPDATEs can touch narrow columns without being blocked
+  by unrelated historical references.
+- **Trade-offs**: A direct SQL UPDATE can still create inconsistent workspace
+  state if it changes only `workspace_id`. Application code must continue to
+  treat workspace movement as unsupported unless a dedicated migration handles
+  every reference deliberately.
+- **What it forbids**:
+  - Do not restore `ON DELETE CASCADE` on `stock_entries.part_id` or
+    `lots.part_id`.
+  - Do not add a public hard-delete endpoint for parts, projects, orders, or
+    builds without a new ADR that defines the retention behavior.
+  - Do not make the workspace triggers re-validate unchanged reference columns
+    on UPDATE.
+  - Do not compute current inventory from preserved NULL-part history; current
+    stock remains a part-scoped read through `domain/stock/service.py`.
+
+## Alternatives considered
+
+- **Block part hard deletes when lots or stock entries exist** — rejected
+  because the accepted AUD-018 behavior is to preserve independent history with
+  `part_id = NULL`.
+- **Keep full UPDATE re-validation in workspace triggers** — rejected because
+  it exceeds the direct-SQL insert defense requirement and can block safe,
+  narrow operational updates.
+- **Disable UPDATE trigger coverage entirely** — rejected because changing a
+  reference column by direct SQL should still be validated against the row's
+  workspace.
+
+## References
+
+- Issue: `#710` / AUD-072
+- ADR: `docs/adr/0001-append-only-stock-ledger.md`
+- ADR: `docs/adr/0027-ledger-history-on-part-delete.md`
+- Migration: `backend/alembic/versions/0058_lots_part_set_null_trigger_update_gates.py`
+- Model: `backend/app/domain/lots/models.py`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -37,3 +37,4 @@ New ADRs follow the template in [STYLE.md](../STYLE.md#adr-pages-docsadrnnnn-slu
 | 0025 | [Universal `audit_log` coverage for workspace mutations](0025-universal-audit-log-policy.md) |
 | 0026 | [Sentry traces are explicitly sampled; Replay is opt-in](0026-sentry-sampling-and-replay.md) |
 | 0027 | [Preserve ledger history on part delete](0027-ledger-history-on-part-delete.md) |
+| 0028 | [Hard-delete policy and workspace trigger contract](0028-hard-delete-policy-and-workspace-trigger-contract.md) |


### PR DESCRIPTION
## Summary

- Add Alembic revision `0058` to make `lots.part_id` nullable with `ON DELETE SET NULL` and to validate the new FK with `NOT VALID` / `VALIDATE CONSTRAINT`.
- Rewrite the workspace FK trigger functions for `stock_entries`, `part_substitutes`, `part_meta_members`, and `part_cad_keys` so INSERT still validates all parent refs, while UPDATE validates only changed reference columns.
- Update the `Lot` ORM FK, add focused migration/trigger regression tests, and document the hard-delete/trigger contract in ADR-0028 plus `CLAUDE.md`.

## Tests

- `cd backend && uv run python -m pytest tests/test_migration_lots_part_set_null.py tests/test_workspace_triggers_tgop.py tests/test_migrations.py -q`  
  Result: `3 passed, 5 deselected` because the repo default excludes `slow` migration round-trip tests.
- `cd backend && uv run python -m pytest tests/test_migrations.py -q -m slow`  
  Result: `5 passed, 1 deselected`.
- `cd backend && uv run ruff check alembic/versions/0058_lots_part_set_null_trigger_update_gates.py tests/test_migration_lots_part_set_null.py tests/test_workspace_triggers_tgop.py app/domain/lots/models.py`  
  Result: passed.
- `ruff check backend`  
  Result: existing repo-wide baseline failure, 270 unrelated errors outside this PR-owned scope.

## Migration Revision

- Revision: `0058_lots_part_set_null_trigger_update_gates.py`
- `revision = "0058"`
- `down_revision = "0057"`

## Merge Order / Conflict Notes

- Based on `origin/main` at `71f04ec` after PR #730 merged.
- If another migration lands after `0057` first, this PR needs a revision renumber/down_revision update before merge.
- This intentionally does not implement custom SQLSTATE mapping from #717; it preserves the existing trigger `ERRCODE = '23514'` behavior while changing the trigger gating semantics.

Refs #710
