### PR TITLE
[codex] Add cron sidecar shutdown grace

### DIFF
--- a/backend/tests/test_ci_workflow.py
+++ b/backend/tests/test_ci_workflow.py
@@ -218,6 +218,22 @@ def test_compose_prod_backend_cron_command_shape():
     assert "uvicorn" not in joined
 
 
+def test_compose_prod_cron_sidecars_have_shutdown_grace_period():
+    """Cron sidecars must outlive their 600s job timeout during shutdown."""
+    assert _COMPOSE_PROD_PATH.exists(), (
+        f"missing compose file at {_COMPOSE_PROD_PATH}"
+    )
+    data = yaml.safe_load(_COMPOSE_PROD_PATH.read_text())
+    services = data["services"]
+
+    for service_name in (
+        "backend-cron",
+        "backend-cron-alerts",
+        "backend-cron-sessions",
+    ):
+        assert services[service_name].get("stop_grace_period") == "605s"
+
+
 def test_compose_prod_has_web_and_cron_healthchecks():
     """docker compose ps must expose health for web and cron sidecars."""
     assert _COMPOSE_PROD_PATH.exists(), (
@@ -244,7 +260,7 @@ def test_compose_prod_has_web_and_cron_healthchecks():
 
 
 def test_compose_prod_backend_cron_sessions_disabled_jobs_stay_healthy():
-    """backend-cron-sessions must create the heartbeat dir before gated loops."""
+    """backend-cron-sessions must set up shutdown and heartbeat guards."""
     assert _COMPOSE_PROD_PATH.exists(), (
         f"missing compose file at {_COMPOSE_PROD_PATH}"
     )
@@ -257,6 +273,8 @@ def test_compose_prod_backend_cron_sessions_disabled_jobs_stay_healthy():
     )
     joined_cmd = " ".join(str(part) for part in cmd)
     mkdir = "mkdir -p /tmp/stockmanager-job-heartbeats"
+    term_trap = "trap 'kill 0' TERM"
+    int_trap = "trap 'kill 0' INT"
     session_branch = "if [ $$session_interval -gt 0 ]"
     reset_branch = "if [ $$reset_interval -gt 0 ]"
     session_interval = (
@@ -267,9 +285,13 @@ def test_compose_prod_backend_cron_sessions_disabled_jobs_stay_healthy():
         "reset_interval=$$(python -m app.cli.run_job "
         "password-reset-purge --print-interval)"
     )
+    assert term_trap in joined_cmd
+    assert int_trap in joined_cmd
     assert mkdir in joined_cmd
     assert session_interval in joined_cmd
     assert reset_interval in joined_cmd
+    assert joined_cmd.index(term_trap) < joined_cmd.index(session_branch)
+    assert joined_cmd.index(int_trap) < joined_cmd.index(reset_branch)
     assert joined_cmd.index(mkdir) < joined_cmd.index(session_branch)
     assert joined_cmd.index(mkdir) < joined_cmd.index(reset_branch)
     assert "$${SESSION_PURGE_INTERVAL_SECONDS" not in joined_cmd

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -174,6 +174,7 @@ services:
     cpus: "0.5"
     pids_limit: 256
     oom_kill_disable: false
+    stop_grace_period: 605s
     logging:
       driver: json-file
       options:
@@ -206,6 +207,7 @@ services:
     cpus: "0.5"
     pids_limit: 256
     oom_kill_disable: false
+    stop_grace_period: 605s
     logging:
       driver: json-file
       options:
@@ -238,6 +240,7 @@ services:
     cpus: "0.5"
     pids_limit: 256
     oom_kill_disable: false
+    stop_grace_period: 605s
     logging:
       driver: json-file
       options:
@@ -262,7 +265,7 @@ services:
     # Settings owns *_PURGE_INTERVAL_SECONDS defaults and validation; setting
     # either to 0 disables only that job. Both loops write independent
     # heartbeat files.
-    command: ["sh", "-c", "mkdir -p /tmp/stockmanager-job-heartbeats; session_interval=$$(python -m app.cli.run_job session-purge --print-interval) || exit $$?; reset_interval=$$(python -m app.cli.run_job password-reset-purge --print-interval) || exit $$?; pids=''; if [ $$session_interval -gt 0 ]; then (while true; do timeout 600 python -m app.cli.run_job session-purge; rc=$$?; if [ $$rc -eq 124 ]; then echo 'session-purge timed out after 600s (exit=124)'; elif [ $$rc -ne 0 ]; then echo \"session-purge failed (exit=$$rc)\"; fi; sleep $$session_interval; done) & pids=\"$$pids $$!\"; fi; if [ $$reset_interval -gt 0 ]; then (while true; do timeout 600 python -m app.cli.run_job password-reset-purge; rc=$$?; if [ $$rc -eq 124 ]; then echo 'password-reset-purge timed out after 600s (exit=124)'; elif [ $$rc -ne 0 ]; then echo \"password-reset-purge failed (exit=$$rc)\"; fi; sleep $$reset_interval; done) & pids=\"$$pids $$!\"; fi; if [ -z \"$$pids\" ]; then echo 'auth retention purges disabled'; sleep infinity; fi; wait"]
+    command: ["sh", "-c", "trap 'kill 0' TERM; trap 'kill 0' INT; mkdir -p /tmp/stockmanager-job-heartbeats; session_interval=$$(python -m app.cli.run_job session-purge --print-interval) || exit $$?; reset_interval=$$(python -m app.cli.run_job password-reset-purge --print-interval) || exit $$?; pids=''; if [ $$session_interval -gt 0 ]; then (while true; do timeout 600 python -m app.cli.run_job session-purge; rc=$$?; if [ $$rc -eq 124 ]; then echo 'session-purge timed out after 600s (exit=124)'; elif [ $$rc -ne 0 ]; then echo \"session-purge failed (exit=$$rc)\"; fi; sleep $$session_interval; done) & pids=\"$$pids $$!\"; fi; if [ $$reset_interval -gt 0 ]; then (while true; do timeout 600 python -m app.cli.run_job password-reset-purge; rc=$$?; if [ $$rc -eq 124 ]; then echo 'password-reset-purge timed out after 600s (exit=124)'; elif [ $$rc -ne 0 ]; then echo \"password-reset-purge failed (exit=$$rc)\"; fi; sleep $$reset_interval; done) & pids=\"$$pids $$!\"; fi; if [ -z \"$$pids\" ]; then echo 'auth retention purges disabled'; sleep infinity; fi; wait"]
     security_opt: ["no-new-privileges:true"]
     cap_drop: ["ALL"]
 


### PR DESCRIPTION
## Summary
- Add `stop_grace_period: 605s` to each production cron sidecar.
- Add TERM/INT traps to `backend-cron-sessions` so its background purge loops receive shutdown signals.
- Add focused compose-shape assertions for the grace period and sessions trap.

Refs #811

## Validation
- `uv run --extra dev python -m pytest tests/test_ci_workflow.py` (18 passed, 1 warning)
- `git diff --check origin/main...HEAD`
- Not run: `docker compose -f docker-compose.prod.yml config -q` because `docker` is not installed in this environment; legacy `docker-compose` is also unavailable.

## Merge Order / Coordination
- Merge after #820; #820 is already merged and present in this branch base.
- Coordinate with any other compose PRs before merging.