### PR TITLE
AUD-127 Restore SourcingAlert updated_by audit mapping

### DIFF
--- a/backend/alembic/versions/0066_sourcing_alerts_updated_by.py
+++ b/backend/alembic/versions/0066_sourcing_alerts_updated_by.py
@@ -1,0 +1,43 @@
+"""Add updated_by audit column to sourcing alerts.
+
+Revision ID: 0066
+Revises: 0065
+Create Date: 2026-05-16
+
+AUD-127 / issue #826.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "0066"
+down_revision = "0065"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "sourcing_alerts",
+        sa.Column("updated_by", sa.UUID(as_uuid=True), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_sourcing_alerts_updated_by_users",
+        "sourcing_alerts",
+        "users",
+        ["updated_by"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "fk_sourcing_alerts_updated_by_users",
+        "sourcing_alerts",
+        type_="foreignkey",
+    )
+    op.drop_column("sourcing_alerts", "updated_by")

--- a/backend/app/domain/sourcing/models.py
+++ b/backend/app/domain/sourcing/models.py
@@ -230,7 +230,11 @@ class PurchasePlanLine(Base):
 
 
 class SourcingAlert(WorkspaceOwned, Base):
-    """Workspace-scoped alert definition evaluated by the sourcing jobs."""
+    """Workspace-scoped alert definition evaluated by the sourcing jobs.
+
+    Alerts retain the ``WorkspaceOwned.updated_by`` audit column so mutation
+    attribution can be read through the ORM.
+    """
 
     __tablename__ = "sourcing_alerts"
     __table_args__ = (
@@ -273,8 +277,6 @@ class SourcingAlert(WorkspaceOwned, Base):
         ),
         Index("ix_sourcing_alerts_last_checked_at", "last_checked_at"),
     )
-
-    updated_by = None
 
     id = Column(
         UUID(as_uuid=True),

--- a/backend/tests/test_sourcing_alerts.py
+++ b/backend/tests/test_sourcing_alerts.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.domain.parts.models import Part
+from app.domain.sourcing.models import SourcingAlert
+from app.domain.users.models import User
+from app.domain.workspaces.models import Workspace, WorkspaceMember
+
+
+def test_updated_by_persists_through_orm(db: Session) -> None:
+    user = User(
+        email=f"sourcing-alert-{uuid.uuid4().hex[:8]}@example.com",
+        name="Sourcing Alert Tester",
+        password_hash="test",
+    )
+    db.add(user)
+    db.flush()
+
+    workspace = Workspace(
+        name=f"sourcing-alerts-{uuid.uuid4().hex[:8]}",
+        kind="organization",
+        owner_user_id=user.id,
+    )
+    db.add(workspace)
+    db.flush()
+    db.add(
+        WorkspaceMember(
+            workspace_id=workspace.id,
+            user_id=user.id,
+            role="owner",
+            status="active",
+        )
+    )
+
+    part = Part(
+        workspace_id=workspace.id,
+        name=f"Part {uuid.uuid4().hex[:8]}",
+        part_type="local",
+        mpn=f"MPN-{uuid.uuid4().hex[:8]}",
+        created_by=user.id,
+        updated_by=user.id,
+    )
+    db.add(part)
+    db.flush()
+
+    alert = SourcingAlert(
+        workspace_id=workspace.id,
+        part_id=part.id,
+        alert_type="stock_below",
+        threshold={"qty": 5},
+        notify_user_ids=[str(user.id)],
+        cooldown_seconds=60,
+        created_by=user.id,
+        updated_by=user.id,
+    )
+    db.add(alert)
+    db.flush()
+
+    alert_id = alert.id
+    db.expunge(alert)
+
+    reloaded = db.execute(select(SourcingAlert).where(SourcingAlert.id == alert_id)).scalar_one()
+
+    assert reloaded.updated_by == user.id


### PR DESCRIPTION
## Summary
- Removes the `SourcingAlert.updated_by = None` shadow so the ORM inherits the `WorkspaceOwned.updated_by` audit column.
- Adds migration `0066` to create the missing `sourcing_alerts.updated_by` FK column for fresh schemas.
- Adds `tests/test_sourcing_alerts.py::test_updated_by_persists_through_orm` to flush and reload an alert with `updated_by`.

## Validation
- `cd backend && python -m pytest -q tests/test_sourcing_alerts.py` could not run directly because `python` is not installed on PATH in this environment.
- `cd backend && uv run --extra dev python -m pytest -q tests/test_sourcing_alerts.py` passed: 1 passed, 1 warning.
- `ruff check backend` failed on pre-existing unrelated lint violations outside this PR.
- `backend/.venv/bin/ruff check backend/app/domain/sourcing/models.py backend/alembic/versions/0066_sourcing_alerts_updated_by.py backend/tests/test_sourcing_alerts.py` passed.

## Merge Order
Independent backend model PR; can merge early after tests green.

Refs #826