### PR TITLE
AUD-136 use ApiError userMessage for login errors

### DIFF
--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -189,6 +189,44 @@ describe("ApiError.userMessage", () => {
     expect(err.userMessage).not.toContain("sqlalchemy");
   });
 
+  it.each([
+    {
+      code: "auth.account_locked",
+      status: 429,
+      category: "validation_error",
+      extra: { retry_after_seconds: 900 },
+      userMessage: "Account temporarily locked. Try again in 15 minutes.",
+    },
+    {
+      code: "auth.email_unverified",
+      status: 403,
+      category: "forbidden",
+      extra: {},
+      userMessage: "Verify your email before signing in. Check your inbox for the verification link.",
+    },
+    {
+      code: "auth.invalid_credentials",
+      status: 401,
+      category: "unauthenticated",
+      extra: {},
+      userMessage: "Invalid email or password.",
+    },
+  ])("maps $code to auth-specific userMessage", ({ code, status, category, extra, userMessage }) => {
+    const err = new ApiError(
+      status,
+      {
+        data: null,
+        status: { category, message: "raw auth message" },
+        code,
+        ...extra,
+      },
+      "raw auth message",
+    );
+
+    expect(err.userMessage).toBe(userMessage);
+    expect(err.message).toBe("raw auth message");
+  });
+
   it("HTTP 404 ApiError thrown by api.parsed carries correct userMessage", async () => {
     mockFetch(404, {
       data: null,

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -25,6 +25,7 @@ export type ApiErr = {
   code?: string;
   errors?: { field: string; message: string }[];
   request_id?: string;
+  retry_after_seconds?: number;
 };
 
 const BASE = "/api";
@@ -48,6 +49,27 @@ export function categoryToUserMessage(category: string | undefined | null): stri
       return "Some fields don't look right. Check the form and retry.";
     default:
       return "Something went wrong. Try again, or refresh.";
+  }
+}
+
+function authCodeToUserMessage(body: ApiErr | null): string | null {
+  switch (body?.code) {
+    case "auth.account_locked":
+    case "auth.locked": {
+      const retrySeconds = body.retry_after_seconds;
+      if (typeof retrySeconds === "number" && Number.isFinite(retrySeconds) && retrySeconds > 0) {
+        const retryMinutes = Math.max(1, Math.ceil(retrySeconds / 60));
+        return `Account temporarily locked. Try again in ${retryMinutes} minutes.`;
+      }
+      return "Account temporarily locked. Try again later.";
+    }
+    case "auth.email_unverified":
+    case "auth.verification_pending":
+      return "Verify your email before signing in. Check your inbox for the verification link.";
+    case "auth.invalid_credentials":
+      return "Invalid email or password.";
+    default:
+      return null;
   }
 }
 
@@ -85,7 +107,7 @@ export class ApiError extends Error {
     this.request_id = requestIdFromBody(body) ?? normalizeRequestId(requestId);
     this.requestId = this.request_id;
     this.userMessage = messageWithRequestId(
-      categoryToUserMessage(body?.status?.category),
+      authCodeToUserMessage(body) ?? categoryToUserMessage(body?.status?.category),
       this.request_id,
     );
   }

--- a/web/src/routes/auth/Login.test.tsx
+++ b/web/src/routes/auth/Login.test.tsx
@@ -66,7 +66,64 @@ describe("Login", () => {
     expect(link.getAttribute("href")).toBe("/auth/request-reset");
   });
 
-  it("test_429_renders_generic_message", async () => {
+  it.each([
+    {
+      name: "locked account",
+      status: 429,
+      body: {
+        data: null,
+        status: { category: "validation_error", message: "too many failed login attempts" },
+        code: "auth.account_locked",
+        retry_after_seconds: 900,
+      } as ApiErr,
+      message: "Account temporarily locked. Try again in 15 minutes.",
+    },
+    {
+      name: "unverified email",
+      status: 403,
+      body: {
+        data: null,
+        status: { category: "forbidden", message: "verification pending" },
+        code: "auth.email_unverified",
+      } as ApiErr,
+      message: "Verify your email before signing in. Check your inbox for the verification link.",
+    },
+    {
+      name: "invalid credentials",
+      status: 401,
+      body: {
+        data: null,
+        status: { category: "unauthenticated", message: "invalid credentials" },
+        code: "auth.invalid_credentials",
+      } as ApiErr,
+      message: "Invalid email or password.",
+    },
+  ])("renders ApiError.userMessage for $name", async ({ status, body, message }) => {
+    mockPost.mockRejectedValue(new ApiError(status, body, body.status.message));
+
+    renderLogin();
+
+    fireEvent.change(screen.getByLabelText("Email"), { target: { value: "user@example.com" } });
+    fireEvent.change(screen.getByLabelText("Password"), { target: { value: "WrongPass!!X" } });
+    fireEvent.click(screen.getByRole("button", { name: "Sign in" }));
+
+    expect(await screen.findByText(message)).toBeDefined();
+    expect(screen.queryByText("Login failed. Check your credentials and try again.")).toBeNull();
+  });
+
+  it("renders fallback message for non-ApiError failures", async () => {
+    mockPost.mockRejectedValue(new Error("network broke"));
+
+    renderLogin();
+
+    fireEvent.change(screen.getByLabelText("Email"), { target: { value: "user@example.com" } });
+    fireEvent.change(screen.getByLabelText("Password"), { target: { value: "WrongPass!!X" } });
+    fireEvent.click(screen.getByRole("button", { name: "Sign in" }));
+
+    expect(await screen.findByText("Login failed")).toBeDefined();
+  });
+
+  it("does not render the raw locked-account server message", async () => {
     const body = {
       data: null,
       status: { category: "validation_error", message: "too many failed login attempts" },
@@ -82,10 +139,7 @@ describe("Login", () => {
     fireEvent.change(screen.getByLabelText("Password"), { target: { value: "WrongPass!!X" } });
     fireEvent.click(screen.getByRole("button", { name: "Sign in" }));
 
-    expect(
-      await screen.findByText("Login failed. Check your credentials and try again."),
-    ).toBeDefined();
+    expect(await screen.findByText("Account temporarily locked. Try again in 15 minutes.")).toBeDefined();
     expect(screen.queryByText(/too many failed login attempts/i)).toBeNull();
-    expect(screen.queryByText(/try again in/i)).toBeNull();
   });
 });

--- a/web/src/routes/auth/Login.tsx
+++ b/web/src/routes/auth/Login.tsx
@@ -27,11 +27,7 @@ export default function Login() {
       nav(fromPath || "/parts", { replace: true });
     },
     onError: (e) => {
-      if (e instanceof ApiError) {
-        setErr("Login failed. Check your credentials and try again.");
-      } else {
-        setErr("Login failed");
-      }
+      setErr(e instanceof ApiError ? e.userMessage : "Login failed");
     },
   });
 


### PR DESCRIPTION
Refs #834

## Summary
- render ApiError.userMessage in the login error banner instead of replacing auth failures with generic copy
- add auth-code-specific ApiError userMessage mapping for lockout, unverified email, and invalid credentials
- cover the Login auth error messages and API mapping behavior in Vitest

## Validation
- npm test -- Login
- npm test -- api.test.ts
- npm run build

## Merge order
Independent frontend PR; can merge after green, rebase if route/test helpers conflict.