### PR TITLE
AUD-129: Export zod schemas for create receive stock forms

### DIFF
--- a/web/src/lib/__tests__/schemas.test.ts
+++ b/web/src/lib/__tests__/schemas.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+import {
+  OrderReceiveSchema,
+  PartAddStockSchema,
+  PartCreateSchema,
+} from "../schemas";
+
+const partId = "11111111-1111-1111-1111-111111111111";
+const orderEntryId = "22222222-2222-2222-2222-222222222222";
+const storageLocationId = "33333333-3333-3333-3333-333333333333";
+
+describe("PartCreateSchema", () => {
+  it("accepts a fixture matching backend PartIn", () => {
+    expect(PartCreateSchema.parse({
+      part_type: "linked",
+      name: "10k resistor",
+      manufacturer: "Yageo",
+      mpn: "RC0402FR-0710KL",
+      internal_part_number: "R-0402-10K",
+      description: "Thick film resistor",
+      notes_markdown: "Preferred part",
+      footprint: "0402",
+      low_stock_report_quantity: 25,
+      attrition_percentage: 2.5,
+      attrition_min_quantity: 3,
+      default_storage_location_id: storageLocationId,
+      default_storage_mandatory: true,
+      serialized: false,
+    })).toMatchInlineSnapshot(`
+      {
+        "attrition_min_quantity": 3,
+        "attrition_percentage": 2.5,
+        "default_storage_location_id": "33333333-3333-3333-3333-333333333333",
+        "default_storage_mandatory": true,
+        "description": "Thick film resistor",
+        "footprint": "0402",
+        "internal_part_number": "R-0402-10K",
+        "low_stock_report_quantity": 25,
+        "manufacturer": "Yageo",
+        "mpn": "RC0402FR-0710KL",
+        "name": "10k resistor",
+        "notes_markdown": "Preferred part",
+        "part_type": "linked",
+        "serialized": false,
+      }
+    `);
+  });
+
+  it("rejects a bad payload", () => {
+    expect(() => PartCreateSchema.parse({
+      part_type: "component",
+      name: "x".repeat(301),
+      extra_field: true,
+    })).toThrow();
+  });
+});
+
+describe("OrderReceiveSchema", () => {
+  it("accepts a fixture matching backend ReceiveIn", () => {
+    expect(OrderReceiveSchema.parse({
+      received_on: "2026-05-16",
+      lines: [{
+        order_entry_id: orderEntryId,
+        quantity: 4,
+        storage_location_id: storageLocationId,
+        lot_name: "PO-100#1",
+        serial_number: null,
+      }],
+    })).toMatchInlineSnapshot(`
+      {
+        "lines": [
+          {
+            "lot_name": "PO-100#1",
+            "order_entry_id": "22222222-2222-2222-2222-222222222222",
+            "quantity": 4,
+            "serial_number": null,
+            "storage_location_id": "33333333-3333-3333-3333-333333333333",
+          },
+        ],
+        "received_on": "2026-05-16",
+      }
+    `);
+  });
+
+  it("rejects a bad payload", () => {
+    expect(() => OrderReceiveSchema.parse({
+      received_on: "2026-05-16",
+      lines: [{
+        order_entry_id: orderEntryId,
+        quantity: 0,
+      }],
+    })).toThrow();
+  });
+});
+
+describe("PartAddStockSchema", () => {
+  it("accepts a fixture matching backend AddStockIn", () => {
+    expect(PartAddStockSchema.parse({
+      part_id: partId,
+      quantity: 12,
+      storage_location_id: storageLocationId,
+      price: {
+        mode: "per_component",
+        unit_price: 0.125,
+        total_price: null,
+        currency: "USD",
+      },
+      lot: {
+        name: "LOT-2026-001",
+        comments: "supplier bag",
+        expiration_date: "2027-01-31",
+        serial_number: null,
+      },
+      comments: "manual receive",
+      bag_signature: "a".repeat(64),
+      raw_bag_code: null,
+    })).toMatchInlineSnapshot(`
+      {
+        "bag_signature": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "comments": "manual receive",
+        "lot": {
+          "comments": "supplier bag",
+          "expiration_date": "2027-01-31",
+          "name": "LOT-2026-001",
+          "serial_number": null,
+        },
+        "part_id": "11111111-1111-1111-1111-111111111111",
+        "price": {
+          "currency": "USD",
+          "mode": "per_component",
+          "total_price": null,
+          "unit_price": 0.125,
+        },
+        "quantity": 12,
+        "raw_bag_code": null,
+        "storage_location_id": "33333333-3333-3333-3333-333333333333",
+      }
+    `);
+  });
+
+  it("rejects a bad payload", () => {
+    expect(() => PartAddStockSchema.parse({
+      part_id: partId,
+      quantity: 0,
+      bag_signature: "not-a-sha256",
+    })).toThrow();
+  });
+});

