### PR TITLE
AUD-139 extend anchor rel TS unwrap coverage

### DIFF
--- a/web/eslint-rules/anchor-rel-noreferrer-noopener.cjs
+++ b/web/eslint-rules/anchor-rel-noreferrer-noopener.cjs
@@ -72,7 +72,9 @@ function unwrapTSConstExpression(expression) {
 
   while (
     currentExpression?.type === "TSAsExpression" ||
-    currentExpression?.type === "TSSatisfiesExpression"
+    currentExpression?.type === "TSSatisfiesExpression" ||
+    currentExpression?.type === "TSTypeAssertion" ||
+    currentExpression?.type === "TSNonNullExpression"
   ) {
     currentExpression = currentExpression.expression;
   }
@@ -111,7 +113,7 @@ function includesRelToken(rel, token) {
   return rel.split(/\s+/u).includes(token);
 }
 
-module.exports = {
+const rule = {
   meta: {
     type: "problem",
     docs: {
@@ -159,4 +161,9 @@ module.exports = {
       },
     };
   },
+};
+
+module.exports = rule;
+module.exports.__test = {
+  unwrapTSConstExpression,
 };

--- a/web/src/__tests__/targetBlankRelLint.test.ts
+++ b/web/src/__tests__/targetBlankRelLint.test.ts
@@ -1,5 +1,6 @@
 // @ts-expect-error ESLint v8 is installed for tests, but this repo does not carry @types/eslint.
 import { ESLint } from "eslint";
+import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
@@ -9,6 +10,18 @@ const targetBlankRelRuleId = "jsx-a11y/anchor-rel-noreferrer-noopener";
 const missingRelMessage = 'Links with target="_blank" must use rel="noopener noreferrer".';
 const dynamicRelMessage =
   'Links with static target="_blank" must use a static rel value containing "noopener noreferrer".';
+const require = createRequire(import.meta.url);
+const {
+  __test: { unwrapTSConstExpression },
+} = require("../../eslint-rules/anchor-rel-noreferrer-noopener.cjs") as {
+  __test: {
+    unwrapTSConstExpression: (
+      expression:
+        | { type: "TSTypeAssertion"; expression: { type: "Literal"; value: string } }
+        | { type: "TSNonNullExpression"; expression: { type: "Literal"; value: string } },
+    ) => { type: "Literal"; value: string };
+  };
+};
 
 type LintMessage = {
   ruleId?: string | null;
@@ -106,6 +119,27 @@ describe("target=_blank rel lint guard", () => {
       targetBlankRelMessages(
         'const unsafeRel = "noreferrer"; export const Link = () => <a href="https://example.com" target="_blank" rel={unsafeRel}>open</a>;',
       ),
+    ).resolves.toEqual([expect.objectContaining({ message: missingRelMessage })]);
+  });
+
+  it("unwraps legacy TypeScript const assertion rel initializers", () => {
+    expect(
+      unwrapTSConstExpression({
+        type: "TSTypeAssertion",
+        expression: { type: "Literal", value: "noreferrer" },
+      }),
+    ).toEqual({ type: "Literal", value: "noreferrer" });
+  });
+
+  it("validates non-null const assertion rel initializers with the existing token checks", async () => {
+    await expect(
+      targetBlankRelMessages(`
+        const nonNullRel = "noopener"!;
+
+        export const NonNullLink = () => (
+          <a href="https://example.com" target="_blank" rel={nonNullRel}>open</a>
+        );
+      `),
     ).resolves.toEqual([expect.objectContaining({ message: missingRelMessage })]);
   });
 


### PR DESCRIPTION
Refs #837

## Summary
- Extend the local `anchor-rel-noreferrer-noopener` unwrap helper to handle `TSTypeAssertion` and `TSNonNullExpression` const initializers.
- Add regression coverage for legacy TypeScript assertion unwrapping and non-null rel initializer token validation.

## Validation
- `cd web && npm test -- anchor-rel` failed: Vitest found no files matching `anchor-rel` in the current test naming.
- `cd web && npm test -- src/__tests__/targetBlankRelLint.test.ts` passed: 11 tests.
- `cd web && npm run lint` failed on pre-existing unrelated lint errors in `src/lib/bagCode.ts` (`no-control-regex`) plus existing warnings.

## Merge Order
This narrow lint PR should merge before the broader package-lock/DataTable PR #849 if conflicts appear.
