### PR TITLE
[codex] Commit revoke-all session deletes

### DIFF
--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -250,6 +250,7 @@ def revoke_all_user_sessions(db: Session, user_id) -> int:
     rows = db.query(UserSession).filter(UserSession.user_id == user_id).all()
     for r in rows:
         db.delete(r)
+    db.commit()
     return len(rows)
 
 

--- a/backend/tests/test_auth_revoke_all.py
+++ b/backend/tests/test_auth_revoke_all.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import uuid
+
+from app.core.auth import create_session_row, revoke_all_user_sessions
+from app.domain.users.models import User, UserSession
+
+
+def test_revoke_all_commits_explicitly(db):
+    user = User(
+        email=f"revoke-all-{uuid.uuid4().hex[:8]}@example.com",
+        name="Revoke All",
+        password_hash="not-used",
+    )
+    db.add(user)
+    db.flush()
+
+    create_session_row(db, user.id)
+    create_session_row(db, user.id)
+    db.commit()
+    assert db.query(UserSession).filter(UserSession.user_id == user.id).count() == 2
+
+    revoked = revoke_all_user_sessions(db, user.id)
+    assert revoked == 2
+
+    try:
+        raise RuntimeError("simulate later caller failure")
+    except RuntimeError:
+        db.rollback()
+
+    db.expire_all()
+    assert db.query(UserSession).filter(UserSession.user_id == user.id).count() == 0


### PR DESCRIPTION
## Summary

- Add an explicit commit after `revoke_all_user_sessions` deletes a user's sessions.
- Add a regression proving a later caller rollback does not restore revoked sessions.

Closes #744

## Validation

- `backend/.venv/bin/python -m pytest backend/tests/test_auth_revoke_all.py -q`
- `uv run --extra dev python -m pytest tests/test_auth_revoke_all.py -q` from `backend/`