### PR TITLE
[codex] Stop persisting unknown password reset requests

### DIFF
--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -517,13 +517,17 @@ def request_password_reset(
     user = db.query(User).filter(func.lower(User.email) == email_normalized).first()
     throttled = _password_reset_request_throttled(db, email_hash=email_hash)
 
+    if user is None:
+        response.status_code = status.HTTP_202_ACCEPTED
+        return ok(_PASSWORD_RESET_REQUEST_DATA, _PASSWORD_RESET_REQUEST_MESSAGE)
+
     reset_request = PasswordResetRequest(
-        user_id=user.id if user else None,
+        user_id=user.id,
         email_hash=email_hash,
         ip=client_ip,
     )
 
-    if user is not None and not throttled:
+    if not throttled:
         token, token_hmac = mint_password_reset_token()
         reset_request.token_hmac = token_hmac
         reset_request.expires_at = now + timedelta(hours=_PASSWORD_RESET_TTL_HOURS)
@@ -540,8 +544,7 @@ def request_password_reset(
         db.add(reset_request)
         db.flush()
 
-    if user is not None:
-        _audit_password_reset_request(db, request, user, throttled=throttled)
+    _audit_password_reset_request(db, request, user, throttled=throttled)
 
     response.status_code = status.HTTP_202_ACCEPTED
     return ok(_PASSWORD_RESET_REQUEST_DATA, _PASSWORD_RESET_REQUEST_MESSAGE)

--- a/backend/tests/test_password_reset.py
+++ b/backend/tests/test_password_reset.py
@@ -206,6 +206,23 @@ def test_throttle_atomic_under_concurrency(db, monkeypatch):
     assert sum(1 for row in rows if row.token_hmac is not None) == 3
 
 
+def test_unknown_email_does_not_persist_row(client, db):
+    with (
+        patch("app.api.routes.auth.send_password_reset_email") as send_mail,
+        patch("app.api.routes.auth.hash_password", return_value="dummy-hash") as hash_password,
+    ):
+        response = client.post(
+            "/api/auth/request-password-reset",
+            json={"email": f"unknown-reset-{uuid.uuid4().hex[:8]}@example.com"},
+        )
+
+    assert response.status_code == 202, response.text
+    assert response.json()["data"] == {"status": "accepted"}
+    send_mail.assert_not_called()
+    hash_password.assert_called_once()
+    assert db.query(PasswordResetRequest).count() == 0
+
+
 def test_password_reset_request_audit_row(client, db):
     email = _signup(client)
 

--- a/backend/tests/test_password_reset_enumeration.py
+++ b/backend/tests/test_password_reset_enumeration.py
@@ -31,7 +31,7 @@ def test_no_enumeration_on_request(client, db):
     assert known_response.json() == unknown_response.json()
     assert send_mail.call_count == 1
     assert hash_password.call_count == 2
-    assert db.query(PasswordResetRequest).count() == 2
+    assert db.query(PasswordResetRequest).count() == 1
 
 
 def test_no_enumeration_timing_parity(client):


### PR DESCRIPTION
Closes #746

## Summary
- stop persisting `password_reset_requests` rows for unknown emails
- keep the generic 202 response and dummy password-reset computation for timing parity
- preserve known-user throttle behavior after #763 by keeping the advisory-lock throttle path

## Validation
- `uv run --extra dev python -m pytest tests/test_password_reset.py tests/test_password_reset_enumeration.py -q`
- `uv run --extra dev ruff check app/api/routes/auth.py tests/test_password_reset.py tests/test_password_reset_enumeration.py`
- `git diff --check`

## Merge order
- #763 has merged and this branch is rebased on top of it.
- Merge before #765, which depends on the final request-password-reset flow.
