### PR TITLE
AUD-096: Mirror weak password blocklist in auth forms

### DIFF
--- a/web/e2e/auth.spec.ts
+++ b/web/e2e/auth.spec.ts
@@ -5,7 +5,7 @@ import { test, expect, DEFAULT_PASSWORD, seedPart } from "./fixtures";
 
 const BASE_URL = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:5173";
 const LOGIN_FAILED = "Login failed. Check your credentials and try again.";
-const SIGNUP_VALIDATION_ERROR = "Some fields don't look right. Check the form and retry.";
+const PASSWORD_BLOCKLIST_ERROR = "Password is too common. Choose a more unique password.";
 
 function uniqueEmail(testInfo: TestInfo, label: string): string {
   const safeId = testInfo.testId.replace(/[^a-zA-Z0-9-]/g, "-").slice(0, 48);
@@ -173,7 +173,7 @@ test(
     await passwordInput.fill("password123");
     await page.getByRole("button", { name: "Create account" }).click();
 
-    await expect(page.getByText(SIGNUP_VALIDATION_ERROR)).toBeVisible();
+    await expect(page.getByText(PASSWORD_BLOCKLIST_ERROR)).toBeVisible();
     await expect(page).toHaveURL(/\/signup$/);
   },
 );

--- a/web/src/lib/passwordStrength.test.ts
+++ b/web/src/lib/passwordStrength.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import {
+  PASSWORD_BLOCKLIST_MESSAGE,
+  PASSWORD_REPETITIVE_MESSAGE,
+  PASSWORD_TOO_SHORT_MESSAGE,
+  getPasswordStrengthError,
+} from "./passwordStrength";
+
+describe("getPasswordStrengthError", () => {
+  it("rejects passwords shorter than 8 characters", () => {
+    expect(getPasswordStrengthError("short")).toBe(PASSWORD_TOO_SHORT_MESSAGE);
+  });
+
+  it("rejects backend mirrored static blocklist entries case-insensitively", () => {
+    expect(getPasswordStrengthError("password")).toBe(PASSWORD_BLOCKLIST_MESSAGE);
+    expect(getPasswordStrengthError("Password123")).toBe(PASSWORD_BLOCKLIST_MESSAGE);
+    expect(getPasswordStrengthError("stockManager")).toBe(PASSWORD_BLOCKLIST_MESSAGE);
+  });
+
+  it("rejects repetitive low-variety passwords", () => {
+    expect(getPasswordStrengthError("aaaaaaaa")).toBe(PASSWORD_REPETITIVE_MESSAGE);
+    expect(getPasswordStrengthError("abababab")).toBe(PASSWORD_REPETITIVE_MESSAGE);
+  });
+
+  it("accepts passwords outside the best-effort frontend checks", () => {
+    expect(getPasswordStrengthError("NewResetPass-2026!!")).toBeNull();
+  });
+});

--- a/web/src/lib/passwordStrength.ts
+++ b/web/src/lib/passwordStrength.ts
@@ -1,0 +1,47 @@
+const WEAK_PASSWORDS = new Set([
+  "12345678",
+  "123456789",
+  "1234567890",
+  "password",
+  "password1",
+  "password12",
+  "password123",
+  "qwerty12",
+  "qwerty123",
+  "qwertyuiop",
+  "letmein",
+  "letmein123",
+  "iloveyou",
+  "monkey123",
+  "welcome1",
+  "welcome123",
+  "admin1234",
+  "admin12345",
+  "administrator",
+  "1q2w3e4r",
+  "1qaz2wsx",
+  "zaq12wsx",
+  "11111111",
+  "00000000",
+  "abcdefgh",
+  "abc12345",
+  "stockmgr",
+  "stockmanager",
+]);
+
+export const PASSWORD_TOO_SHORT_MESSAGE = "Password must be at least 8 characters.";
+export const PASSWORD_BLOCKLIST_MESSAGE = "Password is too common. Choose a more unique password.";
+export const PASSWORD_REPETITIVE_MESSAGE = "Use a less repetitive password.";
+
+export function getPasswordStrengthError(password: string): string | null {
+  if (password.length < 8) {
+    return PASSWORD_TOO_SHORT_MESSAGE;
+  }
+  if (WEAK_PASSWORDS.has(password.toLowerCase())) {
+    return PASSWORD_BLOCKLIST_MESSAGE;
+  }
+  if (new Set(password).size < 4) {
+    return PASSWORD_REPETITIVE_MESSAGE;
+  }
+  return null;
+}

--- a/web/src/routes/auth/ResetPassword.test.tsx
+++ b/web/src/routes/auth/ResetPassword.test.tsx
@@ -90,4 +90,16 @@ describe("ResetPassword", () => {
     expect(screen.getByText("Use a less repetitive password.")).toBeDefined();
     expect(mockPost).not.toHaveBeenCalled();
   });
