### PR TITLE
[codex] Use settings for purge job intervals

### DIFF
--- a/backend/app/cli/run_job.py
+++ b/backend/app/cli/run_job.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import argparse
 import logging
 import sys
+import time
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from uuid import uuid4
 
+from pydantic import ValidationError
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
@@ -20,6 +22,7 @@ logger = logging.getLogger(__name__)
 SessionFactory = Callable[[], Session]
 JobCallable = Callable[[Session], int]
 HEARTBEAT_DIR = Path("/tmp/stockmanager-job-heartbeats")
+HEARTBEAT_MAX_AGE_SECONDS = 90 * 60
 
 
 @dataclass(frozen=True)
@@ -31,10 +34,15 @@ class JobSpec:
     cadence: str
     idempotency: str
     run: JobCallable
+    interval_setting: str | None = None
 
 
 class UnknownJobError(ValueError):
     """Raised when the requested job name is not registered."""
+
+
+class JobConfigError(ValueError):
+    """Raised when a job's settings-backed configuration is invalid."""
 
 
 def _acquire_job_lock(db: Session, job_name: str) -> bool:
@@ -108,6 +116,7 @@ JOBS: dict[str, JobSpec] = {
         cadence="hourly",
         idempotency="Deletes only session rows whose expires_at is already in the past.",
         run=_run_session_purge,
+        interval_setting="SESSION_PURGE_INTERVAL_SECONDS",
     ),
     "password-reset-purge": JobSpec(
         name="password-reset-purge",
@@ -115,8 +124,68 @@ JOBS: dict[str, JobSpec] = {
         cadence="hourly",
         idempotency="Deletes only password-reset request rows older than 30 days.",
         run=_run_password_reset_purge,
+        interval_setting="PASSWORD_RESET_PURGE_INTERVAL_SECONDS",
     ),
 }
+
+
+def _get_job(job_name: str, jobs: Mapping[str, JobSpec]) -> JobSpec:
+    job = jobs.get(job_name)
+    if job is None:
+        available = ", ".join(sorted(jobs)) or "(none)"
+        raise UnknownJobError(f"unknown job {job_name!r}; available jobs: {available}")
+    return job
+
+
+def _job_interval_seconds(job: JobSpec) -> int | None:
+    if job.interval_setting is None:
+        return None
+
+    from app.core.config import settings
+
+    try:
+        interval = int(getattr(settings(), job.interval_setting))
+    except ValidationError as exc:
+        raise JobConfigError(str(exc)) from exc
+    if interval < 0:
+        raise JobConfigError(f"{job.interval_setting} must be greater than or equal to 0")
+    return interval
+
+
+def job_interval_seconds(
+    job_name: str,
+    *,
+    jobs: Mapping[str, JobSpec] = JOBS,
+) -> int:
+    """Return the settings-backed interval for a scheduled job."""
+    job = _get_job(job_name, jobs)
+    interval = _job_interval_seconds(job)
+    if interval is None:
+        raise JobConfigError(f"job {job.name!r} does not define a settings interval")
+    return interval
+
+
+def heartbeat_is_fresh(
+    job_name: str,
+    *,
+    jobs: Mapping[str, JobSpec] = JOBS,
+    heartbeat_dir: Path = HEARTBEAT_DIR,
+    max_age_seconds: int = HEARTBEAT_MAX_AGE_SECONDS,
+) -> bool:
+    """Return True when a scheduled job is disabled or has a fresh heartbeat."""
+    job = _get_job(job_name, jobs)
+    interval = _job_interval_seconds(job)
+    if interval is None:
+        raise JobConfigError(f"job {job.name!r} does not define a settings interval")
+    if interval == 0:
+        return True
+
+    heartbeat_path = heartbeat_dir / job.name
+    try:
+        heartbeat_mtime = heartbeat_path.stat().st_mtime
+    except FileNotFoundError:
+        return False
+    return time.time() - heartbeat_mtime <= max_age_seconds
 
 
 def run_job(
@@ -127,10 +196,8 @@ def run_job(
     heartbeat_dir: Path = HEARTBEAT_DIR,
 ) -> int:
     """Run one registered job and return the job's affected-row count."""
-    job = jobs.get(job_name)
-    if job is None:
-        available = ", ".join(sorted(jobs)) or "(none)"
-        raise UnknownJobError(f"unknown job {job_name!r}; available jobs: {available}")
+    job = _get_job(job_name, jobs)
+    _job_interval_seconds(job)
 
     db = session_factory()
     try:
@@ -169,6 +236,23 @@ def _write_heartbeat(job_name: str, *, heartbeat_dir: Path = HEARTBEAT_DIR) -> N
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Run an allow-listed backend job.")
     parser.add_argument("job_name", help="Registered job name, e.g. sourcing-cache-sweep")
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--print-interval",
+        action="store_true",
+        help="Print the settings-backed interval for this scheduled job.",
+    )
+    mode.add_argument(
+        "--check-heartbeat",
+        action="store_true",
+        help="Exit successfully when this scheduled job is disabled or healthy.",
+    )
+    parser.add_argument(
+        "--heartbeat-max-age-seconds",
+        type=int,
+        default=HEARTBEAT_MAX_AGE_SECONDS,
+        help="Maximum heartbeat age accepted by --check-heartbeat.",
+    )
     return parser
 
 
