### PR TITLE
AUD-109: Document password reset purge interval setting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,8 @@ SESSION_SECRET=dev-change-me-locally
 EXTRA_WEAK_PASSWORDS=
 SESSION_IDLE_HOURS=24
 INVITATION_TTL_DAYS=14
+# Password-reset token purge cadence in seconds. Set to 0 to disable.
+PASSWORD_RESET_PURGE_INTERVAL_SECONDS=3600
 UPLOAD_DIR=/data/uploads
 APP_ENV=dev
 CORS_ORIGINS=http://localhost:5173

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -48,6 +48,9 @@ class Settings(BaseSettings):
     # the periodic task entirely (the migration's index still exists,
     # so a future cron / one-off SQL still benefits).
     SESSION_PURGE_INTERVAL_SECONDS: int = 3600
+    # Cadence (seconds) of the password-reset token purge worker. 0
+    # disables the periodic password-reset purge.
+    PASSWORD_RESET_PURGE_INTERVAL_SECONDS: int = Field(default=3600, ge=0)
     UPLOAD_DIR: str = "/data/uploads"
     # Per-upload size cap. nginx (in web container) and Apache (in front)
     # both cap at 25 MiB, but FastAPI must enforce its own cap so a

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -47,3 +47,16 @@ def test_sentry_traces_rate_accepts_explicit_low_prod_rate(monkeypatch):
     settings = Settings(_env_file=None)
 
     assert settings.SENTRY_TRACES_SAMPLE_RATE == 0.05
+
+
+def test_password_reset_purge_interval_env_overrides_default(monkeypatch):
+    monkeypatch.setenv("APP_ENV", "dev")
+    monkeypatch.delenv("PASSWORD_RESET_PURGE_INTERVAL_SECONDS", raising=False)
+
+    assert Settings(_env_file=None).PASSWORD_RESET_PURGE_INTERVAL_SECONDS == 3600
+
+    monkeypatch.setenv("PASSWORD_RESET_PURGE_INTERVAL_SECONDS", "120")
+
+    settings = Settings(_env_file=None)
+
+    assert settings.PASSWORD_RESET_PURGE_INTERVAL_SECONDS == 120


### PR DESCRIPTION
## Summary
- document `PASSWORD_RESET_PURGE_INTERVAL_SECONDS` in `.env.example`
- expose `PASSWORD_RESET_PURGE_INTERVAL_SECONDS` on backend `Settings` with a 3600-second default and non-negative validation
- add a focused config regression test for env override behavior

Refs #789

## Validation
- `cd backend && uv run --extra dev python -m pytest tests/test_config.py -q`
- `cd backend && uv run --extra dev ruff check app/core/config.py tests/test_config.py`
- `git diff --check`

## Merge order
- independent
