### PR TITLE
[codex] Address AUD sweep follow-ups

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,8 +169,9 @@ them, that's the bug.
   manufacturer URL, …) vs user-curated specs. The PartSpecs and
   PartSourcing tabs split on this boundary; server-side, the catalog
   field shapes live in `backend/app/domain/parts/providers/base.py`
-  and the asset-side reserved-keys subset is `_PROVIDER_RESERVED_KEYS`
-  in `backend/app/api/routes/parts_assets.py`. Adding a new catalog
+  and the reserved custom-field keys live in
+  `PROVIDER_RESERVED_CUSTOM_FIELD_KEYS` in
+  `backend/app/domain/parts/provider_fields.py`. Adding a new catalog
   field needs the FE list AND the relevant server-side touchpoint.
 - **Polymorphic cleanup on hard delete.** `attachments`, `custom_fields`,
   and `tag_links` have no FK on `object_id`. Hard-deleting a registered

--- a/backend/alembic/versions/0056_stock_entries_part_set_null.py
+++ b/backend/alembic/versions/0056_stock_entries_part_set_null.py
@@ -242,7 +242,7 @@ def downgrade() -> None:
         BEGIN
           IF EXISTS (SELECT 1 FROM stock_entries WHERE part_id IS NULL) THEN
             RAISE EXCEPTION
-              'cannot downgrade 0055 while stock_entries rows have NULL part_id';
+              'cannot downgrade 0056 while stock_entries rows have NULL part_id';
           END IF;
         END $$;
         """

--- a/backend/app/api/routes/parts_provider.py
+++ b/backend/app/api/routes/parts_provider.py
@@ -2,9 +2,10 @@
 provider + API key and dispatches."""
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, Request
 
 from app.core.deps import CurrentWorkspace
+from app.core.errors import ErrorCodes, raise_http
 from app.core.ratelimit import limiter, workspace_key
 from app.core.responses import ok
 from app.core.secrets import decrypt
@@ -36,10 +37,12 @@ def lookup_mpn(request: Request, payload: LookupIn, ws: CurrentWorkspace):
     try:
         out = lookup_with_cache(provider, payload.mpn.strip())
     except ProviderUpstreamError as exc:
-        raise HTTPException(
-            status_code=exc.status_code,
-            detail={"message": exc.message, "provider": exc.provider},
-        ) from exc
+        raise_http(
+            exc.status_code,
+            ErrorCodes.PROVIDER_UPSTREAM_ERROR,
+            exc.message,
+            provider=exc.provider,
+        )
     # Tag the response with the provider name so the UI can label its
     # success/failure note.
     return ok({**out, "provider": provider.name})

--- a/backend/app/api/routes/sentry_tunnel.py
+++ b/backend/app/api/routes/sentry_tunnel.py
@@ -25,16 +25,16 @@ Security posture:
 from __future__ import annotations
 
 import json
+from typing import Annotated
 from urllib.parse import urlparse
 
 import httpx
-from fastapi import APIRouter, Request, Response, status
+from fastapi import APIRouter, Depends, Request, Response, status
 
 from app.core.config import settings
-from app.core.deps import get_current_user
+from app.core.deps import DbSession, get_current_user
 from app.core.errors import ErrorCodes, raise_http
 from app.core.ratelimit import limiter
-from app.infra import db as infra_db
 
 router = APIRouter()
 
@@ -125,7 +125,7 @@ def _has_trusted_origin(request: Request) -> bool:
     return referer is not None and referer in _allowed_request_origins()
 
 
-def _require_session_or_trusted_origin(request: Request) -> None:
+def require_session_or_trusted_origin(request: Request, db: DbSession) -> None:
     if _has_trusted_origin(request):
         return
 
@@ -136,17 +136,15 @@ def _require_session_or_trusted_origin(request: Request) -> None:
             "not authenticated",
         )
 
-    db = infra_db.SessionLocal()
-    try:
-        get_current_user(request, db)
-    finally:
-        db.close()
+    get_current_user(request, db)
 
 
 @router.post("/sentry-tunnel")
 @limiter.limit("30/minute")
-async def sentry_tunnel(request: Request) -> Response:
-    _require_session_or_trusted_origin(request)
+async def sentry_tunnel(
+    request: Request,
+    _auth_gate: Annotated[None, Depends(require_session_or_trusted_origin)],
+) -> Response:
 
     allowed = ALLOWED_ENDPOINTS
     if not allowed:

--- a/backend/app/cli/run_job.py
+++ b/backend/app/cli/run_job.py
@@ -36,6 +36,10 @@ class UnknownJobError(ValueError):
 
 
 def _acquire_job_lock(db: Session, job_name: str) -> bool:
