### PR TITLE
AUD-135 constrain modal height on mobile

### DIFF
--- a/web/e2e/modal-mobile.spec.ts
+++ b/web/e2e/modal-mobile.spec.ts
@@ -1,0 +1,97 @@
+import { randomUUID } from "node:crypto";
+import type { APIRequestContext } from "@playwright/test";
+
+import {
+  expect,
+  mockSourcingProviders,
+  seedBomLine,
+  seedPart,
+  seedProject,
+  test,
+} from "./fixtures";
+
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:5173";
+
+function uniqueName(prefix: string): string {
+  return `${prefix} ${randomUUID().slice(0, 8)}`;
+}
+
+function sameOriginHeaders() {
+  return {
+    origin: BASE_URL,
+    referer: `${BASE_URL}/`,
+  };
+}
+
+async function configureSourcingWorkspace(request: APIRequestContext): Promise<void> {
+  const response = await request.patch("/api/workspaces/current", {
+    data: {
+      sourcing_provider: "trustedparts",
+      sourcing_company_id: "e2e-company",
+      sourcing_api_key: "e2e-api-key",
+      sourcing_country_code: "CZ",
+      sourcing_currency_code: "EUR",
+      sourcing_preferred_distributors: ["DigiKey", "Mouser"],
+      active_countries: ["CZ", "US"],
+      active_currencies: ["EUR", "USD"],
+      active_distributors: ["DigiKey", "Mouser"],
+      sourcing_use_cached_for_dashboards: false,
+    },
+    headers: sameOriginHeaders(),
+  });
+  expect(response.ok()).toBe(true);
+}
+
+test(
+  "reusable modal stays scrollable in a mobile viewport",
+  { tag: ["@core"] },
+  async ({ authedPage }) => {
+    const { page, request } = authedPage;
+    await page.setViewportSize({ width: 375, height: 667 });
+    await mockSourcingProviders(page);
+    await configureSourcingWorkspace(request);
+
+    const project = await seedProject(request, {
+      name: uniqueName("E2E Mobile Modal Project"),
+      description: "Mobile modal smoke",
+    });
+    const part = await seedPart(request, {
+      name: uniqueName("E2E Mobile Modal Part"),
+      manufacturer: "E2E TestCo",
+      mpn: "E2E-MOBILE-MODAL",
+    });
+    await seedBomLine(request, project.id, {
+      part_id: part.id,
+      name: part.name,
+      quantity: 10,
+      designators: ["U1"],
+    });
+
+    await page.goto(`/projects/${project.id}/sourcing`);
+    await expect(page.getByRole("heading", { name: "Source BOM" })).toBeVisible();
+    await page.getByRole("button", { name: /^Source$/ }).click();
+    await expect(page.getByRole("heading", { name: "Coverage matrix" })).toBeVisible();
+
+    await page.getByRole("button", { name: "Generate purchase plan" }).click();
+    const dialog = page.getByRole("dialog", { name: "Generate purchase plan" });
+    await expect(dialog).toBeVisible();
+
+    const panel = dialog.locator(":scope > div").first();
+    const metrics = await panel.evaluate((element) => {
+      const style = window.getComputedStyle(element);
+      const rect = element.getBoundingClientRect();
+      return {
+        height: rect.height,
+        maxHeight: Number.parseFloat(style.maxHeight),
+        overflowY: style.overflowY,
+        viewportHeight: window.innerHeight,
+      };
+    });
+
+    expect(metrics.overflowY).toBe("auto");
+    expect(metrics.maxHeight).toBeCloseTo(metrics.viewportHeight * 0.9, 0);
+    expect(metrics.height).toBeLessThanOrEqual(metrics.viewportHeight * 0.9 + 1);
+    await expect(dialog.getByRole("button", { name: "Cancel" })).toBeVisible();
+    await expect(dialog.getByRole("button", { name: /^Generate$/ })).toBeVisible();
+  },
+);

--- a/web/src/components/Modal.tsx
+++ b/web/src/components/Modal.tsx
@@ -113,7 +113,9 @@ export function Modal({
     if (event.target === event.currentTarget) onClose();
   }
 
-  const panelClassName = className ?? `card w-full ${SIZE_CLASSES[size]}`;
+  const panelClassName = `max-h-[90vh] overflow-y-auto ${
+    className ?? `card w-full ${SIZE_CLASSES[size]}`
+  }`;
 
   return (
     <div

--- a/web/src/components/__tests__/Modal.test.tsx
+++ b/web/src/components/__tests__/Modal.test.tsx
@@ -102,4 +102,22 @@ describe("Modal", () => {
     expect(titleId).toBeTruthy();
     expect(titleId ? document.getElementById(titleId)?.textContent : null).toBe("Demo modal");
   });
+
+  it("constrains tall dialog content to the viewport", () => {
+    render(
+      <Modal open onClose={vi.fn()} title="Tall modal" className="card w-full max-w-lg">
+        <div style={{ height: "120vh" }}>
+          <button type="button">Close</button>
+        </div>
+      </Modal>,
+    );
+
+    const dialog = screen.getByRole("dialog", { name: "Tall modal" });
+    const panel = dialog.firstElementChild?.nextElementSibling;
+
+    expect(panel?.classList.contains("max-h-[90vh]")).toBe(true);
+    expect(panel?.classList.contains("overflow-y-auto")).toBe(true);
+    expect(panel?.classList.contains("card")).toBe(true);
+    expect(panel?.classList.contains("max-w-lg")).toBe(true);
+  });
 });


### PR DESCRIPTION
Refs #833

## Summary
- Add a viewport max-height and internal vertical scrolling to the shared Modal panel, including caller-provided panel classes.
- Cover the shared Modal class composition with a focused component test.
- Add a mobile Playwright smoke that opens the purchase-plan Modal at 375x667 and asserts the panel remains within 90vh with action buttons reachable.

## Validation
- `cd web && npm test -- src/components/__tests__/Modal.test.tsx` - passed (6 tests)
- `cd web && npm run build` - passed; existing Vite warnings for missing Umami placeholders and large chunks
- `cd web && npx playwright test modal-mobile` - not run locally; no dev server/API stack was available on localhost:5173

## Merge order
Independent frontend PR; can merge after green. If it conflicts with broader DataTable/package work from #829, merge this first because it is narrow.