### PR TITLE
AUD-099: Add weak password sync drift test

### DIFF
--- a/backend/tests/test_weak_password_sync.py
+++ b/backend/tests/test_weak_password_sync.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+from app.core.auth import _WEAK_PASSWORDS
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PASSWORD_STRENGTH_TS = REPO_ROOT / "web" / "src" / "lib" / "passwordStrength.ts"
+
+WEAK_PASSWORDS_SET_RE = re.compile(
+    r"(?:export\s+)?const\s+WEAK_PASSWORDS\s*=\s*new\s+Set(?:<[^>]+>)?\s*"
+    r"\(\s*\[(?P<items>.*?)\]\s*\)\s*;",
+    re.DOTALL,
+)
+
+
+def _parse_fe_weak_passwords(source: str) -> list[str]:
+    match = WEAK_PASSWORDS_SET_RE.search(source)
+    if not match:
+        pytest.fail(
+            "Could not parse frontend WEAK_PASSWORDS. Expected "
+            "`const WEAK_PASSWORDS = new Set([...]);` in "
+            f"{PASSWORD_STRENGTH_TS}."
+        )
+
+    try:
+        values = ast.literal_eval(f"[{match.group('items')}]")
+    except (SyntaxError, ValueError) as exc:
+        pytest.fail(f"Could not parse frontend WEAK_PASSWORDS string literals: {exc}")
+
+    if not isinstance(values, list) or not all(isinstance(value, str) for value in values):
+        pytest.fail("Frontend WEAK_PASSWORDS must contain only string literals.")
+
+    return values
+
+
+def test_fe_be_weak_password_lists_match() -> None:
+    fe_weak_passwords = _parse_fe_weak_passwords(
+        PASSWORD_STRENGTH_TS.read_text(encoding="utf-8")
+    )
+
+    assert all(value == value.lower() for value in fe_weak_passwords)
+    assert {value.lower() for value in fe_weak_passwords} == _WEAK_PASSWORDS


### PR DESCRIPTION
## Summary

- Adds a backend drift-detection test for the mirrored weak-password blocklist.
- Parses `web/src/lib/passwordStrength.ts` from disk and fails explicitly if `WEAK_PASSWORDS = new Set([...])` cannot be parsed.
- Compares the parsed frontend entries to `app.core.auth._WEAK_PASSWORDS` only; deployment-specific `EXTRA_WEAK_PASSWORDS` is intentionally excluded.

Refs #770

## Validation

- PASS: `cd backend && uv run --extra dev python -m pytest tests/test_weak_password_sync.py -q` (1 passed, 1 Alembic deprecation warning)
- PASS: `cd backend && uv run --extra dev ruff check tests/test_weak_password_sync.py`
- PASS: `git diff --check`

## Merge Order

Independent.
