### PR TITLE
AUD-132 Convert route HTTP errors to raise_http

### DIFF
--- a/backend/app/api/routes/_activity.py
+++ b/backend/app/api/routes/_activity.py
@@ -35,13 +35,80 @@ from __future__ import annotations
 from typing import Iterable
 from uuid import UUID
 
+from fastapi import Request, status
+from sqlalchemy import and_, or_
 from sqlalchemy.orm import Session
 
+from app.core.errors import ErrorCodes, raise_http
 from app.domain.stock.models import StockEntry
 from app.domain.users.models import User
 
 _DEFAULT_LIMIT = 50
 _MAX_LIMIT = 200
+
+
+def parse_activity_cursor(value: str | None):
+    if value is None:
+        return None
+    from datetime import datetime
+
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        raise_http(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            code=ErrorCodes.ACTIVITY_INVALID_CURSOR,
+            message="invalid before_occurred_at",
+        )
+
+
+def activity_stock_rows(db: Session, stmt, *, cursor_at, before_id, limit: int):
+    if cursor_at is not None and before_id is not None:
+        stmt = stmt.where(
+            or_(
+                StockEntry.occurred_at < cursor_at,
+                and_(StockEntry.occurred_at == cursor_at, StockEntry.id < before_id),
+            )
+        )
+    stmt = stmt.order_by(StockEntry.occurred_at.desc(), StockEntry.id.desc()).limit(limit + 1)
+    return list(db.execute(stmt).scalars())
+
+
+def request_user_cache(request: Request):
+    if not hasattr(request.state, "user_cache"):
+        request.state.user_cache = {}
+    return request.state.user_cache
+
+
+def route_activity(
+    request: Request,
+    db: Session,
+    stmt,
+    *,
+    before_occurred_at: str | None,
+    before_id,
+    limit: int,
+    entity,
+    created_kind: str,
+    updated_kind: str,
+):
+    cursor_at = parse_activity_cursor(before_occurred_at)
+    stock_rows = activity_stock_rows(
+        db, stmt, cursor_at=cursor_at, before_id=before_id, limit=limit
+    )
+    return build_activity(
+        db,
+        stock_rows=stock_rows,
+        created_at=entity.created_at,
+        updated_at=entity.updated_at,
+        created_by=entity.created_by,
+        updated_by=entity.updated_by,
+        created_kind=created_kind,
+        updated_kind=updated_kind,
+        limit=limit,
+        include_synthetic=(cursor_at is None),
+        user_cache=request_user_cache(request),
+    )
 
 
 def _user_dict(user: User | None) -> dict | None:

--- a/backend/app/api/routes/_stock_integrity.py
+++ b/backend/app/api/routes/_stock_integrity.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 from typing import NoReturn
 
-from fastapi import HTTPException, status
+from fastapi import status
 from sqlalchemy.exc import DBAPIError
 
-from app.core.errors import ErrorCodes
+from app.core.errors import ErrorCodes, raise_http
 
 _STOCK_NONNEG_NAMES = {
     "ck_stock_nonneg",
@@ -18,22 +18,19 @@ _WORKSPACE_ISOLATION_SQLSTATE = "WS001"
 def raise_integrity_as_409(exc: DBAPIError) -> NoReturn:
     """Map the stock non-negative trigger to the public conflict contract."""
     if _is_workspace_isolation_violation(exc):
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail={
-                "code": ErrorCodes.WORKSPACE_ISOLATION,
-                "message": "workspace isolation violation",
-                "sqlstate": _WORKSPACE_ISOLATION_SQLSTATE,
-            },
-        ) from exc
+        raise_http(
+            status.HTTP_409_CONFLICT,
+            code=ErrorCodes.WORKSPACE_ISOLATION,
+            message="workspace isolation violation",
+            sqlstate=_WORKSPACE_ISOLATION_SQLSTATE,
+        )
     if _is_stock_nonneg_violation(exc):
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail={
-                "message": "insufficient stock",
-                "constraint": "stock_nonneg_trigger",
-            },
-        ) from exc
+        raise_http(
+            status.HTTP_409_CONFLICT,
+            code=ErrorCodes.STOCK_INSUFFICIENT,
+            message="insufficient stock",
+            constraint="stock_nonneg_trigger",
+        )
     raise exc
 
 

--- a/backend/app/api/routes/builds.py
+++ b/backend/app/api/routes/builds.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException, Query, Request, status
+from fastapi import APIRouter, Query, Request, status
 from sqlalchemy import and_, or_, select
 from sqlalchemy.exc import DBAPIError
 
@@ -11,6 +11,7 @@ from app.api._helpers import require_resource_access
 from app.api.routes._activity import _DEFAULT_LIMIT, _MAX_LIMIT, build_activity
 from app.api.routes._stock_integrity import raise_integrity_as_409
 from app.core.deps import CurrentUser, CurrentWorkspace, DbSession
+from app.core.errors import ErrorCodes, raise_http
 from app.core.responses import ok
 from app.core.time import utcnow
 from app.domain.builds.models import Build
@@ -49,14 +50,18 @@ def _serialize(b: Build) -> dict:
 def _get_build(db, ws_id, bid) -> Build:
     b = db.get(Build, bid)
     if not b or b.workspace_id != ws_id:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="build not found")
+        raise_http(
+            status.HTTP_404_NOT_FOUND,
+            code=ErrorCodes.BUILD_NOT_FOUND,
+            message="build not found",
+        )
     return b
 
 
 def _get_project(db, ws_id, pid) -> Project:
     p = db.get(Project, pid)
     if not p or p.workspace_id != ws_id:
-        raise HTTPException(status_code=404, detail="project not found")
+        raise_http(404, code=ErrorCodes.PROJECT_NOT_FOUND, message="project not found")
     return p
 
 
@@ -69,7 +74,9 @@ def list_builds(
     limit: int = Query(default=200, le=1000),
 ):
     stmt = select(Build).where(Build.workspace_id == ws.id)
-    stmt = stmt.where(Build.archived_at.is_(None) if not archived else Build.archived_at.is_not(None))
+    stmt = stmt.where(
+        Build.archived_at.is_(None) if not archived else Build.archived_at.is_not(None)
+    )
     if project_id:
         stmt = stmt.where(Build.project_id == project_id)
     stmt = stmt.order_by(Build.created_at.desc()).limit(limit)
@@ -116,10 +123,16 @@ def get_build(build_id: UUID, db: DbSession, ws: CurrentWorkspace):
 
 
 @router.patch("/{build_id}")
-def patch_build(build_id: UUID, payload: BuildPatchIn, db: DbSession, ws: CurrentWorkspace, user: CurrentUser):
+def patch_build(
+    build_id: UUID,
+    payload: BuildPatchIn,
+    db: DbSession,
+    ws: CurrentWorkspace,
+    user: CurrentUser,
+):
     b = _get_build(db, ws.id, build_id)
     if b.status == "complete" and payload.status != "cancelled":
-        raise HTTPException(status_code=400, detail="completed builds are read-only")
+        raise_http(400, code=ErrorCodes.BUILD_READ_ONLY, message="completed builds are read-only")
     patch_data = payload.model_dump(exclude_unset=True)
     quantity_changed = "quantity" in patch_data and patch_data["quantity"] != b.quantity
     cancelling = patch_data.get("status") == "cancelled" and b.status != "cancelled"
