### PR TITLE
AUD-105: Document three backend cron sidecars

### DIFF
--- a/docs/adr/0021-periodic-jobs-scheduler.md
+++ b/docs/adr/0021-periodic-jobs-scheduler.md
@@ -30,6 +30,8 @@ Jobs using this scheduler:
 
 - `sourcing-cache-sweep` — hourly TrustedParts cache retention sweep in `backend-cron`.
 - `sourcing-alerts-evaluate` — 15-minute sourcing alert evaluator in `backend-cron-alerts`.
+- `session-purge` — hourly expired session cleanup in `backend-cron-sessions`.
+- `password-reset-purge` — hourly expired password reset request cleanup in `backend-cron-sessions`.
 
 ## Consequences
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -385,16 +385,24 @@ docker-compose commands so they run as the same user CI uses (avoids
 cd /srv/stockmanager
 sudo -u deploy docker compose -f docker-compose.prod.yml logs -f backend
 sudo -u deploy docker compose -f docker-compose.prod.yml logs -f backend-cron
+sudo -u deploy docker compose -f docker-compose.prod.yml logs -f backend-cron-alerts
+sudo -u deploy docker compose -f docker-compose.prod.yml logs -f backend-cron-sessions
 sudo -u deploy docker compose -f docker-compose.prod.yml logs -f web
 ```
 
 ### Backend periodic jobs
 
-`backend-cron` runs the allow-listed backend CLI once per hour:
-`python -m app.cli.run_job sourcing-cache-sweep`. The sidecar sleeps after
-each completed run, so a slow sweep delays the next start instead of
-overlapping it. Source: `docker-compose.prod.yml:165-207`,
-`backend/app/cli/run_job.py:46-52`.
+Three cron sidecars run allow-listed backend CLI jobs:
+
+- `backend-cron` runs `sourcing-cache-sweep` once per hour.
+- `backend-cron-alerts` runs `sourcing-alerts-evaluate` every 15 minutes.
+- `backend-cron-sessions` runs `session-purge` and `password-reset-purge`
+  hourly by default.
+
+Each sidecar invokes `python -m app.cli.run_job <job-name>` and sleeps after
+completed runs, so a slow job delays that job's next start instead of
+overlapping it. Source: `docker-compose.prod.yml:170-264`,
+`backend/app/cli/run_job.py:85-119`.
 
 The sourcing cache job opens a backend DB session and sweeps expired
 TrustedParts cache rows by workspace-scoped deletes. Source:

--- a/docs/runbooks/on-call-quickstart.md
+++ b/docs/runbooks/on-call-quickstart.md
@@ -81,11 +81,14 @@ exited with code 0. Cron sidecars should also be running:
 
 - `backend-cron` runs `sourcing-cache-sweep` every 3600 seconds.
 - `backend-cron-alerts` runs `sourcing-alerts-evaluate` every 900 seconds.
+- `backend-cron-sessions` runs `session-purge` and `password-reset-purge`
+  every 3600 seconds by default.
 
-Both cron sidecars wrap each job run in `timeout 600`. Log line `timed out
+Each cron sidecar wraps each job run in `timeout 600`. Log line `timed out
 after 600s (exit=124)` means the job hit the 10-minute cap and was
 terminated; other non-zero exits are logged as `failed (exit=<code>)`. The
-sidecar loop stays alive after either case and sleeps until the next tick.
+sidecar scheduling loops stay alive after either case and sleep until the next
+tick.
 
 If `backend` is `Restarting`:
 ```bash


### PR DESCRIPTION
## Summary

- Updates ADR-0021's scheduler job list to include all four registered jobs and their sidecars.
- Updates the on-call container checklist to enumerate `backend-cron`, `backend-cron-alerts`, and `backend-cron-sessions`.
- Updates deployment docs to tail and describe all three cron sidecars.

Refs #785

## Validation

- `grep -rn "Two backend-cron\|two backend-cron" docs/` returns no matches.
- `git diff --check` passes.

## Merge order

Docs-only independent.