@@ -188,8 +272,20 @@ def main(
         return int(exc.code)
 
     try:
+        if args.print_interval:
+            print(job_interval_seconds(args.job_name, jobs=jobs))
+            return 0
+        if args.check_heartbeat:
+            if heartbeat_is_fresh(
+                args.job_name,
+                jobs=jobs,
+                max_age_seconds=args.heartbeat_max_age_seconds,
+            ):
+                return 0
+            print(f"job={args.job_name} status=unhealthy reason=heartbeat", file=sys.stderr)
+            return 1
         run_job(args.job_name, jobs=jobs, session_factory=session_factory)
-    except UnknownJobError as exc:
+    except (UnknownJobError, JobConfigError) as exc:
         print(str(exc), file=sys.stderr)
         return 2
     return 0

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -4,7 +4,7 @@ import urllib.parse
 from functools import lru_cache
 from typing import Annotated
 
-from pydantic import Field, field_validator, model_validator
+from pydantic import Field, ValidationInfo, field_validator, model_validator
 from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
 
@@ -47,7 +47,7 @@ class Settings(BaseSettings):
     # tests can shorten it; ops should not need to touch it. 0 disables
     # the periodic task entirely (the migration's index still exists,
     # so a future cron / one-off SQL still benefits).
-    SESSION_PURGE_INTERVAL_SECONDS: int = 3600
+    SESSION_PURGE_INTERVAL_SECONDS: int = Field(default=3600, ge=0)
     # Cadence (seconds) of the password-reset token purge worker. 0
     # disables the periodic password-reset purge.
     PASSWORD_RESET_PURGE_INTERVAL_SECONDS: int = Field(default=3600, ge=0)
@@ -123,6 +123,17 @@ class Settings(BaseSettings):
     def _blank_sentry_traces_rate_to_none(cls, value):
         if value == "":
             return None
+        return value
+
+    @field_validator(
+        "SESSION_PURGE_INTERVAL_SECONDS",
+        "PASSWORD_RESET_PURGE_INTERVAL_SECONDS",
+        mode="before",
+    )
+    @classmethod
+    def _blank_purge_interval_to_default(cls, value, info: ValidationInfo):
+        if value == "":
+            return cls.model_fields[info.field_name].default
         return value
 
     @field_validator("EXTRA_WEAK_PASSWORDS", mode="before")

--- a/backend/tests/test_ci_workflow.py
+++ b/backend/tests/test_ci_workflow.py
@@ -259,17 +259,29 @@ def test_compose_prod_backend_cron_sessions_disabled_jobs_stay_healthy():
     mkdir = "mkdir -p /tmp/stockmanager-job-heartbeats"
     session_branch = "if [ $$session_interval -gt 0 ]"
     reset_branch = "if [ $$reset_interval -gt 0 ]"
+    session_interval = (
+        "session_interval=$$(python -m app.cli.run_job "
+        "session-purge --print-interval)"
+    )
+    reset_interval = (
+        "reset_interval=$$(python -m app.cli.run_job "
+        "password-reset-purge --print-interval)"
+    )
     assert mkdir in joined_cmd
+    assert session_interval in joined_cmd
+    assert reset_interval in joined_cmd
     assert joined_cmd.index(mkdir) < joined_cmd.index(session_branch)
     assert joined_cmd.index(mkdir) < joined_cmd.index(reset_branch)
+    assert "$${SESSION_PURGE_INTERVAL_SECONDS" not in joined_cmd
+    assert "$${PASSWORD_RESET_PURGE_INTERVAL_SECONDS" not in joined_cmd
 
     healthcheck = cron.get("healthcheck", {})
     healthcheck_test = " ".join(healthcheck.get("test", []))
-    assert "test -d /tmp/stockmanager-job-heartbeats" in healthcheck_test
-    assert "[ $${SESSION_PURGE_INTERVAL_SECONDS:-3600} -le 0 ]" in healthcheck_test
-    assert "[ $${PASSWORD_RESET_PURGE_INTERVAL_SECONDS:-3600} -le 0 ]" in healthcheck_test
-    assert "session-purge -mmin -90" in healthcheck_test
-    assert "password-reset-purge -mmin -90" in healthcheck_test
+    assert "session-purge --check-heartbeat" in healthcheck_test
+    assert "password-reset-purge --check-heartbeat" in healthcheck_test
+    assert "--heartbeat-max-age-seconds 5400" in healthcheck_test
+    assert "$${SESSION_PURGE_INTERVAL_SECONDS" not in healthcheck_test
+    assert "$${PASSWORD_RESET_PURGE_INTERVAL_SECONDS" not in healthcheck_test
 
 
 def test_compose_prod_backend_cron_alerts_command_shape():

--- a/backend/tests/test_run_job.py
+++ b/backend/tests/test_run_job.py
@@ -6,7 +6,7 @@ from datetime import timedelta
 
 from sqlalchemy.orm import Session
 
-from app.cli.run_job import JOBS, JobSpec, UnknownJobError, main, run_job
+from app.cli.run_job import JOBS, JobConfigError, JobSpec, UnknownJobError, main, run_job
 from app.core.advisory_locks import RUN_JOB_LOCK_CLASSID
 from app.core.time import utcnow
 from app.domain.users.models import User, UserSession
@@ -133,6 +133,33 @@ def test_password_reset_purge_registered() -> None:
     assert spec.owner == "backend/auth-security"
     assert spec.cadence == "hourly"
     assert "older than 30 days" in spec.idempotency
+
+
+def test_password_reset_purge_negative_interval_rejected(monkeypatch, tmp_path) -> None:
+    from app.core.config import settings
+
+    settings.cache_clear()
+    monkeypatch.setenv("PASSWORD_RESET_PURGE_INTERVAL_SECONDS", "-1")
+    session = _FakeSession()
+
+    try:
+        run_job(
+            "password-reset-purge",
+            session_factory=lambda: session,  # type: ignore[return-value]
+            heartbeat_dir=tmp_path,
+        )
+    except JobConfigError as exc:
+        assert "PASSWORD_RESET_PURGE_INTERVAL_SECONDS" in str(exc)
+    else:
+        raise AssertionError("negative password-reset purge interval should be rejected")
+    finally:
+        settings.cache_clear()
+
+    assert session.executed == []
+    assert session.committed is False
+    assert session.rolled_back is False
+    assert session.closed is False
+    assert not (tmp_path / "password-reset-purge").exists()
 
 
 def test_session_purge_idempotent(db, tmp_path) -> None:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -245,23 +245,24 @@ services:
         max-file: "5"
     environment:
       <<: *backend-env
-      SESSION_PURGE_INTERVAL_SECONDS: ${SESSION_PURGE_INTERVAL_SECONDS:-3600}
-      PASSWORD_RESET_PURGE_INTERVAL_SECONDS: ${PASSWORD_RESET_PURGE_INTERVAL_SECONDS:-3600}
+      SESSION_PURGE_INTERVAL_SECONDS:
+      PASSWORD_RESET_PURGE_INTERVAL_SECONDS:
     depends_on:
       backend-init:
         condition: service_completed_successfully
       backend:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "test -d /tmp/stockmanager-job-heartbeats && { [ $${SESSION_PURGE_INTERVAL_SECONDS:-3600} -le 0 ] || find /tmp/stockmanager-job-heartbeats -name session-purge -mmin -90 -print -quit | grep -q .; } && { [ $${PASSWORD_RESET_PURGE_INTERVAL_SECONDS:-3600} -le 0 ] || find /tmp/stockmanager-job-heartbeats -name password-reset-purge -mmin -90 -print -quit | grep -q .; }"]
