### PR TITLE
AUD-134 clean up ADR-0021 scheduler cites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,19 @@ jobs:
             exit 1
           fi
 
+  adr-cite-freshness:
+    # AUD-134 / issue #832: ADR source citations are load-bearing onboarding
+    # pointers. Fail when a backticked file:line or file:start-end cite points
+    # outside the current tracked file.
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Check ADR file-line cites
+        run: scripts/check_adr_code_cites.py
+
   tp-schema-drift:
     # TPS-1 / issue #448: the bundled TrustedParts OpenAPI document and
     # generated Pydantic v2 models are committed artifacts. Regenerate from
@@ -773,6 +786,7 @@ jobs:
   #   - pip-audit         (SEC2-016)   — HIGH/CRITICAL CVEs in the pinned set
   #   - npm-audit         (issue #305) — CVEs in the npm production dep set
   #   - line-count-budget (CQ-002/003) — per-file line-count caps
+  #   - adr-cite-freshness (#832)      — ADR file:line cite freshness
   #   - tp-schema-drift   (#448)       — TrustedParts schema/model drift
   #   - backend-tests                  — pytest + alembic
   #   - web-build                      — tsc -b + vite build (+ sourcemap upload)
@@ -786,7 +800,7 @@ jobs:
     # Only redeploy on green main pushes. PRs and feature branches just run
     # the test/validate/security jobs above.
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: [ci-policy, lockfile-drift, pip-audit, npm-audit, line-count-budget, tp-schema-drift, backend-tests, web-build, prod-validate, playwright-e2e]
+    needs: [ci-policy, lockfile-drift, pip-audit, npm-audit, line-count-budget, adr-cite-freshness, tp-schema-drift, backend-tests, web-build, prod-validate, playwright-e2e]
     runs-on: ubuntu-latest
     # Environment association. Today this just scopes any environment-level
     # secrets we add later; if a "Required reviewers" protection rule is

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -42,11 +42,11 @@ class Settings(BaseSettings):
     # tune this without a release; restart the backend for the env
     # override to be picked up by the cached Settings instance.
     INVITATION_TTL_DAYS: int = Field(default=14, gt=0)
-    # Cadence (seconds) of the in-process expired-session purge driven
-    # by the FastAPI lifespan hook. DB-007 / issue #98. Knob exists so
-    # tests can shorten it; ops should not need to touch it. 0 disables
-    # the periodic task entirely (the migration's index still exists,
-    # so a future cron / one-off SQL still benefits).
+    # Cadence (seconds) of the backend-cron-sessions expired-session
+    # purge job. DB-007 / issue #98. Knob exists so tests can shorten
+    # it; ops should not need to touch it. 0 disables the periodic task
+    # entirely (the migration's index still exists, so a one-off SQL
+    # still benefits).
     SESSION_PURGE_INTERVAL_SECONDS: int = Field(default=3600, ge=0)
     # Cadence (seconds) of the password-reset token purge worker. 0
     # disables the periodic password-reset purge.

--- a/docs/adr/0021-periodic-jobs-scheduler.md
+++ b/docs/adr/0021-periodic-jobs-scheduler.md
@@ -9,20 +9,20 @@ Audience: engineer
 
 ## Context
 
-Phase 1 TrustedParts added a workspace-scoped sourcing cache with a seven-day database cap and a 30-minute service TTL. The database check prevents writes whose `expires_at` is more than seven days after `fetched_at`, but it does not delete expired rows. `sourcing.cache.sweep_expired()` exists for cleanup and is not called by any scheduler yet.
+Phase 1 TrustedParts added a workspace-scoped sourcing cache with a seven-day database cap and a 30-minute service TTL. The database check prevents writes whose `expires_at` is more than seven days after `fetched_at`, but it does not delete expired rows. `sourcing.cache.sweep_expired()` exists for cleanup and is run through the shared backend job runner.
 
-The repo already has one ad hoc in-process periodic task: expired session purge is spawned from FastAPI lifespan in `backend/app/main.py:136` and controlled by `SESSION_PURGE_INTERVAL_SECONDS` in `backend/app/core/config.py:34`. That was acceptable as a single lightweight task, but adding every future periodic job to the request process would create hidden coupling to uvicorn lifecycle, graceful shutdown, and worker count.
+Historical context: expired session purge used to run as an ad hoc FastAPI lifespan task. It now runs through the same `backend-cron-sessions` sidecar as password-reset cleanup, with cadence controlled by `SESSION_PURGE_INTERVAL_SECONDS` in `backend/app/core/config.py:50`. The FastAPI lifespan hook is limited to startup assertions and provider-client shutdown cleanup; periodic jobs stay outside the request process.
 
-The next periodic jobs are:
+The periodic job set now includes:
 
-- `sourcing.cache.sweep_expired` for TrustedParts response retention.
-- Expired session purge, currently in FastAPI lifespan, when the shared runner exists.
-- Phase 5 alert evaluator (TP-503/504).
+- TrustedParts response retention.
+- Expired session and password-reset request cleanup.
+- Sourcing alert evaluation (TP-503/504).
 - Future routine maintenance jobs that need database access but not an HTTP request.
 
 ## Decision
 
-Periodic jobs run through a dedicated `backend-cron` sidecar container that invokes a shared backend CLI entry point, for example `python -m app.cli.run_job <job-name>`. The first implementation job is the sourcing cache sweeper. The sidecar uses the same backend image and database settings as `backend`, but it does not serve HTTP and does not run uvicorn.
+Periodic jobs run through `backend-cron*` sidecar containers that invoke a shared backend CLI entry point, for example `python -m app.cli.run_job <job-name>`. The sidecars use the same backend image and database settings as `backend`, but they do not serve HTTP and do not run uvicorn.
 
 Each job must be registered in the CLI allow-list with a clear owner, cadence, and idempotency expectations. The sidecar owns scheduling; the FastAPI request process does not grow a second scheduler.
 
