### PR TITLE
AUD-078 backfill stale invitation expiries

### DIFF
--- a/backend/alembic/versions/0058_stale_invitation_expiry_backfill.py
+++ b/backend/alembic/versions/0058_stale_invitation_expiry_backfill.py
@@ -1,0 +1,94 @@
+"""Backfill stale invitation expiry windows (AUD-078).
+
+Revision ID: 0058
+Revises: 0057
+Create Date: 2026-05-15
+
+Migration 0053 added ``expires_at`` with a server default of
+``now() + INTERVAL '14 days'``. PostgreSQL evaluated that default while
+adding the column, which gave old pending invitations a fresh window.
+This follow-up clamps already-stale pending rows back to their original
+14-day expiry window and records an audit summary per affected workspace.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy.engine import Connection
+
+from alembic import op
+
+revision = "0058"
+down_revision = "0057"
+branch_labels = None
+depends_on = None
+
+
+def expire_stale_invitations(conn: Connection) -> None:
+    conn.execute(
+        sa.text(
+            """
+            WITH expired AS (
+                UPDATE workspace_invitations
+                SET expires_at = LEAST(
+                    expires_at,
+                    created_at + INTERVAL '14 days'
+                )
+                WHERE status = 'pending'
+                  AND created_at + INTERVAL '14 days' < now()
+                  AND expires_at > created_at + INTERVAL '14 days'
+                RETURNING id, workspace_id
+            ),
+            summary AS (
+                SELECT
+                    workspace_id,
+                    array_agg(id ORDER BY id) AS target_ids,
+                    count(*) AS expired_count
+                FROM expired
+                GROUP BY workspace_id
+            )
+            INSERT INTO audit_log (
+                id,
+                workspace_id,
+                user_id,
+                action,
+                target_type,
+                target_ids,
+                comment,
+                request_id,
+                created_at
+            )
+            SELECT
+                gen_random_uuid(),
+                workspace_id,
+                NULL,
+                'invitation.stale_expiration_backfilled',
+                'invitation',
+                target_ids,
+                format(
+                    'AUD-078 expired %s stale pending workspace invitation(s) '
+                    'at their original 14-day window.',
+                    expired_count
+                ),
+                'migration-0058-aud-078',
+                now()
+            FROM summary
+            """
+        )
+    )
+
+
+def upgrade() -> None:
+    expire_stale_invitations(op.get_bind())
+
+
+def downgrade() -> None:
+    op.execute(
+        sa.text(
+            """
+            DELETE FROM audit_log
+            WHERE action = 'invitation.stale_expiration_backfilled'
+              AND request_id = 'migration-0058-aud-078'
+            """
+        )
+    )

--- a/backend/alembic/versions/0059_stale_invitation_expiry_backfill.py
+++ b/backend/alembic/versions/0059_stale_invitation_expiry_backfill.py
@@ -1,7 +1,7 @@
 """Backfill stale invitation expiry windows (AUD-078).
 
-Revision ID: 0058
-Revises: 0057
+Revision ID: 0059
+Revises: 0058
 Create Date: 2026-05-15
 
 Migration 0053 added ``expires_at`` with a server default of
@@ -18,8 +18,8 @@ from sqlalchemy.engine import Connection
 
 from alembic import op
 
-revision = "0058"
-down_revision = "0057"
+revision = "0059"
+down_revision = "0058"
 branch_labels = None
 depends_on = None
 
@@ -70,7 +70,7 @@ def expire_stale_invitations(conn: Connection) -> None:
                     'at their original 14-day window.',
                     expired_count
                 ),
-                'migration-0058-aud-078',
+                'migration-0059-aud-078',
                 now()
             FROM summary
             """
@@ -88,7 +88,7 @@ def downgrade() -> None:
             """
             DELETE FROM audit_log
             WHERE action = 'invitation.stale_expiration_backfilled'
