### PR TITLE
AUD-122 anchor rel const-fold handles TS const assertions

### DIFF
--- a/web/eslint-rules/anchor-rel-noreferrer-noopener.cjs
+++ b/web/eslint-rules/anchor-rel-noreferrer-noopener.cjs
@@ -67,6 +67,19 @@ function findVariable(scope, name) {
   return undefined;
 }
 
+function unwrapTSConstExpression(expression) {
+  let currentExpression = expression;
+
+  while (
+    currentExpression?.type === "TSAsExpression" ||
+    currentExpression?.type === "TSSatisfiesExpression"
+  ) {
+    currentExpression = currentExpression.expression;
+  }
+
+  return currentExpression;
+}
+
 function getConstStringLiteralValue(expression, scope) {
   if (expression.type !== "Identifier") {
     return null;
@@ -85,7 +98,7 @@ function getConstStringLiteralValue(expression, scope) {
     return null;
   }
 
-  const init = definition.node.init;
+  const init = unwrapTSConstExpression(definition.node.init);
 
   if (!init || init.type !== "Literal" || typeof init.value !== "string") {
     return null;

--- a/web/src/__tests__/targetBlankRelLint.test.ts
+++ b/web/src/__tests__/targetBlankRelLint.test.ts
@@ -84,11 +84,36 @@ describe("target=_blank rel lint guard", () => {
     ).resolves.toHaveLength(0);
   });
 
+  it("accepts as const and satisfies safe rel values", async () => {
+    await expect(
+      targetBlankRelMessages(`
+        const asConstRel = "noopener noreferrer" as const;
+        const satisfiesRel = "noreferrer noopener" satisfies string;
+
+        export const AsConstLink = () => (
+          <a href="https://example.com" target="_blank" rel={asConstRel}>open</a>
+        );
+
+        export const SatisfiesLink = () => (
+          <a href="https://example.com" target="_blank" rel={satisfiesRel}>open</a>
+        );
+      `),
+    ).resolves.toHaveLength(0);
+  });
+
   it("validates const string literal rel values with the existing token checks", async () => {
     await expect(
       targetBlankRelMessages(
         'const unsafeRel = "noreferrer"; export const Link = () => <a href="https://example.com" target="_blank" rel={unsafeRel}>open</a>;',
       ),
     ).resolves.toEqual([expect.objectContaining({ message: missingRelMessage })]);
+  });
+
+  it("reports dynamic rel for const template literal initializers", async () => {
+    await expect(
+      targetBlankRelMessages(
+        'const safeRel = `noopener noreferrer`; export const Link = () => <a href="https://example.com" target="_blank" rel={safeRel}>open</a>;',
+      ),
+    ).resolves.toEqual([expect.objectContaining({ message: dynamicRelMessage })]);
   });
 });


### PR DESCRIPTION
Refs #813

## Summary
- unwrap TypeScript `as` and `satisfies` expressions around same-file const rel string initializers
- add regression coverage for `as const`/`satisfies` safe rel constants
- add a const template-literal initializer fixture that still reports `dynamicRel`, documenting the limitation

## Validation
- PASS: `npm --prefix web run test -- targetBlankRelLint`
- PASS: `git diff --check origin/main...HEAD`
- FAIL (unrelated baseline): `npm --prefix web run lint` reports existing `no-control-regex` errors in `web/src/lib/bagCode.ts` and existing unused-var warnings outside this PR

## Merge order
Independent of backend/doc PRs. This touches only the frontend anchor-rel lint rule and its unit fixture; the main merge risk is another PR editing the same two anchor-rel files.
