### PR TITLE
AUD-083 add password reset purge job

### DIFF
--- a/backend/alembic/versions/0062_password_reset_purge_index.py
+++ b/backend/alembic/versions/0062_password_reset_purge_index.py
@@ -1,0 +1,33 @@
+"""Drop unused password reset expires_at index.
+
+Revision ID: 0062
+Revises: 0061
+Create Date: 2026-05-15
+
+AUD-083 / issue #740.
+
+Password reset retention purges by created_at because throttled and
+non-issued rows can have expires_at NULL. The created_at index remains the
+retention path; the expires_at index is intentionally removed.
+"""
+from __future__ import annotations
+
+from alembic import op
+
+
+revision = "0062"
+down_revision = "0061"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_index("ix_password_reset_requests_expires_at", table_name="password_reset_requests")
+
+
+def downgrade() -> None:
+    op.create_index(
+        "ix_password_reset_requests_expires_at",
+        "password_reset_requests",
+        ["expires_at"],
+    )

--- a/backend/app/cli/run_job.py
+++ b/backend/app/cli/run_job.py
@@ -71,6 +71,12 @@ def _run_session_purge(db: Session) -> int:
     return purge_expired_sessions(db)
 
 
+def _run_password_reset_purge(db: Session) -> int:
+    from app.core.auth import purge_password_reset_requests
+
+    return purge_password_reset_requests(db)
+
+
 JOBS: dict[str, JobSpec] = {
     "sourcing-cache-sweep": JobSpec(
         name="sourcing-cache-sweep",
@@ -97,6 +103,13 @@ JOBS: dict[str, JobSpec] = {
         cadence="hourly",
         idempotency="Deletes only session rows whose expires_at is already in the past.",
         run=_run_session_purge,
+    ),
+    "password-reset-purge": JobSpec(
+        name="password-reset-purge",
+        owner="backend/auth-security",
+        cadence="hourly",
+        idempotency="Deletes only password-reset request rows older than 30 days.",
+        run=_run_password_reset_purge,
     ),
 }
 

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -376,3 +376,22 @@ def purge_expired_sessions(db: Session, *, now: datetime | None = None) -> int:
         .delete(synchronize_session=False)
     )
     return int(deleted)
+
+
+def purge_password_reset_requests(db: Session, *, now: datetime | None = None) -> int:
+    """Delete password-reset request rows older than the retention window.
+
+    Password-reset rows are transient pre-authentication records used for
+    throttling and single-use token validation. They are not needed after the
+    one-hour token lifetime, so a 30-day retention window leaves operational
+    headroom without letting the table grow forever.
+    """
+    from app.domain.users.models import PasswordResetRequest
+
+    cutoff = (now or utcnow()) - timedelta(days=30)
+    deleted = (
+        db.query(PasswordResetRequest)
+        .filter(PasswordResetRequest.created_at < cutoff)
+        .delete(synchronize_session=False)
+    )
+    return int(deleted)

--- a/backend/app/domain/users/models.py
+++ b/backend/app/domain/users/models.py
@@ -105,7 +105,7 @@ class PasswordResetRequest(Base):
     email_hash = Column(String(64), nullable=False, index=True)
     token_hmac = Column(String(64), nullable=True, index=True)
     created_at = Column(DateTime(timezone=True), nullable=False, default=utcnow, index=True)
-    expires_at = Column(DateTime(timezone=True), nullable=True, index=True)
+    expires_at = Column(DateTime(timezone=True), nullable=True)
     used_at = Column(DateTime(timezone=True), nullable=True)
     ip = Column(String(45), nullable=True, index=True)
     sent_at = Column(DateTime(timezone=True), nullable=True)

