### PR TITLE
FEAT-001 password-reset flow

### DIFF
--- a/backend/alembic/versions/0061_password_reset_requests.py
+++ b/backend/alembic/versions/0061_password_reset_requests.py
@@ -1,0 +1,86 @@
+"""Add password reset request table.
+
+Revision ID: 0061
+Revises: 0060
+Create Date: 2026-05-15
+
+FEAT-001 / issue #721.
+
+This revision intentionally uses the next safe numeric id. PR #736 (`0059`)
+and PR #737 (`0060`) merged while this PR was in progress, so this chains
+after `0060` to preserve a single Alembic head.
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = "0061"
+down_revision = "0060"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "password_reset_requests",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("email_hash", sa.String(length=64), nullable=False),
+        sa.Column("token_hmac", sa.String(length=64), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("used_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("ip", sa.String(length=45), nullable=True),
+        sa.Column("sent_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_password_reset_requests_user_id",
+        "password_reset_requests",
+        ["user_id"],
+    )
+    op.create_index(
+        "ix_password_reset_requests_email_hash",
+        "password_reset_requests",
+        ["email_hash"],
+    )
+    op.create_index(
+        "ix_password_reset_requests_token_hmac",
+        "password_reset_requests",
+        ["token_hmac"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_password_reset_requests_created_at",
+        "password_reset_requests",
+        ["created_at"],
+    )
+    op.create_index(
+        "ix_password_reset_requests_expires_at",
+        "password_reset_requests",
+        ["expires_at"],
+    )
+    op.create_index(
+        "ix_password_reset_requests_ip",
+        "password_reset_requests",
+        ["ip"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_password_reset_requests_ip", table_name="password_reset_requests")
+    op.drop_index("ix_password_reset_requests_expires_at", table_name="password_reset_requests")
+    op.drop_index("ix_password_reset_requests_created_at", table_name="password_reset_requests")
+    op.drop_index("ix_password_reset_requests_token_hmac", table_name="password_reset_requests")
+    op.drop_index("ix_password_reset_requests_email_hash", table_name="password_reset_requests")
+    op.drop_index("ix_password_reset_requests_user_id", table_name="password_reset_requests")
+    op.drop_table("password_reset_requests")

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import hashlib
 import hmac as _hmac
 import secrets
 from datetime import timedelta
 from uuid import UUID
 
 from fastapi import APIRouter, Request, Response, status
+from sqlalchemy import func
 
 from app.core.auth import (
     PasswordVerifyResult,
@@ -15,6 +17,8 @@ from app.core.auth import (
     create_session_row,
     hash_password,
     hash_session_token,
+    hmac_token,
+    mint_password_reset_token,
     record_login_failure,
     revoke_all_user_sessions,
     revoke_session,
@@ -34,13 +38,23 @@ from app.core.cookies import (
 from app.core.deps import CurrentUser, DbSession
 from app.core.errors import ErrorCodes, raise_http
 from app.core.logging import get_logger
-from app.core.mail import send_account_exists_email, send_verification_email
+from app.core.mail import (
+    send_account_exists_email,
+    send_password_reset_email,
+    send_verification_email,
+)
 from app.core.ratelimit import limiter
 from app.core.responses import Envelope, ok
 from app.core.time import utcnow
 from app.domain.audit.service import log as _audit_log
-from app.domain.users.models import PendingUser, User, UserSession
-from app.domain.users.schemas import LoginIn, SignupIn, VerifyIn
+from app.domain.users.models import PasswordResetRequest, PendingUser, User, UserSession
+from app.domain.users.schemas import (
+    LoginIn,
+    PasswordResetIn,
+    RequestPasswordResetIn,
+    SignupIn,
+    VerifyIn,
+)
 from app.domain.workspaces.models import Workspace, WorkspaceMember
 
 router = APIRouter()
@@ -48,6 +62,8 @@ log = get_logger(__name__)
 
 # How long a pending signup verification is valid (in hours).
 _VERIFY_TTL_HOURS = 24
+_PASSWORD_RESET_TTL_HOURS = 1
+_PASSWORD_RESET_EMAIL_LIMIT = 3
 _DUMMY_ARGON2 = (
     "$argon2id$v=19$m=65536,t=3,p=4$"
     "yEZFbIMmBabse2MdUks7RA$Iggj8Dn26NU39IQQb7Vs8ADgvJayYRb194wtzFzGsF0"
@@ -63,6 +79,8 @@ def _verify_password_for_login(hash_: str, password: str) -> PasswordVerifyResul
 
 _SIGNUP_VERIFICATION_DATA = {"status": "verification_sent"}
 _SIGNUP_VERIFICATION_MESSAGE = "verification email sent"
+_PASSWORD_RESET_REQUEST_DATA = {"status": "accepted"}
+_PASSWORD_RESET_REQUEST_MESSAGE = "password reset request accepted"
 
 
 def _record_signup_mail_failure(kind: str, exc: Exception) -> None:
@@ -76,6 +94,29 @@ def _record_signup_mail_failure(kind: str, exc: Exception) -> None:
         sentry_sdk.capture_exception(exc)
     except Exception:
         pass
+
+
+def _record_password_reset_mail_failure(exc: Exception) -> None:
+    log.exception(
+        "password reset mail send failed",
+        extra={"mail_kind": "password_reset", "error_code": "mail.send_failed"},
+    )
+    try:
+        import sentry_sdk
+
+        sentry_sdk.capture_exception(exc)
+    except Exception:
+        pass
+
+
+def _hash_email_for_password_reset(email: str) -> str:
+    return hashlib.sha256(email.lower().encode("utf-8")).hexdigest()
+
+
+def _dummy_password_reset_compute() -> None:
+    # Keep known and unknown request paths close enough that the request
+    # endpoint does not become an email-enumeration timing oracle.
+    hash_password(secrets.token_urlsafe(24))
 
 
 def _reap_expired_pending_signup(db: DbSession, email: str) -> None:
@@ -122,8 +163,52 @@ def _hmac_token(plaintext: str) -> str:
     `hmac.compare_digest(_hmac_token(supplied), row.verification_token_hmac)`
     for constant-time comparison (SEC2-013 pattern).
     """
