### PR TITLE
AUD-116: Mark auth purge cadence configurable

### DIFF
--- a/backend/app/cli/run_job.py
+++ b/backend/app/cli/run_job.py
@@ -105,14 +105,14 @@ JOBS: dict[str, JobSpec] = {
     "session-purge": JobSpec(
         name="session-purge",
         owner="backend/auth-security",
-        cadence="hourly",
+        cadence="hourly (configurable)",
         idempotency="Deletes only session rows whose expires_at is already in the past.",
         run=_run_session_purge,
     ),
     "password-reset-purge": JobSpec(
         name="password-reset-purge",
         owner="backend/auth-security",
-        cadence="hourly",
+        cadence="hourly (configurable)",
         idempotency="Deletes only password-reset request rows older than 30 days.",
         run=_run_password_reset_purge,
     ),

--- a/backend/tests/test_run_job.py
+++ b/backend/tests/test_run_job.py
@@ -122,7 +122,7 @@ def test_session_purge_registered() -> None:
 
     assert spec.name == "session-purge"
     assert spec.owner == "backend/auth-security"
-    assert spec.cadence == "hourly"
+    assert spec.cadence == "hourly (configurable)"
     assert "expires_at" in spec.idempotency
 
 
@@ -131,7 +131,7 @@ def test_password_reset_purge_registered() -> None:
 
     assert spec.name == "password-reset-purge"
     assert spec.owner == "backend/auth-security"
-    assert spec.cadence == "hourly"
+    assert spec.cadence == "hourly (configurable)"
     assert "older than 30 days" in spec.idempotency
 
 

--- a/docs/adr/0021-periodic-jobs-scheduler.md
+++ b/docs/adr/0021-periodic-jobs-scheduler.md
@@ -30,8 +30,8 @@ Jobs using this scheduler:
 
 - `sourcing-cache-sweep` — hourly TrustedParts cache retention sweep in `backend-cron`.
 - `sourcing-alerts-evaluate` — 15-minute sourcing alert evaluator in `backend-cron-alerts`.
-- `session-purge` — hourly expired session cleanup in `backend-cron-sessions`.
-- `password-reset-purge` — hourly expired password reset request cleanup in `backend-cron-sessions`.
+- `session-purge` — expired session cleanup in `backend-cron-sessions`; hourly by default, configurable via `SESSION_PURGE_INTERVAL_SECONDS`, set to `0` to disable.
+- `password-reset-purge` — expired password reset request cleanup in `backend-cron-sessions`; hourly by default, configurable via `PASSWORD_RESET_PURGE_INTERVAL_SECONDS`, set to `0` to disable.
 
 ## Consequences
 


### PR DESCRIPTION
## Summary

- Mark the auth purge `JobSpec.cadence` values as `hourly (configurable)`.
- Update ADR-0021 to document hourly defaults, `*_PURGE_INTERVAL_SECONDS` configurability, and `0` disable semantics for auth purges.
- Align the existing `run_job` metadata assertions with the new cadence strings.

Refs #807

## Validation

- Manual grep/review of ADR-0021, `backend/app/cli/run_job.py`, `backend/tests/test_run_job.py`, and compose purge interval wiring.
- `uv run --extra dev pytest tests/test_run_job.py -q` (11 passed, 1 warning: existing Alembic `path_separator` deprecation)
- `git diff --check origin/main...HEAD`

## Merge Order / Coordination

- Merge after #805 if #805 selects the implementation path that touches `backend/app/cli/run_job.py`.
- Coordinate with #814 / PR #819 because both touch `docs/adr/0021-periodic-jobs-scheduler.md`.
