### PR TITLE
AUD-138 Add invitation admin rate limits

### DIFF
--- a/backend/app/api/routes/invitations.py
+++ b/backend/app/api/routes/invitations.py
@@ -18,7 +18,7 @@ from app.core.deps import (
     require_role,
 )
 from app.core.errors import ErrorCodes, raise_http
-from app.core.ratelimit import limiter
+from app.core.ratelimit import limiter, workspace_key
 from app.core.responses import ok
 from app.core.time import utcnow
 from app.domain.audit.service import log as _audit_log
@@ -88,7 +88,9 @@ def _serialize(inv: WorkspaceInvitation, *, plaintext_token: str | None = None) 
     status_code=status.HTTP_201_CREATED,
     dependencies=[Depends(require_role("admin"))],
 )
+@limiter.limit("60/hour", key_func=workspace_key)
 def create_invitation(
+    request: Request,
     payload: InviteIn,
     db: DbSession,
     ws: CurrentWorkspace,
@@ -209,7 +211,9 @@ def create_invitation(
 
 
 @router.get("", dependencies=[Depends(require_role("admin"))])
+@limiter.limit("120/hour", key_func=workspace_key)
 def list_invitations(
+    request: Request,
     db: DbSession,
     ws: CurrentWorkspace,
     limit: int = Query(default=200, le=1000),
@@ -226,7 +230,14 @@ def list_invitations(
 
 
 @router.delete("/{invitation_id}", dependencies=[Depends(require_role("admin"))])
-def revoke_invitation(invitation_id: UUID, db: DbSession, ws: CurrentWorkspace, user: CurrentUser):
+@limiter.limit("120/hour", key_func=workspace_key)
+def revoke_invitation(
+    request: Request,
+    invitation_id: UUID,
+    db: DbSession,
+    ws: CurrentWorkspace,
+    user: CurrentUser,
+):
     try:
         inv = assert_in_workspace(db, WorkspaceInvitation, invitation_id, ws.id, label="invitation")
     except HTTPException:

--- a/backend/tests/test_invitations_ratelimit.py
+++ b/backend/tests/test_invitations_ratelimit.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+
+import app.core.ratelimit as _ratelimit_mod
+from app.main import app
+from tests._factories import signup_user
+
+
+@pytest.fixture
+def limiter_enabled():
+    original = _ratelimit_mod.limiter.enabled
+    _ratelimit_mod.limiter.enabled = True
+    try:
+        _ratelimit_mod.limiter.reset()
+    except Exception:
+        pass
+    yield
+    _ratelimit_mod.limiter.enabled = original
+    try:
+        _ratelimit_mod.limiter.reset()
+    except Exception:
+        pass
+
+
+def _signup_admin(email: str | None = None) -> TestClient:
+    client = TestClient(app)
+    signup_user(client, email=email or f"admin-{uuid.uuid4().hex[:8]}@x.com")
+    return client
+
+
+def _create_invitation(client: TestClient, email: str | None = None):
+    return client.post(
+        "/api/invitations",
+        json={
+            "email": email or f"invitee-{uuid.uuid4().hex[:8]}@x.com",
+            "role": "member",
+        },
+    )
+
+
+def test_create_invitation_rate_limited_after_60_per_hour(db, limiter_enabled):
+    admin = _signup_admin()
+
+    for i in range(60):
+        response = _create_invitation(admin, f"create-{i}-{uuid.uuid4().hex[:8]}@x.com")
+        assert response.status_code == 201, response.text
+
+    response = _create_invitation(admin, f"create-overflow-{uuid.uuid4().hex[:8]}@x.com")
+    assert response.status_code == 429, response.text
+    assert response.json()["status"]["category"] == "rate_limited"
+
+
+def test_list_invitations_rate_limit_is_per_workspace(db, limiter_enabled):
+    workspace_a = _signup_admin()
+    workspace_b = _signup_admin()
+
+    for i in range(120):
+        response = workspace_a.get("/api/invitations")
+        assert response.status_code == 200, f"call {i}: {response.status_code} {response.text}"
+
+    response = workspace_a.get("/api/invitations")
+    assert response.status_code == 429, response.text
+    assert response.json()["status"]["category"] == "rate_limited"
+
+    response = workspace_b.get("/api/invitations")
+    assert response.status_code == 200, response.text
+
+
+def test_revoke_invitation_rate_limited_after_120_per_hour(db, limiter_enabled):
+    admin = _signup_admin()
+    invitation = _create_invitation(admin).json()["data"]
+
+    for i in range(120):
+        response = admin.delete(f"/api/invitations/{invitation['id']}")
+        assert response.status_code != 429, f"call {i}: {response.status_code} {response.text}"
+
+    response = admin.delete(f"/api/invitations/{invitation['id']}")
+    assert response.status_code == 429, response.text
+    assert response.json()["status"]["category"] == "rate_limited"


### PR DESCRIPTION
Refs #836

## Summary
- Add workspace-keyed SlowAPI limits to admin invitation create, list, and revoke endpoints.
- Cover create/list/revoke bucket exhaustion with focused invitation rate-limit tests, including workspace isolation for list.

## Validation
- `cd backend && uv run --extra dev python -m pytest -q tests/test_invitations_ratelimit.py` (3 passed, 1 Alembic deprecation warning)
- `cd backend && uv run --extra dev ruff check app/api/routes/invitations.py tests/test_invitations_ratelimit.py`

## Merge Order
Independent backend security PR; can merge after green.