### PR TITLE
[codex] Document in-tree anchor rel rule

### DIFF
--- a/web/.eslintrc.cjs
+++ b/web/.eslintrc.cjs
@@ -1,5 +1,6 @@
 const jsxA11y = require("eslint-plugin-jsx-a11y");
 
+// In-tree rule; see eslint-rules/anchor-rel-noreferrer-noopener.cjs for details.
 jsxA11y.rules["anchor-rel-noreferrer-noopener"] ??= require(
   "./eslint-rules/anchor-rel-noreferrer-noopener.cjs",
 );

--- a/web/eslint-rules/anchor-rel-noreferrer-noopener.cjs
+++ b/web/eslint-rules/anchor-rel-noreferrer-noopener.cjs
@@ -1,3 +1,18 @@
+/**
+ * In-tree implementation of jsx-a11y/anchor-rel-noreferrer-noopener.
+ *
+ * eslint-plugin-jsx-a11y does not ship a rule with this name, so this repo
+ * carries the rule locally and web/.eslintrc.cjs grafts it into the imported
+ * plugin's rules map before enabling it as jsx-a11y/anchor-rel-noreferrer-noopener.
+ *
+ * Behavior and limitations:
+ * - Checks JSX <a> elements only when target is statically known to be "_blank".
+ * - Requires a static rel value containing both whitespace-delimited noopener and
+ *   noreferrer tokens.
+ * - After AUD-100 / #771, a static target="_blank" with dynamic rel reports a
+ *   dedicated diagnostic because the rule cannot prove the required tokens exist.
+ * - Dynamic target values and custom link components are ignored.
+ */
 const TARGET_BLANK_MESSAGE = 'Links with target="_blank" must use rel="noopener noreferrer".';
 const DYNAMIC_REL_MESSAGE =
   'Links with static target="_blank" must use a static rel value containing "noopener noreferrer".';


### PR DESCRIPTION
## Summary
- Document why the in-tree anchor-rel-noreferrer-noopener rule exists because upstream jsx-a11y does not ship it.
- Document the web/.eslintrc.cjs graft and the rule behavior/limitations, including AUD-100/#771 dynamic-rel reporting.

## Validation
- Manual review of the two-file diff.
- git diff --check
- npm --prefix /mnt/data/WORK/stockManager-1/.codex-worktrees/aud-104-anchor-rule-doc-775/web ci (completed; transitive EBADENGINE warnings under Node 18)
- npm --prefix /mnt/data/WORK/stockManager-1/.codex-worktrees/aud-104-anchor-rule-doc-775/web run test -- src/__tests__/targetBlankRelLint.test.ts (5 tests passed)

## Merge Order
- Must merge after #779. This branch is based on codex/aud-100-dynamic-rel-warning-771.

Refs #775