+    # hashtext() returns int4, so different job names can theoretically
+    # collide. Acceptable for today's tiny allow-list; switch to explicit
+    # reserved bigint IDs or pg_try_advisory_xact_lock(classid, objid)
+    # before this grows into a broad scheduler.
     result = db.execute(
         text("SELECT pg_try_advisory_xact_lock(hashtext(:job_name))"),
         {"job_name": job_name},

--- a/backend/app/core/errors.py
+++ b/backend/app/core/errors.py
@@ -221,3 +221,6 @@ class ErrorCodes:
     # Custom fields router.
     CUSTOM_FIELD_RESERVED_KEY = "custom_field.reserved_key"
     CUSTOM_FIELD_NOT_OVERRIDE = "custom_field.not_override"
+
+    # Legacy parts-provider lookup route.
+    PROVIDER_UPSTREAM_ERROR = "provider.upstream_error"

--- a/backend/app/domain/sourcing/providers/factory.py
+++ b/backend/app/domain/sourcing/providers/factory.py
@@ -89,9 +89,19 @@ def make_retrying_client(
     yield _pooled_client(provider_name=provider_name, timeout=timeout)
 
 
-def _reset_provider_client_pool_for_tests() -> None:
+def close_provider_client_pool() -> None:
+    """Close all pooled provider HTTP clients.
+
+    FastAPI calls this during lifespan shutdown so graceful process exits
+    release keep-alive sockets promptly instead of waiting for interpreter
+    teardown.
+    """
     with _CLIENTS_LOCK:
         clients = list(_CLIENTS.values())
         _CLIENTS.clear()
     for client in clients:
         client.close()
+
+
+def _reset_provider_client_pool_for_tests() -> None:
+    close_provider_client_pool()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -107,7 +107,7 @@ def _scrub_event(event, _hint):
     request.pop("query_string", None)
     headers = request.get("headers")
     if isinstance(headers, dict):
-        drop = {"cookie", "authorization", "x-workspace-id"}
+        drop = {"cookie", "authorization", "x-api-key", "x-workspace-id"}
         for k in list(headers.keys()):
             if k.lower() in drop:
                 headers.pop(k, None)
@@ -239,10 +239,15 @@ def assert_proxy_headers_trusted(argv: Sequence[str] | None = None) -> None:
 
 
 def assert_cors_origins_not_wildcard() -> None:
-    """Fail prod startup when credentialed CORS is configured for every origin."""
+    """Fail prod startup when credentialed CORS origins are unsafe or empty."""
     cfg = settings()
     if cfg.APP_ENV != "prod":
         return
+    if not cfg.cors_origin_list:
+        raise RuntimeError(
+            "APP_ENV=prod requires at least one CORS_ORIGINS entry. Configure "
+            "explicit frontend origins instead of starting with broken CORS."
+        )
     if "*" in cfg.cors_origin_list:
         raise RuntimeError(
             "APP_ENV=prod rejects CORS_ORIGINS=* because wildcard origins cannot "
@@ -255,7 +260,12 @@ async def lifespan(_app: FastAPI):
     """Run synchronous startup assertions before serving requests."""
     assert_cors_origins_not_wildcard()
     assert_proxy_headers_trusted()
-    yield
+    try:
+        yield
+    finally:
+        from app.domain.sourcing.providers.factory import close_provider_client_pool
+
+        close_provider_client_pool()
 
 
 app = FastAPI(

--- a/backend/tests/test_cors_startup_assert.py
+++ b/backend/tests/test_cors_startup_assert.py
@@ -18,6 +18,17 @@ async def test_wildcard_in_prod_rejected(monkeypatch):
             pass
 
 
+@pytest.mark.asyncio
+async def test_empty_cors_origins_in_prod_rejected(monkeypatch):
+    cfg = settings()
+    monkeypatch.setattr(cfg, "APP_ENV", "prod")
+    monkeypatch.setattr(cfg, "CORS_ORIGINS", "")
+
+    with pytest.raises(RuntimeError, match="requires at least one CORS_ORIGINS"):
+        async with lifespan(app):
+            pass
+
+
 def test_cors_allow_headers_are_explicit():
     middleware = next(m for m in app.user_middleware if m.cls is CORSMiddleware)
     allowed_headers = middleware.kwargs["allow_headers"]

--- a/backend/tests/test_parts_provider.py
+++ b/backend/tests/test_parts_provider.py
@@ -6,6 +6,7 @@ import httpx
 import pytest
 from fastapi.testclient import TestClient
 
+from app.core.errors import ErrorCodes
 from app.main import app
 
 
@@ -236,6 +237,7 @@ def test_lookup_mouser_network_failure_is_graceful(authed, monkeypatch):
     assert r.status_code == 502, r.text
     body = r.json()
     assert body["data"] is None
+    assert body["code"] == ErrorCodes.PROVIDER_UPSTREAM_ERROR
     assert "upstream unavailable" in body["status"]["message"]
     assert "connection failed" in body["status"]["message"]
     assert body["provider"] == "mouser"

--- a/backend/tests/test_parts_provider_upstream_errors.py
+++ b/backend/tests/test_parts_provider_upstream_errors.py
@@ -6,6 +6,7 @@ from contextlib import contextmanager
 import httpx
 from fastapi.testclient import TestClient
 
+from app.core.errors import ErrorCodes
 from app.main import app
 
 
@@ -86,6 +87,7 @@ def test_mouser_503_returns_502(monkeypatch):
     assert r.status_code == 502, r.text
     body = r.json()
     assert body["data"] is None
+    assert body["code"] == ErrorCodes.PROVIDER_UPSTREAM_ERROR
     assert body["status"]["category"] == "server_error"
     assert "HTTP 503" in body["status"]["message"]
     assert body["provider"] == "mouser"

--- a/backend/tests/test_provider_pooling.py
+++ b/backend/tests/test_provider_pooling.py
@@ -30,3 +30,29 @@ def test_single_client_per_provider(monkeypatch):
         assert created == [mouser_1, digikey]
     finally:
         factory._reset_provider_client_pool_for_tests()
+
+
+def test_public_close_provider_client_pool_closes_and_clears(monkeypatch):
+    factory._reset_provider_client_pool_for_tests()
+    created = []
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.is_closed = False
+            created.append(self)
+
+        def close(self):
+            self.is_closed = True
+
+    monkeypatch.setattr(factory.httpx, "Client", FakeClient)
+
+    with factory.make_retrying_client(provider_name="mouser", timeout=8.0) as first:
+        pass
+    factory.close_provider_client_pool()
+    with factory.make_retrying_client(provider_name="mouser", timeout=8.0) as second:
+        pass
+
+    assert first.is_closed is True
+    assert second.is_closed is False
+    assert created == [first, second]

--- a/backend/tests/test_run_job.py
+++ b/backend/tests/test_run_job.py
@@ -75,6 +75,17 @@ def test_run_job_dispatches_allow_listed_job(tmp_path) -> None:
     assert (tmp_path / "example").read_text(encoding="utf-8") == "ok\n"
 
 
+def test_run_job_lock_hash_collision_note_is_kept() -> None:
+    from pathlib import Path
+
+    source = Path(__file__).parents[1] / "app" / "cli" / "run_job.py"
+    text = source.read_text(encoding="utf-8")
+
+    assert "hashtext() returns int4" in text
+    assert "collide" in text
+    assert "reserved bigint IDs" in text
+
+
 def test_run_job_rejects_unknown_job() -> None:
     try:
         run_job("missing", jobs={}, session_factory=lambda: _FakeSession())  # type: ignore[return-value]

--- a/backend/tests/test_secret_rotation_doc_snippets.py
+++ b/backend/tests/test_secret_rotation_doc_snippets.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import pathlib
+
+DOCS_ROOT = pathlib.Path(__file__).parents[2] / "docs"
+
+
+def test_password_pepper_rotation_requires_password_reset_campaign() -> None:
+    text = (DOCS_ROOT / "runbooks" / "secret-rotation.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "### 2.2 `PASSWORD_PEPPER`" in text
+    assert "planned password-reset campaign" in text
+    assert "Force a password reset for all users before replacing the value." in text

--- a/backend/tests/test_sentry_scrubber.py
+++ b/backend/tests/test_sentry_scrubber.py
@@ -111,6 +111,7 @@ def test_scrubber_strips_sensitive_headers_on_get():
             "Cookie": "stockmgr_session=abc",
             "x-workspace-id": "ws-uuid",
             "authorization": "Bearer xyz",
+            "X-Api-Key": "future-provider-key",
             "X-Trace-Id": "trace-1",
             "user-agent": "Mozilla/5.0",
         },
@@ -120,6 +121,7 @@ def test_scrubber_strips_sensitive_headers_on_get():
     assert "Cookie" not in h
     assert "x-workspace-id" not in h
     assert "authorization" not in h
+    assert "X-Api-Key" not in h
     # Non-sensitive headers are kept for triage value.
     assert "X-Trace-Id" in h
     assert "user-agent" in h

--- a/backend/tests/test_sentry_tunnel.py
+++ b/backend/tests/test_sentry_tunnel.py
@@ -162,3 +162,11 @@ def test_sentry_tunnel_route_has_rate_limit_decorator():
             "expected @limiter.limit to wrap sentry_tunnel — none of "
             f"{markers} found and __wrapped__ unset"
         )
+
+
+def test_sentry_tunnel_auth_uses_dependency_session():
+    source = Path(sentry_tunnel_route.__file__).read_text(encoding="utf-8")
+
+    assert "SessionLocal" not in source
+    assert "Depends(require_session_or_trusted_origin)" in source
+    assert "DbSession" in source

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -14,6 +14,55 @@
 #     static Vite bundle.
 #   - backend and db never publish a host port — only the docker network.
 
+x-backend-env: &backend-env
+  # INFRA2-005: pass discrete parts instead of the assembled URL so
+  # the password is not interpolated into DATABASE_URL and thus does
+  # not appear verbatim in `docker inspect` output. Settings assembles
+  # the final URL at runtime (see backend/app/core/config.py).
+  POSTGRES_USER: ${POSTGRES_USER}
+  POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+  POSTGRES_DB: ${POSTGRES_DB}
+  POSTGRES_HOST: db
+  POSTGRES_PORT: "5432"
+  SESSION_SECRET: ${SESSION_SECRET}
+  SESSION_IDLE_HOURS: ${SESSION_IDLE_HOURS:-24}
+  PASSWORD_PEPPER: ${PASSWORD_PEPPER}
+  UPLOAD_DIR: /data/uploads
+  APP_ENV: prod
+  CORS_ORIGINS: ${CORS_ORIGINS}
+  # Fernet key for encrypting workspace-level secrets at rest
+  # (provider API keys, scanner license keys). The backend's
+  # Settings validator rejects an empty value when APP_ENV=prod, so
+  # leaving this unset in .env.prod fails the deploy fast (loud
+  # ValidationError on import) instead of silently encrypting under
+  # a fallback key. Generate with:
+  #   python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+  WORKSPACE_SECRETS_KEY: ${WORKSPACE_SECRETS_KEY}
+  # Empty in unset / dev — SDK becomes a no-op.
+  SENTRY_DSN: ${SENTRY_DSN:-}
+  SENTRY_TRACES_SAMPLE_RATE: ${SENTRY_TRACES_SAMPLE_RATE}
+  # Release identifier — populated by the deploy script with the
+  # current git SHA so Sentry groups issues per release.
+  SENTRY_RELEASE: ${SENTRY_RELEASE:-}
+  # Frontend DSN, read by the backend solely so /api/sentry-tunnel
+  # can allow-list its forwarder against the React project. Vite
+  # also bakes this into the SPA bundle at build time (see web
+  # service below).
+  VITE_SENTRY_DSN: ${VITE_SENTRY_DSN:-}
+  # Email / SMTP for the email-verification flow (issue #281).
+  # No `:-` defaults on the required values (HOST/USER/PASSWORD/MAIL_FROM/
+  # APP_BASE_URL) — a missing entry in .env.prod becomes a Compose
+  # "variable is not set" warning, AND the backend's
+  # `_require_smtp_in_prod` validator hard-fails at import. Both are
+  # intentional: the silent-fallback failure mode (verification link
+  # written to container logs) is exactly what this issue removed.
+  SMTP_HOST: ${SMTP_HOST}
+  SMTP_PORT: ${SMTP_PORT:-587}
+  SMTP_USER: ${SMTP_USER}
+  SMTP_PASSWORD: ${SMTP_PASSWORD}
+  MAIL_FROM: ${MAIL_FROM}
+  APP_BASE_URL: ${APP_BASE_URL}
+
 services:
   db:
     image: postgres:16-alpine
@@ -70,53 +119,7 @@ services:
         max-size: "10m"
         max-file: "5"
     environment:
-      # INFRA2-005: pass discrete parts instead of the assembled URL so
-      # the password is not interpolated into DATABASE_URL and thus does
-      # not appear verbatim in `docker inspect` output.  Settings assembles
-      # the final URL at runtime (see backend/app/core/config.py).
-      POSTGRES_USER: ${POSTGRES_USER}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-      POSTGRES_DB: ${POSTGRES_DB}
-      POSTGRES_HOST: db
-      POSTGRES_PORT: "5432"
-      SESSION_SECRET: ${SESSION_SECRET}
-      SESSION_IDLE_HOURS: ${SESSION_IDLE_HOURS:-24}
-      PASSWORD_PEPPER: ${PASSWORD_PEPPER}
-      UPLOAD_DIR: /data/uploads
-      APP_ENV: prod
-      CORS_ORIGINS: ${CORS_ORIGINS}
-      # Fernet key for encrypting workspace-level secrets at rest
-      # (provider API keys, scanner license keys). The backend's
-      # Settings validator rejects an empty value when APP_ENV=prod, so
-      # leaving this unset in .env.prod fails the deploy fast (loud
-      # ValidationError on import) instead of silently encrypting under
-      # a fallback key. Generate with:
-      #   python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
-      WORKSPACE_SECRETS_KEY: ${WORKSPACE_SECRETS_KEY}
-      # Empty in unset / dev — SDK becomes a no-op.
-      SENTRY_DSN: ${SENTRY_DSN:-}
-      SENTRY_TRACES_SAMPLE_RATE: ${SENTRY_TRACES_SAMPLE_RATE}
-      # Release identifier — populated by the deploy script with the
-      # current git SHA so Sentry groups issues per release.
-      SENTRY_RELEASE: ${SENTRY_RELEASE:-}
-      # Frontend DSN, read by the backend solely so /api/sentry-tunnel
-      # can allow-list its forwarder against the React project. Vite
-      # also bakes this into the SPA bundle at build time (see web
-      # service below).
-      VITE_SENTRY_DSN: ${VITE_SENTRY_DSN:-}
-      # Email / SMTP for the email-verification flow (issue #281).
-      # No `:-` defaults on the required values (HOST/USER/PASSWORD/MAIL_FROM/
-      # APP_BASE_URL) — a missing entry in .env.prod becomes a Compose
-      # "variable is not set" warning, AND the backend's
-      # `_require_smtp_in_prod` validator hard-fails at import. Both are
-      # intentional: the silent-fallback failure mode (verification link
-      # written to container logs) is exactly what this issue removed.
-      SMTP_HOST: ${SMTP_HOST}
-      SMTP_PORT: ${SMTP_PORT:-587}
-      SMTP_USER: ${SMTP_USER}
-      SMTP_PASSWORD: ${SMTP_PASSWORD}
-      MAIL_FROM: ${MAIL_FROM}
-      APP_BASE_URL: ${APP_BASE_URL}
+      <<: *backend-env
     volumes:
       - uploads:/data/uploads
     depends_on:
@@ -177,31 +180,7 @@ services:
         max-size: "10m"
         max-file: "5"
     environment:
-      # Same runtime config shape as backend. Keep POSTGRES_* discrete so
-      # DATABASE_URL is assembled inside Settings without leaking the password
-      # through docker inspect interpolation.
-      POSTGRES_USER: ${POSTGRES_USER}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-      POSTGRES_DB: ${POSTGRES_DB}
-      POSTGRES_HOST: db
-      POSTGRES_PORT: "5432"
-      SESSION_SECRET: ${SESSION_SECRET}
-      SESSION_IDLE_HOURS: ${SESSION_IDLE_HOURS:-24}
-      PASSWORD_PEPPER: ${PASSWORD_PEPPER}
-      UPLOAD_DIR: /data/uploads
-      APP_ENV: prod
-      CORS_ORIGINS: ${CORS_ORIGINS}
-      WORKSPACE_SECRETS_KEY: ${WORKSPACE_SECRETS_KEY}
-      SENTRY_DSN: ${SENTRY_DSN:-}
-      SENTRY_TRACES_SAMPLE_RATE: ${SENTRY_TRACES_SAMPLE_RATE}
-      SENTRY_RELEASE: ${SENTRY_RELEASE:-}
-      VITE_SENTRY_DSN: ${VITE_SENTRY_DSN:-}
-      SMTP_HOST: ${SMTP_HOST}
-      SMTP_PORT: ${SMTP_PORT:-587}
-      SMTP_USER: ${SMTP_USER}
-      SMTP_PASSWORD: ${SMTP_PASSWORD}
-      MAIL_FROM: ${MAIL_FROM}
-      APP_BASE_URL: ${APP_BASE_URL}
+      <<: *backend-env
     depends_on:
       backend-init:
         condition: service_completed_successfully
@@ -233,31 +212,7 @@ services:
         max-size: "10m"
         max-file: "5"
     environment:
-      # Same runtime config shape as backend. Keep POSTGRES_* discrete so
-      # DATABASE_URL is assembled inside Settings without leaking the password
-      # through docker inspect interpolation.
-      POSTGRES_USER: ${POSTGRES_USER}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-      POSTGRES_DB: ${POSTGRES_DB}
-      POSTGRES_HOST: db
-      POSTGRES_PORT: "5432"
-      SESSION_SECRET: ${SESSION_SECRET}
-      SESSION_IDLE_HOURS: ${SESSION_IDLE_HOURS:-24}
-      PASSWORD_PEPPER: ${PASSWORD_PEPPER}
-      UPLOAD_DIR: /data/uploads
-      APP_ENV: prod
-      CORS_ORIGINS: ${CORS_ORIGINS}
-      WORKSPACE_SECRETS_KEY: ${WORKSPACE_SECRETS_KEY}
-      SENTRY_DSN: ${SENTRY_DSN:-}
-      SENTRY_TRACES_SAMPLE_RATE: ${SENTRY_TRACES_SAMPLE_RATE}
-      SENTRY_RELEASE: ${SENTRY_RELEASE:-}
-      VITE_SENTRY_DSN: ${VITE_SENTRY_DSN:-}
-      SMTP_HOST: ${SMTP_HOST}
-      SMTP_PORT: ${SMTP_PORT:-587}
-      SMTP_USER: ${SMTP_USER}
-      SMTP_PASSWORD: ${SMTP_PASSWORD}
-      MAIL_FROM: ${MAIL_FROM}
-      APP_BASE_URL: ${APP_BASE_URL}
+      <<: *backend-env
     depends_on:
       backend-init:
         condition: service_completed_successfully
@@ -289,31 +244,8 @@ services:
         max-size: "10m"
         max-file: "5"
     environment:
-      # Same runtime config shape as backend. Keep POSTGRES_* discrete so
-      # DATABASE_URL is assembled inside Settings without leaking the password
-      # through docker inspect interpolation.
-      POSTGRES_USER: ${POSTGRES_USER}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-      POSTGRES_DB: ${POSTGRES_DB}
-      POSTGRES_HOST: db
-      POSTGRES_PORT: "5432"
-      SESSION_SECRET: ${SESSION_SECRET}
-      PASSWORD_PEPPER: ${PASSWORD_PEPPER}
+      <<: *backend-env
       SESSION_PURGE_INTERVAL_SECONDS: ${SESSION_PURGE_INTERVAL_SECONDS:-3600}
-      UPLOAD_DIR: /data/uploads
-      APP_ENV: prod
-      CORS_ORIGINS: ${CORS_ORIGINS}
-      WORKSPACE_SECRETS_KEY: ${WORKSPACE_SECRETS_KEY}
-      SENTRY_DSN: ${SENTRY_DSN:-}
-      SENTRY_TRACES_SAMPLE_RATE: ${SENTRY_TRACES_SAMPLE_RATE}
-      SENTRY_RELEASE: ${SENTRY_RELEASE:-}
-      VITE_SENTRY_DSN: ${VITE_SENTRY_DSN:-}
-      SMTP_HOST: ${SMTP_HOST}
-      SMTP_PORT: ${SMTP_PORT:-587}
-      SMTP_USER: ${SMTP_USER}
-      SMTP_PASSWORD: ${SMTP_PASSWORD}
-      MAIL_FROM: ${MAIL_FROM}
-      APP_BASE_URL: ${APP_BASE_URL}
     depends_on:
       backend-init:
         condition: service_completed_successfully

--- a/docs/development.md
+++ b/docs/development.md
@@ -146,6 +146,16 @@ you write a similar test, request the `real_db` fixture instead of
 ~1000× slower per test — only use it when the savepoint pattern truly
 can't model the test.
 
+### Polymorphic cleanup
+
+SQLAlchemy `before_delete` mapper events do not fire for bulk
+`delete().where(...)` statements. Hard-delete code for polymorphic parent
+models must either delete ORM instances so the listeners in
+`backend/app/domain/_polymorphic_cleanup.py:164-168` run, or explicitly call
+`purge_polymorphic(...)` (`backend/app/domain/_polymorphic_cleanup.py:100-121`);
+use `backend/scripts/purge_polymorphic_orphans.py` as the safety net for any
+bulk-delete path that bypasses mapper events.
+
 ### Slow tests
 
 The migration round-trip suite (`tests/test_migrations.py`,

--- a/web/src/components/scanner/ZxingScanner.tsx
+++ b/web/src/components/scanner/ZxingScanner.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { readBarcodes, prepareZXingModule, type ReadInputBarcodeFormat } from "zxing-wasm/reader";
 import { useAuth } from "@/lib/auth";
-import { scannerDevicePreferenceKey } from "./storage";
+import { readScannerDevicePreference, scannerDevicePreferenceKey } from "./storage";
 
 /**
  * Open-source ZXing-C++ wasm decoder. Default scanner backend so workspaces
@@ -141,7 +141,7 @@ export default function ZxingScanner({ onScan, className, symbologies }: Props) 
   const [devices, setDevices] = useState<MediaDeviceInfo[]>([]);
   const [deviceId, setDeviceId] = useState<string | undefined>(() => {
     try {
-      return localStorage.getItem(devicePrefKey) || undefined;
+      return readScannerDevicePreference(workspaceId);
     } catch {
       return undefined;
     }
@@ -155,11 +155,11 @@ export default function ZxingScanner({ onScan, className, symbologies }: Props) 
   useEffect(() => { zoomModeRef.current = zoomMode; }, [zoomMode]);
   useEffect(() => {
     try {
-      setDeviceId(localStorage.getItem(devicePrefKey) || undefined);
+      setDeviceId(readScannerDevicePreference(workspaceId));
     } catch {
       setDeviceId(undefined);
     }
-  }, [devicePrefKey]);
+  }, [workspaceId]);
 
   // ---------------------------------------------------------------------
   // Camera + decoder loop. Restarts whenever the picked camera changes.

--- a/web/src/components/scanner/storage.test.ts
+++ b/web/src/components/scanner/storage.test.ts
@@ -1,7 +1,21 @@
-import { describe, expect, it } from "vitest";
-import { scannerDevicePreferenceKey } from "./storage";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  LEGACY_SCANNER_DEVICE_PREF_KEY,
+  readScannerDevicePreference,
+  scannerDevicePreferenceKey,
+} from "./storage";
 
 describe("scanner device preference storage", () => {
+  beforeEach(() => {
+    const values = new Map<string, string>();
+    vi.stubGlobal("localStorage", {
+      clear: () => values.clear(),
+      getItem: (key: string) => values.get(key) ?? null,
+      removeItem: (key: string) => values.delete(key),
+      setItem: (key: string, value: string) => values.set(key, value),
+    });
+  });
+
   it("scopes the remembered camera device to the workspace", () => {
     expect(scannerDevicePreferenceKey("ws-a")).toBe("ws:ws-a:scanner.deviceId");
     expect(scannerDevicePreferenceKey("ws-b")).toBe("ws:ws-b:scanner.deviceId");
@@ -10,5 +24,24 @@ describe("scanner device preference storage", () => {
   it("uses a non-tenant fallback before workspace bootstrap", () => {
     expect(scannerDevicePreferenceKey(null)).toBe("ws:none:scanner.deviceId");
     expect(scannerDevicePreferenceKey(undefined)).toBe("ws:none:scanner.deviceId");
+  });
+
+  it("migrates the stale global key on first workspace-scoped read", () => {
+    localStorage.clear();
+    localStorage.setItem(LEGACY_SCANNER_DEVICE_PREF_KEY, "camera-legacy");
+
+    expect(readScannerDevicePreference("ws-a")).toBe("camera-legacy");
+    expect(localStorage.getItem("ws:ws-a:scanner.deviceId")).toBe("camera-legacy");
+    expect(localStorage.getItem(LEGACY_SCANNER_DEVICE_PREF_KEY)).toBeNull();
+  });
+
+  it("keeps an existing workspace value while sweeping the stale global key", () => {
+    localStorage.clear();
+    localStorage.setItem(LEGACY_SCANNER_DEVICE_PREF_KEY, "camera-legacy");
+    localStorage.setItem("ws:ws-a:scanner.deviceId", "camera-workspace");
+
+    expect(readScannerDevicePreference("ws-a")).toBe("camera-workspace");
+    expect(localStorage.getItem("ws:ws-a:scanner.deviceId")).toBe("camera-workspace");
+    expect(localStorage.getItem(LEGACY_SCANNER_DEVICE_PREF_KEY)).toBeNull();
   });
 });

--- a/web/src/components/scanner/storage.ts
+++ b/web/src/components/scanner/storage.ts
@@ -1,7 +1,29 @@
 export const SCANNER_DEVICE_PREF_SUFFIX = "scanner.deviceId";
+export const LEGACY_SCANNER_DEVICE_PREF_KEY = SCANNER_DEVICE_PREF_SUFFIX;
 
 export function scannerDevicePreferenceKey(
   workspaceId: string | null | undefined,
 ): string {
   return `ws:${workspaceId ?? "none"}:${SCANNER_DEVICE_PREF_SUFFIX}`;
+}
+
+export function readScannerDevicePreference(
+  workspaceId: string | null | undefined,
+): string | undefined {
+  const key = scannerDevicePreferenceKey(workspaceId);
+  const current = localStorage.getItem(key) || undefined;
+  if (!workspaceId) {
+    return current;
+  }
+
+  const legacy = localStorage.getItem(LEGACY_SCANNER_DEVICE_PREF_KEY);
+  if (legacy === null) {
+    return current;
+  }
+
+  if (!current && legacy) {
+    localStorage.setItem(key, legacy);
+  }
+  localStorage.removeItem(LEGACY_SCANNER_DEVICE_PREF_KEY);
+  return current || legacy || undefined;
 }

--- a/web/src/instrument.test.ts
+++ b/web/src/instrument.test.ts
@@ -34,6 +34,7 @@ describe("Sentry beforeSend", () => {
         method: "GET",
         headers: {
           Referer: "https://parts.matescb.cz/search?q=secret#results?sort=qty",
+          "X-Api-Key": "provider-secret",
         },
       },
       breadcrumbs: [
@@ -55,6 +56,7 @@ describe("Sentry beforeSend", () => {
     expect(scrubbed?.request?.headers?.Referer).toBe(
       "https://parts.matescb.cz/search#results",
     );
+    expect(scrubbed?.request?.headers?.["X-Api-Key"]).toBeUndefined();
     expect(scrubbed?.breadcrumbs?.[0]?.data?.url).toBe("/api/parts");
     expect(scrubbed?.breadcrumbs?.[0]?.data?.to).toBe("/projects#bom");
     expect(JSON.stringify(scrubbed)).not.toContain("secret");
@@ -133,6 +135,7 @@ describe("Sentry beforeSend", () => {
         headers: {
           Referer: "https://parts.matescb.cz/search?q=secret",
           Cookie: "stockmgr_session=secret",
+          "x-api-key": "provider-secret",
         },
       },
       contexts: {
@@ -165,6 +168,7 @@ describe("Sentry beforeSend", () => {
     expect(scrubbed?.request?.query_string).toBeUndefined();
     expect(scrubbed?.request?.headers?.Referer).toBe("https://parts.matescb.cz/search");
     expect(scrubbed?.request?.headers?.Cookie).toBeUndefined();
+    expect(scrubbed?.request?.headers?.["x-api-key"]).toBeUndefined();
     expect(scrubbed?.contexts?.trace?.data?.["http.url"]).toBe("https://parts.matescb.cz/api/parts");
     expect(scrubbed?.contexts?.trace?.data?.url).toBe("/api/parts");
     expect(scrubbed?.spans?.[0]?.description).toBe("GET /api/parts");

--- a/web/src/instrument.ts
+++ b/web/src/instrument.ts
@@ -33,7 +33,12 @@ const replaysOnErrorSampleRate = parseSampleRate(
   "VITE_SENTRY_REPLAYS_ON_ERROR_SAMPLE_RATE",
   "default-zero",
 );
-const requestHeaderDenylist = new Set(["cookie", "authorization", "x-workspace-id"]);
+const requestHeaderDenylist = new Set([
+  "cookie",
+  "authorization",
+  "x-api-key",
+  "x-workspace-id",
+]);
 const requestUrlHeaders = new Set(["referer", "referrer"]);
 const breadcrumbUrlKeys = new Set(["url", "from", "to"]);
 const transactionUrlKeys = new Set(["url", "from", "to", "http.url"]);


### PR DESCRIPTION
Refs #708

## Summary
- Fail prod startup on empty CORS origins and explicitly scrub `x-api-key` from backend/frontend Sentry request headers.
- Convert the Sentry tunnel session gate to dependency-backed DB session handling without changing the trusted-origin bypass.
- Add `provider.upstream_error` for legacy provider lookup upstream failures and route/test coverage.
- Add the scanner legacy `scanner.deviceId` migration, provider HTTP pool shutdown hook, advisory-lock collision note, compose backend env anchor, and scoped docs/migration text updates.

## Tests run
- `uv run ruff check app/main.py app/api/routes/sentry_tunnel.py app/api/routes/parts_provider.py app/cli/run_job.py app/core/errors.py app/domain/sourcing/providers/factory.py tests/test_cors_startup_assert.py tests/test_sentry_scrubber.py tests/test_sentry_tunnel.py tests/test_parts_provider.py tests/test_parts_provider_upstream_errors.py tests/test_provider_pooling.py tests/test_run_job.py tests/test_secret_rotation_doc_snippets.py --select E9,F,I`
- `uv run python -m pytest tests/test_cors_startup_assert.py tests/test_sentry_scrubber.py tests/test_sentry_tunnel.py tests/test_provider_pooling.py tests/test_run_job.py tests/test_secret_rotation_doc_snippets.py -q`
- `uv run python -m pytest tests/test_parts_provider.py tests/test_parts_provider_upstream_errors.py -q`
- `npm test -- --run src/instrument.test.ts src/components/scanner/storage.test.ts`
- `npm run typecheck`
- YAML parse smoke for `docker-compose.prod.yml` via `uv run python` + PyYAML

`docker compose -f docker-compose.prod.yml config -q` could not run in this environment because the Docker CLI is not installed (`docker: command not found`).

## Already satisfied / scoped notes
- AUD-022: `docs/runbooks/secret-rotation.md` already documents forced password-reset campaign requirements for `PASSWORD_PEPPER`; this PR adds a focused doc drift test.
- AUD-025: the same runbook already documents the `MultiFernet` dual-key transition, including encrypt-with-first / decrypt-with-any behavior.
- AUD-028: left unchanged; it was not in the scoped implementation list for this PR.

## Decision-only / hold items
- AUD-032 connect timeout bump: no change without ops evidence.
- Dependabot digest-pin date policy: no change pending policy choice.
- Node 26 smoke check: no CI/runtime change; operational smoke remains pending.

## Merge-order notes
- Based on latest `origin/main` after PR #738 (`0b04e29`).
- No known dependency on the sibling AUD worktrees beyond normal conflict resolution against `main`.