+      test: ["CMD-SHELL", "python -m app.cli.run_job session-purge --check-heartbeat --heartbeat-max-age-seconds 5400 && python -m app.cli.run_job password-reset-purge --check-heartbeat --heartbeat-max-age-seconds 5400"]
       interval: 60s
       timeout: 5s
       retries: 3
       start_period: 11m
     # Runs auth-retention purges through the shared backend CLI.
-    # *_PURGE_INTERVAL_SECONDS defaults to one hour; setting either to 0
-    # disables only that job. Both loops write independent heartbeat files.
-    command: ["sh", "-c", "mkdir -p /tmp/stockmanager-job-heartbeats; session_interval=$${SESSION_PURGE_INTERVAL_SECONDS:-3600}; reset_interval=$${PASSWORD_RESET_PURGE_INTERVAL_SECONDS:-3600}; pids=''; if [ $$session_interval -gt 0 ]; then (while true; do timeout 600 python -m app.cli.run_job session-purge; rc=$$?; if [ $$rc -eq 124 ]; then echo 'session-purge timed out after 600s (exit=124)'; elif [ $$rc -ne 0 ]; then echo \"session-purge failed (exit=$$rc)\"; fi; sleep $$session_interval; done) & pids=\"$$pids $$!\"; fi; if [ $$reset_interval -gt 0 ]; then (while true; do timeout 600 python -m app.cli.run_job password-reset-purge; rc=$$?; if [ $$rc -eq 124 ]; then echo 'password-reset-purge timed out after 600s (exit=124)'; elif [ $$rc -ne 0 ]; then echo \"password-reset-purge failed (exit=$$rc)\"; fi; sleep $$reset_interval; done) & pids=\"$$pids $$!\"; fi; if [ -z \"$$pids\" ]; then echo 'auth retention purges disabled'; sleep infinity; fi; wait"]
+    # Settings owns *_PURGE_INTERVAL_SECONDS defaults and validation; setting
+    # either to 0 disables only that job. Both loops write independent
+    # heartbeat files.
+    command: ["sh", "-c", "mkdir -p /tmp/stockmanager-job-heartbeats; session_interval=$$(python -m app.cli.run_job session-purge --print-interval) || exit $$?; reset_interval=$$(python -m app.cli.run_job password-reset-purge --print-interval) || exit $$?; pids=''; if [ $$session_interval -gt 0 ]; then (while true; do timeout 600 python -m app.cli.run_job session-purge; rc=$$?; if [ $$rc -eq 124 ]; then echo 'session-purge timed out after 600s (exit=124)'; elif [ $$rc -ne 0 ]; then echo \"session-purge failed (exit=$$rc)\"; fi; sleep $$session_interval; done) & pids=\"$$pids $$!\"; fi; if [ $$reset_interval -gt 0 ]; then (while true; do timeout 600 python -m app.cli.run_job password-reset-purge; rc=$$?; if [ $$rc -eq 124 ]; then echo 'password-reset-purge timed out after 600s (exit=124)'; elif [ $$rc -ne 0 ]; then echo \"password-reset-purge failed (exit=$$rc)\"; fi; sleep $$reset_interval; done) & pids=\"$$pids $$!\"; fi; if [ -z \"$$pids\" ]; then echo 'auth retention purges disabled'; sleep infinity; fi; wait"]
     security_opt: ["no-new-privileges:true"]
     cap_drop: ["ALL"]
 