-    key = settings().SESSION_SECRET.encode("utf-8")
-    return _hmac.new(key, plaintext.encode("utf-8"), "sha256").hexdigest()
+    return hmac_token(plaintext)
+
+
+def _first_workspace_for_user(db: DbSession, user: User) -> Workspace | None:
+    membership = (
+        db.query(WorkspaceMember)
+        .filter(WorkspaceMember.user_id == user.id, WorkspaceMember.status == "active")
+        .order_by(WorkspaceMember.created_at.asc())
+        .first()
+    )
+    return db.get(Workspace, membership.workspace_id) if membership else None
+
+
+def _password_reset_request_throttled(db: DbSession, *, email_hash: str) -> bool:
+    cutoff = utcnow() - timedelta(hours=1)
+    count = (
+        db.query(PasswordResetRequest)
+        .filter(
+            PasswordResetRequest.email_hash == email_hash,
+            PasswordResetRequest.created_at >= cutoff,
+        )
+        .count()
+    )
+    return count >= _PASSWORD_RESET_EMAIL_LIMIT
+
+
+def _audit_password_reset_request(
+    db: DbSession,
+    request: Request,
+    user: User,
+    *,
+    throttled: bool,
+) -> None:
+    workspace = _first_workspace_for_user(db, user)
+    if workspace is None:
+        return
+    _audit_log(
+        db,
+        ws=workspace,
+        user=user,
+        action="user.password_reset_requested",
+        target_type="user",
+        target_ids=[user.id],
+        comment="throttled" if throttled else None,
+        request_id=getattr(request.state, "request_id", None),
+    )
 
 
 def _workspace_for_logout_audit(db, request: Request, user: User) -> Workspace | None:
@@ -402,6 +487,131 @@ def verify(
             "workspace_id": str(ws.id),
         },
         "email verified",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Password reset — pre-auth request + single-use email token
+# ---------------------------------------------------------------------------
+
+
+@router.post("/request-password-reset")
+@limiter.limit("10/hour")
+def request_password_reset(
+    request: Request,
+    payload: RequestPasswordResetIn,
+    response: Response,
+    db: DbSession,
+) -> Envelope[dict]:
+    email = str(payload.email).strip()
+    email_normalized = email.lower()
+    email_hash = _hash_email_for_password_reset(email_normalized)
+    client_ip = request.client.host if request.client else None
+    now = utcnow()
+
+    _dummy_password_reset_compute()
+    user = db.query(User).filter(func.lower(User.email) == email_normalized).first()
+    throttled = _password_reset_request_throttled(db, email_hash=email_hash)
+
+    reset_request = PasswordResetRequest(
+        user_id=user.id if user else None,
+        email_hash=email_hash,
+        ip=client_ip,
+    )
+
+    if user is not None and not throttled:
+        token, token_hmac = mint_password_reset_token()
+        reset_request.token_hmac = token_hmac
+        reset_request.expires_at = now + timedelta(hours=_PASSWORD_RESET_TTL_HOURS)
+        db.add(reset_request)
+        db.flush()
+
+        link = f"{settings().APP_BASE_URL}/auth/reset-password?token={token}"
+        try:
+            send_password_reset_email(to=user.email, reset_link=link)
+            reset_request.sent_at = now
+        except Exception as exc:
+            _record_password_reset_mail_failure(exc)
+    else:
+        db.add(reset_request)
+        db.flush()
+
+    if user is not None:
+        _audit_password_reset_request(db, request, user, throttled=throttled)
+
+    response.status_code = status.HTTP_202_ACCEPTED
+    return ok(_PASSWORD_RESET_REQUEST_DATA, _PASSWORD_RESET_REQUEST_MESSAGE)
+
+
+@router.post("/reset-password")
+@limiter.limit("10/minute")
+def reset_password(
+    request: Request,
+    payload: PasswordResetIn,
+    db: DbSession,
+) -> Envelope[dict]:
+    token_hmac = hmac_token(payload.token)
+    reset_request = (
+        db.query(PasswordResetRequest)
+        .filter(PasswordResetRequest.token_hmac == token_hmac)
+        .first()
+    )
+    if reset_request is None:
+        raise_http(
+            status.HTTP_400_BAD_REQUEST,
+            ErrorCodes.AUTH_RESET_INVALID,
+            "invalid password reset link",
+        )
+    if reset_request.used_at is not None:
+        raise_http(
+            status.HTTP_400_BAD_REQUEST,
+            ErrorCodes.AUTH_RESET_USED,
+            "password reset link already used",
+        )
+    if reset_request.expires_at is None or reset_request.expires_at < utcnow():
+        raise_http(
+            status.HTTP_400_BAD_REQUEST,
+            ErrorCodes.AUTH_RESET_EXPIRED,
+            "password reset link expired",
+        )
+
+    user = db.get(User, reset_request.user_id) if reset_request.user_id else None
+    if user is None:
+        raise_http(
+            status.HTTP_400_BAD_REQUEST,
+            ErrorCodes.AUTH_RESET_INVALID,
+            "invalid password reset link",
+        )
+
+    try:
+        validate_password_strength(payload.new_password)
+    except WeakPasswordError as exc:
+        raise_http(
+            status.HTTP_400_BAD_REQUEST,
+            ErrorCodes.AUTH_WEAK_PASSWORD,
+            str(exc),
+        )
+
+    reset_request.used_at = utcnow()
+    user.password_hash = hash_password(payload.new_password)
+    revoked_sessions = revoke_all_user_sessions(db, user.id)
+    clear_login_failures(db, email=user.email)
+
+    workspace = _first_workspace_for_user(db, user)
+    if workspace is not None:
+        _audit_log(
+            db,
+            ws=workspace,
+            user=user,
+            action="user.password_reset",
+            target_type="user",
+            target_ids=[user.id],
+            request_id=getattr(request.state, "request_id", None),
+        )
+
+    return ok(
+        {"status": "password_reset", "revoked_sessions": revoked_sessions},
+        "password reset",
     )
 
 

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -171,6 +171,22 @@ def verify_password(hash_: str, password: str) -> bool:
     return verify_password_with_rehash(hash_, password).valid
 
 
