### PR TITLE
[codex] Audit orphan password reset requests

### DIFF
--- a/backend/alembic/versions/0065_nullable_audit_workspace.py
+++ b/backend/alembic/versions/0065_nullable_audit_workspace.py
@@ -1,0 +1,38 @@
+"""Allow workspace-less audit rows for auth/system events.
+
+Revision ID: 0065
+Revises: 0064
+Create Date: 2026-05-15
+
+AUD-094 / issue #751.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision = "0065"
+down_revision = "0064"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "audit_log",
+        "workspace_id",
+        existing_type=postgresql.UUID(as_uuid=True),
+        nullable=True,
+    )
+
+
+def downgrade() -> None:
+    op.execute("DELETE FROM audit_log WHERE workspace_id IS NULL")
+    op.alter_column(
+        "audit_log",
+        "workspace_id",
+        existing_type=postgresql.UUID(as_uuid=True),
+        nullable=False,
+    )

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -201,8 +201,6 @@ def _audit_password_reset_request(
     throttled: bool,
 ) -> None:
     workspace = _first_workspace_for_user(db, user)
-    if workspace is None:
-        return
     _audit_log(
         db,
         ws=workspace,

--- a/backend/app/domain/audit/README.md
+++ b/backend/app/domain/audit/README.md
@@ -24,7 +24,8 @@ Reads are direct SQL from the audit route (`backend/app/api/routes/audit.py`).
 
 1. **One write entry point.** All audit writes go through `service.py::log` so the row shape stays uniform.
 2. **Append-only.** Audit rows are never updated or deleted by application code. Retention is a DB-side concern (TODO(verify): retention policy).
-3. **Workspace-scoped.** `AuditLog.workspace_id` is required on every row; the query API filters by the caller's workspace.
+3. **Workspace-scoped by default.** Workspace events must set `AuditLog.workspace_id`; the query API filters by the caller's workspace.
+4. **Auth/system exception.** Auth/system events with no workspace context may store `workspace_id = NULL`; those rows are not returned by tenant-scoped audit queries.
 
 ## See also
 
@@ -35,4 +36,4 @@ Reads are direct SQL from the audit route (`backend/app/api/routes/audit.py`).
 
 - Don't insert `AuditLog` rows directly from routes — go through `service.py::log`.
 - Don't use the audit log as a source of truth for business state. It's a record of changes, not a substitute for the entity tables.
-- Don't strip workspace_id from a log row "because the action is global" — every row has a workspace.
+- Don't strip workspace_id from workspace-scoped rows "because the action is global". Use `workspace_id = NULL` only for auth/system events with no workspace context.

--- a/backend/app/domain/audit/models.py
+++ b/backend/app/domain/audit/models.py
@@ -17,7 +17,7 @@ class AuditLog(Base):
     workspace_id = Column(
         UUID(as_uuid=True),
         ForeignKey("workspaces.id", ondelete="CASCADE"),
-        nullable=False,
+        nullable=True,
         index=True,
     )
     user_id = Column(

--- a/backend/app/domain/audit/schemas.py
+++ b/backend/app/domain/audit/schemas.py
@@ -11,7 +11,7 @@ class AuditLogOut(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     id: UUID
-    workspace_id: UUID
+    workspace_id: UUID | None
     user_id: UUID | None
     action: str
     target_type: str | None

--- a/backend/app/domain/audit/service.py
+++ b/backend/app/domain/audit/service.py
@@ -2,6 +2,7 @@
 
 Single entry point: ``log()``. Callers pass the workspace, the acting
 user, the action string, and an optional list of affected object IDs.
+Auth/system events that have no workspace context may pass ``ws=None``.
 The row is flushed (not committed) so it rides the route's own
 transaction — if the route rolls back, the audit row disappears too,
 which is the correct behaviour.
@@ -20,7 +21,7 @@ from app.domain.workspaces.models import Workspace
 def log(
     db: Session,
     *,
-    ws: Workspace,
+    ws: Workspace | None,
     user: User | None,
     action: str,
     target_type: str | None = None,
@@ -35,12 +36,17 @@ def log(
     commits at clean exit.  A rollback in the route will also roll back
     this row — there is no separate audit-only transaction.
 
+    ``ws`` is required for workspace-scoped events. Pass ``None`` only
+    for auth/system events where no workspace membership exists; the
+    workspace audit API filters by workspace_id, so those rows remain
+    outside tenant-scoped audit views.
+
     Never store decrypted credentials here (invariant from CLAUDE.md /
     BE2-024): callers that log credential rotation MUST NOT pass the
     key material as ``comment``.
     """
     row = AuditLog(
-        workspace_id=ws.id,
+        workspace_id=ws.id if ws else None,
         user_id=user.id if user else None,
         action=action,
         target_type=target_type,

--- a/backend/tests/test_password_reset.py
+++ b/backend/tests/test_password_reset.py
@@ -15,6 +15,7 @@ from app.core.auth import hmac_token
 from app.core.time import utcnow
 from app.domain.audit.models import AuditLog
 from app.domain.users.models import PasswordResetRequest, User, UserSession
+from app.domain.workspaces.models import WorkspaceMember
 from app.main import app
 from tests._factories import DEFAULT_PASSWORD, signup_user
 
@@ -335,5 +336,22 @@ def test_password_reset_request_audit_row(client, db):
         .filter(AuditLog.action == "user.password_reset_requested")
         .one()
     )
