### PR TITLE
[codex] AUD-101 namespace advisory lock class IDs

### DIFF
--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -9,6 +9,7 @@ from uuid import UUID
 from fastapi import APIRouter, Request, Response, status
 from sqlalchemy import func, text
 
+from app.core.advisory_locks import PASSWORD_RESET_THROTTLE_LOCK_CLASSID
 from app.core.auth import (
     PasswordVerifyResult,
     WeakPasswordError,
@@ -178,8 +179,15 @@ def _first_workspace_for_user(db: DbSession, user: User) -> Workspace | None:
 
 def _password_reset_request_throttled(db: DbSession, *, email_hash: str) -> bool:
     db.execute(
-        text("SELECT pg_advisory_xact_lock(hashtext(:lock_key))"),
-        {"lock_key": f"reset:{email_hash}"},
+        text(
+            "SELECT pg_advisory_xact_lock("
+            "CAST(:classid AS int4), CAST(hashtext(:lock_key) AS int4)"
+            ")"
+        ),
+        {
+            "classid": PASSWORD_RESET_THROTTLE_LOCK_CLASSID,
+            "lock_key": f"reset:{email_hash}",
+        },
     )
     cutoff = utcnow() - timedelta(hours=1)
     count = (

--- a/backend/app/cli/run_job.py
+++ b/backend/app/cli/run_job.py
@@ -13,6 +13,8 @@ from uuid import uuid4
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
+from app.core.advisory_locks import RUN_JOB_LOCK_CLASSID
+
 logger = logging.getLogger(__name__)
 
 SessionFactory = Callable[[], Session]
@@ -36,13 +38,16 @@ class UnknownJobError(ValueError):
 
 
 def _acquire_job_lock(db: Session, job_name: str) -> bool:
-    # hashtext() returns int4, so different job names can theoretically
-    # collide. Acceptable for today's tiny allow-list; switch to explicit
-    # reserved bigint IDs or pg_try_advisory_xact_lock(classid, objid)
-    # before this grows into a broad scheduler.
+    # Class ID namespaces this feature from other hashtext-backed locks.
+    # hashtext() still returns int4, so job names can theoretically collide
+    # within the run-job namespace.
     result = db.execute(
-        text("SELECT pg_try_advisory_xact_lock(hashtext(:job_name))"),
-        {"job_name": job_name},
+        text(
+            "SELECT pg_try_advisory_xact_lock("
+            "CAST(:classid AS int4), CAST(hashtext(:job_name) AS int4)"
+            ")"
+        ),
+        {"classid": RUN_JOB_LOCK_CLASSID, "job_name": job_name},
     )
     return bool(result.scalar())
 

--- a/backend/app/core/advisory_locks.py
+++ b/backend/app/core/advisory_locks.py
@@ -1,0 +1,17 @@
+"""Advisory-lock namespace registry."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from types import MappingProxyType
+from typing import Final
+
+RUN_JOB_LOCK_CLASSID: Final[int] = 1
+PASSWORD_RESET_THROTTLE_LOCK_CLASSID: Final[int] = 2
+
+ADVISORY_LOCK_CLASSIDS: Final[Mapping[str, int]] = MappingProxyType(
+    {
+        "run_job": RUN_JOB_LOCK_CLASSID,
+        "password_reset_throttle": PASSWORD_RESET_THROTTLE_LOCK_CLASSID,
+    }
+)

--- a/backend/tests/test_advisory_lock_classids.py
+++ b/backend/tests/test_advisory_lock_classids.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from app.core.advisory_locks import (
+    ADVISORY_LOCK_CLASSIDS,
+    PASSWORD_RESET_THROTTLE_LOCK_CLASSID,
+    RUN_JOB_LOCK_CLASSID,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INT4_MIN = -(2**31)
+INT4_MAX = 2**31 - 1
+
+
+def test_classids_disjoint() -> None:
+    classids = dict(ADVISORY_LOCK_CLASSIDS)
+
+    assert classids == {
+        "run_job": RUN_JOB_LOCK_CLASSID,
+        "password_reset_throttle": PASSWORD_RESET_THROTTLE_LOCK_CLASSID,
+    }
+    assert len(set(classids.values())) == len(classids)
+    assert all(INT4_MIN <= classid <= INT4_MAX for classid in classids.values())
+
+
+def test_classids_documented() -> None:
+    docs = (REPO_ROOT / "docs" / "development.md").read_text(encoding="utf-8")
+
+    for feature, classid in ADVISORY_LOCK_CLASSIDS.items():
+        assert re.search(
+            rf"\|\s*`{classid}`\s*\|\s*`{re.escape(feature)}`\s*\|",
+            docs,
+        )
+
+
+def test_hashtext_lock_sites_use_two_arg_namespaces() -> None:
+    run_job_source = (
+        REPO_ROOT / "backend" / "app" / "cli" / "run_job.py"
+    ).read_text(encoding="utf-8")
+    auth_source = (
+        REPO_ROOT / "backend" / "app" / "api" / "routes" / "auth.py"
+    ).read_text(encoding="utf-8")
+
+    assert "pg_try_advisory_xact_lock(hashtext(" not in run_job_source
+    assert "pg_advisory_xact_lock(hashtext(" not in auth_source
+    assert "RUN_JOB_LOCK_CLASSID" in run_job_source
+    assert "PASSWORD_RESET_THROTTLE_LOCK_CLASSID" in auth_source
+    assert "CAST(:classid AS int4)" in run_job_source
+    assert "CAST(:classid AS int4)" in auth_source
+    assert "CAST(hashtext(:job_name) AS int4)" in run_job_source
+    assert "CAST(hashtext(:lock_key) AS int4)" in auth_source

--- a/backend/tests/test_run_job.py
+++ b/backend/tests/test_run_job.py
@@ -7,6 +7,7 @@ from datetime import timedelta
 from sqlalchemy.orm import Session
 
 from app.cli.run_job import JOBS, JobSpec, UnknownJobError, main, run_job
+from app.core.advisory_locks import RUN_JOB_LOCK_CLASSID
 from app.core.time import utcnow
 from app.domain.users.models import User, UserSession
 
@@ -67,7 +68,11 @@ def test_run_job_dispatches_allow_listed_job(tmp_path) -> None:
     assert affected == 4
     assert calls == [session]
     assert session.executed == [
-        ("SELECT pg_try_advisory_xact_lock(hashtext(:job_name))", {"job_name": "example"})
+        (
+            "SELECT pg_try_advisory_xact_lock(CAST(:classid AS int4), "
+            "CAST(hashtext(:job_name) AS int4))",
+            {"classid": RUN_JOB_LOCK_CLASSID, "job_name": "example"},
+        )
     ]
     assert session.committed is True
     assert session.rolled_back is False
@@ -75,15 +80,15 @@ def test_run_job_dispatches_allow_listed_job(tmp_path) -> None:
     assert (tmp_path / "example").read_text(encoding="utf-8") == "ok\n"
 
 
-def test_run_job_lock_hash_collision_note_is_kept() -> None:
+def test_run_job_lock_namespace_collision_note_is_kept() -> None:
     from pathlib import Path
 
     source = Path(__file__).parents[1] / "app" / "cli" / "run_job.py"
     text = source.read_text(encoding="utf-8")
 
-    assert "hashtext() returns int4" in text
+    assert "Class ID namespaces this feature" in text
     assert "collide" in text
-    assert "reserved bigint IDs" in text
+    assert "run-job namespace" in text
 
 
 def test_run_job_rejects_unknown_job() -> None:

--- a/docs/development.md
+++ b/docs/development.md
@@ -146,6 +146,17 @@ you write a similar test, request the `real_db` fixture instead of
 ~1000× slower per test — only use it when the savepoint pattern truly
 can't model the test.
 
+## Advisory lock class IDs
+
+Postgres two-int advisory locks use `classid` as the feature namespace
+and `objid` as the per-feature key. Allocate a unique int4 class ID here
+before adding a new hashtext-backed advisory lock.
+
+| Class ID | Feature | Object ID |
+|----------|---------|-----------|
+| `1` | `run_job` | `hashtext(job_name)` for allow-listed maintenance jobs. |
+| `2` | `password_reset_throttle` | `hashtext("reset:" || email_hash)` for password-reset request throttling. |
+
 ### Polymorphic cleanup
 
 SQLAlchemy `before_delete` mapper events do not fire for bulk


### PR DESCRIPTION

## Summary
- Namespaces run-job advisory locks with class ID 1 while preserving try-lock behavior.
- Namespaces password-reset throttle locks with class ID 2 while preserving blocking lock behavior.
- Documents the class ID registry and adds class ID disjointness/source-shape tests.

Refs #772

## Validation
- `uv run --extra dev python -m pytest tests/test_advisory_lock_classids.py tests/test_run_job_advisory_lock.py tests/test_password_reset.py -q` (17 passed, 9 warnings: Alembic `path_separator` deprecation)
- `uv run --extra dev python -m pytest tests/test_run_job.py -q` (11 passed, 1 warning: Alembic `path_separator` deprecation)
- `uv run --extra dev ruff check app/api/routes/auth.py app/cli/run_job.py app/core/advisory_locks.py tests/test_advisory_lock_classids.py tests/test_run_job.py` (passed)
- `git diff --check` (passed)
- `git diff --cached --check` (passed)

## Merge order
Must merge before #773.

## Blockers
None.
