### PR TITLE
AUD-126 invalidate report queries after stock mutations

### DIFF
--- a/web/src/lib/queryKeys.test.ts
+++ b/web/src/lib/queryKeys.test.ts
@@ -12,6 +12,7 @@ import {
   archiveStorageKeys,
   lotMutationKeys,
   archiveProjectKeys,
+  stockReportKeys,
 } from "./queryKeys";
 
 const WS = "ws-abc";
@@ -132,6 +133,16 @@ describe("lotMutationKeys", () => {
     const keys = lotMutationKeys(WS, lot, [STORAGE_ID, S2]);
     expect(keys.some(k => (k as unknown[]).includes(STORAGE_ID))).toBe(true);
     expect(keys.some(k => (k as unknown[]).includes(S2))).toBe(true);
+  });
+});
+
+describe("stockReportKeys", () => {
+  it("returns the stock-rollup report keys for a workspace", () => {
+    expect(stockReportKeys(WS)).toEqual([
+      ["ws", WS, "report", "low-stock"],
+      ["ws", WS, "report", "stock-value"],
+      ["ws", WS, "report", "expiring"],
+    ]);
   });
 });
 

--- a/web/src/lib/queryKeys.ts
+++ b/web/src/lib/queryKeys.ts
@@ -104,6 +104,17 @@ export function archiveStorageKeys(
   ];
 }
 
