### PR TITLE
AUD-079: map workspace isolation SQLSTATE WS001

### DIFF
--- a/backend/alembic/versions/0060_workspace_isolation_sqlstate.py
+++ b/backend/alembic/versions/0060_workspace_isolation_sqlstate.py
@@ -1,0 +1,67 @@
+"""Use a custom SQLSTATE for workspace-isolation trigger failures.
+
+Revision ID: 0060
+Revises: 0059
+Create Date: 2026-05-15
+
+AUD-079 / issue #717.
+
+The trigger bodies were last updated in 0058 to preserve the #710 update-gating
+semantics. Rewrite only the ERRCODE inside those current function definitions
+so this migration does not drift from that trigger logic.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0060"
+down_revision = "0059"
+branch_labels = None
+depends_on = None
+
+
+_WORKSPACE_TRIGGER_FUNCTIONS = (
+    "check_stock_entries_workspace_fks()",
+    "check_part_substitutes_workspace_fks()",
+    "check_part_meta_members_workspace_fks()",
+    "check_part_cad_keys_workspace()",
+)
+
+
+def _rewrite_sqlstate(from_sqlstate: str, to_sqlstate: str) -> None:
+    for function_signature in _WORKSPACE_TRIGGER_FUNCTIONS:
+        op.execute(
+            f"""
+            DO $$
+            DECLARE
+              function_def text;
+              rewritten text;
+            BEGIN
+              SELECT pg_get_functiondef('{function_signature}'::regprocedure)
+                INTO function_def;
+
+              rewritten := replace(
+                function_def,
+                $needle$ERRCODE = '{from_sqlstate}'$needle$,
+                $replacement$ERRCODE = '{to_sqlstate}'$replacement$
+              );
+
+              IF rewritten = function_def THEN
+                RAISE EXCEPTION
+                  'function {function_signature} did not contain SQLSTATE {from_sqlstate}';
+              END IF;
+
+              EXECUTE rewritten;
+            END
+            $$;
+            """
+        )
+
+
+def upgrade() -> None:
+    _rewrite_sqlstate("23514", "WS001")
+
+
+def downgrade() -> None:
+    _rewrite_sqlstate("WS001", "23514")

--- a/backend/app/api/routes/_stock_integrity.py
+++ b/backend/app/api/routes/_stock_integrity.py
@@ -3,17 +3,29 @@ from __future__ import annotations
 from typing import NoReturn
 
 from fastapi import HTTPException, status
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import DBAPIError
+
+from app.core.errors import ErrorCodes
 
 _STOCK_NONNEG_NAMES = {
     "ck_stock_nonneg",
     "check_stock_nonneg",
     "stock_nonneg_trigger",
 }
+_WORKSPACE_ISOLATION_SQLSTATE = "WS001"
 
 
-def raise_integrity_as_409(exc: IntegrityError) -> NoReturn:
+def raise_integrity_as_409(exc: DBAPIError) -> NoReturn:
     """Map the stock non-negative trigger to the public conflict contract."""
+    if _is_workspace_isolation_violation(exc):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "code": ErrorCodes.WORKSPACE_ISOLATION,
+                "message": "workspace isolation violation",
+                "sqlstate": _WORKSPACE_ISOLATION_SQLSTATE,
+            },
+        ) from exc
     if _is_stock_nonneg_violation(exc):
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
@@ -25,7 +37,18 @@ def raise_integrity_as_409(exc: IntegrityError) -> NoReturn:
     raise exc
 
 
-def _is_stock_nonneg_violation(exc: IntegrityError) -> bool:
+def _is_workspace_isolation_violation(exc: DBAPIError) -> bool:
+    orig = getattr(exc, "orig", None)
+    return _sqlstate(orig) == _WORKSPACE_ISOLATION_SQLSTATE
+
+
+def _sqlstate(orig: object | None) -> str | None:
+    if orig is None:
+        return None
+    return getattr(orig, "sqlstate", None) or getattr(orig, "pgcode", None)
+
+
+def _is_stock_nonneg_violation(exc: DBAPIError) -> bool:
     orig = getattr(exc, "orig", None)
     diag = getattr(orig, "diag", None)
     if diag is None:

--- a/backend/app/api/routes/builds.py
+++ b/backend/app/api/routes/builds.py
@@ -5,7 +5,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, Query, Request, status
 from sqlalchemy import and_, or_, select
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import DBAPIError
 
 from app.api._helpers import require_resource_access
 from app.api.routes._activity import _DEFAULT_LIMIT, _MAX_LIMIT, build_activity
@@ -96,7 +96,7 @@ def create_build(payload: BuildCreateIn, db: DbSession, ws: CurrentWorkspace, us
         apply_reservations(
             db, workspace_id=ws.id, user_id=user.id, build=b, project=project
         )
-    except IntegrityError as exc:
+    except DBAPIError as exc:
         raise_integrity_as_409(exc)
     return ok(_serialize(b))
 
@@ -142,7 +142,7 @@ def patch_build(build_id: UUID, payload: BuildPatchIn, db: DbSession, ws: Curren
             apply_reservations(
                 db, workspace_id=ws.id, user_id=user.id, build=b, project=project
             )
-    except IntegrityError as exc:
+    except DBAPIError as exc:
         raise_integrity_as_409(exc)
 
     return ok(_serialize(b))
@@ -158,7 +158,7 @@ def archive_build(build_id: UUID, db: DbSession, ws: CurrentWorkspace, user: Cur
     )
     try:
         release_reservations(db, workspace_id=ws.id, user_id=user.id, build=b)
-    except IntegrityError as exc:
+    except DBAPIError as exc:
         raise_integrity_as_409(exc)
     b.archived_at = utcnow()
     return ok(None, "archived")
@@ -200,7 +200,7 @@ def consume_build(
         # `get_db` rolls back on raise (BE2-010), so dropping the
         # explicit db.rollback() here is safe.
         raise HTTPException(status_code=400, detail=str(exc))
-    except IntegrityError as exc:
+    except DBAPIError as exc:
         raise_integrity_as_409(exc)
     return ok(result)
 

--- a/backend/app/api/routes/lots.py
+++ b/backend/app/api/routes/lots.py
@@ -5,7 +5,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Query, status
 from sqlalchemy import select
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import DBAPIError
 
 from app.api.routes._stock_integrity import raise_integrity_as_409
 from app.core.deps import CurrentUser, CurrentWorkspace, DbSession
@@ -117,7 +117,7 @@ def move_lot(lot_id: UUID, payload: MoveStockIn, db: DbSession, ws: CurrentWorks
     except StockError as exc:
         # `get_db` rolls back on raise (BE2-010).
         raise_http(400, code=ErrorCodes.LOT_MOVE_STOCK_ERROR, message=str(exc))
-    except IntegrityError as exc:
+    except DBAPIError as exc:
         raise_integrity_as_409(exc)
     return ok({"out": str(out_e.id), "in": str(in_e.id)})
 
@@ -136,7 +136,7 @@ def adjust_lot(lot_id: UUID, payload: LotAdjustIn, db: DbSession, ws: CurrentWor
         e = adjust_stock(db, workspace_id=ws.id, user_id=user.id, payload=aip)
     except StockError as exc:
         raise_http(400, code=ErrorCodes.LOT_ADJUST_STOCK_ERROR, message=str(exc))
-    except IntegrityError as exc:
+    except DBAPIError as exc:
         raise_integrity_as_409(exc)
     return ok({"id": str(e.id) if e else None, "delta": e.quantity_delta if e else 0})
 

--- a/backend/app/api/routes/orders.py
+++ b/backend/app/api/routes/orders.py
@@ -6,7 +6,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, Query, Request, status
 from sqlalchemy import and_, or_, select
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import DBAPIError
 
 from app.api._helpers import assert_child_in_parent, assert_in_workspace, require_resource_access
 from app.api.routes._activity import _DEFAULT_LIMIT, _MAX_LIMIT, build_activity
@@ -316,7 +316,7 @@ def receive_order(order_id: UUID, payload: ReceiveIn, db: DbSession, ws: Current
         # the route raises (BE2-010), so we don't need an explicit
         # db.rollback() here.
         raise HTTPException(status_code=400, detail=str(exc))
-    except IntegrityError as exc:
+    except DBAPIError as exc:
         raise_integrity_as_409(exc)
     return ok(result)
 

--- a/backend/app/api/routes/stock.py
+++ b/backend/app/api/routes/stock.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, HTTPException, Query, status
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import DBAPIError
 
 from app.api.routes._stock_integrity import raise_integrity_as_409
 from app.core.deps import CurrentUser, CurrentWorkspace, DbSession
@@ -99,7 +99,7 @@ def add(
         )
     except StockError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
-    except IntegrityError as exc:
+    except DBAPIError as exc:
         raise_integrity_as_409(exc)
     return ok(_serialize_entry(e))
 
@@ -112,7 +112,7 @@ def remove(
         e = remove_stock(db, workspace_id=ws.id, user_id=user.id, payload=payload)
     except StockError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
-    except IntegrityError as exc:
+    except DBAPIError as exc:
         raise_integrity_as_409(exc)
     return ok(_serialize_entry(e))
 
@@ -132,7 +132,7 @@ def move(payload: MoveStockIn, db: DbSession, ws: CurrentWorkspace, user: Curren
         )
     except StockError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
-    except IntegrityError as exc:
+    except DBAPIError as exc:
         raise_integrity_as_409(exc)
     return ok({"out": _serialize_entry(out_e), "in": _serialize_entry(in_e)})
 
@@ -143,7 +143,7 @@ def adjust(payload: AdjustStockIn, db: DbSession, ws: CurrentWorkspace, user: Cu
         e = adjust_stock(db, workspace_id=ws.id, user_id=user.id, payload=payload)
     except StockError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
-    except IntegrityError as exc:
+    except DBAPIError as exc:
         raise_integrity_as_409(exc)
     return ok(_serialize_entry(e) if e is not None else None, "no change" if e is None else "OK")
 

--- a/backend/app/core/errors.py
+++ b/backend/app/core/errors.py
@@ -111,6 +111,7 @@ class ErrorCodes:
     WORKSPACE_OWNER_ONLY = "workspace.owner_only"
     WORKSPACE_LAST_OWNER = "workspace.last_owner"
     WORKSPACE_SELF_REMOVE = "workspace.self_remove"
+    WORKSPACE_ISOLATION = "workspace.isolation"
 
     # Invitations
     INVITATION_NOT_FOUND = "invitation.not_found"

--- a/backend/tests/test_workspace_isolation.py
+++ b/backend/tests/test_workspace_isolation.py
@@ -5,8 +5,11 @@ import uuid
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 
 from app.api._helpers import _polymorphic_resolvers, assert_polymorphic_in_workspace
+from app.api.routes import stock as stock_routes
+from app.core.errors import ErrorCodes
 from app.domain.builds.models import Build
 from app.domain.lots.models import Lot
 from app.domain.orders.models import Order
@@ -15,6 +18,7 @@ from app.domain.projects.bom_import import ParsedRow, _match_part
 from app.domain.projects.models import Project
 from app.domain.sourcing.budget import BUDGET
 from app.domain.sourcing.models import SourcingCache
+from app.domain.stock.models import StockEntry
 from app.domain.storage.models import StorageLocation
 from app.main import app
 from tests._factories import (
@@ -220,6 +224,63 @@ def test_part_cad_keys_workspace_trigger_rejects_mismatch():
                 },
             )
             s.commit()
+
+
+class _StockNonnegDiag:
+    constraint_name = "stock_nonneg_trigger"
+
+
+class _StockNonnegOrig(Exception):
+    diag = _StockNonnegDiag()
+
+
+def _stock_nonneg_integrity_error() -> IntegrityError:
+    return IntegrityError("INSERT INTO stock_entries ...", {}, _StockNonnegOrig())
+
+
+def test_cross_workspace_error_code_distinct_from_stock_negative(monkeypatch):
+    a = TestClient(app)
+    b = TestClient(app)
+    _signup(a, f"a-{uuid.uuid4().hex[:6]}@x.com")
+    _signup(b, f"b-{uuid.uuid4().hex[:6]}@x.com")
+    part_a = uuid.UUID(_create_part(a, "A-stock-trigger-part"))
+
+    def insert_foreign_part(db, *, workspace_id, user_id, payload):
+        entry = StockEntry(
+            workspace_id=workspace_id,
+            part_id=part_a,
+            quantity_delta=payload.quantity,
+            operation_type="add",
+            created_by=user_id,
+        )
+        db.add(entry)
+        db.flush()
+        return entry
+
+    monkeypatch.setattr(stock_routes, "add_stock", insert_foreign_part)
+    cross_workspace = b.post(
+        "/api/stock/add",
+        json={"part_id": str(uuid.uuid4()), "quantity": 1},
+    )
+
+    assert cross_workspace.status_code == 409, cross_workspace.text
+    cross_workspace_body = cross_workspace.json()
+    assert cross_workspace_body["code"] == ErrorCodes.WORKSPACE_ISOLATION
+    assert cross_workspace_body["sqlstate"] == "WS001"
+
+    def raise_stock_negative(*args, **kwargs):
+        raise _stock_nonneg_integrity_error()
+
+    monkeypatch.setattr(stock_routes, "remove_stock", raise_stock_negative)
+    stock_negative = b.post(
+        "/api/stock/remove",
+        json={"part_id": str(uuid.uuid4()), "quantity": 1},
+    )
+
+    assert stock_negative.status_code == 409, stock_negative.text
+    stock_negative_body = stock_negative.json()
+    assert stock_negative_body.get("code") != ErrorCodes.WORKSPACE_ISOLATION
+    assert stock_negative_body["constraint"] == "stock_nonneg_trigger"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add Alembic revision `0060` to rewrite the four workspace-isolation trigger functions from SQLSTATE `23514` to custom SQLSTATE `WS001` while preserving the trigger bodies installed by `0058`.
- Map `WS001` through the stock integrity helper to `ErrorCodes.WORKSPACE_ISOLATION`; widen the existing helper catch sites to `DBAPIError` because custom SQLSTATEs are not classified by SQLAlchemy as `IntegrityError`.
- Add regression coverage for cross-workspace stock insert error code separation from stock-negative trigger errors.

## Tests
- `uv --project backend run --extra dev python -m pytest backend/tests/test_workspace_isolation.py -q`
- `uv --project backend run --extra dev python -m pytest backend/tests/test_migrations.py::test_per_revision_round_trip -q -m slow`
- `uv --project backend run --extra dev ruff check backend/app/api/routes/_stock_integrity.py backend/app/core/errors.py backend/tests/test_workspace_isolation.py`
- `cd backend && uv run --extra dev alembic heads` -> `0060 (head)`
- `uv --project /mnt/data/WORK/stockManager-717/backend run --extra dev alembic heads` -> `0060 (head)`
- `uv --project /mnt/data/WORK/stockManager-717/backend run --extra dev python -m pytest backend/tests/test_workspace_isolation.py::test_cross_workspace_error_code_distinct_from_stock_negative -q`

## Migration
- Revision: `0060_workspace_isolation_sqlstate.py` (`revision = "0060"`, `down_revision = "0059"`).

## Merge Order / Conflicts
- PR #736 has merged first and installed `0059_stale_invitation_expiry_backfill.py`.
- This PR is rebased on `origin/main` after #736 and now depends on `0059`, so merge after #736 deploy validation finishes.

Refs #717
