### PR TITLE
AUD-107: Cross-reference 0062 downgrade runbook

### DIFF
--- a/backend/alembic/versions/0062_password_reset_purge_index.py
+++ b/backend/alembic/versions/0062_password_reset_purge_index.py
@@ -9,6 +9,7 @@ AUD-083 / issue #740.
 Password reset retention purges by created_at because throttled and
 non-issued rows can have expires_at NULL. The created_at index remains the
 retention path; the expires_at index is intentionally removed.
+Runbook: docs/runbooks/migration-recovery.md#downgrading-through-migration-0062-after-manually-recreating-the-password-reset-index.
 """
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary
- Add a one-line runbook reference to the 0062 migration docstring.
- Leave upgrade and downgrade SQL unchanged.

Refs #787

## Validation
- Manual review: confirmed the diff is docstring-only and upgrade/downgrade SQL is unchanged.
- git -C /mnt/data/WORK/stockManager-1/.codex-worktrees/aud-107-0062-runbook-docstring-787 diff --check origin/main...HEAD

## Merge order
Independent but touches merged migration docstring only.