+def hmac_token(token: str) -> str:
+    """HMAC-SHA-256 hex digest for bearer tokens stored at rest.
+
+    Used by email verification and password reset flows so database
+    dumps cannot replay raw email-link credentials.
+    """
+    key = settings().SESSION_SECRET.encode("utf-8")
+    return hmac.new(key, token.encode("utf-8"), "sha256").hexdigest()
+
+
+def mint_password_reset_token() -> tuple[str, str]:
+    """Return (plaintext token, HMAC digest) for a password reset link."""
+    token = secrets.token_urlsafe(48)
+    return token, hmac_token(token)
+
+
 def new_session_token() -> str:
     """Mint a fresh plaintext session token. Lives only on the client
     cookie; the server stores `hash_session_token(token)` in

--- a/backend/app/core/errors.py
+++ b/backend/app/core/errors.py
@@ -103,6 +103,9 @@ class ErrorCodes:
     AUTH_VERIFICATION_PENDING = "auth.verification_pending"
     AUTH_VERIFICATION_INVALID = "auth.verification_invalid"
     AUTH_VERIFICATION_EXPIRED = "auth.verification_expired"
+    AUTH_RESET_INVALID = "auth.reset_invalid"
+    AUTH_RESET_EXPIRED = "auth.reset_expired"
+    AUTH_RESET_USED = "auth.reset_used"
 
     # Workspace / membership
     WORKSPACE_NOT_FOUND = "workspace.not_found"

--- a/backend/app/core/mail.py
+++ b/backend/app/core/mail.py
@@ -159,6 +159,31 @@ def send_account_exists_email(*, to: str) -> None:
     )
 
 
+def send_password_reset_email(*, to: str, reset_link: str) -> None:
+    """Send a password-reset message to ``to``."""
+    cfg = settings()
+    if cfg.APP_ENV == "prod":
+        _send_smtp_message(
+            to=to,
+            subject="Reset your Stock Manager password",
+            text_body=(
+                "We received a request to reset your Stock Manager password.\n\n"
+                f"Reset your password here:\n{reset_link}\n\n"
+                "This link expires in 1 hour and works only once.\n\n"
+                "If you did not request this, you can safely ignore this email."
+            ),
+            html_body=(
+                "<p>We received a request to reset your Stock Manager password.</p>"
+                f'<p><a href="{reset_link}">Reset my password</a></p>'
+                f"<p>Or copy and paste this URL: {reset_link}</p>"
+                "<p><small>This link expires in 1 hour and works only once. "
+                "If you did not request this, ignore this email.</small></p>"
+            ),
+        )
+        return
+    _send_password_reset_stdout(to=to, reset_link=reset_link)
+
+
 def _send_stdout(*, to: str, verification_link: str) -> None:
     """Dev backend: log a single WARNING with the verification link.
 
@@ -181,6 +206,19 @@ def _send_stdout(*, to: str, verification_link: str) -> None:
         "dev mail backend (SMTP not configured): verification link for %s: %s",
         to,
         verification_link,
+    )
+
+
+def _send_password_reset_stdout(*, to: str, reset_link: str) -> None:
+    cfg = settings()
+    if cfg.APP_ENV == "prod":
+        raise RuntimeError(
+            "stdout mail backend refused in prod: SMTP must be configured"
+        )
+    _log.warning(
+        "dev mail backend (SMTP not configured): password reset link for %s: %s",
+        to,
+        reset_link,
     )
 
 

