### PR TITLE
AUD-108: Fold const rel values in target blank lint

### DIFF
--- a/web/eslint-rules/anchor-rel-noreferrer-noopener.cjs
+++ b/web/eslint-rules/anchor-rel-noreferrer-noopener.cjs
@@ -11,6 +11,8 @@
  *   noreferrer tokens.
  * - After AUD-100 / #771, a static target="_blank" with dynamic rel reports a
  *   dedicated diagnostic because the rule cannot prove the required tokens exist.
+ * - AUD-108 / #788 folds same-file const string literal rel identifiers only;
+ *   imports, re-exports, template literals, and computed initializers stay dynamic.
  * - Dynamic target values and custom link components are ignored.
  */
 const TARGET_BLANK_MESSAGE = 'Links with target="_blank" must use rel="noopener noreferrer".';
@@ -49,6 +51,49 @@ function getStaticStringValue(attribute) {
   return null;
 }
 
+function findVariable(scope, name) {
+  let currentScope = scope;
+
+  while (currentScope) {
+    const variable = currentScope.set?.get(name);
+
+    if (variable) {
+      return variable;
+    }
+
+    currentScope = currentScope.upper;
+  }
+
+  return undefined;
+}
+
+function getConstStringLiteralValue(expression, scope) {
+  if (expression.type !== "Identifier") {
+    return null;
+  }
+
+  const variable = findVariable(scope, expression.name);
+  const definition = variable?.defs?.[0];
+
+  if (!definition || definition.type !== "Variable") {
+    return null;
+  }
+
+  const declaration = definition.parent ?? definition.node.parent;
+
+  if (declaration?.kind !== "const") {
+    return null;
+  }
+
+  const init = definition.node.init;
+
+  if (!init || init.type !== "Literal" || typeof init.value !== "string") {
+    return null;
+  }
+
+  return init.value;
+}
+
 function includesRelToken(rel, token) {
   return rel.split(/\s+/u).includes(token);
 }
@@ -78,18 +123,23 @@ module.exports = {
           return;
         }
 
-        const rel = getStaticStringValue(getAttribute(node, "rel"));
+        const relAttribute = getAttribute(node, "rel");
+        const rel = getStaticStringValue(relAttribute);
+        const resolvedRel =
+          rel === null && relAttribute?.value?.type === "JSXExpressionContainer"
+            ? getConstStringLiteralValue(relAttribute.value.expression, context.getScope())
+            : rel;
 
-        if (rel === null) {
-          // Option A for AUD-100: static target="_blank" cannot verify dynamic rel tokens.
+        if (resolvedRel === null) {
+          // The const lookup could not prove the dynamic rel tokens.
           context.report({ node, messageId: "dynamicRel" });
           return;
         }
 
         if (
-          rel === undefined ||
-          !includesRelToken(rel, "noopener") ||
-          !includesRelToken(rel, "noreferrer")
+          resolvedRel === undefined ||
+          !includesRelToken(resolvedRel, "noopener") ||
+          !includesRelToken(resolvedRel, "noreferrer")
         ) {
           context.report({ node, messageId: "missingRel" });
         }

--- a/web/src/__tests__/targetBlankRelLint.test.ts
+++ b/web/src/__tests__/targetBlankRelLint.test.ts
@@ -6,6 +6,9 @@ import { describe, expect, it } from "vitest";
 
 const webRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const targetBlankRelRuleId = "jsx-a11y/anchor-rel-noreferrer-noopener";
+const missingRelMessage = 'Links with target="_blank" must use rel="noopener noreferrer".';
+const dynamicRelMessage =
+  'Links with static target="_blank" must use a static rel value containing "noopener noreferrer".';
 
 type LintMessage = {
   ruleId?: string | null;
@@ -58,8 +61,34 @@ describe("target=_blank rel lint guard", () => {
   it("reports dynamic rel for static target blank anchors", async () => {
     await expect(
       targetBlankRelMessages(
-        'const someVar = "noreferrer"; export const Link = () => <a href="https://example.com" target="_blank" rel={someVar}>open</a>;',
+        'let someVar = "noopener noreferrer"; export const Link = () => <a href="https://example.com" target="_blank" rel={someVar}>open</a>;',
       ),
-    ).resolves.toHaveLength(1);
+    ).resolves.toEqual([expect.objectContaining({ message: dynamicRelMessage })]);
+  });
+
+  it("allows target=_blank links with rel from module and local const string literals", async () => {
+    await expect(
+      targetBlankRelMessages(`
+        const MODULE_SAFE_REL = "noopener noreferrer";
+
+        export const ModuleLink = () => (
+          <a href="https://example.com" target="_blank" rel={MODULE_SAFE_REL}>open</a>
+        );
+
+        export const LocalLink = () => {
+          const localSafeRel = "noreferrer noopener";
+
+          return <a href="https://example.com" target="_blank" rel={localSafeRel}>open</a>;
+        };
+      `),
+    ).resolves.toHaveLength(0);
+  });
+
+  it("validates const string literal rel values with the existing token checks", async () => {
+    await expect(
+      targetBlankRelMessages(
+        'const unsafeRel = "noreferrer"; export const Link = () => <a href="https://example.com" target="_blank" rel={unsafeRel}>open</a>;',
+      ),
+    ).resolves.toEqual([expect.objectContaining({ message: missingRelMessage })]);
   });
 });


### PR DESCRIPTION
## Summary
- Fold same-file const string literal identifiers used in anchor rel values before reporting dynamic rel.
- Keep the existing noopener/noreferrer token validation for resolved literals.
- Document the boundary: no import, re-export, const template literal, or computed initializer analysis.

Refs #788

## Validation
- `npm --prefix web run test -- targetBlankRelLint` passed (7 tests).
- `npm exec -- eslint src/__tests__/targetBlankRelLint.test.ts` passed.
- `git diff --check` passed.
- `npm --prefix web run lint` failed due unrelated existing issues:
  - `web/src/lib/bagCode.ts:91:22` no-control-regex.
  - `web/src/lib/bagCode.ts:164:14` no-control-regex.
  - Unused-var warnings in `web/src/routes/__tests__/responsive-grids.test.ts:29:7`, `web/src/routes/orders/OrderDetail.tsx:55:9`, and `web/src/routes/parts/detail/__dom__/PartLayout.navigation.dom.test.tsx:109:10`.

## Merge order
Must merge after #800 because this branch is based on `codex/aud-111-targetblank-test-name-791`.