--- a/backend/tests/test_password_reset_purge.py
+++ b/backend/tests/test_password_reset_purge.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import inspect
+
+from app.core.auth import hmac_token, purge_password_reset_requests
+from app.domain.users.models import PasswordResetRequest, User
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _make_user(db) -> User:
+    user = User(
+        id=uuid.uuid4(),
+        email=f"reset-purge-{uuid.uuid4().hex[:8]}@example.com",
+        name="Reset Purge",
+        password_hash="$argon2id$dummy",
+    )
+    db.add(user)
+    db.flush()
+    return user
+
+
+def _make_reset_request(
+    db,
+    *,
+    user_id,
+    created_at: datetime,
+    token_seed: str,
+    expires_at: datetime | None,
+) -> PasswordResetRequest:
+    row = PasswordResetRequest(
+        id=uuid.uuid4(),
+        user_id=user_id,
+        email_hash="a" * 64,
+        token_hmac=hmac_token(token_seed),
+        created_at=created_at,
+        expires_at=expires_at,
+        ip="127.0.0.1",
+        sent_at=created_at,
+    )
+    db.add(row)
+    db.flush()
+    return row
+
+
+def test_purge_deletes_old_rows(db):
+    user = _make_user(db)
+    now = _utcnow()
+    old_issued = _make_reset_request(
+        db,
+        user_id=user.id,
+        created_at=now - timedelta(days=31),
+        token_seed="old-issued",
+        expires_at=now - timedelta(days=31) + timedelta(hours=1),
+    )
+    old_throttle = _make_reset_request(
+        db,
+        user_id=user.id,
+        created_at=now - timedelta(days=31),
+        token_seed="old-throttle",
+        expires_at=None,
+    )
+    recent = _make_reset_request(
+        db,
+        user_id=user.id,
+        created_at=now - timedelta(days=29),
+        token_seed="recent",
+        expires_at=now - timedelta(days=29) + timedelta(hours=1),
+    )
+
+    first = purge_password_reset_requests(db, now=now)
+    db.commit()
+    second = purge_password_reset_requests(db, now=now)
+    db.commit()
+
+    remaining_ids = {row.id for row in db.query(PasswordResetRequest).all()}
+    assert first == 2
+    assert second == 0
+    assert old_issued.id not in remaining_ids
+    assert old_throttle.id not in remaining_ids
+    assert recent.id in remaining_ids
+
+
+def test_password_reset_retention_uses_created_at_index(db):
+    insp = inspect(db.get_bind())
+    index_names = {ix["name"] for ix in insp.get_indexes("password_reset_requests")}
+
+    assert "ix_password_reset_requests_created_at" in index_names
+    assert "ix_password_reset_requests_expires_at" not in index_names

--- a/backend/tests/test_run_job.py
+++ b/backend/tests/test_run_job.py
@@ -121,6 +121,15 @@ def test_session_purge_registered() -> None:
     assert "expires_at" in spec.idempotency
 
 
+def test_password_reset_purge_registered() -> None:
+    spec = JOBS["password-reset-purge"]
+
+    assert spec.name == "password-reset-purge"
+    assert spec.owner == "backend/auth-security"
+    assert spec.cadence == "hourly"
+    assert "older than 30 days" in spec.idempotency
+
+
 def test_session_purge_idempotent(db, tmp_path) -> None:
     user = User(
         id=uuid.uuid4(),
@@ -130,6 +139,7 @@ def test_session_purge_idempotent(db, tmp_path) -> None:
     )
     now = utcnow()
     db.add(user)
