### PR TITLE
AUD-137 add Docker digest freshness guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,18 @@ jobs:
         working-directory: web
         run: npm audit --audit-level=moderate || true
 
+  digest-freshness:
+    # AUD-137 / issue #835: fail before prod image builds if reviewed
+    # digest-pinned base images sit untouched past the manual review window.
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Check Docker base-image digest freshness
+        run: python3 scripts/check_docker_digest_freshness.py --max-age-days 30
+
   line-count-budget:
     # CQ-002 / CQ-003 paper-close guard. Caps the line count of files that
     # were intentionally split so they don't silently grow back. To raise a
@@ -847,6 +859,7 @@ jobs:
   #   - lockfile-drift    (SEC2-016)   — pyproject ↔ uv.lock ↔ requirements.lock
   #   - pip-audit         (SEC2-016)   — HIGH/CRITICAL CVEs in the pinned set
   #   - npm-audit         (issue #305) — CVEs in the npm production dep set
+  #   - digest-freshness  (#835)       — Docker base-image digest review window
   #   - line-count-budget (CQ-002/003) — per-file line-count caps
   #   - adr-cite-freshness (#832)      — ADR file:line cite freshness
   #   - tp-schema-drift   (#448)       — TrustedParts schema/model drift
@@ -862,7 +875,7 @@ jobs:
     # Only redeploy on green main pushes. PRs and feature branches just run
     # the test/validate/security jobs above.
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: [ci-policy, lockfile-drift, pip-audit, npm-audit, line-count-budget, adr-cite-freshness, tp-schema-drift, backend-tests, web-build, prod-validate, playwright-e2e]
+    needs: [ci-policy, lockfile-drift, pip-audit, npm-audit, digest-freshness, line-count-budget, adr-cite-freshness, tp-schema-drift, backend-tests, web-build, prod-validate, playwright-e2e]
     runs-on: ubuntu-latest
     # Environment association. Today this just scopes any environment-level
     # secrets we add later; if a "Required reviewers" protection rule is

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Single-VPS, single-uvicorn-worker (slowapi rate-limit correctness — see [ADR-0
 
 Read [`CONTRIBUTING.md`](CONTRIBUTING.md) and [`CLAUDE.md`](CLAUDE.md) before opening a PR. The "Hard invariants" and "Things that have bitten us" sections of `CLAUDE.md` are not style preferences — they are the rules each ADR codifies.
 
-CI gates: ruff (Python) + eslint (JS/TS) **delta-blocking** vs the checked-in baselines (`.ruff-baseline.txt`, `.eslint-baseline.txt`); `tsc -b` + `vite build`; pytest with a real Postgres service container; vitest; Playwright e2e; pip-audit + npm-audit; lockfile-drift; line-count-budget; ci-policy meta-gate.
+CI gates: ruff (Python) + eslint (JS/TS) **delta-blocking** vs the checked-in baselines (`.ruff-baseline.txt`, `.eslint-baseline.txt`); `tsc -b` + `vite build`; pytest with a real Postgres service container; vitest; Playwright e2e; pip-audit + npm-audit; lockfile-drift; digest-freshness; line-count-budget; ci-policy meta-gate.
 
 ## License
 

--- a/backend/tests/test_ci_workflow.py
+++ b/backend/tests/test_ci_workflow.py
@@ -18,12 +18,18 @@ in CI only.
 
 from __future__ import annotations
 
+import subprocess
+import sys
+import textwrap
 from pathlib import Path
 
 import yaml
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _CI_PATH = _REPO_ROOT / ".github" / "workflows" / "ci.yml"
+_DIGEST_FRESHNESS_SCRIPT_PATH = (
+    _REPO_ROOT / "scripts" / "check_docker_digest_freshness.py"
+)
 _UV_LOCK_PATH = _REPO_ROOT / "backend" / "uv.lock"
 _COMPOSE_PROD_PATH = _REPO_ROOT / "docker-compose.prod.yml"
 _DOCKERFILE_PROD_PATH = _REPO_ROOT / "web" / "Dockerfile.prod"
@@ -169,6 +175,59 @@ def test_ci_has_uv_lock_check_step():
         "no `uv lock --check` step found in backend-tests job; "
         "add it so CI fails when uv.lock is stale"
     )
+
+
+# ---------------------------------------------------------------------------
+# AUD-137 / issue #835: Docker base-image digest pins must not silently age out
+# ---------------------------------------------------------------------------
+
+
+def test_ci_has_docker_digest_freshness_gate():
+    data = _load()
+    job = data["jobs"].get("digest-freshness")
+    assert job is not None, "missing digest-freshness CI job"
+
+    runs = [step.get("run", "") for step in job["steps"] if "run" in step]
+    assert any(
+        "scripts/check_docker_digest_freshness.py --max-age-days 30" in run
+        for run in runs
+    ), "digest-freshness job does not run the 30-day Docker digest guard"
+
+    deploy_needs = data["jobs"]["deploy"].get("needs") or []
+    assert "digest-freshness" in deploy_needs, (
+        "deploy must gate on digest-freshness so stale base images cannot ship"
+    )
+
+
+def test_docker_digest_freshness_script_rejects_stale_pin(tmp_path):
+    dockerfile = tmp_path / "Dockerfile"
+    dockerfile.write_text(
+        textwrap.dedent(
+            """\
+            # Digest pinned on 2026-04-01; bump via Dependabot.
+            FROM python:3.14@sha256:1111111111111111111111111111111111111111111111111111111111111111
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(_DIGEST_FRESHNESS_SCRIPT_PATH),
+            "--today",
+            "2026-05-16",
+            "--max-age-days",
+            "30",
+            str(dockerfile),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "digest pin is 45 days old; max is 30 days" in result.stderr
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/check_docker_digest_freshness.py
+++ b/scripts/check_docker_digest_freshness.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Fail when Docker base-image digest pins are stale or undocumented.
+
+The Dockerfiles intentionally pin base images by digest. Dependabot rotates
+those digests, and the nearby "Digest pinned on YYYY-MM-DD" comment records
+when the pinned digest entered the repo. This guard keeps manual review queues
+from leaving a known-old base layer in place indefinitely.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+
+
+DEFAULT_DOCKERFILES = (
+    Path("backend/Dockerfile"),
+    Path("web/Dockerfile.prod"),
+)
+
+PINNED_ON_RE = re.compile(r"^\s*#\s*Digest pinned on (\d{4}-\d{2}-\d{2})\b")
+FROM_RE = re.compile(r"^\s*FROM\s+(?P<image>\S+)(?:\s+AS\s+\S+)?\s*$", re.IGNORECASE)
+SHA256_RE = re.compile(r"@sha256:[0-9a-f]{64}\b", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class Violation:
+    path: Path
+    line: int
+    message: str
+
+    def format(self) -> str:
+        return f"{self.path}:{self.line}: {self.message}"
+
+
+def _parse_iso_date(raw: str, *, path: Path, line: int) -> date | Violation:
+    try:
+        return date.fromisoformat(raw)
+    except ValueError:
+        return Violation(path, line, f"invalid digest pin date {raw!r}")
+
+
+def check_file(path: Path, *, today: date, max_age_days: int) -> list[Violation]:
+    violations: list[Violation] = []
+    pending_pin: tuple[date, int] | None = None
+    saw_from = False
+
+    if not path.exists():
+        return [Violation(path, 1, "Dockerfile does not exist")]
+
+    for line_no, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        pinned_on = PINNED_ON_RE.match(line)
+        if pinned_on:
+            parsed = _parse_iso_date(pinned_on.group(1), path=path, line=line_no)
+            if isinstance(parsed, Violation):
+                violations.append(parsed)
+                pending_pin = None
+            else:
+                pending_pin = (parsed, line_no)
+            continue
+
+        from_match = FROM_RE.match(line)
+        if not from_match:
+            continue
+
+        saw_from = True
+        image = from_match.group("image")
+        if not SHA256_RE.search(image):
+            violations.append(
+                Violation(path, line_no, f"base image is not digest-pinned: {image}")
+            )
+            pending_pin = None
+            continue
+
+        if pending_pin is None:
+            violations.append(
+                Violation(
+                    path,
+                    line_no,
+                    "digest-pinned FROM is missing preceding "
+                    "'Digest pinned on YYYY-MM-DD' comment",
+                )
+            )
+            continue
+
+        pinned_date, comment_line = pending_pin
+        age_days = (today - pinned_date).days
+        if age_days < 0:
+            violations.append(
+                Violation(
+                    path,
+                    comment_line,
+                    f"digest pin date {pinned_date.isoformat()} is in the future",
+                )
+            )
+        elif age_days > max_age_days:
+            violations.append(
+                Violation(
+                    path,
+                    comment_line,
+                    f"digest pin is {age_days} days old; max is {max_age_days} days",
+                )
+            )
+        pending_pin = None
+
+    if not saw_from:
+        violations.append(Violation(path, 1, "no FROM instruction found"))
+
+    return violations
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Check Dockerfile base-image digest pin freshness."
+    )
+    parser.add_argument(
+        "dockerfiles",
+        nargs="*",
+        type=Path,
+        default=list(DEFAULT_DOCKERFILES),
+        help="Dockerfiles to check (default: backend and web production images).",
+    )
+    parser.add_argument(
+        "--max-age-days",
+        type=int,
+        default=30,
+        help="Maximum allowed age for digest pin comments.",
+    )
+    parser.add_argument(
+        "--today",
+        type=date.fromisoformat,
+        default=date.today(),
+        help="Override today's date for tests, in YYYY-MM-DD format.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    if args.max_age_days < 0:
+        print("--max-age-days must be non-negative", file=sys.stderr)
+        return 2
+
+    violations: list[Violation] = []
+    for dockerfile in args.dockerfiles:
+        violations.extend(
+            check_file(dockerfile, today=args.today, max_age_days=args.max_age_days)
+        )
+
+    if violations:
+        print("Docker base-image digest freshness check failed:", file=sys.stderr)
+        for violation in violations:
+            print(f"  - {violation.format()}", file=sys.stderr)
+        return 1
+
+    checked = ", ".join(str(path) for path in args.dockerfiles)
+    print(
+        f"Docker base-image digest pins are fresh "
+        f"(max age: {args.max_age_days} days): {checked}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
Refs #835

## Summary
- Add `scripts/check_docker_digest_freshness.py` to enforce digest-pinned Docker base images and fail when their `Digest pinned on YYYY-MM-DD` comments exceed a 30-day review window.
- Add a `digest-freshness` CI job and wire it into `deploy.needs` so stale base-image pins cannot ship to production.
- Pin the new CI contract in `backend/tests/test_ci_workflow.py` and update the README CI gate list.

## Validation
- `gh pr list --repo matescb/stockManager --label dependencies --state open` returned no open dependency PRs.
- `python3 scripts/check_docker_digest_freshness.py --today 2026-05-16 --max-age-days 30`
- `python3 -m py_compile scripts/check_docker_digest_freshness.py`
- `python3 - <<'PY' ... yaml.safe_load('.github/workflows/ci.yml') ... PY` verified the workflow shape and deploy needs.
- `cd backend && uv run pytest tests/test_ci_workflow.py -q` passed: 20 passed, 1 existing Alembic deprecation warning.

## Merge Order / Conflict Note
This PR edits `.github/workflows/ci.yml`; merge order may conflict with #827, #832, and #841. If one lands first, rebase this branch and preserve the `digest-freshness` job plus its direct `deploy.needs` entry.