+
+  it("validates_blocklisted_password_before_submit", () => {
+    renderResetPassword();
+
+    fireEvent.change(screen.getByLabelText("New password"), {
+      target: { value: "password" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save new password" }));
+
+    expect(screen.getByText("Password is too common. Choose a more unique password.")).toBeDefined();
+    expect(mockPost).not.toHaveBeenCalled();
+  });
 });

--- a/web/src/routes/auth/ResetPassword.tsx
+++ b/web/src/routes/auth/ResetPassword.tsx
@@ -1,13 +1,9 @@
 import { Link, useSearchParams } from "react-router-dom";
 import { useState } from "react";
-import { z } from "zod";
 import { api, ApiError } from "@/lib/api";
 import { useApiMutation } from "@/lib/mutations";
+import { getPasswordStrengthError } from "@/lib/passwordStrength";
 import AuthShell from "./AuthShell";
-
-const passwordSchema = z.string()
-  .min(8, "Password must be at least 8 characters.")
-  .refine(value => new Set(value).size >= 4, "Use a less repetitive password.");
 
 function resetErrorMessage(e: unknown): string {
   if (!(e instanceof ApiError)) {
@@ -48,9 +44,9 @@ export default function ResetPassword() {
 
   function submit(e: React.FormEvent) {
     e.preventDefault();
-    const parsed = passwordSchema.safeParse(password);
-    if (!parsed.success) {
-      setErr(parsed.error.issues[0]?.message || "Password does not meet the requirements.");
+    const passwordError = getPasswordStrengthError(password);
+    if (passwordError) {
+      setErr(passwordError);
       return;
     }
     setErr(null);

--- a/web/src/routes/auth/Signup.test.tsx
+++ b/web/src/routes/auth/Signup.test.tsx
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { api } from "@/lib/api";
+import { useAuth } from "@/lib/auth";
+import Signup from "./Signup";
+
+vi.mock("@/lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api")>();
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      post: vi.fn(),
+    },
+  };
+});
+
+vi.mock("@/lib/auth", () => ({
+  useAuth: vi.fn(),
+}));
+
+const mockPost = api.post as ReturnType<typeof vi.fn>;
+const mockUseAuth = useAuth as ReturnType<typeof vi.fn>;
+
+function renderSignup() {
+  const queryClient = new QueryClient({
+    defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={["/signup"]}>
+        <Routes>
+          <Route path="/signup" element={<Signup />} />
+          <Route path="/login" element={<div>login-page</div>} />
+          <Route path="/parts" element={<div>parts-page</div>} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  mockUseAuth.mockReturnValue({
+    me: null,
+    loading: false,
+    refresh: vi.fn().mockResolvedValue(undefined),
+    logout: vi.fn(),
+    workspaceId: null,
+    switchWorkspace: vi.fn(),
+  });
+});
+
+describe("Signup", () => {
+  it("validates_blocklisted_password_before_submit", () => {
+    renderSignup();
+
+    fireEvent.change(screen.getByLabelText("Name"), { target: { value: "Test User" } });
+    fireEvent.change(screen.getByLabelText("Email"), { target: { value: "test@example.com" } });
+    fireEvent.change(screen.getByLabelText("Password (min 8)"), {
+      target: { value: "password" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create account" }));
+
+    expect(screen.getByText("Password is too common. Choose a more unique password.")).toBeDefined();
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/routes/auth/Signup.tsx
+++ b/web/src/routes/auth/Signup.tsx
@@ -3,6 +3,7 @@ import { Link, useLocation, useNavigate, type Location } from "react-router-dom"
 import { api, ApiError } from "@/lib/api";
 import { useAuth } from "@/lib/auth";
 import { useApiMutation } from "@/lib/mutations";
+import { getPasswordStrengthError } from "@/lib/passwordStrength";
 import AuthShell from "./AuthShell";
 
 export default function Signup() {
@@ -46,6 +47,11 @@ export default function Signup() {
 
   function submit(e: React.FormEvent) {
     e.preventDefault();
+    const passwordError = getPasswordStrengthError(password);
+    if (passwordError) {
+      setErr(passwordError);
+      return;
+    }
     setErr(null);
     signupMutation.mutate({
       name,


### PR DESCRIPTION
Closes #753

## Summary
- add a frontend password strength helper mirroring the backend static weak-password blocklist for best-effort UX
- use the helper before submit in reset-password and signup forms
- cover the helper and auth form validation with focused tests

## Validation
- npm --prefix web run test -- passwordStrength
- npm --prefix web run test -- ResetPassword Signup
- npm --prefix web run typecheck
- npx eslint src/lib/passwordStrength.ts src/lib/passwordStrength.test.ts src/routes/auth/ResetPassword.tsx src/routes/auth/ResetPassword.test.tsx src/routes/auth/Signup.tsx src/routes/auth/Signup.test.tsx

Note: full `npm --prefix web run lint` currently fails on existing unrelated `web/src/lib/bagCode.ts` no-control-regex errors.