+/** Report keys backed by current stock totals. */
+export function stockReportKeys(
+  workspaceId: string | null | undefined,
+): unknown[][] {
+  return [
+    wsKeyOf(workspaceId, "report", "low-stock"),
+    wsKeyOf(workspaceId, "report", "stock-value"),
+    wsKeyOf(workspaceId, "report", "expiring"),
+  ];
+}
+
 /**
  * Keys to invalidate after a lot move or adjust-count.
  *
@@ -132,9 +143,7 @@ export function lotMutationKeys(
     // every sub-key (`:stock`, `:lots`, `:history`, `:custom-fields`, …)
     // off it, so don't enumerate them separately.
     wsKeyOf(workspaceId, "part", lot.part_id),
-    wsKeyOf(workspaceId, "report", "low-stock"),
-    wsKeyOf(workspaceId, "report", "stock-value"),
-    wsKeyOf(workspaceId, "report", "expiring"),
+    ...stockReportKeys(workspaceId),
   ];
   for (const sid of storageIds) {
     keys.push(wsKeyOf(workspaceId, "storage", sid));

--- a/web/src/routes/builds/BuildDetail.test.tsx
+++ b/web/src/routes/builds/BuildDetail.test.tsx
@@ -200,6 +200,62 @@ describe("BuildDetail archive mutation", () => {
 });
 
 describe("BuildDetail consumption plan", () => {
+  it("invalidates report queries on consume", async () => {
+    vi.mocked(api.get).mockImplementation((path: string) => {
+      if (path === "/builds/build-1") {
+        return Promise.resolve({
+          build: buildDetail.build,
+          shortage: [{
+            project_entry_id: "entry-1",
+            part_id: "part-1",
+            part_name: "Part 1",
+            required: 2,
+            available: 2,
+            substitute_ids: [],
+            substitute_available: 0,
+            short_by: 0,
+          }],
+        });
+      }
+      if (path === "/projects/project-1") return Promise.resolve({ id: "project-1", name: "Project 1" });
+      if (path === "/projects/project-1/entries") {
+        return Promise.resolve([{
+          id: "entry-1",
+          project_id: "project-1",
+          entry_type: "part",
+          part_id: "part-1",
+          meta_part_id: null,
+          name: null,
+          quantity: 2,
+          comments: null,
+          designators: [],
+          cad_footprint: null,
+          cad_key: null,
+          dnp: false,
+          order_index: 0,
+        }]);
+      }
+      if (path === "/parts?limit=200") return Promise.resolve([{ id: "part-1", name: "Part 1" }]);
+      if (path === "/storage") return Promise.resolve([]);
+      return Promise.resolve(null);
+    });
+    vi.mocked(api.post).mockResolvedValue(null);
+
+    const { client } = renderBuildDetail();
+    const invalidateSpy = vi.spyOn(client, "invalidateQueries");
+
+    fireEvent.click(await screen.findByRole("button", { name: "Auto-fill" }));
+    fireEvent.click(screen.getByRole("button", { name: "Consume & complete build" }));
+
+    await waitFor(() => {
+      expect(api.post).toHaveBeenCalledWith("/builds/build-1/consume", expect.any(Object));
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["ws", "ws-1", "report", "low-stock"] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["ws", "ws-1", "report", "stock-value"] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["ws", "ws-1", "report", "expiring"] });
+  });
+
   it("submits output lot and storage fields", async () => {
     vi.mocked(api.get).mockImplementation((path: string) => {
       if (path === "/builds/build-1") {

--- a/web/src/routes/builds/BuildDetail.tsx
+++ b/web/src/routes/builds/BuildDetail.tsx
@@ -4,7 +4,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { api, ApiError } from "@/lib/api";
 import { useApiMutation } from "@/lib/mutations";
-import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
+import { stockReportKeys, useWsKey, wsKeyOf } from "@/lib/queryKeys";
 import { useAuth } from "@/lib/auth";
 import { formatDateTime } from "@/lib/format";
 import EntityHeader from "@/components/EntityHeader";
@@ -82,6 +82,9 @@ function BuildDetailBody({ buildId, detail }: { buildId: string; detail: DetailO
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "build", buildId) });
       qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "parts") });
+      for (const queryKey of stockReportKeys(workspaceId)) {
+        qc.invalidateQueries({ queryKey });
+      }
       toast.success("Build complete — stock decremented.");
     },
     onError: (e) => {

--- a/web/src/routes/orders/OrderDetail.tsx
+++ b/web/src/routes/orders/OrderDetail.tsx
@@ -4,7 +4,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { api, ApiError } from "@/lib/api";
 import { useApiMutation } from "@/lib/mutations";
-import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
+import { stockReportKeys, useWsKey, wsKeyOf } from "@/lib/queryKeys";
 import { useAuth } from "@/lib/auth";
 import EntityHeader from "@/components/EntityHeader";
 import { DataTable } from "@/components/DataTable";
@@ -108,6 +108,9 @@ export default function OrderDetail() {
       setReceiveLines({});
       qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "order", orderId) });
       qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "parts") });
+      for (const queryKey of stockReportKeys(workspaceId)) {
+        qc.invalidateQueries({ queryKey });
+      }
       toast.success(`Received ${totalQty} unit${totalQty === 1 ? "" : "s"}.`);
     },
     onError: (e) => {

--- a/web/src/routes/parts/detail/PartAddStock.tsx
+++ b/web/src/routes/parts/detail/PartAddStock.tsx
@@ -4,7 +4,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { z } from "zod";
 import { api, ApiError } from "@/lib/api";
 import { useApiMutation } from "@/lib/mutations";
-import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
+import { stockReportKeys, useWsKey, wsKeyOf } from "@/lib/queryKeys";
 import { useAuth } from "@/lib/auth";
 import { InlineQueryError } from "@/components/QueryStateBoundary";
 import type { StorageLocation } from "@/types";
@@ -60,6 +60,9 @@ export default function PartAddStock() {
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "part", partId) });
       qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "parts") });
+      for (const queryKey of stockReportKeys(workspaceId)) {
+        qc.invalidateQueries({ queryKey });
+      }
       nav(`/parts/${partId}/stock`);
     },
     onError: (e) => {

--- a/web/src/routes/parts/detail/PartMoveStock.tsx
+++ b/web/src/routes/parts/detail/PartMoveStock.tsx
@@ -3,7 +3,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { api, ApiError } from "@/lib/api";
 import { useApiMutation } from "@/lib/mutations";
-import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
+import { stockReportKeys, useWsKey, wsKeyOf } from "@/lib/queryKeys";
 import { useAuth } from "@/lib/auth";
 import { InlineQueryError } from "@/components/QueryStateBoundary";
 import type { StorageLocation } from "@/types";
@@ -93,6 +93,9 @@ export default function PartMoveStock() {
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "part", partId) });
       qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "part", partId, "stock") });
+      for (const queryKey of stockReportKeys(workspaceId)) {
+        qc.invalidateQueries({ queryKey });
+      }
       nav(`/parts/${partId}/stock`);
     },
     onError: (e) => {

--- a/web/src/routes/parts/detail/PartRemoveStock.tsx
+++ b/web/src/routes/parts/detail/PartRemoveStock.tsx
@@ -3,7 +3,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { api, ApiError } from "@/lib/api";
 import { useApiMutation } from "@/lib/mutations";
-import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
+import { stockReportKeys, useWsKey, wsKeyOf } from "@/lib/queryKeys";
 import { useAuth } from "@/lib/auth";
 import { InlineQueryError } from "@/components/QueryStateBoundary";
 import type { StorageLocation } from "@/types";
@@ -98,6 +98,9 @@ export default function PartRemoveStock() {
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "part", partId) });
       qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "part", partId, "stock") });
+      for (const queryKey of stockReportKeys(workspaceId)) {
+        qc.invalidateQueries({ queryKey });
+      }
       nav(`/parts/${partId}/stock`);
     },
     onError: (e) => {


### PR DESCRIPTION
Refs #825

## Summary
- Add a canonical stock report query-key helper for low-stock, stock-value, and expiring reports.
- Invalidate those report keys after build consume, order receive, and part stock add/remove/move mutations.
- Add a BuildDetail regression test that asserts consume invalidates all three report keys.

## Validation
- `cd web && npm test -- BuildDetail` - passed (6 tests)
- `cd web && npm test -- queryKeys` - passed (26 tests)
- `cd web && npm run build` - passed; Vite emitted existing warnings for missing Umami env placeholders and >500 kB chunks

## Changed files
- `web/src/lib/queryKeys.ts`
- `web/src/lib/queryKeys.test.ts`
- `web/src/routes/builds/BuildDetail.tsx`
- `web/src/routes/builds/BuildDetail.test.tsx`
- `web/src/routes/orders/OrderDetail.tsx`
- `web/src/routes/parts/detail/PartAddStock.tsx`
- `web/src/routes/parts/detail/PartMoveStock.tsx`
- `web/src/routes/parts/detail/PartRemoveStock.tsx`

## Merge order
Independent frontend PR; if it conflicts with #828/#829, merge this first because it is P1 and narrow.