+    db.flush()
     db.add_all(
         [
             UserSession(
@@ -162,6 +172,58 @@ def test_session_purge_idempotent(db, tmp_path) -> None:
     assert second == 0
     assert [row.token_hash for row in remaining] == ["b" * 64]
     assert (tmp_path / "session-purge").read_text(encoding="utf-8") == "ok\n"
+
+
+def test_password_reset_purge_idempotent(db, tmp_path) -> None:
+    from app.domain.users.models import PasswordResetRequest
+
+    user = User(
+        id=uuid.uuid4(),
+        email=f"{uuid.uuid4()}@example.test",
+        name="Password Reset Purge",
+        password_hash="hash",
+    )
+    now = utcnow()
+    db.add(user)
+    db.flush()
+    db.add_all(
+        [
+            PasswordResetRequest(
+                id=uuid.uuid4(),
+                user_id=user.id,
+                email_hash="a" * 64,
+                token_hmac="a" * 64,
+                created_at=now - timedelta(days=31),
+                expires_at=now - timedelta(days=31) + timedelta(hours=1),
+            ),
+            PasswordResetRequest(
+                id=uuid.uuid4(),
+                user_id=user.id,
+                email_hash="b" * 64,
+                token_hmac="b" * 64,
+                created_at=now - timedelta(days=1),
+                expires_at=now - timedelta(days=1) + timedelta(hours=1),
+            ),
+        ]
+    )
+    db.flush()
+
+    first = run_job(
+        "password-reset-purge",
+        session_factory=lambda: db,
+        heartbeat_dir=tmp_path,
+    )
+    second = run_job(
+        "password-reset-purge",
+        session_factory=lambda: db,
+        heartbeat_dir=tmp_path,
+    )
+
+    remaining = db.query(PasswordResetRequest).all()
+    assert first == 1
+    assert second == 0
+    assert [row.email_hash for row in remaining] == ["b" * 64]
+    assert (tmp_path / "password-reset-purge").read_text(encoding="utf-8") == "ok\n"
 
 
 def test_sourcing_alerts_evaluate_dispatches_to_module(monkeypatch, tmp_path) -> None:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -246,21 +246,22 @@ services:
     environment:
       <<: *backend-env
       SESSION_PURGE_INTERVAL_SECONDS: ${SESSION_PURGE_INTERVAL_SECONDS:-3600}
+      PASSWORD_RESET_PURGE_INTERVAL_SECONDS: ${PASSWORD_RESET_PURGE_INTERVAL_SECONDS:-3600}
     depends_on:
       backend-init:
         condition: service_completed_successfully
       backend:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "test -d /tmp/stockmanager-job-heartbeats && find /tmp/stockmanager-job-heartbeats -name session-purge -mmin -90 -print -quit | grep -q ."]
+      test: ["CMD-SHELL", "test -d /tmp/stockmanager-job-heartbeats && { [ $${SESSION_PURGE_INTERVAL_SECONDS:-3600} -le 0 ] || find /tmp/stockmanager-job-heartbeats -name session-purge -mmin -90 -print -quit | grep -q .; } && { [ $${PASSWORD_RESET_PURGE_INTERVAL_SECONDS:-3600} -le 0 ] || find /tmp/stockmanager-job-heartbeats -name password-reset-purge -mmin -90 -print -quit | grep -q .; }"]
       interval: 60s
       timeout: 5s
       retries: 3
       start_period: 11m
-    # Runs the session retention purge through the shared backend CLI.
-    # SESSION_PURGE_INTERVAL_SECONDS defaults to the previous one-hour
-    # lifespan cadence; setting it to 0 disables the loop.
-    command: ["sh", "-c", "interval=$${SESSION_PURGE_INTERVAL_SECONDS:-3600}; if [ $$interval -le 0 ]; then echo 'session-purge disabled'; sleep infinity; fi; while true; do timeout 600 python -m app.cli.run_job session-purge; rc=$$?; if [ $$rc -eq 124 ]; then echo 'session-purge timed out after 600s (exit=124)'; elif [ $$rc -ne 0 ]; then echo \"session-purge failed (exit=$$rc)\"; fi; sleep $$interval; done"]
+    # Runs auth-retention purges through the shared backend CLI.
+    # *_PURGE_INTERVAL_SECONDS defaults to one hour; setting either to 0
+    # disables only that job. Both loops write independent heartbeat files.
+    command: ["sh", "-c", "session_interval=$${SESSION_PURGE_INTERVAL_SECONDS:-3600}; reset_interval=$${PASSWORD_RESET_PURGE_INTERVAL_SECONDS:-3600}; pids=''; if [ $$session_interval -gt 0 ]; then (while true; do timeout 600 python -m app.cli.run_job session-purge; rc=$$?; if [ $$rc -eq 124 ]; then echo 'session-purge timed out after 600s (exit=124)'; elif [ $$rc -ne 0 ]; then echo \"session-purge failed (exit=$$rc)\"; fi; sleep $$session_interval; done) & pids=\"$$pids $$!\"; fi; if [ $$reset_interval -gt 0 ]; then (while true; do timeout 600 python -m app.cli.run_job password-reset-purge; rc=$$?; if [ $$rc -eq 124 ]; then echo 'password-reset-purge timed out after 600s (exit=124)'; elif [ $$rc -ne 0 ]; then echo \"password-reset-purge failed (exit=$$rc)\"; fi; sleep $$reset_interval; done) & pids=\"$$pids $$!\"; fi; if [ -z \"$$pids\" ]; then echo 'auth retention purges disabled'; sleep infinity; fi; wait"]
     security_opt: ["no-new-privileges:true"]
     cap_drop: ["ALL"]
 


### PR DESCRIPTION
Closes #740

## Summary
- add password-reset-purge to the shared backend run_job allow-list
- purge password_reset_requests older than 30 days by created_at
- drop the unused expires_at index in migration 0062 and remove the ORM index marker
- run password-reset-purge from the auth retention cron sidecar with heartbeat healthcheck

## Validation
- `uv run --extra dev python -m pytest tests/test_password_reset_purge.py tests/test_run_job.py -q`
- `uv run --extra dev python -m pytest tests/test_ci_workflow.py::test_compose_prod_has_web_and_cron_healthchecks -q`
- `git diff --check`

Could not run `docker compose -f docker-compose.prod.yml config -q`: Docker/Podman/Compose is not installed on this host.

## Merge order
- Merge this before #748 and #750, because this introduces migration 0062 and the later database PRs should rebase to the next migration number.