### PR TITLE
[codex] Document throttle audit log comment change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ follow that model — it's a continuous flow of product work + production
 hardening landing per-commit. Themes are summarised below; `git log` is
 the canonical record.
 
+## Breaking changes
+
+- **AUD-121 / #812** `audit_log.comment` throttle rows changed from the
+  legacy `throttled` literal to `throttled:rate` for rate-limit throttles
+  and `throttled:concurrent` for concurrent-request throttles. Downstream
+  consumers filtering audit logs by the old value must update their filters.
+
 ## 2026-05 — feedback brief fixes
 
 - **E2E-1 / #686** Playwright E2E now has smoke/core/nightly project


### PR DESCRIPTION
## Summary
- Add a Breaking changes entry documenting that `audit_log.comment` throttle rows changed from `throttled` to `throttled:rate` / `throttled:concurrent`.

## Validation
- `grep -n "throttled:rate\|throttled:concurrent" CHANGELOG.md`
- `git diff --check origin/main...HEAD`

## Merge-order risks
- Independent.

Refs #812