### PR TITLE
AUD-140 reject heartbeat max age with print interval

### DIFF
--- a/backend/app/cli/run_job.py
+++ b/backend/app/cli/run_job.py
@@ -251,10 +251,20 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--heartbeat-max-age-seconds",
         type=int,
-        default=HEARTBEAT_MAX_AGE_SECONDS,
+        default=None,
         help="Maximum heartbeat age accepted by --check-heartbeat.",
     )
     return parser
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = _parser()
+    args = parser.parse_args(argv)
+    if args.heartbeat_max_age_seconds is not None and not args.check_heartbeat:
+        parser.error("--heartbeat-max-age-seconds requires --check-heartbeat")
+    if args.heartbeat_max_age_seconds is None:
+        args.heartbeat_max_age_seconds = HEARTBEAT_MAX_AGE_SECONDS
+    return args
 
 
 def main(
@@ -268,7 +278,7 @@ def main(
         format="%(asctime)s %(levelname)s %(name)s %(message)s",
     )
     try:
-        args = _parser().parse_args(argv)
+        args = _parse_args(argv)
     except SystemExit as exc:
         return int(exc.code)
 

--- a/backend/tests/test_run_job_main.py
+++ b/backend/tests/test_run_job_main.py
@@ -149,6 +149,41 @@ def test_check_heartbeat_stale(
     )
 
 
+def test_print_interval_rejects_heartbeat_max_age(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    heartbeat_job: JobSpec,
+) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        run_job_cli._parse_args(
+            [
+                heartbeat_job.name,
+                "--print-interval",
+                "--heartbeat-max-age-seconds",
+                "30",
+            ]
+        )
+
+    output = capsys.readouterr()
+    assert exc_info.value.code == 2
+    assert output.out == ""
+    assert "--heartbeat-max-age-seconds requires --check-heartbeat" in output.err
+
+    exit_code = _run_main(
+        monkeypatch,
+        heartbeat_job.name,
+        "--print-interval",
+        "--heartbeat-max-age-seconds",
+        "30",
+        jobs={heartbeat_job.name: heartbeat_job},
+    )
+
+    output = capsys.readouterr()
+    assert exit_code == 2
+    assert output.out == ""
+    assert "--heartbeat-max-age-seconds requires --check-heartbeat" in output.err
+
+
 def test_check_heartbeat_sentinel(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],


### PR DESCRIPTION
Refs #838

## Summary
- Reject explicit `--heartbeat-max-age-seconds` unless `--check-heartbeat` is selected.
- Preserve the default heartbeat max age for normal heartbeat checks.
- Add focused coverage for the rejected `--print-interval` combination.

## Validation
- `cd backend && /home/matyas/.local/bin/uv run python -m pytest -q tests/test_run_job_main.py` (9 passed, 1 Alembic deprecation warning)

## Merge Order
- Merge after #824 (already merged).
- Merge before #827/#845 if possible.
- Rebase #845/#839 after this if conflicts appear.