--- a/web/src/lib/schemas.ts
+++ b/web/src/lib/schemas.ts
@@ -33,6 +33,8 @@ const uuid = z.string().uuid();
 const isoDate = z.string();           // ISO 8601 string; not parsed to Date
 const nullableString = z.string().nullable();
 const nullableNumber = z.number().nullable();
+const optionalNullableString = z.string().nullable().optional();
+const optionalNullableUuid = uuid.nullable().optional();
 
 // ---------------------------------------------------------------------
 // Resource schemas. Mirror types.ts; export inferred types so consumers
@@ -69,6 +71,24 @@ export const PartSchema = z.object({
 export type Part = z.infer<typeof PartSchema>;
 
 export const PartsListSchema = z.array(PartSchema);
+
+export const PartCreateSchema = z.object({
+  part_type: z.enum(["linked", "local", "meta", "sub_assembly"]).optional(),
+  name: z.string().max(300).nullable().optional(),
+  manufacturer: optionalNullableString,
+  mpn: optionalNullableString,
+  internal_part_number: optionalNullableString,
+  description: optionalNullableString,
+  notes_markdown: optionalNullableString,
+  footprint: optionalNullableString,
+  low_stock_report_quantity: z.number().int().nullable().optional(),
+  attrition_percentage: z.number().optional(),
+  attrition_min_quantity: z.number().int().optional(),
+  default_storage_location_id: optionalNullableUuid,
+  default_storage_mandatory: z.boolean().optional(),
+  serialized: z.boolean().optional(),
+}).strict();
+export type PartCreate = z.infer<typeof PartCreateSchema>;
 
 /** Paged parts response — returned by GET /parts with cursor pagination. */
 export const PagedPartsSchema = z.object({
@@ -139,6 +159,32 @@ export const StockEntrySchema = z.object({
 });
 export type StockEntry = z.infer<typeof StockEntrySchema>;
 
+const PriceInputSchema = z.object({
+  mode: z.enum(["none", "per_component", "entire_lot"]).optional(),
+  unit_price: z.number().nullable().optional(),
+  total_price: z.number().nullable().optional(),
+  currency: optionalNullableString,
+}).strict();
+
+const LotInputSchema = z.object({
+  name: optionalNullableString,
+  comments: optionalNullableString,
+  expiration_date: optionalNullableString,
+  serial_number: optionalNullableString,
+}).strict();
+
+export const PartAddStockSchema = z.object({
+  part_id: uuid,
+  quantity: z.number().int().gt(0),
+  storage_location_id: optionalNullableUuid,
+  price: PriceInputSchema.nullable().optional(),
+  lot: LotInputSchema.nullable().optional(),
+  comments: optionalNullableString,
+  bag_signature: z.string().regex(/^[a-f0-9]{64}$/).nullable().optional(),
+  raw_bag_code: z.string().max(4096).nullable().optional(),
+}).strict();
+export type PartAddStock = z.infer<typeof PartAddStockSchema>;
+
 export const ProjectSchema = z.object({
   id: uuid,
   name: z.string(),
@@ -186,6 +232,26 @@ export const OrderEntrySchema = z.object({
   order_index: z.number(),
 });
 export type OrderEntry = z.infer<typeof OrderEntrySchema>;
+
+export const OrderReceiveSchema = z.object({
+  received_on: optionalNullableString,
+  lines: z.array(z.object({
+    order_entry_id: uuid,
+    quantity: z.number().int().gt(0),
+    storage_location_id: optionalNullableUuid,
+    lot_name: optionalNullableString,
+    serial_number: optionalNullableString,
+  }).strict()).min(1),
+}).strict();
+export type OrderReceive = z.infer<typeof OrderReceiveSchema>;
+
+export const OrderReceiveResultSchema = z.object({
+  order_id: uuid,
+  status: z.enum(["draft", "open", "partial", "received", "cancelled"]),
+  lots: z.array(uuid),
+  stock_entries: z.array(uuid),
+});
+export type OrderReceiveResult = z.infer<typeof OrderReceiveResultSchema>;
 
 export const BuildSchema = z.object({
   id: uuid,

--- a/web/src/routes/orders/OrderDetail.test.tsx
+++ b/web/src/routes/orders/OrderDetail.test.tsx
@@ -19,6 +19,7 @@ vi.mock("@/lib/api", () => ({
   api: {
     get: vi.fn(),
     post: vi.fn(),
+    parsed: { post: vi.fn() },
     delete: vi.fn(),
   },
 }));
@@ -70,6 +71,8 @@ afterEach(() => {
 describe("OrderDetail receive", () => {
   it("submits lot name on receive lines", async () => {
     const user = userEvent.setup();
+    const partId = "11111111-1111-1111-1111-111111111111";
+    const entryId = "22222222-2222-2222-2222-222222222222";
     vi.mocked(api.get).mockImplementation((path: string) => {
       if (path === "/orders/order-1") {
         return Promise.resolve({
@@ -90,9 +93,9 @@ describe("OrderDetail receive", () => {
             updated_at: "2026-01-01T00:00:00Z",
           },
           entries: [{
-            id: "entry-1",
+            id: entryId,
             order_id: "order-1",
-            part_id: "part-1",
+            part_id: partId,
             name: null,
             quantity_ordered: 10,
             quantity_received: 0,
@@ -103,11 +106,16 @@ describe("OrderDetail receive", () => {
           }],
         });
       }
-      if (path === "/parts?limit=200") return Promise.resolve([{ id: "part-1", name: "Part 1", serialized: false }]);
+      if (path === "/parts?limit=200") return Promise.resolve([{ id: partId, name: "Part 1", serialized: false }]);
       if (path === "/storage") return Promise.resolve([]);
       return Promise.resolve(null);
     });
-    vi.mocked(api.post).mockResolvedValue(null);
+    vi.mocked(api.parsed.post).mockResolvedValue({
+      order_id: "11111111-1111-1111-1111-111111111111",
+      status: "partial",
+      lots: [],
+      stock_entries: [],
+    });
 
     renderOrderDetail();
 
@@ -116,16 +124,20 @@ describe("OrderDetail receive", () => {
     await user.click(screen.getByRole("button", { name: "Receive" }));
 
     await waitFor(() => {
-      expect(api.post).toHaveBeenCalledWith("/orders/order-1/receive", {
-        received_on: undefined,
-        lines: [{
-          order_entry_id: "entry-1",
-          quantity: 4,
-          storage_location_id: undefined,
-          lot_name: "LOT-PO-100",
-          serial_number: undefined,
-        }],
-      });
+      expect(api.parsed.post).toHaveBeenCalledWith(
+        "/orders/order-1/receive",
+        expect.any(Object),
+        {
+          received_on: undefined,
+          lines: [{
+            order_entry_id: entryId,
+            quantity: 4,
+            storage_location_id: undefined,
+            lot_name: "LOT-PO-100",
+            serial_number: undefined,
+          }],
+        },
+      );
     });
   });
 });

--- a/web/src/routes/orders/OrderDetail.tsx
+++ b/web/src/routes/orders/OrderDetail.tsx
@@ -2,10 +2,12 @@ import { useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
+import { z } from "zod";
 import { api, ApiError } from "@/lib/api";
 import { useApiMutation } from "@/lib/mutations";
 import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
 import { useAuth } from "@/lib/auth";
+import { OrderReceiveResultSchema, OrderReceiveSchema } from "@/lib/schemas";
 import EntityHeader from "@/components/EntityHeader";
 import { DataTable } from "@/components/DataTable";
 import AttachmentsPanel from "@/components/AttachmentsPanel";
@@ -23,18 +25,19 @@ type AddEntryRequest = {
   currency?: string;
 };
 
-type ReceiveLine = {
-  order_entry_id: string;
-  quantity: number;
-  storage_location_id?: string;
-  lot_name?: string;
-  serial_number?: string;
-};
+type ReceiveRequest = z.input<typeof OrderReceiveSchema>;
 
-type ReceiveRequest = {
-  received_on?: string;
-  lines: ReceiveLine[];
-};
+function zodMessage(e: z.ZodError): string {
+  const issue = e.issues[0];
+  const field = issue?.path.join(".");
+  return field ? `${field}: ${issue.message}` : issue?.message ?? "Invalid form data.";
+}
+
+function receiveErrorMessage(e: unknown): string {
+  if (e instanceof ApiError) return e.userMessage;
+  if (e instanceof z.ZodError) return zodMessage(e);
+  return "Receive failed";
+}
 
 export default function OrderDetail() {
   const { orderId } = useParams<{ orderId: string }>();
@@ -102,7 +105,12 @@ export default function OrderDetail() {
 
   const receiveMutation = useApiMutation<unknown, ReceiveRequest>({
     mutationKey: ["order", orderId, "receive"],
-    mutationFn: (input) => api.post(`/orders/${orderId}/receive`, input),
+    mutationFn: (input) =>
+      api.parsed.post(
+        `/orders/${orderId}/receive`,
+        OrderReceiveResultSchema,
+        OrderReceiveSchema.parse(input),
+      ),
     onSuccess: (_data, vars) => {
       const totalQty = vars.lines.reduce((s, l) => s + l.quantity, 0);
       setReceiveLines({});
@@ -111,7 +119,7 @@ export default function OrderDetail() {
       toast.success(`Received ${totalQty} unit${totalQty === 1 ? "" : "s"}.`);
     },
     onError: (e) => {
-      const msg = e instanceof ApiError ? e.userMessage : "Receive failed";
+      const msg = receiveErrorMessage(e);
       setErr(msg);
       toast.error(msg);
     },

--- a/web/src/routes/parts/PartCreate.tsx
+++ b/web/src/routes/parts/PartCreate.tsx
@@ -1,30 +1,29 @@
 import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
+import { z } from "zod";
 import { api, ApiError, getConflictDetail } from "@/lib/api";
 import { useApiMutation } from "@/lib/mutations";
 import { useQuery } from "@tanstack/react-query";
 import { useWsKey } from "@/lib/queryKeys";
 import { isSafeHttpOrSameOriginUrl } from "@/lib/url";
-import type { MpnLookupResult, ProviderSpec, StorageLocation } from "@/types";
+import { PartCreateSchema, PartSchema } from "@/lib/schemas";
+import type { MpnLookupResult, Part, ProviderSpec, StorageLocation } from "@/types";
 import MpnLookup from "@/components/MpnLookup";
 import { InlineQueryError } from "@/components/QueryStateBoundary";
 
-/**
- * Mirror of `backend/app/api/routes/_parts_shared.py::PartIn`.
- * The optional fields are sent as `undefined` when blank — the server
- * defaults `name` to `mpn` and treats omitted optional FKs as null.
- */
-type PartCreateRequest = {
-  part_type: "linked" | "local" | "meta" | "sub_assembly";
-  name?: string;
-  manufacturer?: string;
-  mpn?: string;
-  internal_part_number?: string;
-  description?: string;
-  footprint?: string;
-  default_storage_location_id?: string;
-  serialized?: boolean;
-};
+type PartCreateRequest = z.input<typeof PartCreateSchema>;
+
+function zodMessage(e: z.ZodError): string {
+  const issue = e.issues[0];
+  const field = issue?.path.join(".");
+  return field ? `${field}: ${issue.message}` : issue?.message ?? "Invalid form data.";
+}
+
+function mutationMessage(e: unknown): string {
+  if (e instanceof ApiError) return e.userMessage;
+  if (e instanceof z.ZodError) return zodMessage(e);
+  return "Failed";
+}
 
 export default function PartCreate() {
   const nav = useNavigate();
@@ -68,10 +67,10 @@ export default function PartCreate() {
   // FE2-006: gate concurrent submits via mutationKey so a double-click
   // on Create can't post two parts; the 409 conflict-link branch stays
   // in `onError`, just routed through `getConflictDetail(error)`.
-  const createMutation = useApiMutation<{ id: string }, PartCreateRequest>({
+  const createMutation = useApiMutation<Part, PartCreateRequest>({
     mutationKey: ["parts", "create"],
     mutationFn: (payload) =>
-      api.post<{ id: string }, PartCreateRequest>("/parts", payload),
+      api.parsed.post("/parts", PartSchema, PartCreateSchema.parse(payload)),
     onSuccess: async (res) => {
       // If the user successfully ran the MPN lookup and the part is
       // linked-type with an MPN, re-run the lookup against the new
@@ -101,7 +100,7 @@ export default function PartCreate() {
         setErr(null);
         return;
       }
-      setErr(e instanceof ApiError ? e.userMessage : "Failed");
+      setErr(mutationMessage(e));
     },
   });
 

--- a/web/src/routes/parts/detail/PartAddStock.tsx
+++ b/web/src/routes/parts/detail/PartAddStock.tsx
@@ -6,30 +6,25 @@ import { api, ApiError } from "@/lib/api";
 import { useApiMutation } from "@/lib/mutations";
 import { useWsKey, wsKeyOf } from "@/lib/queryKeys";
 import { useAuth } from "@/lib/auth";
+import { PartAddStockSchema, StockEntrySchema } from "@/lib/schemas";
 import { InlineQueryError } from "@/components/QueryStateBoundary";
 import type { StorageLocation } from "@/types";
 
-/**
- * Mirror of `backend/app/domain/stock/schemas.py::AddStockIn` (extra="forbid").
- * Optional sub-objects (`price`, `lot`) follow the BE Pydantic shape so a
- * future schema change surfaces as a TS error in this file rather than as
- * silent FE/BE drift on a 4xx response.
- */
-type AddStockRequest = {
-  part_id: string;
-  quantity: number;
-  storage_location_id?: string;
-  price?: {
-    mode: "per_component" | "entire_lot";
-    currency: string;
-    unit_price?: number;
-    total_price?: number;
-  };
-  lot?: { name?: string; expiration_date?: string; serial_number?: string };
-  comments?: string;
-};
+type AddStockRequest = z.input<typeof PartAddStockSchema>;
 
 const currencySchema = z.string().regex(/^[A-Z]{3}$/, "Currency must be a three-letter uppercase code.");
+
+function zodMessage(e: z.ZodError): string {
+  const issue = e.issues[0];
+  const field = issue?.path.join(".");
+  return field ? `${field}: ${issue.message}` : issue?.message ?? "Invalid form data.";
+}
+
+function mutationMessage(e: unknown): string {
+  if (e instanceof ApiError) return e.userMessage;
+  if (e instanceof z.ZodError) return zodMessage(e);
+  return "Failed";
+}
 
 export default function PartAddStock() {
   const { partId } = useParams<{ partId: string }>();
@@ -56,14 +51,15 @@ export default function PartAddStock() {
   // `stock_entries` rows. Key on the part to hard-block double POST.
   const addMutation = useApiMutation<unknown, AddStockRequest>({
     mutationKey: ["part", partId, "stock-add"],
-    mutationFn: (payload) => api.post<unknown, AddStockRequest>("/stock/add", payload),
+    mutationFn: (payload) =>
+      api.parsed.post("/stock/add", StockEntrySchema, PartAddStockSchema.parse(payload)),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "part", partId) });
       qc.invalidateQueries({ queryKey: wsKeyOf(workspaceId, "parts") });
       nav(`/parts/${partId}/stock`);
     },
     onError: (e) => {
-      setErr(e instanceof ApiError ? e.userMessage : "Failed");
+      setErr(mutationMessage(e));
     },
   });
 

--- a/web/src/routes/parts/detail/__tests__/PartAddStock.test.tsx
+++ b/web/src/routes/parts/detail/__tests__/PartAddStock.test.tsx
@@ -36,7 +36,7 @@ describe("PartAddStock", () => {
   it("test_lot_expiry_submits", async () => {
     const user = userEvent.setup();
     vi.spyOn(api, "get").mockResolvedValue([]);
-    const postSpy = vi.spyOn(api, "post").mockResolvedValue({});
+    const postSpy = vi.spyOn(api.parsed, "post").mockResolvedValue({});
 
     renderAddStock();
 
@@ -46,23 +46,27 @@ describe("PartAddStock", () => {
     await user.click(screen.getByRole("button", { name: "Add" }));
 
     await waitFor(() => {
-      expect(postSpy).toHaveBeenCalledWith("/stock/add", {
-        part_id: "11111111-1111-1111-1111-111111111111",
-        quantity: 5,
-        comments: undefined,
-        lot: {
-          name: "LOT-2026-001",
-          expiration_date: "2026-12-31",
-          serial_number: undefined,
+      expect(postSpy).toHaveBeenCalledWith(
+        "/stock/add",
+        expect.any(Object),
+        {
+          part_id: "11111111-1111-1111-1111-111111111111",
+          quantity: 5,
+          comments: undefined,
+          lot: {
+            name: "LOT-2026-001",
+            expiration_date: "2026-12-31",
+            serial_number: undefined,
+          },
         },
-      });
+      );
     });
   });
 
   it("test_currency_regex rejects non-letter currency codes inline", async () => {
     const user = userEvent.setup();
     vi.spyOn(api, "get").mockResolvedValue([]);
-    const postSpy = vi.spyOn(api, "post").mockResolvedValue({});
+    const postSpy = vi.spyOn(api.parsed, "post").mockResolvedValue({});
 
     renderAddStock();
 


### PR DESCRIPTION
Refs #828

## Summary
- Export zod request schemas for PartCreate, OrderReceive, and PartAddStock, plus the receive response schema.
- Validate each form payload with the exported schema before POST, then route submissions through `api.parsed.post` while preserving the API envelope flow in `web/src/lib/api.ts`.
- Add focused schema snapshot/negative tests and update existing form tests for parsed POST calls.

## Validation
- `npm test -- schemas OrderDetail PartAddStock`
- `npm run build`

## Merge Order
- Independent. Merge after #825 only if a query/test conflict appears.