### PR TITLE
[codex] Reject archived users in password reset

### DIFF
--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -517,7 +517,7 @@ def request_password_reset(
     user = db.query(User).filter(func.lower(User.email) == email_normalized).first()
     throttled = _password_reset_request_throttled(db, email_hash=email_hash)
 
-    if user is None:
+    if user is None or getattr(user, "archived_at", None) is not None:
         response.status_code = status.HTTP_202_ACCEPTED
         return ok(_PASSWORD_RESET_REQUEST_DATA, _PASSWORD_RESET_REQUEST_MESSAGE)
 
@@ -584,7 +584,7 @@ def reset_password(
         )
 
     user = db.get(User, reset_request.user_id) if reset_request.user_id else None
-    if user is None:
+    if user is None or getattr(user, "archived_at", None) is not None:
         raise_http(
             status.HTTP_400_BAD_REQUEST,
             ErrorCodes.AUTH_RESET_INVALID,

--- a/backend/tests/test_password_reset.py
+++ b/backend/tests/test_password_reset.py
@@ -199,6 +199,39 @@ def test_password_reset_rejects_weak_password(client):
     assert response.json()["code"] == "auth.weak_password"
 
 
+def test_archived_user_cannot_reset(client, db):
+    email = _signup(client)
+    token = _request_reset(client, email)
+
+    user = db.query(User).filter(User.email == email).one()
+    user.archived_at = utcnow()
+    db.flush()
+
+    response = client.post(
+        "/api/auth/reset-password",
+        json={"token": token, "new_password": NEW_PASSWORD},
+    )
+
+    assert response.status_code == 400, response.text
+    assert response.json()["code"] == "auth.reset_invalid"
+    assert db.query(UserSession).count() == 1
+
+
+def test_archived_user_cannot_request_reset_token(client, db):
+    email = _signup(client)
+    user = db.query(User).filter(User.email == email).one()
+    user.archived_at = utcnow()
+    db.flush()
+
+    with patch("app.api.routes.auth.send_password_reset_email") as send_mail:
+        response = client.post("/api/auth/request-password-reset", json={"email": email})
+
+    assert response.status_code == 202, response.text
+    assert response.json()["data"] == {"status": "accepted"}
+    send_mail.assert_not_called()
+    assert db.query(PasswordResetRequest).count() == 0
+
+
 def test_password_reset_email_throttle_suppresses_fourth_send(client, db):
     email = _signup(client)
 


### PR DESCRIPTION
## Summary

- treat soft-archived users like unknown emails on password-reset requests, so no reset row or email token is created
- reject password-reset redemption when the linked user is missing or soft-archived
- add regression coverage for both archived-user request and redemption paths

Closes #747.

## Validation

- `uv run --extra dev python -m pytest tests/test_password_reset.py tests/test_password_reset_enumeration.py -q` — 13 passed, 5 Alembic deprecation warnings
- `uv run --extra dev ruff check app/api/routes/auth.py tests/test_password_reset.py` — passed
- `git -C /mnt/data/WORK/stockManager-1/.codex-worktrees/aud-090-747 diff --check` — passed

## Merge order

- #762 (#745) has merged; this branch was rebased onto `origin/main` at `975a2e972464` after #761/#762. PR #764 is ready to merge independently of #765/#767.