--- a/backend/app/domain/all_models.py
+++ b/backend/app/domain/all_models.py
@@ -52,7 +52,13 @@ from app.domain.sourcing.models import (  # noqa: F401
 from app.domain.stock.models import StockEntry  # noqa: F401
 from app.domain.storage.models import StorageLocation  # noqa: F401
 from app.domain.tags.models import Tag, TagLink  # noqa: F401
-from app.domain.users.models import PendingUser, User, UserLoginFailure, UserSession  # noqa: F401
+from app.domain.users.models import (  # noqa: F401
+    PasswordResetRequest,
+    PendingUser,
+    User,
+    UserLoginFailure,
+    UserSession,
+)
 from app.domain.workspaces.models import (  # noqa: F401
     Workspace,
     WorkspaceCatalogToken,

--- a/backend/app/domain/users/models.py
+++ b/backend/app/domain/users/models.py
@@ -85,6 +85,32 @@ class UserLoginFailure(Base):
     client_ip = Column(String(45), nullable=True)  # IPv4 or IPv6
 
 
+class PasswordResetRequest(Base):
+    """Transient password reset request.
+
+    Password reset is a pre-authentication flow, so this table is not
+    workspace-scoped. The email is stored as a hash for throttle rows;
+    reset tokens are HMACed at rest and are single-use via `used_at`.
+    """
+
+    __tablename__ = "password_reset_requests"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    email_hash = Column(String(64), nullable=False, index=True)
+    token_hmac = Column(String(64), nullable=True, index=True)
+    created_at = Column(DateTime(timezone=True), nullable=False, default=utcnow, index=True)
+    expires_at = Column(DateTime(timezone=True), nullable=True, index=True)
+    used_at = Column(DateTime(timezone=True), nullable=True)
+    ip = Column(String(45), nullable=True, index=True)
+    sent_at = Column(DateTime(timezone=True), nullable=True)
+
+
 class PendingUser(Base):
     """Transient signup record held until the user verifies their email.
 

--- a/backend/app/domain/users/schemas.py
+++ b/backend/app/domain/users/schemas.py
@@ -12,8 +12,10 @@ from __future__ import annotations
 from pydantic import BaseModel, ConfigDict, EmailStr, Field
 
 __all__ = [
-    "SignupIn",
     "LoginIn",
+    "PasswordResetIn",
+    "RequestPasswordResetIn",
+    "SignupIn",
     "VerifyIn",
 ]
 
@@ -39,3 +41,16 @@ class VerifyIn(BaseModel):
 
     id: str
     token: str
+
+
+class RequestPasswordResetIn(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    email: EmailStr
+
+
+class PasswordResetIn(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    token: str = Field(min_length=1, max_length=256)
+    new_password: str = Field(min_length=8, max_length=200)

--- a/backend/tests/test_password_reset.py
+++ b/backend/tests/test_password_reset.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import re
+import uuid
+from datetime import timedelta
+from unittest.mock import patch
+
+from app.core.auth import hmac_token
+from app.core.time import utcnow
+from app.domain.audit.models import AuditLog
+from app.domain.users.models import PasswordResetRequest, User, UserSession
+from tests._factories import DEFAULT_PASSWORD, signup_user
+
+NEW_PASSWORD = "NewResetPass-2026!!"
+
+
+def _signup(client, email: str | None = None) -> str:
+    email = email or f"reset-{uuid.uuid4().hex[:8]}@example.com"
+    signup_user(client, email=email)
+    return email
+
+
+def _request_reset(client, email: str) -> str:
+    captured: dict[str, str] = {}
+
+    def _capture(*, to: str, reset_link: str) -> None:
+        assert to == email
+        captured["link"] = reset_link
+
+    with patch("app.api.routes.auth.send_password_reset_email", side_effect=_capture):
+        response = client.post("/api/auth/request-password-reset", json={"email": email})
+
+    assert response.status_code == 202, response.text
+    assert response.json()["data"] == {"status": "accepted"}
+    match = re.search(r"[?&]token=([^&]+)", captured["link"])
+    assert match
+    return match.group(1)
+
+
+def test_password_reset_happy_path_revokes_sessions_and_audits(client, db):
+    email = _signup(client)
+    assert db.query(UserSession).count() == 1
+
+    token = _request_reset(client, email)
+    reset_row = db.query(PasswordResetRequest).one()
+    assert reset_row.token_hmac == hmac_token(token)
+    assert token not in str(reset_row.__dict__)
+
+    response = client.post(
+        "/api/auth/reset-password",
+        json={"token": token, "new_password": NEW_PASSWORD},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["data"]["status"] == "password_reset"
+    assert db.query(UserSession).count() == 0
+    assert reset_row.used_at is not None
+
+    stale_me = client.get("/api/auth/me")
+    assert stale_me.status_code == 401
+
+    old_login = client.post(
+        "/api/auth/login",
+        json={"email": email, "password": DEFAULT_PASSWORD},
+    )
+    assert old_login.status_code == 401
+
+    new_login = client.post(
+        "/api/auth/login",
+        json={"email": email, "password": NEW_PASSWORD},
+    )
+    assert new_login.status_code == 200, new_login.text
+
+    actions = [row.action for row in db.query(AuditLog).order_by(AuditLog.created_at).all()]
+    assert "user.password_reset_requested" in actions
+    assert "user.password_reset" in actions
+
+
+def test_password_reset_expired_token_returns_friendly_code(client, db):
+    email = _signup(client)
+    token = _request_reset(client, email)
+
+    reset_row = db.query(PasswordResetRequest).one()
+    reset_row.expires_at = utcnow() - timedelta(seconds=1)
+    db.commit()
+
+    response = client.post(
+        "/api/auth/reset-password",
+        json={"token": token, "new_password": NEW_PASSWORD},
+    )
+
+    assert response.status_code == 400, response.text
+    assert response.json()["code"] == "auth.reset_expired"
+
+
+def test_password_reset_token_is_single_use(client):
+    email = _signup(client)
+    token = _request_reset(client, email)
+
+    first = client.post(
+        "/api/auth/reset-password",
+        json={"token": token, "new_password": NEW_PASSWORD},
+    )
+    assert first.status_code == 200, first.text
+
+    second = client.post(
+        "/api/auth/reset-password",
+        json={"token": token, "new_password": "AnotherPass-2026!!"},
+    )
+    assert second.status_code == 400, second.text
+    assert second.json()["code"] == "auth.reset_used"
+
+
+def test_password_reset_rejects_weak_password(client):
+    email = _signup(client)
+    token = _request_reset(client, email)
+
+    response = client.post(
+        "/api/auth/reset-password",
+        json={"token": token, "new_password": "password123"},
+    )
+
+    assert response.status_code == 400, response.text
+    assert response.json()["code"] == "auth.weak_password"
+
+
+def test_password_reset_email_throttle_suppresses_fourth_send(client, db):
+    email = _signup(client)
+
+    with patch("app.api.routes.auth.send_password_reset_email") as send_mail:
+        for _ in range(4):
+            response = client.post(
+                "/api/auth/request-password-reset",
+                json={"email": email},
+            )
+            assert response.status_code == 202, response.text
+
+    assert send_mail.call_count == 3
+    rows = db.query(PasswordResetRequest).order_by(PasswordResetRequest.created_at).all()
+    assert len(rows) == 4
+    assert rows[-1].token_hmac is None
+
+
+def test_password_reset_request_audit_row(client, db):
+    email = _signup(client)
+
+    _request_reset(client, email)
+
+    user = db.query(User).filter(User.email == email).one()
+    row = (
+        db.query(AuditLog)
+        .filter(AuditLog.action == "user.password_reset_requested")
+        .one()
+    )
+    assert row.user_id == user.id
+    assert row.target_ids == [user.id]

--- a/backend/tests/test_password_reset_enumeration.py
+++ b/backend/tests/test_password_reset_enumeration.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import statistics
+import time
+import uuid
+from unittest.mock import patch
+
+from app.domain.users.models import PasswordResetRequest
+from tests._factories import signup_user
+
+
+def test_no_enumeration_on_request(client, db):
+    known_email = f"known-reset-{uuid.uuid4().hex[:8]}@example.com"
+    unknown_email = f"unknown-reset-{uuid.uuid4().hex[:8]}@example.com"
+    signup_user(client, email=known_email)
+
+    with (
+        patch("app.api.routes.auth.send_password_reset_email") as send_mail,
+        patch("app.api.routes.auth.hash_password", return_value="dummy-hash") as hash_password,
+    ):
+        known_response = client.post(
+            "/api/auth/request-password-reset",
+            json={"email": known_email},
+        )
+        unknown_response = client.post(
+            "/api/auth/request-password-reset",
+            json={"email": unknown_email},
+        )
+
+    assert known_response.status_code == unknown_response.status_code == 202
+    assert known_response.json() == unknown_response.json()
+    assert send_mail.call_count == 1
+    assert hash_password.call_count == 2
+    assert db.query(PasswordResetRequest).count() == 2
+
+
+def test_no_enumeration_timing_parity(client):
+    known_email = f"known-reset-timing-{uuid.uuid4().hex[:8]}@example.com"
+    signup_user(client, email=known_email)
+    samples = 4
+
+    def _delayed_hash(password: str) -> str:
+        assert password
+        time.sleep(0.05)
+        return "dummy-hash"
+
+    def _timed_request(email: str) -> tuple[int, dict, float]:
+        start = time.perf_counter()
+        response = client.post(
+            "/api/auth/request-password-reset",
+            json={"email": email},
+        )
+        return response.status_code, response.json(), time.perf_counter() - start
+
+    known_times: list[float] = []
+    unknown_times: list[float] = []
+    with (
+        patch("app.api.routes.auth.hash_password", side_effect=_delayed_hash),
+        patch("app.api.routes.auth.send_password_reset_email"),
+    ):
+        for _ in range(samples):
+            known_status, known_body, known_elapsed = _timed_request(known_email)
+            unknown_status, unknown_body, unknown_elapsed = _timed_request(
+                f"unknown-reset-timing-{uuid.uuid4().hex[:8]}@example.com"
+            )
+
+            assert known_status == unknown_status == 202
+            assert known_body == unknown_body
+            known_times.append(known_elapsed)
+            unknown_times.append(unknown_elapsed)
+
+    known_mean = statistics.fmean(known_times)
+    unknown_mean = statistics.fmean(unknown_times)
+    slower_times = known_times if known_mean >= unknown_mean else unknown_times
+    tolerance = max(0.050, 2 * statistics.pstdev(slower_times))
+    delta = abs(known_mean - unknown_mean)
+    assert delta <= tolerance, (
+        f"password reset timing diverged: known_mean={known_mean:.4f}s "
+        f"unknown_mean={unknown_mean:.4f}s tolerance={tolerance:.4f}s"
+    )

--- a/backend/tests/test_password_strength.py
+++ b/backend/tests/test_password_strength.py
@@ -124,6 +124,7 @@ def test_strong_password_succeeds_on_signup():
 # Format: (method, path).
 PASSWORD_VALIDATING_ROUTES = {
     ("POST", "/api/auth/signup"),
+    ("POST", "/api/auth/reset-password"),
 }
 
 

--- a/web/e2e/password-reset.spec.ts
+++ b/web/e2e/password-reset.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from "./fixtures";
+
+test(
+  "password reset: request and complete flow renders generic states",
+  { tag: ["@core"] },
+  async ({ page }) => {
+    await page.route("**/api/auth/request-password-reset", async (route) => {
+      await route.fulfill({
+        status: 202,
+        contentType: "application/json",
+        body: JSON.stringify({
+          data: { status: "accepted" },
+          status: { category: "ok", message: "password reset request accepted" },
+        }),
+      });
+    });
+    await page.route("**/api/auth/reset-password", async (route) => {
+      const body = route.request().postDataJSON() as {
+        token: string;
+        new_password: string;
+      };
+      expect(body.token).toBe("e2e-token");
+      expect(body.new_password).toBe("NewResetPass-2026!!");
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          data: { status: "password_reset" },
+          status: { category: "ok", message: "password reset" },
+        }),
+      });
+    });
+
+    await page.goto("/login");
+    await page.getByRole("link", { name: "Forgot password?" }).click();
+    await expect(page).toHaveURL(/\/auth\/request-reset$/);
+
+    await page.getByLabel("Email").fill("reset@example.com");
+    await page.getByRole("button", { name: "Send reset link" }).click();
+    await expect(page.getByText(/If an account exists for reset@example.com/i)).toBeVisible();
+
+    await page.goto("/auth/reset-password?token=e2e-token");
+    await page.getByLabel("New password").fill("NewResetPass-2026!!");
+    await page.getByRole("button", { name: "Save new password" }).click();
+    await expect(page.getByText("Your password has been updated.")).toBeVisible();
+  },
+);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -9,6 +9,8 @@ import { RouteSkeleton } from "@/components/RouteSkeleton";
 // Auth pages — small, eager-loaded so the login form renders without
 // a fallback flash on first paint.
 import Login from "@/routes/auth/Login";
+import RequestReset from "@/routes/auth/RequestReset";
+import ResetPassword from "@/routes/auth/ResetPassword";
 import Signup from "@/routes/auth/Signup";
 // SEC2-014: email-verification landing page.
 import Verify from "@/routes/auth/Verify";
@@ -193,6 +195,8 @@ export default function App() {
         <Suspense fallback={lazyFallback}>
         <Routes>
           <Route path="/login" element={<RedirectIfAuthed><Login /></RedirectIfAuthed>} />
+          <Route path="/auth/request-reset" element={<RequestReset />} />
+          <Route path="/auth/reset-password" element={<ResetPassword />} />
           <Route path="/signup" element={<RedirectIfAuthed><Signup /></RedirectIfAuthed>} />
           {/* SEC2-014: email verification landing — pre-auth, no Gate wrapper */}
           <Route path="/verify" element={<Verify />} />

--- a/web/src/routes/auth/Login.test.tsx
+++ b/web/src/routes/auth/Login.test.tsx
@@ -38,6 +38,7 @@ function renderLogin() {
           <Route path="/login" element={<Login />} />
           <Route path="/parts" element={<div>parts-page</div>} />
           <Route path="/signup" element={<div>signup-page</div>} />
+          <Route path="/auth/request-reset" element={<div>request-reset-page</div>} />
         </Routes>
       </MemoryRouter>
     </QueryClientProvider>,
@@ -58,6 +59,13 @@ beforeEach(() => {
 });
 
 describe("Login", () => {
+  it("test_forgot_password_link_visible", () => {
+    renderLogin();
+
+    const link = screen.getByRole("link", { name: "Forgot password?" });
+    expect(link.getAttribute("href")).toBe("/auth/request-reset");
+  });
+
   it("test_429_renders_generic_message", async () => {
     const body = {
       data: null,

--- a/web/src/routes/auth/Login.tsx
+++ b/web/src/routes/auth/Login.tsx
@@ -64,7 +64,12 @@ export default function Login() {
           />
         </div>
         <div>
-          <label className="label" htmlFor="login-password">Password</label>
+          <div className="flex items-center justify-between gap-3">
+            <label className="label" htmlFor="login-password">Password</label>
+            <Link to="/auth/request-reset" className="text-sm text-accent hover:underline">
+              Forgot password?
+            </Link>
+          </div>
           <input
             id="login-password"
             className="input"

--- a/web/src/routes/auth/RequestReset.test.tsx
+++ b/web/src/routes/auth/RequestReset.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { api, ApiError, type ApiErr } from "@/lib/api";
+import RequestReset from "./RequestReset";
+
+vi.mock("@/lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api")>();
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      post: vi.fn(),
+    },
+  };
+});
+
+const mockPost = api.post as ReturnType<typeof vi.fn>;
+
+function renderRequestReset() {
+  const queryClient = new QueryClient({
+    defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={["/auth/request-reset"]}>
+        <Routes>
+          <Route path="/auth/request-reset" element={<RequestReset />} />
+          <Route path="/login" element={<div>login-page</div>} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("RequestReset", () => {
+  it("test_happy_path_acknowledges_generically", async () => {
+    mockPost.mockResolvedValue({ status: "accepted" });
+
+    renderRequestReset();
+
+    fireEvent.change(screen.getByLabelText("Email"), { target: { value: "u@example.com" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send reset link" }));
+
+    expect(await screen.findByText("u@example.com")).toBeDefined();
+    expect(mockPost).toHaveBeenCalledWith(
+      "/auth/request-password-reset",
+      { email: "u@example.com" },
+    );
+  });
+
+  it("test_throttled_after_3_attempts", async () => {
+    const body = {
+      data: null,
+      status: { category: "validation_error", message: "rate limit exceeded" },
+      code: "rate_limited",
+    } as ApiErr;
+    mockPost.mockRejectedValue(new ApiError(429, body, body.status.message));
+
+    renderRequestReset();
+
+    fireEvent.change(screen.getByLabelText("Email"), { target: { value: "u@example.com" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send reset link" }));
+
+    expect(
+      await screen.findByText("Some fields don't look right. Check the form and retry."),
+    ).toBeDefined();
+  });
+});

--- a/web/src/routes/auth/RequestReset.tsx
+++ b/web/src/routes/auth/RequestReset.tsx
@@ -1,0 +1,73 @@
+import { Link } from "react-router-dom";
+import { useState } from "react";
+import { api, ApiError } from "@/lib/api";
+import { useApiMutation } from "@/lib/mutations";
+import AuthShell from "./AuthShell";
+
+export default function RequestReset() {
+  const [email, setEmail] = useState("");
+  const [submittedEmail, setSubmittedEmail] = useState<string | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  const requestMutation = useApiMutation<unknown, { email: string }>({
+    mutationKey: ["auth", "request-password-reset"],
+    mutationFn: (payload) => api.post("/auth/request-password-reset", payload),
+    onSuccess: () => {
+      setSubmittedEmail(email);
+    },
+    onError: (e) => {
+      setErr(e instanceof ApiError ? e.userMessage : "Password reset request failed");
+    },
+  });
+
+  function submit(e: React.FormEvent) {
+    e.preventDefault();
+    setErr(null);
+    requestMutation.mutate({ email });
+  }
+
+  if (submittedEmail) {
+    return (
+      <AuthShell title="Check your inbox">
+        <div className="space-y-4">
+          <p className="text-sm">
+            If an account exists for <strong>{submittedEmail}</strong>, a password reset link will arrive shortly.
+          </p>
+          <p className="text-sm text-muted">
+            <Link to="/login" className="text-accent hover:underline">Back to sign in</Link>
+          </p>
+        </div>
+      </AuthShell>
+    );
+  }
+
+  return (
+    <AuthShell title="Reset password">
+      <form onSubmit={submit} className="space-y-4">
+        {err && (
+          <div className="rounded-md border border-danger/40 bg-danger/10 px-3 py-2 text-danger text-sm">
+            {err}
+          </div>
+        )}
+        <div>
+          <label className="label" htmlFor="reset-email">Email</label>
+          <input
+            id="reset-email"
+            className="input"
+            type="email"
+            autoComplete="email"
+            required
+            value={email}
+            onChange={e => setEmail(e.target.value)}
+          />
+        </div>
+        <button className="btn-primary w-full" disabled={requestMutation.isPending}>
+          {requestMutation.isPending ? "Sending…" : "Send reset link"}
+        </button>
+        <p className="text-sm text-muted">
+          Remembered it? <Link to="/login" className="text-accent hover:underline">Sign in</Link>
+        </p>
+      </form>
+    </AuthShell>
+  );
+}

--- a/web/src/routes/auth/ResetPassword.test.tsx
+++ b/web/src/routes/auth/ResetPassword.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { api, ApiError, type ApiErr } from "@/lib/api";
+import ResetPassword from "./ResetPassword";
+
+vi.mock("@/lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api")>();
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      post: vi.fn(),
+    },
+  };
+});
+
+const mockPost = api.post as ReturnType<typeof vi.fn>;
+
+function renderResetPassword(initialPath = "/auth/reset-password?token=abc123") {
+  const queryClient = new QueryClient({
+    defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[initialPath]}>
+        <Routes>
+          <Route path="/auth/reset-password" element={<ResetPassword />} />
+          <Route path="/login" element={<div>login-page</div>} />
+          <Route path="/auth/request-reset" element={<div>request-reset-page</div>} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("ResetPassword", () => {
+  it("test_happy_path", async () => {
+    mockPost.mockResolvedValue({ status: "password_reset" });
+
+    renderResetPassword();
+
+    fireEvent.change(screen.getByLabelText("New password"), {
+      target: { value: "NewResetPass-2026!!" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save new password" }));
+
+    expect(await screen.findByText("Your password has been updated.")).toBeDefined();
+    expect(mockPost).toHaveBeenCalledWith(
+      "/auth/reset-password",
+      { token: "abc123", new_password: "NewResetPass-2026!!" },
+    );
+  });
+
+  it("renders_invalid_expired_and_used_states", async () => {
+    const expiredBody = {
+      data: null,
+      status: { category: "validation_error", message: "password reset link expired" },
+      code: "auth.reset_expired",
+    } as ApiErr;
+    mockPost.mockRejectedValue(new ApiError(400, expiredBody, expiredBody.status.message));
+
+    renderResetPassword();
+
+    fireEvent.change(screen.getByLabelText("New password"), {
+      target: { value: "NewResetPass-2026!!" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save new password" }));
+
+    expect(await screen.findByText("This reset link has expired.")).toBeDefined();
+  });
+
+  it("validates_password_strength_before_submit", () => {
+    renderResetPassword();
+
+    fireEvent.change(screen.getByLabelText("New password"), {
+      target: { value: "aaaaaaaa" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save new password" }));
+
+    expect(screen.getByText("Use a less repetitive password.")).toBeDefined();
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/routes/auth/ResetPassword.tsx
+++ b/web/src/routes/auth/ResetPassword.tsx
@@ -1,0 +1,104 @@
+import { Link, useSearchParams } from "react-router-dom";
+import { useState } from "react";
+import { z } from "zod";
+import { api, ApiError } from "@/lib/api";
+import { useApiMutation } from "@/lib/mutations";
+import AuthShell from "./AuthShell";
+
+const passwordSchema = z.string()
+  .min(8, "Password must be at least 8 characters.")
+  .refine(value => new Set(value).size >= 4, "Use a less repetitive password.");
+
+function resetErrorMessage(e: unknown): string {
+  if (!(e instanceof ApiError)) {
+    return "Password reset failed";
+  }
+  if (e.code === "auth.reset_expired") {
+    return "This reset link has expired.";
+  }
+  if (e.code === "auth.reset_used") {
+    return "This reset link has already been used.";
+  }
+  if (e.code === "auth.reset_invalid") {
+    return "This reset link is invalid.";
+  }
+  if (e.code === "auth.weak_password") {
+    return e.message;
+  }
+  return e.userMessage;
+}
+
+export default function ResetPassword() {
+  const [params] = useSearchParams();
+  const token = params.get("token") || "";
+  const [password, setPassword] = useState("");
+  const [err, setErr] = useState<string | null>(token ? null : "This reset link is missing a token.");
+  const [complete, setComplete] = useState(false);
+
+  const resetMutation = useApiMutation<unknown, { token: string; new_password: string }>({
+    mutationKey: ["auth", "reset-password"],
+    mutationFn: (payload) => api.post("/auth/reset-password", payload),
+    onSuccess: () => {
+      setComplete(true);
+    },
+    onError: (e) => {
+      setErr(resetErrorMessage(e));
+    },
+  });
+
+  function submit(e: React.FormEvent) {
+    e.preventDefault();
+    const parsed = passwordSchema.safeParse(password);
+    if (!parsed.success) {
+      setErr(parsed.error.issues[0]?.message || "Password does not meet the requirements.");
+      return;
+    }
+    setErr(null);
+    resetMutation.mutate({ token, new_password: password });
+  }
+
+  if (complete) {
+    return (
+      <AuthShell title="Password reset">
+        <div className="space-y-4">
+          <p className="text-sm">Your password has been updated.</p>
+          <p className="text-sm text-muted">
+            <Link to="/login" className="text-accent hover:underline">Sign in</Link>
+          </p>
+        </div>
+      </AuthShell>
+    );
+  }
+
+  return (
+    <AuthShell title="Set new password">
+      <form onSubmit={submit} className="space-y-4">
+        {err && (
+          <div className="rounded-md border border-danger/40 bg-danger/10 px-3 py-2 text-danger text-sm">
+            {err}
+          </div>
+        )}
+        <div>
+          <label className="label" htmlFor="new-password">New password</label>
+          <input
+            id="new-password"
+            className="input"
+            type="password"
+            autoComplete="new-password"
+            required
+            minLength={8}
+            value={password}
+            onChange={e => setPassword(e.target.value)}
+            disabled={!token}
+          />
+        </div>
+        <button className="btn-primary w-full" disabled={!token || resetMutation.isPending}>
+          {resetMutation.isPending ? "Saving…" : "Save new password"}
+        </button>
+        <p className="text-sm text-muted">
+          Need a fresh link? <Link to="/auth/request-reset" className="text-accent hover:underline">Request one</Link>
+        </p>
+      </form>
+    </AuthShell>
+  );
+}


### PR DESCRIPTION
Refs #721

## Summary
- Add password reset request persistence with HMAC-at-rest tokens, 1h TTL, single-use consumption, per-email request throttling, IP slowapi limits, SMTP failure capture, session revocation, and audit rows.
- Add password reset mail helper/template and token helpers alongside existing auth hashing.
- Add login forgot-password link, request-reset and reset-password routes/forms, friendly reset-link states, and focused FE/e2e coverage.

## Tests run
- `git -C /mnt/data/WORK/stockManager-721 diff --check`
- `uv run ruff check app/api/routes/auth.py app/core/auth.py app/core/errors.py app/core/mail.py app/domain/all_models.py app/domain/users/models.py app/domain/users/schemas.py tests/test_password_reset.py tests/test_password_reset_enumeration.py`
- `uv run --extra dev python -m pytest tests/test_password_reset.py tests/test_password_reset_enumeration.py -q`
- `uv run --extra dev python -m pytest tests/test_migrations.py -q`
- `npm --prefix web ci` (installed locked deps; npm reported Node 18 engine warnings for some packages and 6 moderate audit findings)
- `npm --prefix web run test -- ResetPassword RequestReset Login`
- `npm --prefix web run typecheck`
- `PLAYWRIGHT_BASE_URL=http://127.0.0.1:5174 npm --prefix web run e2e -- password-reset.spec.ts --project=core`
- `uv --project /mnt/data/WORK/stockManager-721/backend run --extra dev alembic heads` -> `0061 (head)`
- `uv --project /mnt/data/WORK/stockManager-721/backend run --extra dev python -m pytest tests/test_password_reset.py tests/test_password_reset_enumeration.py -q`
- `uv --project /mnt/data/WORK/stockManager-721/backend run --extra dev python -m pytest tests/test_password_strength.py::test_every_password_setting_route_validates_strength tests/test_password_reset.py::test_password_reset_rejects_weak_password -q`
- `uv --project /mnt/data/WORK/stockManager-721/backend run --extra dev ruff check tests/test_password_strength.py tests/test_password_reset.py`

## Merge order / migration notes
- Branch is rebased on current `origin/main` after #737 merged (`e62e5fe`).
- Migration `0061_password_reset_requests.py` now chains after `0060`, preserving a single Alembic head.

## CI follow-up
- Fixed backend-tests failure by adding `/api/auth/reset-password` to the password-strength guard allow-list and adding explicit weak-password reset coverage.
