### PR TITLE
AUD-115: Document session purge interval env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,8 @@ SESSION_SECRET=dev-change-me-locally
 EXTRA_WEAK_PASSWORDS=
 SESSION_IDLE_HOURS=24
 INVITATION_TTL_DAYS=14
+# Session purge cadence in seconds. Set to 0 to disable.
+SESSION_PURGE_INTERVAL_SECONDS=3600
 # Password-reset token purge cadence in seconds. Set to 0 to disable.
 PASSWORD_RESET_PURGE_INTERVAL_SECONDS=3600
 UPLOAD_DIR=/data/uploads


### PR DESCRIPTION
## Summary
- Add SESSION_PURGE_INTERVAL_SECONDS=3600 to .env.example next to the password-reset purge interval.

Refs #806

## Validation
- grep -c PURGE_INTERVAL_SECONDS .env.example -> 2
- git diff --check origin/main...HEAD -> passed

## Merge order
Can merge after #805 if #805 also touches config/env docs, otherwise independent.