### PR TITLE
[codex] Report dynamic rel for target blank anchors

### DIFF
--- a/web/eslint-rules/anchor-rel-noreferrer-noopener.cjs
+++ b/web/eslint-rules/anchor-rel-noreferrer-noopener.cjs
@@ -1,4 +1,6 @@
 const TARGET_BLANK_MESSAGE = 'Links with target="_blank" must use rel="noopener noreferrer".';
+const DYNAMIC_REL_MESSAGE =
+  'Links with static target="_blank" must use a static rel value containing "noopener noreferrer".';
 
 function getAttribute(node, name) {
   return node.attributes.find(
@@ -44,6 +46,7 @@ module.exports = {
     },
     schema: [],
     messages: {
+      dynamicRel: DYNAMIC_REL_MESSAGE,
       missingRel: TARGET_BLANK_MESSAGE,
     },
   },
@@ -63,6 +66,8 @@ module.exports = {
         const rel = getStaticStringValue(getAttribute(node, "rel"));
 
         if (rel === null) {
+          // Option A for AUD-100: static target="_blank" cannot verify dynamic rel tokens.
+          context.report({ node, messageId: "dynamicRel" });
           return;
         }
 

--- a/web/src/__tests__/targetBlankRelLint.test.ts
+++ b/web/src/__tests__/targetBlankRelLint.test.ts
@@ -55,11 +55,11 @@ describe("target=_blank rel lint guard", () => {
     ).resolves.toHaveLength(0);
   });
 
-  it("allows computed rel values", async () => {
+  it("test_dynamic_rel_warning", async () => {
     await expect(
       targetBlankRelMessages(
         'const someVar = "noreferrer"; export const Link = () => <a href="https://example.com" target="_blank" rel={someVar}>open</a>;',
       ),
-    ).resolves.toHaveLength(0);
+    ).resolves.toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary

- Report dynamic `rel` expressions when `target="_blank"` is statically known, so the custom anchor rule no longer silently skips unverifiable rel tokens.
- Keep literal `rel` token validation unchanged.
- Update `targetBlankRelLint` with `test_dynamic_rel_warning`.

## Validation

- PASS `npm --prefix web run test -- targetBlankRelLint`
- PASS `npm exec -- eslint src/__tests__/targetBlankRelLint.test.ts` (run from `web`)
- PASS `git diff --check`
- FAIL `npm --prefix web run lint` due existing unrelated lint findings:
  - `web/src/lib/bagCode.ts:91:22` and `web/src/lib/bagCode.ts:164:14` `no-control-regex` errors
  - unused-var warnings in `responsive-grids.test.ts`, `OrderDetail.tsx`, and `PartLayout.navigation.dom.test.tsx`

## Merge Order

Merge before #775 because #775 documents the same rule file.

Refs #771