### PR TITLE
AUD-130: Virtualize DataTable tbody

### DIFF
--- a/web/e2e/datatable-virtualization-harness.tsx
+++ b/web/e2e/datatable-virtualization-harness.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { DataTable, type Column } from "../src/components/DataTable";
+import "../src/index.css";
+
+type Row = {
+  id: string;
+  name: string;
+  qty: number;
+  location: string;
+};
+
+const rows: Row[] = Array.from({ length: 10_000 }, (_, index) => ({
+  id: `part-${index}`,
+  name: `Part ${String(index).padStart(5, "0")}`,
+  qty: index,
+  location: `Shelf ${index % 20}`,
+}));
+
+const columns: Column<Row>[] = [
+  { key: "name", header: "Name", accessor: row => row.name },
+  { key: "qty", header: "Qty", accessor: row => row.qty, align: "right" },
+  { key: "location", header: "Location", accessor: row => row.location },
+];
+
+function Harness() {
+  return (
+    <main className="p-4">
+      <DataTable<Row>
+        rows={rows}
+        columns={columns}
+        rowKey={row => row.id}
+        onRowClick={() => undefined}
+        selectable
+        exportFilename="datatable-virtualization"
+      />
+    </main>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <Harness />
+  </React.StrictMode>,
+);

--- a/web/e2e/datatable-virtualization.html
+++ b/web/e2e/datatable-virtualization.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>DataTable virtualization harness</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./datatable-virtualization-harness.tsx"></script>
+  </body>
+</html>

--- a/web/e2e/datatable-virtualization.spec.ts
+++ b/web/e2e/datatable-virtualization.spec.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("DataTable virtualization", () => {
+  test("bounds mounted rows for a 10k-row table @core", async ({ page }) => {
+    await page.goto("/e2e/datatable-virtualization.html");
+
+    await expect(page.getByText("Part 00000")).toBeVisible();
+    await expect
+      .poll(() => page.locator("tbody tr").count())
+      .toBeLessThan(200);
+
+    await page.getByPlaceholder("Search…").fill("Part 09999");
+    await expect(page.getByText("Part 09999")).toBeVisible();
+    await expect(page.locator("tbody tr")).toHaveCount(1);
+  });
+});

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -12,6 +12,7 @@
         "@scandit/web-datacapture-core": "8.1.1",
         "@sentry/react": "^10.51.0",
         "@tanstack/react-query": "^5.59.0",
+        "@tanstack/react-virtual": "^3.13.24",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
         "lucide-react": "^0.460.0",
@@ -2373,6 +2374,31 @@
       },
       "peerDependencies": {
         "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.24",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.24.tgz",
+      "integrity": "sha512-aIJvz5OSkhNIhZIpYivrxrPTKYsjW9Uzy+sP/mx0S3sev2HyvPb7xmjbYvokzEpfgYHy/HjzJ2zFAETuUfgCpg==",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.14.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.14.0.tgz",
+      "integrity": "sha512-JLANqGy/D6k4Ujmh8Tr25lGimuOXNiaVyXaCAZS0W+1390sADdGnyUdSWNIfd49gebtIxGMij4IktRVzrdr12Q==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/web/package.json
+++ b/web/package.json
@@ -26,6 +26,7 @@
     "@scandit/web-datacapture-core": "8.1.1",
     "@sentry/react": "^10.51.0",
     "@tanstack/react-query": "^5.59.0",
+    "@tanstack/react-virtual": "^3.13.24",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "lucide-react": "^0.460.0",

--- a/web/src/components/DataTable.tsx
+++ b/web/src/components/DataTable.tsx
@@ -1,4 +1,5 @@
 import React, { ReactNode, useEffect, useMemo, useRef, useState } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import { Rows3, Rows4 } from "lucide-react";
 import { cn } from "@/lib/cn";
 import { useOptionalAuth } from "@/lib/authContext";
@@ -88,6 +89,13 @@ export type Column<T> = {
 };
 
 type Density = "comfortable" | "compact";
+
+const VIRTUALIZATION_THRESHOLD = 200;
+const VIRTUALIZATION_OVERSCAN = 12;
+const ESTIMATED_ROW_HEIGHT: Record<Density, number> = {
+  comfortable: 40,
+  compact: 32,
+};
 
 type Props<T> = {
   rows: T[];
@@ -190,6 +198,7 @@ export function DataTable<T>({
   );
   const columnsRef = useRef(columns);
   const activeStorageKeyRef = useRef(storageKey);
+  const scrollParentRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     columnsRef.current = columns;
@@ -285,6 +294,27 @@ export function DataTable<T>({
 
   const padCls = density === "compact" ? "py-1" : "py-2";
   const textCls = density === "compact" ? "text-[13px]" : "text-sm";
+  const shouldVirtualize = sorted.length > VIRTUALIZATION_THRESHOLD;
+  const rowVirtualizer = useVirtualizer<HTMLDivElement, HTMLTableRowElement>({
+    count: sorted.length,
+    enabled: shouldVirtualize,
+    getScrollElement: () => scrollParentRef.current,
+    estimateSize: () => ESTIMATED_ROW_HEIGHT[density],
+    getItemKey: index => rowKey(sorted[index]),
+    overscan: VIRTUALIZATION_OVERSCAN,
+  });
+  const virtualRows = rowVirtualizer.getVirtualItems();
+  const topSpacerHeight = shouldVirtualize && virtualRows.length > 0 ? virtualRows[0].start : 0;
+  const bottomSpacerHeight =
+    shouldVirtualize && virtualRows.length > 0
+      ? rowVirtualizer.getTotalSize() - virtualRows[virtualRows.length - 1].end
+      : 0;
+  const tableColSpan = visibleCols.length + (selectable ? 1 : 0);
+
+  useEffect(() => {
+    if (!shouldVirtualize) return;
+    rowVirtualizer.scrollToIndex(0);
+  }, [rowVirtualizer, shouldVirtualize, search, sort?.key, sort?.dir, density]);
 
   function cellText(c: Column<T>, r: T): string {
     // Prefer the structured accessor — it returns the raw scalar
@@ -327,6 +357,94 @@ export function DataTable<T>({
     // can keep the reference around forever otherwise (memory leak on
     // long-lived sessions that export repeatedly).
     URL.revokeObjectURL(url);
+  }
+
+  function focusRowAtIndex(index: number) {
+    if (index < 0 || index >= sorted.length) return;
+    if (shouldVirtualize) {
+      rowVirtualizer.scrollToIndex(index, { align: "auto" });
+    }
+    window.requestAnimationFrame(() => {
+      window.requestAnimationFrame(() => {
+        scrollParentRef.current
+          ?.querySelector<HTMLTableRowElement>(`tr[data-row-index="${index}"]`)
+          ?.focus();
+      });
+    });
+  }
+
+  function renderDataRow(r: T, i: number, measure: boolean) {
+    const id = rowKey(r);
+    const isSel = selected.has(id);
+    const canClick = !!onRowClick && (rowCanClick ? rowCanClick(r) : true);
+
+    return (
+      <tr
+        key={id}
+        ref={measure ? rowVirtualizer.measureElement : undefined}
+        data-index={measure ? i : undefined}
+        data-row-index={i}
+        tabIndex={canClick ? 0 : undefined}
+        onClick={() => {
+          if (canClick) onRowClick?.(r);
+        }}
+        {...(canClick ? {
+          "aria-label": rowAriaLabel(r, visibleCols),
+          onKeyDown: (e: React.KeyboardEvent<HTMLTableRowElement>) => {
+            if (e.key === "Enter" || e.key === " ") {
+              if (e.key === " ") e.preventDefault();
+              onRowClick?.(r);
+            } else if (e.key === "ArrowDown") {
+              e.preventDefault();
+              focusRowAtIndex(i + 1);
+            } else if (e.key === "ArrowUp") {
+              e.preventDefault();
+              focusRowAtIndex(i - 1);
+            }
+          },
+        } : {})}
+        className={cn(
+          canClick && "cursor-pointer focus-visible:ring-2 focus-visible:ring-accent/40 focus-visible:outline-none",
+          // Subtle zebra striping — only odd rows pick up panel2.
+          i % 2 === 1 && "bg-panel2/40",
+          isSel && "bg-accent/10",
+          rowClassName?.(r),
+        )}
+      >
+        {selectable && (
+          <td
+            className={cn(padCls, "w-8 text-center")}
+            onClick={e => e.stopPropagation()}
+            onKeyDown={(e: React.KeyboardEvent<HTMLTableCellElement>) => {
+              if (e.key === "Enter" || e.key === " ") e.stopPropagation();
+            }}
+          >
+            <input
+              type="checkbox"
+              checked={isSel}
+              onChange={() => toggleSelected(id)}
+              aria-label={isSel ? "Deselect row" : "Select row"}
+            />
+          </td>
+        )}
+        {visibleCols.map(c => {
+          const align = defaultAlignFor(c, sample);
+          return (
+            <td
+              key={c.key}
+              className={cn(
+                padCls,
+                align === "right" && "text-right tabular-nums",
+                align === "center" && "text-center",
+              )}
+            >
+              {/* FIXME: typed row-access requires a generic constraint refactor — see issue #57. */}
+              {c.render ? c.render(r) : String((c.accessor ? c.accessor(r) : (r as Record<string, unknown>)[c.key]) ?? "")}
+            </td>
+          );
+        })}
+      </tr>
+    );
   }
 
   // All currently-filtered/sorted ids — used for select-all semantics
@@ -386,7 +504,11 @@ export function DataTable<T>({
         </details>
         <button className="btn" onClick={exportCsv}>Export CSV</button>
       </div>
-      <div className="overflow-auto">
+      <div
+        ref={scrollParentRef}
+        className="overflow-auto"
+        style={shouldVirtualize ? { maxHeight: "min(70vh, 720px)" } : undefined}
+      >
         <table className={cn("table", textCls)}>
           <thead>
             <tr>
@@ -433,76 +555,40 @@ export function DataTable<T>({
             {sorted.length === 0 && (
               <tr>
                 <td
-                  colSpan={visibleCols.length + (selectable ? 1 : 0)}
+                  colSpan={tableColSpan}
                   className="text-center py-8 text-muted"
                 >
                   {empty || "No rows."}
                 </td>
               </tr>
             )}
-            {sorted.map((r, i) => {
-              const id = rowKey(r);
-              const isSel = selected.has(id);
-              const canClick = !!onRowClick && (rowCanClick ? rowCanClick(r) : true);
-              return (
+            {topSpacerHeight > 0 && (
               <tr
-                key={id}
-                tabIndex={canClick ? 0 : undefined}
-                onClick={() => {
-                  if (canClick) onRowClick?.(r);
-                }}
-                {...(canClick ? {
-                  "aria-label": rowAriaLabel(r, visibleCols),
-                  onKeyDown: (e: React.KeyboardEvent<HTMLTableRowElement>) => {
-                    if (e.key === "Enter" || e.key === " ") {
-                      if (e.key === " ") e.preventDefault();
-                      onRowClick?.(r);
-                    }
-                  },
-                } : {})}
-                className={cn(
-                  canClick && "cursor-pointer focus-visible:ring-2 focus-visible:ring-accent/40 focus-visible:outline-none",
-                  // Subtle zebra striping — only odd rows pick up panel2.
-                  i % 2 === 1 && "bg-panel2/40",
-                  isSel && "bg-accent/10",
-                  rowClassName?.(r),
-                )}
+                aria-hidden="true"
+                role="presentation"
               >
-                {selectable && (
-                  <td
-                    className={cn(padCls, "w-8 text-center")}
-                    onClick={e => e.stopPropagation()}
-                    onKeyDown={(e: React.KeyboardEvent<HTMLTableCellElement>) => {
-                      if (e.key === "Enter" || e.key === " ") e.stopPropagation();
-                    }}
-                  >
-                    <input
-                      type="checkbox"
-                      checked={isSel}
-                      onChange={() => toggleSelected(id)}
-                      aria-label={isSel ? "Deselect row" : "Select row"}
-                    />
-                  </td>
-                )}
-                {visibleCols.map(c => {
-                  const align = defaultAlignFor(c, sample);
-                  return (
-                    <td
-                      key={c.key}
-                      className={cn(
-                        padCls,
-                        align === "right" && "text-right tabular-nums",
-                        align === "center" && "text-center",
-                      )}
-                    >
-                      {/* FIXME: typed row-access requires a generic constraint refactor — see issue #57. */}
-                      {c.render ? c.render(r) : String((c.accessor ? c.accessor(r) : (r as Record<string, unknown>)[c.key]) ?? "")}
-                    </td>
-                  );
-                })}
+                <td
+                  colSpan={tableColSpan}
+                  className="border-0 p-0"
+                  style={{ height: topSpacerHeight }}
+                />
               </tr>
-              );
-            })}
+            )}
+            {shouldVirtualize
+              ? virtualRows.map(virtualRow => renderDataRow(sorted[virtualRow.index], virtualRow.index, true))
+              : sorted.map((r, i) => renderDataRow(r, i, false))}
+            {bottomSpacerHeight > 0 && (
+              <tr
+                aria-hidden="true"
+                role="presentation"
+              >
+                <td
+                  colSpan={tableColSpan}
+                  className="border-0 p-0"
+                  style={{ height: bottomSpacerHeight }}
+                />
+              </tr>
+            )}
           </tbody>
         </table>
       </div>


### PR DESCRIPTION
Refs #829

## Summary
- Added `@tanstack/react-virtual` and virtualized the shared `DataTable` body for large row sets while preserving full-array search, sort, CSV export, hidden columns, and multi-select semantics.
- Kept semantic table rows with spacer rows and added arrow-key focus movement for virtualized clickable rows.
- Added a focused Playwright harness/spec that renders 10k rows and asserts the mounted `<tbody>` row count stays below 200.

## Validation
- `npm test`
- `npm run build`
- `PLAYWRIGHT_BASE_URL=http://127.0.0.1:5174 npx playwright test datatable-virtualization`

## Merge order
If `web/package-lock.json` conflicts with #828 or #837, rebase after those narrower PRs. This can merge after #825/#833/#834.
