### PR TITLE
Rename target blank rel lint test

### DIFF
--- a/web/src/__tests__/targetBlankRelLint.test.ts
+++ b/web/src/__tests__/targetBlankRelLint.test.ts
@@ -55,7 +55,7 @@ describe("target=_blank rel lint guard", () => {
     ).resolves.toHaveLength(0);
   });
 
-  it("test_dynamic_rel_warning", async () => {
+  it("reports dynamic rel for static target blank anchors", async () => {
     await expect(
       targetBlankRelMessages(
         'const someVar = "noreferrer"; export const Link = () => <a href="https://example.com" target="_blank" rel={someVar}>open</a>;',


### PR DESCRIPTION
## Summary
- Rename the dynamic rel lint guard test from snake_case to sentence-form naming.
- Leave the lint fixture input and assertion behavior unchanged.

Refs #791

## Validation
- `npm --prefix web run test -- targetBlankRelLint` (passes: 5 tests)
- `git diff --check` (passes)

## Merge order
- Must merge before #788 if #788 touches `web/src/__tests__/targetBlankRelLint.test.ts`; issue #788 currently calls for extending that same test file.