### PR TITLE
[codex] Tune password reset request autovacuum

### DIFF
--- a/backend/alembic/versions/0063_password_reset_requests_autovacuum.py
+++ b/backend/alembic/versions/0063_password_reset_requests_autovacuum.py
@@ -1,0 +1,43 @@
+"""Tune password reset request autovacuum settings.
+
+Revision ID: 0063
+Revises: 0062
+Create Date: 2026-05-15
+
+AUD-091 / issue #748.
+
+This follows 0062 from PR #760, preserving a single Alembic head.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0063"
+down_revision = "0062"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE password_reset_requests SET (
+            autovacuum_vacuum_scale_factor = 0.05,
+            autovacuum_analyze_scale_factor = 0.05,
+            autovacuum_vacuum_threshold = 1000
+        )
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE password_reset_requests RESET (
+            autovacuum_vacuum_scale_factor,
+            autovacuum_analyze_scale_factor,
+            autovacuum_vacuum_threshold
+        )
+        """
+    )

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -364,6 +364,43 @@ def test_invitation_token_hash_drop_round_trips(round_trip_url: str) -> None:
 
 
 @pytest.mark.slow
+def test_password_reset_requests_autovacuum_reloptions_round_trip(
+    round_trip_url: str,
+) -> None:
+    cfg = _alembic_config(round_trip_url)
+    expected = {
+        "autovacuum_vacuum_scale_factor=0.05",
+        "autovacuum_analyze_scale_factor=0.05",
+        "autovacuum_vacuum_threshold=1000",
+    }
+
+    def password_reset_reloptions() -> set[str]:
+        eng = create_engine(round_trip_url, future=True)
+        try:
+            with eng.connect() as conn:
+                return {
+                    row.reloption
+                    for row in conn.execute(
+                        text(
+                            "SELECT unnest(coalesce(reloptions, ARRAY[]::text[])) "
+                            "AS reloption "
+                            "FROM pg_class "
+                            "WHERE oid = 'password_reset_requests'::regclass"
+                        )
+                    )
+                }
+        finally:
+            eng.dispose()
+
+    _reset_schema(round_trip_url)
+    _upgrade(cfg, round_trip_url, "0063")
+    assert expected <= password_reset_reloptions()
+
+    _downgrade(cfg, round_trip_url, "0062")
+    assert expected.isdisjoint(password_reset_reloptions())
+
+
+@pytest.mark.slow
 def test_snapshot_schema_captures_server_default(round_trip_url: str) -> None:
     _reset_schema(round_trip_url)
     eng = create_engine(round_trip_url, future=True)


### PR DESCRIPTION
Closes #748

## Summary
- add migration 0063 to tune `password_reset_requests` autovacuum reloptions
- reset those reloptions on downgrade
- add a slow migration test for `pg_class.reloptions`

## Validation
- `uv run --extra dev python -m pytest tests/test_migrations.py::test_password_reset_requests_autovacuum_reloptions_round_trip -q -m slow`
- Alembic single-head check: `['0063']`
- `git diff --check`

## Merge order
- #760 has merged and introduced migration 0062.
- This PR is now rebased and renumbered as migration 0063.
- Merge before #767, which should rebase/renumber to 0064 afterward.