@@ -188,18 +201,17 @@ def consume_build(
         # producer write into the chosen output storage; if that storage
         # is constrained the violation surfaces as a structured 409 with
         # the same body shape as /api/stock/add.
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail={
-                "message": str(exc),
-                "constraint": exc.constraint,
-                "storage_location_id": str(exc.storage_location_id),
-            },
+        raise_http(
+            status.HTTP_409_CONFLICT,
+            code=ErrorCodes.STOCK_CONSTRAINT_VIOLATION,
+            message=str(exc),
+            constraint=exc.constraint,
+            storage_location_id=str(exc.storage_location_id),
         )
     except BuildError as exc:
         # `get_db` rolls back on raise (BE2-010), so dropping the
         # explicit db.rollback() here is safe.
-        raise HTTPException(status_code=400, detail=str(exc))
+        raise_http(400, code=ErrorCodes.BUILD_CONSUME_ERROR, message=str(exc))
     except DBAPIError as exc:
         raise_integrity_as_409(exc)
     return ok(result)
@@ -222,7 +234,11 @@ def build_activity_route(
         try:
             cursor_at = datetime.fromisoformat(before_occurred_at)
         except ValueError:
-            raise HTTPException(status_code=422, detail="invalid before_occurred_at")
+            raise_http(
+                422,
+                code=ErrorCodes.ACTIVITY_INVALID_CURSOR,
+                message="invalid before_occurred_at",
+            )
 
     stmt = (
         select(StockEntry)

--- a/backend/app/api/routes/orders.py
+++ b/backend/app/api/routes/orders.py
@@ -4,7 +4,7 @@ import logging
 from datetime import datetime
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException, Query, Request, status
+from fastapi import APIRouter, Query, Request, status
 from sqlalchemy import and_, or_, select
 from sqlalchemy.exc import DBAPIError
 
@@ -12,6 +12,7 @@ from app.api._helpers import assert_child_in_parent, assert_in_workspace, requir
 from app.api.routes._activity import _DEFAULT_LIMIT, _MAX_LIMIT, build_activity
 from app.api.routes._stock_integrity import raise_integrity_as_409
 from app.core.deps import CurrentUser, CurrentWorkspace, DbSession
+from app.core.errors import ErrorCodes, raise_http
 from app.core.responses import ok
 from app.core.time import utcnow
 from app.domain.orders.models import Order, OrderEntry
@@ -39,7 +40,11 @@ def _assert_part_live(db, ws_id: UUID, part_id) -> None:
         return
     part = assert_in_workspace(db, Part, part_id, ws_id, label="part")
     if part.archived_at is not None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="part not found")
+        raise_http(
+            status.HTTP_404_NOT_FOUND,
+            code=ErrorCodes.PART_NOT_FOUND,
+            message="part not found",
+        )
 
 
 def _serialize(o: Order, *, totals: tuple[int, int] | None = None) -> dict:
@@ -80,7 +85,11 @@ def _serialize_entry(e: OrderEntry) -> dict:
 def _get_order(db, ws_id, oid) -> Order:
     o = db.get(Order, oid)
     if not o or o.workspace_id != ws_id:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="order not found")
+        raise_http(
+            status.HTTP_404_NOT_FOUND,
+            code=ErrorCodes.ORDER_NOT_FOUND,
+            message="order not found",
+        )
     return o
 
 
@@ -112,10 +121,18 @@ def list_orders(
     limit: int = Query(default=200, le=1000),
 ):
     stmt = select(Order).where(Order.workspace_id == ws.id)
-    stmt = stmt.where(Order.archived_at.is_(None) if not archived else Order.archived_at.is_not(None))
+    stmt = stmt.where(
+        Order.archived_at.is_(None) if not archived else Order.archived_at.is_not(None)
+    )
     if q:
         like = f"%{q}%"
-        stmt = stmt.where(or_(Order.name.ilike(like), Order.supplier.ilike(like), Order.comments.ilike(like)))
+        stmt = stmt.where(
+            or_(
+                Order.name.ilike(like),
+                Order.supplier.ilike(like),
+                Order.comments.ilike(like),
+            )
+        )
     if order_status:
         stmt = stmt.where(Order.status == order_status)
     stmt = stmt.order_by(Order.updated_at.desc()).limit(limit)
@@ -176,7 +193,13 @@ def get_order(order_id: UUID, db: DbSession, ws: CurrentWorkspace):
 
 
 @router.patch("/{order_id}")
-def patch_order(order_id: UUID, payload: OrderPatchIn, db: DbSession, ws: CurrentWorkspace, user: CurrentUser):
+def patch_order(
+    order_id: UUID,
+    payload: OrderPatchIn,
+    db: DbSession,
+    ws: CurrentWorkspace,
+    user: CurrentUser,
+):
     o = _get_order(db, ws.id, order_id)
     for k, v in payload.model_dump(exclude_unset=True).items():
         setattr(o, k, v)
@@ -233,7 +256,13 @@ def restore_order(order_id: UUID, db: DbSession, ws: CurrentWorkspace, user: Cur
 
 
 @router.post("/{order_id}/entries", status_code=status.HTTP_201_CREATED)
-def add_entry(order_id: UUID, payload: OrderEntryIn, db: DbSession, ws: CurrentWorkspace, user: CurrentUser):
+def add_entry(
+    order_id: UUID,
+    payload: OrderEntryIn,
+    db: DbSession,
+    ws: CurrentWorkspace,
+    user: CurrentUser,
+):
     o = _get_order(db, ws.id, order_id)
     _assert_part_live(db, ws.id, payload.part_id)
     next_idx = (
@@ -266,7 +295,14 @@ def add_entry(order_id: UUID, payload: OrderEntryIn, db: DbSession, ws: CurrentW
 
 
 @router.patch("/{order_id}/entries/{entry_id}")
-def patch_entry(order_id: UUID, entry_id: UUID, payload: OrderEntryPatch, db: DbSession, ws: CurrentWorkspace, user: CurrentUser):
+def patch_entry(
+    order_id: UUID,
+    entry_id: UUID,
+    payload: OrderEntryPatch,
+    db: DbSession,
+    ws: CurrentWorkspace,
+    user: CurrentUser,
+):
     o = _get_order(db, ws.id, order_id)
     e = assert_child_in_parent(db, OrderEntry, entry_id, o, parent_fk="order_id", label="entry")
     data = payload.model_dump(exclude_unset=True)
@@ -274,9 +310,10 @@ def patch_entry(order_id: UUID, entry_id: UUID, payload: OrderEntryPatch, db: Db
         _assert_part_live(db, ws.id, data["part_id"])
     if "quantity_ordered" in data and data["quantity_ordered"] is not None:
         if data["quantity_ordered"] < e.quantity_received:
-            raise HTTPException(
-                status_code=400,
-                detail="quantity_ordered cannot be less than already-received quantity",
+            raise_http(
+                400,
+                code=ErrorCodes.ORDER_QUANTITY_ORDERED_BELOW_RECEIVED,
+                message="quantity_ordered cannot be less than already-received quantity",
             )
     for k, v in data.items():
         setattr(e, k, v)
@@ -289,13 +326,23 @@ def del_entry(order_id: UUID, entry_id: UUID, db: DbSession, ws: CurrentWorkspac
     o = _get_order(db, ws.id, order_id)
     e = assert_child_in_parent(db, OrderEntry, entry_id, o, parent_fk="order_id", label="entry")
     if e.quantity_received > 0:
-        raise HTTPException(status_code=400, detail="cannot delete entry with received stock")
+        raise_http(
+            400,
+            code=ErrorCodes.ORDER_DELETE_RECEIVED_ENTRY,
+            message="cannot delete entry with received stock",
+        )
     db.delete(e)
     return ok(None, "deleted")
 
 
 @router.post("/{order_id}/receive")
-def receive_order(order_id: UUID, payload: ReceiveIn, db: DbSession, ws: CurrentWorkspace, user: CurrentUser):
+def receive_order(
+    order_id: UUID,
+    payload: ReceiveIn,
+    db: DbSession,
+    ws: CurrentWorkspace,
+    user: CurrentUser,
+):
     o = _get_order(db, ws.id, order_id)
     try:
         result = receive(db, workspace_id=ws.id, user_id=user.id, order=o, payload=payload)
@@ -303,19 +350,18 @@ def receive_order(order_id: UUID, payload: ReceiveIn, db: DbSession, ws: Current
         # BE-004 follow-up (#280): receive lines into a constrained
         # destination must surface a structured 409 with the same body
         # shape as /api/stock/add so existing client-side handlers work.
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail={
-                "message": str(exc),
-                "constraint": exc.constraint,
-                "storage_location_id": str(exc.storage_location_id),
-            },
+        raise_http(
+            status.HTTP_409_CONFLICT,
+            code=ErrorCodes.STOCK_CONSTRAINT_VIOLATION,
+            message=str(exc),
+            constraint=exc.constraint,
+            storage_location_id=str(exc.storage_location_id),
         )
     except OrderError as exc:
         # Re-raise as a 4xx — `get_db` rolls back automatically when
         # the route raises (BE2-010), so we don't need an explicit
         # db.rollback() here.
-        raise HTTPException(status_code=400, detail=str(exc))
+        raise_http(400, code=ErrorCodes.ORDER_RECEIVE_ERROR, message=str(exc))
     except DBAPIError as exc:
         raise_integrity_as_409(exc)
     return ok(result)
@@ -338,7 +384,11 @@ def order_activity(
         try:
             cursor_at = datetime.fromisoformat(before_occurred_at)
         except ValueError:
-            raise HTTPException(status_code=422, detail="invalid before_occurred_at")
+            raise_http(
+                422,
+                code=ErrorCodes.ACTIVITY_INVALID_CURSOR,
+                message="invalid before_occurred_at",
+            )
 
     stmt = (
         select(StockEntry)

--- a/backend/app/api/routes/orders.py
+++ b/backend/app/api/routes/orders.py
@@ -1,15 +1,18 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime
 from uuid import UUID
 
 from fastapi import APIRouter, Query, Request, status
-from sqlalchemy import and_, or_, select
+from sqlalchemy import or_, select
 from sqlalchemy.exc import DBAPIError
 
 from app.api._helpers import assert_child_in_parent, assert_in_workspace, require_resource_access
-from app.api.routes._activity import _DEFAULT_LIMIT, _MAX_LIMIT, build_activity
+from app.api.routes._activity import (
+    _DEFAULT_LIMIT,
+    _MAX_LIMIT,
+    route_activity,
+)
 from app.api.routes._stock_integrity import raise_integrity_as_409
 from app.core.deps import CurrentUser, CurrentWorkspace, DbSession
 from app.core.errors import ErrorCodes, raise_http
@@ -379,49 +382,19 @@ def order_activity(
 ):
     o = _get_order(db, ws.id, order_id)
 
-    cursor_at: datetime | None = None
-    if before_occurred_at is not None:
-        try:
-            cursor_at = datetime.fromisoformat(before_occurred_at)
-        except ValueError:
-            raise_http(
-                422,
-                code=ErrorCodes.ACTIVITY_INVALID_CURSOR,
-                message="invalid before_occurred_at",
-            )
-
     stmt = (
         select(StockEntry)
         .where(StockEntry.workspace_id == ws.id)
         .where(StockEntry.order_id == o.id)
     )
-    if cursor_at is not None and before_id is not None:
-        stmt = stmt.where(
-            or_(
-                StockEntry.occurred_at < cursor_at,
-                and_(
-                    StockEntry.occurred_at == cursor_at,
-                    StockEntry.id < before_id,
-                ),
-            )
-        )
-    stmt = stmt.order_by(StockEntry.occurred_at.desc(), StockEntry.id.desc()).limit(limit + 1)
-    stock_rows = list(db.execute(stmt).scalars())
-
-    if not hasattr(request.state, "user_cache"):
-        request.state.user_cache = {}
-
-    result = build_activity(
+    return ok(route_activity(
+        request,
         db,
-        stock_rows=stock_rows,
-        created_at=o.created_at,
-        updated_at=o.updated_at,
-        created_by=o.created_by,
-        updated_by=o.updated_by,
+        stmt,
+        before_occurred_at=before_occurred_at,
+        before_id=before_id,
+        limit=limit,
+        entity=o,
         created_kind="order_created",
         updated_kind="order_updated",
-        limit=limit,
-        include_synthetic=(cursor_at is None),
-        user_cache=request.state.user_cache,
-    )
-    return ok(result)
+    ))

--- a/backend/app/api/routes/parts_assets.py
+++ b/backend/app/api/routes/parts_assets.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import os
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException, Query, Request, status
+from fastapi import APIRouter, Query, Request, status
 from fastapi.responses import FileResponse
 from sqlalchemy import select
 
@@ -23,6 +23,7 @@ from app.api.routes._parts_shared import (
 )
 from app.core.config import settings
 from app.core.deps import CurrentUser, CurrentWorkspace, DbSession
+from app.core.errors import ErrorCodes, raise_http
 from app.core.ratelimit import limiter, workspace_key
 from app.core.responses import ok
 from app.core.secrets import decrypt
@@ -75,14 +76,26 @@ def get_provider_asset(
     # their workspace's folder. The `ws` dep already proves membership in
     # the request's current workspace; this matches them.
     if ws_id != ws.id:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="asset not found")
+        raise_http(
+            status.HTTP_404_NOT_FOUND,
+            code=ErrorCodes.PART_ASSET_NOT_FOUND,
+            message="asset not found",
+        )
     # Disallow path traversal — filename must be a flat content-addressed name.
     if "/" in filename or "\\" in filename or filename.startswith("."):
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="invalid filename")
+        raise_http(
+            status.HTTP_400_BAD_REQUEST,
+            code=ErrorCodes.PART_ASSET_INVALID_FILENAME,
+            message="invalid filename",
+        )
 
     abs_path = os.path.join(settings().UPLOAD_DIR, "parts", str(ws_id), filename)
     if not os.path.isfile(abs_path):
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="asset not found")
+        raise_http(
+            status.HTTP_404_NOT_FOUND,
+            code=ErrorCodes.PART_ASSET_NOT_FOUND,
+            message="asset not found",
+        )
 
     ext = filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
     served_mime = _ASSET_MIME_BY_EXT.get(ext, "application/octet-stream")
@@ -136,7 +149,11 @@ def refresh_from_provider(
     it hasn't been locally edited."""
     p = _get_part(db, ws.id, part_id)
     if not (p.mpn or "").strip():
-        raise HTTPException(status_code=400, detail="part has no MPN to look up")
+        raise_http(
+            400,
+            code=ErrorCodes.PART_PROVIDER_MISSING_MPN,
+            message="part has no MPN to look up",
+        )
 
     provider = make_provider(
         ws.parts_provider,
@@ -144,9 +161,10 @@ def refresh_from_provider(
         decrypt(ws.parts_provider_api_secret),
     )
     if provider is None:
-        raise HTTPException(
-            status_code=400,
-            detail="no parts provider configured (set one in Workspace settings)",
+        raise_http(
+            400,
+            code=ErrorCodes.PART_PROVIDER_NOT_CONFIGURED,
+            message="no parts provider configured (set one in Workspace settings)",
         )
 
     # Use lookup_fresh (not lookup_with_cache) — the operator explicitly
@@ -155,10 +173,12 @@ def refresh_from_provider(
     try:
         out = lookup_fresh(provider, p.mpn.strip())
     except ProviderUpstreamError as exc:
-        raise HTTPException(
-            status_code=exc.status_code,
-            detail={"message": exc.message, "provider": exc.provider},
-        ) from exc
+        raise_http(
+            exc.status_code,
+            code=ErrorCodes.PROVIDER_UPSTREAM_ERROR,
+            message=exc.message,
+            provider=exc.provider,
+        )
     if not out.get("found") or not out.get("result"):
         return ok(
             {

--- a/backend/app/api/routes/parts_core.py
+++ b/backend/app/api/routes/parts_core.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import logging
 import re
-from datetime import datetime
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Query, Request, status
@@ -15,7 +14,11 @@ from sqlalchemy import or_, select
 from sqlalchemy.exc import IntegrityError
 
 from app.api._helpers import assert_in_workspace, require_resource_access
-from app.api.routes._activity import _DEFAULT_LIMIT, _MAX_LIMIT, build_activity
+from app.api.routes._activity import (
+    _DEFAULT_LIMIT,
+    _MAX_LIMIT,
+    route_activity,
+)
 from app.api.routes._parts_shared import (
     get_part as _get_part,
 )
@@ -97,9 +100,6 @@ def list_parts(
         the next page.  ``next_cursor`` is null when no further pages
         exist. The ``cursor`` is an HMAC-signed blob — tampering returns
         400.
-
-    The ``limit`` query param is honoured in both modes; ``paged=true``
-    only changes the response envelope shape (adds ``next_cursor``).
 
     Every query is scoped to the current workspace (CLAUDE.md invariant).
     """
@@ -682,52 +682,19 @@ def part_activity(
     # Read endpoint — let archived parts surface their history too.
     p = _get_part(db, ws.id, part_id, include_archived=True)
 
-    # Parse cursor
-    cursor_at: datetime | None = None
-    if before_occurred_at is not None:
-        try:
-            cursor_at = datetime.fromisoformat(before_occurred_at)
-        except ValueError:
-            raise_http(
-                422,
-                code=ErrorCodes.ACTIVITY_INVALID_CURSOR,
-                message="invalid before_occurred_at",
-            )
-
     stmt = (
         select(StockEntry)
         .where(StockEntry.workspace_id == ws.id)
         .where(StockEntry.part_id == p.id)
     )
-    if cursor_at is not None and before_id is not None:
-        from sqlalchemy import and_, or_
-        stmt = stmt.where(
-            or_(
-                StockEntry.occurred_at < cursor_at,
-                and_(
-                    StockEntry.occurred_at == cursor_at,
-                    StockEntry.id < before_id,
-                ),
-            )
-        )
-    stmt = stmt.order_by(StockEntry.occurred_at.desc(), StockEntry.id.desc()).limit(limit + 1)
-    stock_rows = list(db.execute(stmt).scalars())
-
-    # Per-request user cache stashed on request.state so it's isolated per request.
-    if not hasattr(request.state, "user_cache"):
-        request.state.user_cache = {}
-
-    result = build_activity(
+    return ok(route_activity(
+        request,
         db,
-        stock_rows=stock_rows,
-        created_at=p.created_at,
-        updated_at=p.updated_at,
-        created_by=p.created_by,
-        updated_by=p.updated_by,
+        stmt,
+        before_occurred_at=before_occurred_at,
+        before_id=before_id,
+        limit=limit,
+        entity=p,
         created_kind="part_created",
         updated_kind="part_updated",
-        limit=limit,
-        include_synthetic=(cursor_at is None),
-        user_cache=request.state.user_cache,
-    )
-    return ok(result)
+    ))

--- a/backend/app/api/routes/parts_core.py
+++ b/backend/app/api/routes/parts_core.py
@@ -10,7 +10,7 @@ import re
 from datetime import datetime
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from fastapi import APIRouter, Depends, Query, Request, status
 from sqlalchemy import or_, select
 from sqlalchemy.exc import IntegrityError
 
@@ -59,13 +59,12 @@ logger = logging.getLogger(__name__)
 
 
 def _raise_mpn_conflict(existing: Part) -> None:
-    raise HTTPException(
-        status_code=status.HTTP_409_CONFLICT,
-        detail={
-            "message": f"MPN already used by part \"{existing.name}\"",
-            "existing_id": str(existing.id),
-            "existing_name": existing.name,
-        },
+    raise_http(
+        status.HTTP_409_CONFLICT,
+        code=ErrorCodes.PART_MPN_CONFLICT,
+        message=f"MPN already used by part \"{existing.name}\"",
+        existing_id=str(existing.id),
+        existing_name=existing.name,
     )
 
 
@@ -148,8 +147,12 @@ def list_parts(
 
     part_ids = [p.id for p in parts]
     image_urls = _image_urls_for_parts(db, ws.id, part_ids)
-    on_hand_map = bulk_current_quantities(db, workspace_id=ws.id, part_ids=part_ids, status="on_hand")
-    reserved_map = bulk_current_quantities(db, workspace_id=ws.id, part_ids=part_ids, status="reserved")
+    on_hand_map = bulk_current_quantities(
+        db, workspace_id=ws.id, part_ids=part_ids, status="on_hand"
+    )
+    reserved_map = bulk_current_quantities(
+        db, workspace_id=ws.id, part_ids=part_ids, status="reserved"
+    )
     items = []
     for p in parts:
         items.append(_serialize(
@@ -174,9 +177,10 @@ def create_part(
     name = (payload.name or "").strip()
     mpn = (payload.mpn or "").strip()
     if not name and not mpn:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail="provide at least one of `name` or `mpn`",
+        raise_http(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            code=ErrorCodes.PART_NAME_OR_MPN_REQUIRED,
+            message="provide at least one of `name` or `mpn`",
         )
     if not name:
         name = mpn
@@ -244,7 +248,13 @@ def get_part(part_id: UUID, db: DbSession, ws: CurrentWorkspace):
 
 
 @router.patch("/{part_id}")
-def patch_part(part_id: UUID, payload: PartPatch, db: DbSession, ws: CurrentWorkspace, user: CurrentUser):
+def patch_part(
+    part_id: UUID,
+    payload: PartPatch,
+    db: DbSession,
+    ws: CurrentWorkspace,
+    user: CurrentUser,
+):
     # Write — refuse archived parts. Editing a retired part would create
     # a misleading audit trail and is the BE2-016 vector.
     p = _get_part(db, ws.id, part_id)
@@ -256,9 +266,14 @@ def patch_part(part_id: UUID, payload: PartPatch, db: DbSession, ws: CurrentWork
     if p.linked_provider and not unlink:
         for f in ("manufacturer", "mpn"):
             if f in data and data[f] != getattr(p, f):
-                raise HTTPException(
-                    status_code=400,
-                    detail=f"{f} is provider-owned on a linked part; pass unlink_provider=true to take ownership",
+                raise_http(
+                    400,
+                    code=ErrorCodes.PART_LINKED_PROVIDER_OWNED_FIELD,
+                    message=(
+                        f"{f} is provider-owned on a linked part; "
+                        "pass unlink_provider=true to take ownership"
+                    ),
+                    field=f,
                 )
 
     # Editing description on a linked part flips the locally-edited flag so
@@ -523,7 +538,9 @@ def part_stock(part_id: UUID, db: DbSession, ws: CurrentWorkspace):
             "total_on_hand": total_for_part(db, workspace_id=ws.id, part_id=p.id),
             "rows": [
                 {
-                    "storage_location_id": str(r["storage_location_id"]) if r["storage_location_id"] else None,
+                    "storage_location_id": (
+                        str(r["storage_location_id"]) if r["storage_location_id"] else None
+                    ),
                     "lot_id": str(r["lot_id"]) if r["lot_id"] else None,
                     "quantity": r["quantity"],
                 }
@@ -539,25 +556,32 @@ def part_lots(part_id: UUID, db: DbSession, ws: CurrentWorkspace):
     p = _get_part(db, ws.id, part_id, include_archived=True)
     lots = list(
         db.execute(
-            select(Lot).where(Lot.workspace_id == ws.id).where(Lot.part_id == p.id).order_by(Lot.created_at.desc())
+            select(Lot)
+            .where(Lot.workspace_id == ws.id)
+            .where(Lot.part_id == p.id)
+            .order_by(Lot.created_at.desc())
         ).scalars()
     )
     return ok(
         [
             {
-                "id": str(l.id),
-                "name": l.name,
-                "serial_number": l.serial_number,
-                "purchase_quantity": l.purchase_quantity,
-                "purchase_unit_cost": float(l.purchase_unit_cost) if l.purchase_unit_cost is not None else None,
-                "purchase_currency": l.purchase_currency,
-                "expiration_date": l.expiration_date.isoformat() if l.expiration_date else None,
-                "comments": l.comments,
-                "parent_lot_id": str(l.parent_lot_id) if l.parent_lot_id else None,
-                "source_type": l.source_type,
-                "created_at": l.created_at.isoformat(),
+                "id": str(lot.id),
+                "name": lot.name,
+                "serial_number": lot.serial_number,
+                "purchase_quantity": lot.purchase_quantity,
+                "purchase_unit_cost": (
+                    float(lot.purchase_unit_cost)
+                    if lot.purchase_unit_cost is not None
+                    else None
+                ),
+                "purchase_currency": lot.purchase_currency,
+                "expiration_date": lot.expiration_date.isoformat() if lot.expiration_date else None,
+                "comments": lot.comments,
+                "parent_lot_id": str(lot.parent_lot_id) if lot.parent_lot_id else None,
+                "source_type": lot.source_type,
+                "created_at": lot.created_at.isoformat(),
             }
-            for l in lots
+            for lot in lots
         ]
     )
 
@@ -610,12 +634,20 @@ def list_members(meta_id: UUID, db: DbSession, ws: CurrentWorkspace):
 def add_member(meta_id: UUID, payload: MetaMemberIn, db: DbSession, ws: CurrentWorkspace):
     meta = _get_part(db, ws.id, meta_id)
     if meta.part_type != "meta":
-        raise HTTPException(status_code=400, detail="part is not a meta-part")
+        raise_http(400, code=ErrorCodes.PART_NOT_META, message="part is not a meta-part")
     member = _get_part(db, ws.id, payload.member_part_id)
     if member.id == meta.id:
-        raise HTTPException(status_code=400, detail="meta-part cannot include itself")
+        raise_http(
+            400,
+            code=ErrorCodes.PART_META_SELF_MEMBER,
+            message="meta-part cannot include itself",
+        )
     if member.part_type == "meta":
-        raise HTTPException(status_code=400, detail="meta-part members cannot themselves be meta")
+        raise_http(
+            400,
+            code=ErrorCodes.PART_META_MEMBER_META,
+            message="meta-part members cannot themselves be meta",
+        )
     existing = db.query(PartMetaMember).filter_by(
         workspace_id=ws.id, meta_part_id=meta.id, part_id=member.id
     ).first()
@@ -656,7 +688,11 @@ def part_activity(
         try:
             cursor_at = datetime.fromisoformat(before_occurred_at)
         except ValueError:
-            raise HTTPException(status_code=422, detail="invalid before_occurred_at")
+            raise_http(
+                422,
+                code=ErrorCodes.ACTIVITY_INVALID_CURSOR,
+                message="invalid before_occurred_at",
+            )
 
     stmt = (
         select(StockEntry)

--- a/backend/app/api/routes/parts_scan.py
+++ b/backend/app/api/routes/parts_scan.py
@@ -16,13 +16,14 @@ from datetime import datetime, timedelta, timezone
 from time import monotonic
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, Request
 from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import IntegrityError
 
 from app.api.routes._parts_shared import get_part as _get_part
 from app.core.deps import CurrentUser, CurrentWorkspace, DbSession
+from app.core.errors import ErrorCodes, raise_http
 from app.core.ratelimit import limiter, workspace_key
 from app.core.responses import ok
 from app.core.secrets import decrypt
@@ -166,9 +167,10 @@ def bulk_import_from_scan(
         decrypt(ws.parts_provider_api_secret),
     )
     if provider is None:
-        raise HTTPException(
-            status_code=400,
-            detail="no parts provider configured (set one in Workspace settings)",
+        raise_http(
+            400,
+            code=ErrorCodes.PART_PROVIDER_NOT_CONFIGURED,
+            message="no parts provider configured (set one in Workspace settings)",
         )
 
     # ------------------------------------------------------------------
@@ -559,5 +561,5 @@ def quick_remove_bag(
             ),
         )
     except StockError as exc:
-        raise HTTPException(status_code=400, detail=str(exc))
+        raise_http(400, code=ErrorCodes.STOCK_OPERATION_ERROR, message=str(exc))
     return ok(None, "removed")

--- a/backend/app/api/routes/stock.py
+++ b/backend/app/api/routes/stock.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException, Query, status
+from fastapi import APIRouter, Query, status
 from sqlalchemy.exc import DBAPIError
 
 from app.api.routes._stock_integrity import raise_integrity_as_409
@@ -77,28 +77,28 @@ def add(
     if payload.bag_signature and payload.raw_bag_code is not None:
         expected = compute_bag_signature(payload.raw_bag_code)
         if expected != payload.bag_signature:
-            raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                detail={
-                    "message": (
-                        "bag_signature does not match recomputed digest of raw_bag_code"
-                    )
-                },
+            raise_http(
+                status.HTTP_422_UNPROCESSABLE_ENTITY,
+                code=ErrorCodes.STOCK_BAG_SIGNATURE_MISMATCH,
+                message="bag_signature does not match recomputed digest of raw_bag_code",
             )
     _validate_add_stock_currency(payload, ws)
     try:
         e = add_stock(db, workspace_id=ws.id, user_id=user.id, payload=payload)
     except StockConflictError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail={
-                "message": str(exc),
-                "constraint": exc.constraint,
-                "storage_location_id": str(exc.storage_location_id),
-            },
+        raise_http(
+            status.HTTP_409_CONFLICT,
+            code=ErrorCodes.STOCK_CONSTRAINT_VIOLATION,
+            message=str(exc),
+            constraint=exc.constraint,
+            storage_location_id=str(exc.storage_location_id),
         )
     except StockError as exc:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
+        raise_http(
+            status.HTTP_400_BAD_REQUEST,
+            code=ErrorCodes.STOCK_OPERATION_ERROR,
+            message=str(exc),
+        )
     except DBAPIError as exc:
         raise_integrity_as_409(exc)
     return ok(_serialize_entry(e))
@@ -111,7 +111,11 @@ def remove(
     try:
         e = remove_stock(db, workspace_id=ws.id, user_id=user.id, payload=payload)
     except StockError as exc:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
+        raise_http(
+            status.HTTP_400_BAD_REQUEST,
+            code=ErrorCodes.STOCK_OPERATION_ERROR,
+            message=str(exc),
+        )
     except DBAPIError as exc:
         raise_integrity_as_409(exc)
     return ok(_serialize_entry(e))
@@ -122,16 +126,19 @@ def move(payload: MoveStockIn, db: DbSession, ws: CurrentWorkspace, user: Curren
     try:
         out_e, in_e = move_stock(db, workspace_id=ws.id, user_id=user.id, payload=payload)
     except StockConflictError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail={
-                "message": str(exc),
-                "constraint": exc.constraint,
-                "storage_location_id": str(exc.storage_location_id),
-            },
+        raise_http(
+            status.HTTP_409_CONFLICT,
+            code=ErrorCodes.STOCK_CONSTRAINT_VIOLATION,
+            message=str(exc),
+            constraint=exc.constraint,
+            storage_location_id=str(exc.storage_location_id),
         )
     except StockError as exc:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
+        raise_http(
+            status.HTTP_400_BAD_REQUEST,
+            code=ErrorCodes.STOCK_OPERATION_ERROR,
+            message=str(exc),
+        )
     except DBAPIError as exc:
         raise_integrity_as_409(exc)
     return ok({"out": _serialize_entry(out_e), "in": _serialize_entry(in_e)})
@@ -142,7 +149,11 @@ def adjust(payload: AdjustStockIn, db: DbSession, ws: CurrentWorkspace, user: Cu
     try:
         e = adjust_stock(db, workspace_id=ws.id, user_id=user.id, payload=payload)
     except StockError as exc:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
+        raise_http(
+            status.HTTP_400_BAD_REQUEST,
+            code=ErrorCodes.STOCK_OPERATION_ERROR,
+            message=str(exc),
+        )
     except DBAPIError as exc:
         raise_integrity_as_409(exc)
     return ok(_serialize_entry(e) if e is not None else None, "no change" if e is None else "OK")

--- a/backend/app/core/errors.py
+++ b/backend/app/core/errors.py
@@ -168,6 +168,10 @@ class ErrorCodes:
 
     # Stock router.
     STOCK_INVALID_CURRENCY = "stock.invalid_currency"
+    STOCK_BAG_SIGNATURE_MISMATCH = "stock.bag_signature_mismatch"
+    STOCK_CONSTRAINT_VIOLATION = "stock.constraint_violation"
+    STOCK_OPERATION_ERROR = "stock.operation_error"
+    STOCK_INSUFFICIENT = "stock.insufficient"
 
     # Workspace dependency-injection edge cases (deps.py).
     # WORKSPACE_NONE: caller has no active membership in any workspace
@@ -205,6 +209,30 @@ class ErrorCodes:
     # Parts shared helpers.
     PART_NOT_FOUND = "part.not_found"
     PART_HAS_RESERVED_STOCK = "part.has_reserved_stock"
+    PART_MPN_CONFLICT = "part.mpn_conflict"
+    PART_NAME_OR_MPN_REQUIRED = "part.name_or_mpn_required"
+    PART_LINKED_PROVIDER_OWNED_FIELD = "part.linked_provider_owned_field"
+    PART_NOT_META = "part.not_meta"
+    PART_META_SELF_MEMBER = "part.meta_self_member"
+    PART_META_MEMBER_META = "part.meta_member_meta"
+    PART_PROVIDER_NOT_CONFIGURED = "part.provider_not_configured"
+    PART_PROVIDER_MISSING_MPN = "part.provider_missing_mpn"
+    PART_ASSET_NOT_FOUND = "part.asset_not_found"
+    PART_ASSET_INVALID_FILENAME = "part.asset_invalid_filename"
+
+    # Activity cursor parsing.
+    ACTIVITY_INVALID_CURSOR = "activity.invalid_cursor"
+
+    # Orders router.
+    ORDER_NOT_FOUND = "order.not_found"
+    ORDER_QUANTITY_ORDERED_BELOW_RECEIVED = "order.quantity_ordered_below_received"
+    ORDER_DELETE_RECEIVED_ENTRY = "order.delete_received_entry"
+    ORDER_RECEIVE_ERROR = "order.receive_error"
+
+    # Builds router.
+    BUILD_NOT_FOUND = "build.not_found"
+    BUILD_READ_ONLY = "build.read_only"
+    BUILD_CONSUME_ERROR = "build.consume_error"
 
     # Projects router.
     PROJECT_NOT_FOUND = "project.not_found"

--- a/backend/tests/test_envelope_consistency.py
+++ b/backend/tests/test_envelope_consistency.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import ast
+import inspect
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+
+from app.core.errors import ErrorCodes, raise_http
+from app.main import app
+
+
+def _route_modules() -> list[Path]:
+    files: set[Path] = set()
+    for route in app.routes:
+        endpoint = getattr(route, "endpoint", None)
+        if endpoint is None:
+            continue
+        try:
+            source = Path(inspect.getsourcefile(endpoint) or "").resolve()
+        except TypeError:
+            continue
+        if source.parts[-4:-1] == ("app", "api", "routes"):
+            files.add(source)
+    return sorted(files)
+
+
+@pytest.mark.parametrize("route_module", _route_modules(), ids=lambda p: p.name)
+def test_all_error_paths_return_detail_dict(route_module: Path) -> None:
+    tree = ast.parse(route_module.read_text())
+    offenders: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        name = func.id if isinstance(func, ast.Name) else getattr(func, "attr", None)
+        if name == "HTTPException":
+            offenders.append(f"{route_module}:{node.lineno}")
+
+    assert not offenders, (
+        "Route modules must use raise_http(...) so HTTPException.detail is "
+        f"a dict with code/message keys. Raw call sites: {', '.join(offenders)}"
+    )
+
+
+def test_raise_http_detail_contract() -> None:
+    with pytest.raises(HTTPException) as raised:
+        raise_http(400, ErrorCodes.STOCK_OPERATION_ERROR, "bad stock request", field="quantity")
+
+    detail = raised.value.detail
+    assert isinstance(detail, dict)
+    assert detail["code"] == ErrorCodes.STOCK_OPERATION_ERROR
+    assert detail["message"] == "bad stock request"
+    assert detail["field"] == "quantity"


### PR DESCRIPTION
Refs #831

## Summary
- Convert raw route-level HTTPException call sites in stock, parts, orders, builds, assets, scan import, and stock-integrity helpers to raise_http.
- Add scoped ErrorCodes for the previously unregistered route error cases while preserving existing codes.
- Add a route-walking envelope consistency regression test that rejects raw HTTPException call sites under app/api/routes.

## Validation
- uv run --extra dev python -m pytest -q tests/test_envelope_consistency.py (20 passed, 1 warning)
- ruff check touched backend route/core/test files (passed)
- rg 'HTTPException\(' backend/app/api/routes (no matches)
- ruff check backend was attempted; it still fails on pre-existing unrelated lint across untouched files.

## Merge order
Merge before #840/#841 if they touch the same route files, or rebase those PRs after this one.