### PR TITLE
AUD-128 Reduce backend-cron-sessions healthcheck cost

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -459,7 +459,54 @@ jobs:
       # Build the backend prod image. Catches broken COPY paths, missing
       # apt packages, pip install failures.
       - name: Build backend prod image
-        run: docker buildx build --load -f backend/Dockerfile backend/
+        run: |
+          docker buildx build --load \
+            -t stockmanager-backend-prod-validate:ci \
+            -f backend/Dockerfile backend/
+
+      # AUD-128 / issue #827: keep the backend-cron-sessions healthcheck
+      # comfortably below its configured timeout. The probe runs inside an
+      # already-started backend image so the timing measures cold Python import
+      # and CLI work without adding container startup overhead.
+      - name: Time backend-cron-sessions healthcheck probe
+        run: |
+          timeout_ms=$(python3 - <<'PY'
+          import re
+          import yaml
+
+          cfg = yaml.safe_load(open("docker-compose.prod.yml"))
+          timeout = cfg["services"]["backend-cron-sessions"]["healthcheck"]["timeout"]
+          match = re.fullmatch(r"(\d+)s", str(timeout))
+          if not match:
+              raise SystemExit(f"unsupported backend-cron-sessions timeout: {timeout!r}")
+          print(int(match.group(1)) * 1000)
+          PY
+          )
+          threshold_ms=$((timeout_ms / 2))
+          container=$(
+            docker run -d \
+              --env-file .env.prod.ci \
+              -e SESSION_PURGE_INTERVAL_SECONDS=0 \
+              -e PASSWORD_RESET_PURGE_INTERVAL_SECONDS=0 \
+              stockmanager-backend-prod-validate:ci \
+              sleep 60
+          )
+          trap 'docker rm -f "$container" >/dev/null 2>&1 || true' EXIT
+          start_ns=$(date +%s%N)
+          docker exec "$container" \
+            python -m app.cli.run_job --check-all-heartbeats session-purge password-reset-purge --heartbeat-max-age-seconds 5400
+          end_ns=$(date +%s%N)
+          elapsed_ms=$(((end_ns - start_ns) / 1000000))
+          echo "backend-cron-sessions probe elapsed ${elapsed_ms}ms; threshold ${threshold_ms}ms"
+          python3 - <<PY
+          elapsed_ms = int("${elapsed_ms}")
+          threshold_ms = int("${threshold_ms}")
+          if elapsed_ms > threshold_ms:
+              raise SystemExit(
+                  f"backend-cron-sessions healthcheck probe took {elapsed_ms}ms, "
+                  f"exceeding timeout/2 budget {threshold_ms}ms"
+              )
+          PY
 
       # Build the web prod image (context = repo root, matching compose).
       # Catches Dockerfile syntax errors, broken npm build, nginx config