### PR DESCRIPTION
Refs #805

## Summary
- Route auth-retention purge interval reads through `app.cli.run_job` so Settings is the source of truth.
- Keep the existing compose shell loops and `timeout 600`, but fetch intervals via `--print-interval` and health status via `--check-heartbeat`.
- Validate negative purge intervals through Pydantic before scheduled purge jobs touch the database, including the password-reset regression case.

## Validation
- Requested command `python -m pytest backend/tests/test_run_job.py backend/tests/test_config.py -q` was not feasible on this host because `python` is not installed.
- `uv run --project backend --extra dev python -m pytest backend/tests/test_run_job.py backend/tests/test_config.py -q` (16 passed, 1 warning)
- `uv run --project backend --extra dev python -m pytest backend/tests/test_ci_workflow.py::test_compose_prod_backend_cron_sessions_disabled_jobs_stay_healthy -q` (1 passed, 1 warning)
- `uv run --project backend --extra dev ruff check backend/app/cli/run_job.py backend/app/core/config.py backend/tests/test_run_job.py backend/tests/test_ci_workflow.py`
- `PASSWORD_RESET_PURGE_INTERVAL_SECONDS=-1 uv run --project backend --extra dev python -m app.cli.run_job password-reset-purge --print-interval` exits 2 with the Pydantic ge=0 validation error.

## Merge Order / Risks
- This touches `backend/app/cli/run_job.py` and `docker-compose.prod.yml`; merge before #807, #810, and #811 to reduce conflict risk.