+    assert row.user_id == user.id
+    assert row.target_ids == [user.id]
+
+
+def test_orphan_user_audit_behavior(client, db):
+    email = _signup(client)
+    user = db.query(User).filter(User.email == email).one()
+    db.query(WorkspaceMember).filter(WorkspaceMember.user_id == user.id).delete()
+
+    _request_reset(client, email)
+
+    row = (
+        db.query(AuditLog)
+        .filter(AuditLog.action == "user.password_reset_requested")
+        .one()
+    )
+    assert row.workspace_id is None
     assert row.user_id == user.id
     assert row.target_ids == [user.id]


### PR DESCRIPTION
## Summary
- Allow `audit_log.workspace_id` to be NULL for auth/system events that have no workspace context.
- Log password reset requests for orphan users instead of returning early when no active workspace membership exists.
- Renumber the nullable audit workspace migration to `0065`, after main's `0064` migration.
- Document the auth/system exception in the local audit module README and add the orphan-user regression test.

## Decision
Selected nullable `audit_log.workspace_id` for auth/system events. Tenant audit views remain isolated because the audit API filters by the current `workspace_id`, so NULL rows are not returned from workspace-scoped reads.

## Validation
- `cd backend && uv run --extra dev python -m pytest tests/test_password_reset.py tests/test_password_reset_enumeration.py tests/test_password_reset_purge.py -q`
- `cd backend && uv run --extra dev python -m pytest tests/test_audit_log_bulk_delete.py tests/test_audit_log_isolation.py tests/test_audit_log_no_secret_leak.py tests/test_audit_log_coverage.py -q`
- `cd backend && uv run --extra dev alembic heads`
- `cd backend && uv run --extra dev python -m pytest tests/test_migration_isolation.py tests/test_migrations.py::test_upgrade_head_then_downgrade_base_then_upgrade_head -m 'slow or not slow' -q`
- `cd backend && uv run --extra dev ruff check app/api/routes/auth.py app/domain/audit/models.py app/domain/audit/schemas.py app/domain/audit/service.py tests/test_password_reset.py alembic/versions/0065_nullable_audit_workspace.py`
- `git diff --check origin/main...HEAD`

## Merge order
Must merge after #764 and #767. Both are already merged; this branch has been rebased onto current `origin/main` after #761, #764, and #767.

Closes #751
