### PR TITLE
AUD-110 Split password reset throttle audit comments

### DIFF
--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -82,6 +82,8 @@ _SIGNUP_VERIFICATION_DATA = {"status": "verification_sent"}
 _SIGNUP_VERIFICATION_MESSAGE = "verification email sent"
 _PASSWORD_RESET_REQUEST_DATA = {"status": "accepted"}
 _PASSWORD_RESET_REQUEST_MESSAGE = "password reset request accepted"
+_PASSWORD_RESET_THROTTLED_RATE_COMMENT = "throttled:rate"
+_PASSWORD_RESET_THROTTLED_CONCURRENT_COMMENT = "throttled:concurrent"
 
 
 def _record_signup_mail_failure(kind: str, exc: Exception) -> None:
@@ -177,7 +179,9 @@ def _first_workspace_for_user(db: DbSession, user: User) -> Workspace | None:
     return db.get(Workspace, membership.workspace_id) if membership else None
 
 
-def _password_reset_request_throttled(db: DbSession, *, email_hash: str) -> bool:
+def _password_reset_request_throttle_comment(
+    db: DbSession, *, email_hash: str
+) -> str | None:
     result = db.execute(
         text(
             "SELECT pg_try_advisory_xact_lock("
@@ -191,7 +195,7 @@ def _password_reset_request_throttled(db: DbSession, *, email_hash: str) -> bool
     )
     if not bool(result.scalar()):
         log.info("password_reset_request status=throttled reason=lock_denied")
-        return True
+        return _PASSWORD_RESET_THROTTLED_CONCURRENT_COMMENT
 
     cutoff = utcnow() - timedelta(hours=1)
     count = (
@@ -202,7 +206,9 @@ def _password_reset_request_throttled(db: DbSession, *, email_hash: str) -> bool
         )
         .count()
     )
-    return count >= _PASSWORD_RESET_EMAIL_LIMIT
+    if count >= _PASSWORD_RESET_EMAIL_LIMIT:
+        return _PASSWORD_RESET_THROTTLED_RATE_COMMENT
+    return None
 
 
 def _audit_password_reset_request(
@@ -210,7 +216,7 @@ def _audit_password_reset_request(
     request: Request,
     user: User,
     *,
-    throttled: bool,
+    throttle_comment: str | None,
 ) -> None:
     workspace = _first_workspace_for_user(db, user)
     _audit_log(
@@ -220,7 +226,7 @@ def _audit_password_reset_request(
         action="user.password_reset_requested",
         target_type="user",
         target_ids=[user.id],
-        comment="throttled" if throttled else None,
+        comment=throttle_comment,
         request_id=getattr(request.state, "request_id", None),
     )
 
@@ -525,7 +531,10 @@ def request_password_reset(
 
     _dummy_password_reset_compute()
     user = db.query(User).filter(func.lower(User.email) == email_normalized).first()
-    throttled = _password_reset_request_throttled(db, email_hash=email_hash)
+    throttle_comment = _password_reset_request_throttle_comment(
+        db, email_hash=email_hash
+    )
+    throttled = throttle_comment is not None
 
     if user is None or getattr(user, "archived_at", None) is not None:
         response.status_code = status.HTTP_202_ACCEPTED
@@ -554,7 +563,7 @@ def request_password_reset(
         db.add(reset_request)
         db.flush()
 
-    _audit_password_reset_request(db, request, user, throttled=throttled)
+    _audit_password_reset_request(db, request, user, throttle_comment=throttle_comment)
 
     response.status_code = status.HTTP_202_ACCEPTED
     return ok(_PASSWORD_RESET_REQUEST_DATA, _PASSWORD_RESET_REQUEST_MESSAGE)

--- a/backend/app/domain/audit/README.md
+++ b/backend/app/domain/audit/README.md
@@ -20,6 +20,15 @@ Owns the activity log: a single append-only `AuditLog` table that records "who d
 
 Reads are direct SQL from the audit route (`backend/app/api/routes/audit.py`).
 
+## Auth Event Comments
+
+Password-reset request throttling records the rejected cause on
+`user.password_reset_requested`:
+
+- `throttled:rate` means the per-email hourly reset cap was already reached.
+- `throttled:concurrent` means the request lost the advisory-lock race to an
+  in-flight request for the same email hash.
+
 ## Hard rules (this module)
 
 1. **One write entry point.** All audit writes go through `service.py::log` so the row shape stays uniform.

--- a/backend/tests/test_password_reset.py
+++ b/backend/tests/test_password_reset.py
@@ -253,6 +253,29 @@ def test_password_reset_email_throttle_suppresses_fourth_send(client, db):
     assert rows[-1].token_hmac is None
 
 
+def test_throttle_rate_emits_distinct_audit_comment(client, db):
+    email = _signup(client)
+
+    with patch("app.api.routes.auth.send_password_reset_email") as send_mail:
+        for _ in range(4):
+            response = client.post(
+                "/api/auth/request-password-reset",
+                json={"email": email},
+            )
+            assert response.status_code == 202, response.text
+
+    assert send_mail.call_count == 3
+    comments = [
+        row.comment
+        for row in db.query(AuditLog)
+        .filter(AuditLog.action == "user.password_reset_requested")
+        .all()
+    ]
+    assert comments.count(None) == 3
+    assert comments.count("throttled:rate") == 1
+    assert "throttled:concurrent" not in comments
+
+
 @pytest.mark.real_db
 def test_throttle_atomic_under_concurrency(db, monkeypatch):
     email = f"reset-race-{uuid.uuid4().hex[:8]}@example.com"
@@ -357,7 +380,7 @@ def test_throttle_lock_denied_returns_throttled(db, caplog):
         .filter(AuditLog.action == "user.password_reset_requested")
         .one()
     )
-    assert audit.comment == "throttled"
+    assert audit.comment == "throttled:concurrent"
 
 
 def test_unknown_email_does_not_persist_row(client, db):


### PR DESCRIPTION
## Summary
- Split password-reset throttling audit comments into `throttled:rate` and `throttled:concurrent`.
- Added regression coverage for the per-email hourly rate cap and updated advisory-lock denial coverage.
- Documented the password-reset throttle comment values in the audit README.

## Validation
- `cd backend && uv run --extra dev python -m pytest tests/test_password_reset.py -q` (14 passed, 7 warnings: Alembic config deprecation)
- `cd backend && uv run --extra dev ruff check app/api/routes/auth.py tests/test_password_reset.py`
- `git diff --check`

## Merge Order
- Must merge before #793.

Refs #790