@@ -57,9 +57,9 @@ Jobs using this scheduler:
 
 ## References
 
-- Source: `backend/app/domain/sourcing/cache.py:73`
-- Source: `backend/app/cli/run_job.py:105-122`
-- Source: `backend/app/core/config.py:34`
+- Source: `backend/app/domain/sourcing/cache.py:152`
+- Source: `backend/app/cli/run_job.py:93`
+- Source: `backend/app/core/config.py:50`
 - Related ADR: [ADR-0012](0012-uvicorn-single-worker-slowapi.md)
 - Related ADR: [ADR-0020](0020-trustedparts-sourcing-provider-split.md)
 - Issue: `https://github.com/matescb/stockManager/issues/341`

--- a/scripts/check_adr_code_cites.py
+++ b/scripts/check_adr_code_cites.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Verify ADR backtick file:line citations still point inside tracked files."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ADR_GLOB = "docs/adr/*.md"
+EXPLICIT_CITE_RE = re.compile(
+    r"(?P<path>(?:[A-Za-z0-9_.-]+/)*[A-Za-z0-9_.-]+)"
+    r":(?P<start>[0-9]+)(?:-(?P<end>[0-9]+))?"
+)
+SHORTHAND_CITE_RE = re.compile(r"^:(?P<start>[0-9]+)(?:-(?P<end>[0-9]+))?$")
+CODE_SPAN_RE = re.compile(r"`([^`\n]+)`")
+ROOT_LEVEL_CITABLE_FILES = {"CLAUDE.md", "CONTRIBUTING.md", "Makefile"}
+
+
+def _tracked_adr_files() -> list[Path]:
+    result = subprocess.run(
+        ["git", "-C", str(ROOT), "grep", "-l", ".", "--", ADR_GLOB],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if result.returncode not in (0, 1):
+        print(result.stderr, file=sys.stderr, end="")
+        raise SystemExit(result.returncode)
+    return [ROOT / line for line in result.stdout.splitlines()]
+
+
+def _line_count(path: Path, cache: dict[Path, int]) -> int | None:
+    if path in cache:
+        return cache[path]
+    try:
+        cache[path] = len(path.read_text(encoding="utf-8").splitlines())
+    except FileNotFoundError:
+        return None
+    return cache[path]
+
+
+def _looks_like_repo_path(path: str) -> bool:
+    return "/" in path or path in ROOT_LEVEL_CITABLE_FILES
+
+
+def main() -> int:
+    failures: list[str] = []
+    counts: dict[Path, int] = {}
+
+    for adr_path in _tracked_adr_files():
+        last_path_on_line: Path | None = None
+        for line_no, line in enumerate(
+            adr_path.read_text(encoding="utf-8").splitlines(),
+            start=1,
+        ):
+            for span in CODE_SPAN_RE.findall(line):
+                shorthand = SHORTHAND_CITE_RE.match(span.strip())
+                if shorthand and last_path_on_line is not None:
+                    start = int(shorthand.group("start"))
+                    end = int(shorthand.group("end") or start)
+                    target_path = last_path_on_line
+                    cites = [(target_path, start, end, span)]
+                else:
+                    cites = []
+                    for match in EXPLICIT_CITE_RE.finditer(span):
+                        if not _looks_like_repo_path(match.group("path")):
+                            continue
+                        target_path = ROOT / match.group("path")
+                        start = int(match.group("start"))
+                        end = int(match.group("end") or start)
+                        last_path_on_line = target_path
+                        cites.append((target_path, start, end, match.group(0)))
+
+                for target_path, start, end, raw in cites:
+                    target_lines = _line_count(target_path, counts)
+                    rel_adr = adr_path.relative_to(ROOT)
+                    rel_target = target_path.relative_to(ROOT)
+                    if target_lines is None:
+                        failures.append(f"{rel_adr}:{line_no}: missing file for `{raw}`")
+                    elif start <= 0 or end < start:
+                        failures.append(f"{rel_adr}:{line_no}: invalid range in `{raw}`")
+                    elif end > target_lines:
+                        failures.append(
+                            f"{rel_adr}:{line_no}: `{raw}` exceeds {rel_target} "
+                            f"line count ({target_lines})"
+                        )
+
+    if failures:
+        print("Stale ADR file:line citations found:")
+        for failure in failures:
+            print(f"  - {failure}")
+        return 1
+
+    print("ADR file:line citations are within existing tracked files.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Refs #832

## Summary

- Updates ADR-0021 so the context and decision text describe the current backend-cron sidecar topology.
- Refreshes ADR-0021 source citations to live lines in sourcing cache cleanup, the run_job registry, and purge interval config.
- Adds an adr-cite-freshness CI gate backed by scripts/check_adr_code_cites.py and wires it into deploy.needs.

## Validation

- scripts/check_adr_code_cites.py
- grep -nP '`[a-zA-Z_./]+\.py:\d+`' docs/adr/0021-periodic-jobs-scheduler.md
- git diff --check
- cd backend && uv sync --frozen --extra dev
- cd backend && uv run pytest -q tests/test_ci_workflow.py (18 passed, 1 warning: Alembic path_separator deprecation)

## Merge Order

If .github/workflows/ci.yml conflicts with #827/#841, merge this after the run_job infra PRs or rebase before merge.