--- a/backend/app/cli/run_job.py
+++ b/backend/app/cli/run_job.py
@@ -181,6 +181,25 @@ def heartbeat_is_fresh(
     return time.time() - heartbeat_mtime <= max_age_seconds
 
 
+def all_heartbeats_are_fresh(
+    job_names: list[str],
+    *,
+    jobs: Mapping[str, JobSpec] = JOBS,
+    heartbeat_dir: Path = HEARTBEAT_DIR,
+    max_age_seconds: int = HEARTBEAT_MAX_AGE_SECONDS,
+) -> bool:
+    """Return True when every scheduled job is disabled or has a fresh heartbeat."""
+    return all(
+        heartbeat_is_fresh(
+            job_name,
+            jobs=jobs,
+            heartbeat_dir=heartbeat_dir,
+            max_age_seconds=max_age_seconds,
+        )
+        for job_name in job_names
+    )
+
+
 def run_job(
     job_name: str,
     *,
@@ -229,7 +248,11 @@ def _write_heartbeat(job_name: str, *, heartbeat_dir: Path = HEARTBEAT_DIR) -> N
 
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Run an allow-listed backend job.")
-    parser.add_argument("job_name", help="Registered job name, e.g. sourcing-cache-sweep")
+    parser.add_argument(
+        "job_name",
+        nargs="?",
+        help="Registered job name, e.g. sourcing-cache-sweep",
+    )
     mode = parser.add_mutually_exclusive_group()
     mode.add_argument(
         "--print-interval",
@@ -241,11 +264,20 @@ def _parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Exit successfully when this scheduled job is disabled or healthy.",
     )
+    mode.add_argument(
+        "--check-all-heartbeats",
+        nargs="+",
+        metavar="JOB_NAME",
+        help=(
+            "Exit successfully when every listed scheduled job is disabled or "
+            "healthy. Loads backend settings once for the full probe."
+        ),
+    )
     parser.add_argument(
         "--heartbeat-max-age-seconds",
         type=int,
         default=None,
-        help="Maximum heartbeat age accepted by --check-heartbeat.",
+        help="Maximum heartbeat age accepted by heartbeat checks.",
     )
     return parser
 
@@ -253,8 +285,13 @@ def _parser() -> argparse.ArgumentParser:
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = _parser()
     args = parser.parse_args(argv)
-    if args.heartbeat_max_age_seconds is not None and not args.check_heartbeat:
-        parser.error("--heartbeat-max-age-seconds requires --check-heartbeat")
+    if args.heartbeat_max_age_seconds is not None and not (
+        args.check_heartbeat or args.check_all_heartbeats
+    ):
+        parser.error(
+            "--heartbeat-max-age-seconds requires --check-heartbeat "
+            "or --check-all-heartbeats"
+        )
     if args.heartbeat_max_age_seconds is None:
         args.heartbeat_max_age_seconds = HEARTBEAT_MAX_AGE_SECONDS
     return args
@@ -265,6 +302,7 @@ def main(
     *,
     jobs: Mapping[str, JobSpec] = JOBS,
     session_factory: SessionFactory = _default_session_factory,
+    heartbeat_dir: Path = HEARTBEAT_DIR,
 ) -> int:
     logging.basicConfig(
         level=logging.INFO,
@@ -276,6 +314,24 @@ def main(
         return int(exc.code)
 
     try:
+        if args.check_all_heartbeats:
+            if all_heartbeats_are_fresh(
+                args.check_all_heartbeats,
+                jobs=jobs,
+                heartbeat_dir=heartbeat_dir,
+                max_age_seconds=args.heartbeat_max_age_seconds,
+            ):
+                return 0
+            print(
+                "jobs="
+                f"{','.join(args.check_all_heartbeats)} "
+                "status=unhealthy reason=heartbeat",
+                file=sys.stderr,
+            )
+            return 1
+        if args.job_name is None:
+            print("job_name is required unless --check-all-heartbeats is used", file=sys.stderr)
+            return 2
         if args.print_interval:
             print(job_interval_seconds(args.job_name, jobs=jobs))
             return 0
@@ -283,12 +339,18 @@ def main(
             if heartbeat_is_fresh(
                 args.job_name,
                 jobs=jobs,
+                heartbeat_dir=heartbeat_dir,
                 max_age_seconds=args.heartbeat_max_age_seconds,
             ):
                 return 0
             print(f"job={args.job_name} status=unhealthy reason=heartbeat", file=sys.stderr)
             return 1
-        run_job(args.job_name, jobs=jobs, session_factory=session_factory)
+        run_job(
+            args.job_name,
+            jobs=jobs,
+            session_factory=session_factory,
+            heartbeat_dir=heartbeat_dir,
+        )
     except (UnknownJobError, JobConfigError) as exc:
         print(str(exc), file=sys.stderr)
         return 2

--- a/backend/tests/test_ci_workflow.py
+++ b/backend/tests/test_ci_workflow.py
@@ -299,11 +299,32 @@ def test_compose_prod_backend_cron_sessions_disabled_jobs_stay_healthy():
 
     healthcheck = cron.get("healthcheck", {})
     healthcheck_test = " ".join(healthcheck.get("test", []))
-    assert "session-purge --check-heartbeat" in healthcheck_test
-    assert "password-reset-purge --check-heartbeat" in healthcheck_test
+    assert "--check-all-heartbeats session-purge password-reset-purge" in healthcheck_test
+    assert healthcheck_test.count("python -m app.cli.run_job") == 1
     assert "--heartbeat-max-age-seconds 5400" in healthcheck_test
     assert "$${SESSION_PURGE_INTERVAL_SECONDS" not in healthcheck_test
     assert "$${PASSWORD_RESET_PURGE_INTERVAL_SECONDS" not in healthcheck_test
+
+
+def test_prod_validate_times_backend_cron_sessions_probe():
+    data = _load()
+    prod_validate = data["jobs"]["prod-validate"]
+    timing_step = next(
+        (
+            step
+            for step in prod_validate["steps"]
+            if step.get("name") == "Time backend-cron-sessions healthcheck probe"
+        ),
+        None,
+    )
+
+    assert timing_step is not None, (
+        "prod-validate must time the backend-cron-sessions healthcheck probe"
+    )
+    run = timing_step.get("run", "")
+    assert "docker exec" in run
+    assert "--check-all-heartbeats session-purge password-reset-purge" in run
+    assert "timeout_ms / 2" in run
 
 
 def test_compose_prod_backend_cron_alerts_command_shape():

--- a/backend/tests/test_run_job.py
+++ b/backend/tests/test_run_job.py
@@ -10,9 +10,9 @@ from sqlalchemy.orm import Session
 
 from app.cli.run_job import (
     JOBS,
-    JobConfigError,
     JobSpec,
     UnknownJobError,
+    all_heartbeats_are_fresh,
     heartbeat_is_fresh,
     job_interval_seconds,
     main,
@@ -393,3 +393,94 @@ def test_healthcheck_detects_missing_or_stale_heartbeat(monkeypatch, tmp_path) -
         )
     finally:
         settings.cache_clear()
+
+
+def test_all_heartbeats_check_loads_settings_once_for_multiple_jobs(
+    monkeypatch, tmp_path
+) -> None:
+    from app.core.config import settings
+
+    settings.cache_clear()
+    monkeypatch.setenv("SESSION_PURGE_INTERVAL_SECONDS", "3600")
+    monkeypatch.setenv("PASSWORD_RESET_PURGE_INTERVAL_SECONDS", "3600")
+    jobs = {
+        "session": JobSpec(
+            name="session",
+            owner="tests",
+            cadence="manual",
+            idempotency="test-only",
+            run=lambda db: 0,
+            interval_setting="SESSION_PURGE_INTERVAL_SECONDS",
+        ),
+        "reset": JobSpec(
+            name="reset",
+            owner="tests",
+            cadence="manual",
+            idempotency="test-only",
+            run=lambda db: 0,
+            interval_setting="PASSWORD_RESET_PURGE_INTERVAL_SECONDS",
+        ),
+    }
+
+    try:
+        for job_name in ("session", "reset"):
+            (tmp_path / job_name).write_text("ok\n", encoding="utf-8")
+
+        assert all_heartbeats_are_fresh(
+            ["session", "reset"],
+            jobs=jobs,
+            heartbeat_dir=tmp_path,
+            max_age_seconds=60,
+        )
+
+        stale_mtime = time.time() - 120
+        os.utime(tmp_path / "reset", (stale_mtime, stale_mtime))
+
+        assert (
+            all_heartbeats_are_fresh(
+                ["session", "reset"],
+                jobs=jobs,
+                heartbeat_dir=tmp_path,
+                max_age_seconds=60,
+            )
+            is False
+        )
+    finally:
+        settings.cache_clear()
+
+
+def test_main_check_all_heartbeats_reports_combined_failure(
+    monkeypatch, tmp_path, capsys
+) -> None:
+    from app.core.config import settings
+
+    settings.cache_clear()
+    monkeypatch.setenv("SESSION_PURGE_INTERVAL_SECONDS", "3600")
+    jobs = {
+        "example": JobSpec(
+            name="example",
+            owner="tests",
+            cadence="manual",
+            idempotency="test-only",
+            run=lambda db: 0,
+            interval_setting="SESSION_PURGE_INTERVAL_SECONDS",
+        )
+    }
+
+    try:
+        exit_code = main(
+            [
+                "--check-all-heartbeats",
+                "example",
+                "--heartbeat-max-age-seconds",
+                "60",
+            ],
+            jobs=jobs,
+            session_factory=lambda: _FakeSession(),  # type: ignore[return-value]
+            heartbeat_dir=tmp_path,
+        )
+    finally:
+        settings.cache_clear()
+
+    assert exit_code == 1
+    assert "jobs=example status=unhealthy reason=heartbeat" in capsys.readouterr().err

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -256,7 +256,7 @@ services:
       backend:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "python -m app.cli.run_job session-purge --check-heartbeat --heartbeat-max-age-seconds 5400 && python -m app.cli.run_job password-reset-purge --check-heartbeat --heartbeat-max-age-seconds 5400"]
+      test: ["CMD-SHELL", "python -m app.cli.run_job --check-all-heartbeats session-purge password-reset-purge --heartbeat-max-age-seconds 5400"]
       interval: 60s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
## Summary
- Add a combined `--check-all-heartbeats` mode to `app.cli.run_job` so `backend-cron-sessions` healthchecks load backend settings once for both auth-retention jobs.
- Switch the prod compose healthcheck to the combined CLI probe while keeping the existing scheduler sidecar path.
- Add regression coverage for the combined CLI, compose healthcheck shape, and a prod-validate timing guard for the probe.

Refs #827

## Validation
- `PYTHONPATH=/mnt/data/WORK/stockManager-1/.codex-worktrees/aud-128-827/backend/.venv/lib/python3.12/site-packages uv run pytest -q tests/test_run_job.py tests/test_ci_workflow.py --tb=short` -> 35 passed, 1 warning
- `uv run ruff check app/cli/run_job.py tests/test_run_job.py tests/test_ci_workflow.py` -> passed
- `python3` YAML parse checks for `.github/workflows/ci.yml` and `docker-compose.prod.yml` -> passed
- `SESSION_PURGE_INTERVAL_SECONDS=0 PASSWORD_RESET_PURGE_INTERVAL_SECONDS=0 uv run python -m app.cli.run_job --check-all-heartbeats session-purge password-reset-purge --heartbeat-max-age-seconds 5400` -> passed
- `docker compose -f docker-compose.prod.yml config` -> not run locally; `docker` is not installed in this environment

## Merge order
Merge after #824, #838, and #839 if those PRs touch `backend/app/cli/run_job.py` or `backend/tests/test_run_job.py`; rebase before merge.
