### PR TITLE
AUD-123: Refresh ADR-0021 references

### DIFF
--- a/docs/adr/0021-periodic-jobs-scheduler.md
+++ b/docs/adr/0021-periodic-jobs-scheduler.md
@@ -58,7 +58,7 @@ Jobs using this scheduler:
 ## References
 
 - Source: `backend/app/domain/sourcing/cache.py:73`
-- Source: `backend/app/main.py:136`
+- Source: `backend/app/cli/run_job.py:105-122`
 - Source: `backend/app/core/config.py:34`
 - Related ADR: [ADR-0012](0012-uvicorn-single-worker-slowapi.md)
 - Related ADR: [ADR-0020](0020-trustedparts-sourcing-provider-split.md)


### PR DESCRIPTION
## Summary

- Refresh ADR-0021 References to cite the current periodic job registry in `backend/app/cli/run_job.py:105-122`.
- Remove the stale `backend/app/main.py:136` citation from the References section only.

Refs #814

## Validation

- Manual review of `docs/adr/0021-periodic-jobs-scheduler.md` References section.
- `git diff --check origin/main...HEAD`

## Merge-order note

Coordinate with #807 because both may touch ADR-0021; whichever merges second may need rebase.