-              AND request_id = 'migration-0058-aud-078'
+              AND request_id = 'migration-0059-aud-078'
             """
         )
     )

--- a/backend/tests/test_invitations_backfill.py
+++ b/backend/tests/test_invitations_backfill.py
@@ -21,9 +21,9 @@ def _load_backfill_migration():
         Path(__file__).resolve().parent.parent
         / "alembic"
         / "versions"
-        / "0058_stale_invitation_expiry_backfill.py"
+        / "0059_stale_invitation_expiry_backfill.py"
     )
-    spec = importlib.util.spec_from_file_location("migration_0058", path)
+    spec = importlib.util.spec_from_file_location("migration_0059", path)
     assert spec is not None
     assert spec.loader is not None
     module = importlib.util.module_from_spec(spec)

--- a/backend/tests/test_invitations_backfill.py
+++ b/backend/tests/test_invitations_backfill.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import importlib.util
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from sqlalchemy import select
+
+from app.core.time import utcnow
+from app.domain.audit.models import AuditLog
+from app.domain.workspaces.models import WorkspaceInvitation
+
+
+def _utc(value):
+    return value.astimezone(timezone.utc)
+
+
+def _load_backfill_migration():
+    path = (
+        Path(__file__).resolve().parent.parent
+        / "alembic"
+        / "versions"
+        / "0058_stale_invitation_expiry_backfill.py"
+    )
+    spec = importlib.util.spec_from_file_location("migration_0058", path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _create_invitation(authed_client, email: str) -> uuid.UUID:
+    response = authed_client.post(
+        "/api/invitations",
+        json={"email": email, "role": "member"},
+    )
+    assert response.status_code == 201, response.text
+    return uuid.UUID(response.json()["data"]["id"])
+
+
+def test_stale_invites_expire_at_original_window(authed_client, db):
+    now = utcnow()
+    stale_created = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+    stale_original_expiry = stale_created + timedelta(days=14)
+    reactivated_expiry = now + timedelta(days=14)
+    recent_created = now - timedelta(days=2)
+    recent_expiry = now + timedelta(days=12)
+
+    stale_one_id = _create_invitation(
+        authed_client,
+        f"stale-one-{uuid.uuid4().hex[:8]}@example.com",
+    )
+    stale_two_id = _create_invitation(
+        authed_client,
+        f"stale-two-{uuid.uuid4().hex[:8]}@example.com",
+    )
+    recent_id = _create_invitation(
+        authed_client,
+        f"recent-{uuid.uuid4().hex[:8]}@example.com",
+    )
+
+    stale_one = db.get(WorkspaceInvitation, stale_one_id)
+    stale_two = db.get(WorkspaceInvitation, stale_two_id)
+    recent = db.get(WorkspaceInvitation, recent_id)
+    assert stale_one is not None
+    assert stale_two is not None
+    assert recent is not None
+
+    stale_one.created_at = stale_created
+    stale_one.expires_at = reactivated_expiry
+    stale_two.created_at = stale_created
+    stale_two.expires_at = reactivated_expiry
+    recent.created_at = recent_created
+    recent.expires_at = recent_expiry
+    db.flush()
+
+    migration = _load_backfill_migration()
+    migration.expire_stale_invitations(db.connection())
+    db.expire_all()
+
+    stale_one = db.get(WorkspaceInvitation, stale_one_id)
+    stale_two = db.get(WorkspaceInvitation, stale_two_id)
+    recent = db.get(WorkspaceInvitation, recent_id)
+    assert stale_one is not None
+    assert stale_two is not None
+    assert recent is not None
+    assert _utc(stale_one.expires_at) == stale_original_expiry
+    assert _utc(stale_two.expires_at) == stale_original_expiry
+    assert _utc(recent.expires_at) == recent_expiry
+
+    audit_row = db.execute(
+        select(AuditLog).where(
+            AuditLog.action == "invitation.stale_expiration_backfilled"
+        )
+    ).scalar_one()
+    assert audit_row.workspace_id == stale_one.workspace_id
+    assert set(audit_row.target_ids or []) == {stale_one_id, stale_two_id}
+    assert "AUD-078 expired 2 stale pending workspace invitation" in (
+        audit_row.comment or ""
+    )


### PR DESCRIPTION
## Summary
- Add Alembic migration 0059 to clamp stale pending workspace invitations back to their original 14-day expiry window.
- Write an audit-log summary row per affected workspace with the expired invitation ids and count.
- Add the focused AUD-078 regression test.

## Tests
- `cd backend && uv run --extra dev python -m pytest tests/test_invitations_backfill.py -q`
- `cd backend && uv run --extra dev alembic heads` -> `0059 (head)`
- `cd backend && uv run --extra dev ruff check tests/test_invitations_backfill.py alembic/versions/0059_stale_invitation_expiry_backfill.py`
- `cd backend && uv run --extra dev python -m pytest tests/test_migrations.py -q`
- Local rerun of `cd backend && uv run --extra dev python -m pytest tests/test_migrations.py -m slow -q` failed in the reused local DB at legacy migration 0020 (`stock_entries` missing) before reaching this PR migration; CI should be treated as authoritative for clean DB round-trip.

## Migration
- Revision: `0059_stale_invitation_expiry_backfill.py`
- Chain: `0058 -> 0059` after PR #735.

## Merge Order / Conflict Notes
- PR #735 has merged and this branch was rebased onto `origin/main` at `0d4e2a0`.
- No migration-number conflict remains; this should merge after #735.

Refs #716