### PR TITLE
AUD-133 replace manual workspace checks with assert_in_workspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -398,6 +398,21 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
+      - name: Forbid ad-hoc workspace db.get checks
+        run: |
+          matches=$(
+            grep -R -n "db\.get(" backend/app/api/routes --include="*.py" | while IFS=: read -r file line _; do
+              end=$((line + 3))
+              if sed -n "${line},${end}p" "$file" | grep -qE "workspace_id[[:space:]]*!="; then
+                echo "${file}:${line}: db.get followed by workspace_id != within 3 lines; use assert_in_workspace"
+              fi
+            done
+          )
+          if [ -n "$matches" ]; then
+            echo "$matches"
+            exit 1
+          fi
+
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: "20"

--- a/backend/app/api/routes/_parts_shared.py
+++ b/backend/app/api/routes/_parts_shared.py
@@ -13,9 +13,10 @@ endpoint groups out of `parts.py` and import from this module.
 """
 from __future__ import annotations
 
-from fastapi import status
+from fastapi import HTTPException, status
 from sqlalchemy import select
 
+from app.api._helpers import assert_in_workspace
 from app.core.errors import ErrorCodes, raise_http
 from app.domain.custom_fields.models import CustomField
 from app.domain.parts.models import Part
@@ -92,9 +93,14 @@ def get_part(db, ws_id, part_id, *, include_archived: bool = False) -> Part:
     surfaces pass `include_archived=True` so the detail page and
     activity timeline still load for archived parts.
     """
-    p = db.get(Part, part_id)
-    if not p or p.workspace_id != ws_id:
-        raise_http(status.HTTP_404_NOT_FOUND, code=ErrorCodes.PART_NOT_FOUND, message="part not found")
+    try:
+        p = assert_in_workspace(db, Part, part_id, ws_id, label="part")
+    except HTTPException:
+        raise_http(
+            status.HTTP_404_NOT_FOUND,
+            code=ErrorCodes.PART_NOT_FOUND,
+            message="part not found",
+        )
     if not include_archived and p.archived_at is not None:
         # 404 (not 400) — the part is "not available" for binds. We
         # don't distinguish "doesn't exist" from "archived" because the

--- a/backend/app/api/routes/bom_presets.py
+++ b/backend/app/api/routes/bom_presets.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import json
 from uuid import UUID
 
-from fastapi import APIRouter, Query, status
+from fastapi import APIRouter, HTTPException, Query, status
 from sqlalchemy import select
 
+from app.api._helpers import assert_in_workspace
 from app.core.deps import CurrentUser, CurrentWorkspace, DbSession
 from app.core.errors import ErrorCodes, raise_http
 from app.core.responses import ok
@@ -58,10 +59,14 @@ def create_preset(payload: PresetIn, db: DbSession, ws: CurrentWorkspace, user: 
 
 
 def _get(db, ws_id, pid) -> BomImportPreset:
-    p = db.get(BomImportPreset, pid)
-    if not p or p.workspace_id != ws_id:
-        raise_http(status.HTTP_404_NOT_FOUND, code=ErrorCodes.BOM_PRESET_NOT_FOUND, message="preset not found")
-    return p
+    try:
+        return assert_in_workspace(db, BomImportPreset, pid, ws_id, label="preset")
+    except HTTPException:
+        raise_http(
+            status.HTTP_404_NOT_FOUND,
+            code=ErrorCodes.BOM_PRESET_NOT_FOUND,
+            message="preset not found",
+        )
 
 
 @router.get("/{preset_id}")

--- a/backend/app/api/routes/builds.py
+++ b/backend/app/api/routes/builds.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 from datetime import datetime
 from uuid import UUID
 
-from fastapi import APIRouter, Query, Request, status
+from fastapi import APIRouter, HTTPException, Query, Request, status
 from sqlalchemy import and_, or_, select
 from sqlalchemy.exc import DBAPIError
 
-from app.api._helpers import require_resource_access
+from app.api._helpers import assert_in_workspace, require_resource_access
 from app.api.routes._activity import _DEFAULT_LIMIT, _MAX_LIMIT, build_activity
 from app.api.routes._stock_integrity import raise_integrity_as_409
 from app.core.deps import CurrentUser, CurrentWorkspace, DbSession
@@ -48,21 +48,21 @@ def _serialize(b: Build) -> dict:
 
 
 def _get_build(db, ws_id, bid) -> Build:
-    b = db.get(Build, bid)
-    if not b or b.workspace_id != ws_id:
+    try:
+        return assert_in_workspace(db, Build, bid, ws_id, label="build")
+    except HTTPException:
         raise_http(
             status.HTTP_404_NOT_FOUND,
             code=ErrorCodes.BUILD_NOT_FOUND,
             message="build not found",
         )
-    return b
 
 
 def _get_project(db, ws_id, pid) -> Project:
-    p = db.get(Project, pid)
-    if not p or p.workspace_id != ws_id:
+    try:
+        return assert_in_workspace(db, Project, pid, ws_id, label="project")
+    except HTTPException:
         raise_http(404, code=ErrorCodes.PROJECT_NOT_FOUND, message="project not found")
-    return p
 
 
 @router.get("")

--- a/backend/app/api/routes/invitations.py
+++ b/backend/app/api/routes/invitations.py
@@ -5,10 +5,11 @@ import secrets
 from datetime import timezone
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Query, Request, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
 
+from app.api._helpers import assert_in_workspace
 from app.core.config import settings
 from app.core.deps import (
     CurrentUser,
@@ -226,8 +227,9 @@ def list_invitations(
 
 @router.delete("/{invitation_id}", dependencies=[Depends(require_role("admin"))])
 def revoke_invitation(invitation_id: UUID, db: DbSession, ws: CurrentWorkspace, user: CurrentUser):
-    inv = db.get(WorkspaceInvitation, invitation_id)
-    if not inv or inv.workspace_id != ws.id:
+    try:
+        inv = assert_in_workspace(db, WorkspaceInvitation, invitation_id, ws.id, label="invitation")
+    except HTTPException:
         raise_http(
             status.HTTP_404_NOT_FOUND,
             ErrorCodes.INVITATION_NOT_FOUND,

--- a/backend/app/api/routes/lots.py
+++ b/backend/app/api/routes/lots.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from uuid import UUID
 
-from fastapi import APIRouter, Query, status
+from fastapi import APIRouter, HTTPException, Query, status
 from sqlalchemy import select
 from sqlalchemy.exc import DBAPIError
 
+from app.api._helpers import assert_in_workspace
 from app.api.routes._stock_integrity import raise_integrity_as_409
 from app.core.deps import CurrentUser, CurrentWorkspace, DbSession
 from app.core.errors import ErrorCodes, raise_http
@@ -69,10 +70,14 @@ def list_lots(
 
 
 def _get(db, ws_id, lot_id) -> Lot:
-    l = db.get(Lot, lot_id)
-    if not l or l.workspace_id != ws_id:
-        raise_http(status.HTTP_404_NOT_FOUND, code=ErrorCodes.LOT_NOT_FOUND, message="lot not found")
-    return l
+    try:
+        return assert_in_workspace(db, Lot, lot_id, ws_id, label="lot")
+    except HTTPException:
+        raise_http(
+            status.HTTP_404_NOT_FOUND,
+            code=ErrorCodes.LOT_NOT_FOUND,
+            message="lot not found",
+        )
 
 
 @router.get("/{lot_id}")

--- a/backend/app/api/routes/orders.py
+++ b/backend/app/api/routes/orders.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from uuid import UUID
 
-from fastapi import APIRouter, Query, Request, status
+from fastapi import APIRouter, HTTPException, Query, Request, status
 from sqlalchemy import or_, select
 from sqlalchemy.exc import DBAPIError
 
@@ -86,14 +86,14 @@ def _serialize_entry(e: OrderEntry) -> dict:
 
 
 def _get_order(db, ws_id, oid) -> Order:
-    o = db.get(Order, oid)
-    if not o or o.workspace_id != ws_id:
+    try:
+        return assert_in_workspace(db, Order, oid, ws_id, label="order")
+    except HTTPException:
         raise_http(
             status.HTTP_404_NOT_FOUND,
             code=ErrorCodes.ORDER_NOT_FOUND,
             message="order not found",
         )
-    return o
 
 
 def _entries_for(db, ws_id, oid) -> list[OrderEntry]:

--- a/backend/app/api/routes/parts_scan.py
+++ b/backend/app/api/routes/parts_scan.py
@@ -16,11 +16,12 @@ from datetime import datetime, timedelta, timezone
 from time import monotonic
 from uuid import UUID
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, HTTPException, Request
 from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import IntegrityError
 
+from app.api._helpers import assert_in_workspace
 from app.api.routes._parts_shared import get_part as _get_part
 from app.core.deps import CurrentUser, CurrentWorkspace, DbSession
 from app.core.errors import ErrorCodes, raise_http
@@ -218,8 +219,15 @@ def bulk_import_from_scan(
         # foot-gun). Same fix as create_part / patch_part — surface the
         # failure as `invalid` so the rest of the batch still runs.
         if row.storage_location_id is not None:
-            sl = db.get(StorageLocation, row.storage_location_id)
-            if sl is None or sl.workspace_id != ws.id:
+            try:
+                assert_in_workspace(
+                    db,
+                    StorageLocation,
+                    row.storage_location_id,
+                    ws.id,
+                    label="storage",
+                )
+            except HTTPException:
                 out_rows.append({
                     "mpn": mpn,
                     "status": "invalid",

--- a/backend/app/api/routes/projects.py
+++ b/backend/app/api/routes/projects.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from uuid import UUID
 
-from fastapi import APIRouter, Query, Request, status
+from fastapi import APIRouter, HTTPException, Query, Request, status
 from sqlalchemy import or_, select
 
 from app.api._helpers import assert_child_in_parent, assert_in_workspace, require_resource_access
@@ -99,10 +99,14 @@ def create_project(payload: ProjectCreateIn, db: DbSession, ws: CurrentWorkspace
 
 
 def _get(db, ws_id, pid) -> Project:
-    p = db.get(Project, pid)
-    if not p or p.workspace_id != ws_id:
-        raise_http(status.HTTP_404_NOT_FOUND, code=ErrorCodes.PROJECT_NOT_FOUND, message="project not found")
-    return p
+    try:
+        return assert_in_workspace(db, Project, pid, ws_id, label="project")
+    except HTTPException:
+        raise_http(
+            status.HTTP_404_NOT_FOUND,
+            code=ErrorCodes.PROJECT_NOT_FOUND,
+            message="project not found",
+        )
 
 
 @router.get("/{project_id}")

--- a/backend/app/api/routes/reports.py
+++ b/backend/app/api/routes/reports.py
@@ -5,9 +5,10 @@ from collections import defaultdict
 from datetime import date, timedelta
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from sqlalchemy import select
 
+from app.api._helpers import assert_in_workspace
 from app.core.deps import CurrentUser, CurrentWorkspace, DbSession, require_role
 from app.core.errors import ErrorCodes, raise_http
 from app.core.ratelimit import limiter, workspace_key
@@ -70,8 +71,9 @@ def bom_shortage(
 ):
     """Project-wide shortage analysis at a given build quantity.
     Same engine as Build detail — no build is created."""
-    project = db.get(Project, project_id)
-    if not project or project.workspace_id != ws.id:
+    try:
+        project = assert_in_workspace(db, Project, project_id, ws.id, label="project")
+    except HTTPException:
         raise_http(404, code=ErrorCodes.REPORT_PROJECT_NOT_FOUND, message="project not found")
     rows = shortage_analysis(db, workspace_id=ws.id, project=project, build_quantity=quantity)
     total_short = sum(r["short_by"] for r in rows)

--- a/backend/app/api/routes/storage.py
+++ b/backend/app/api/routes/storage.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 from uuid import UUID
 
-from fastapi import APIRouter, Query, status
+from fastapi import APIRouter, HTTPException, Query, status
 from sqlalchemy import or_, select
 
-from app.api._helpers import require_resource_access
+from app.api._helpers import assert_in_workspace, require_resource_access
 from app.core.deps import CurrentUser, CurrentWorkspace, DbSession
 from app.core.errors import ErrorCodes, raise_http
 from app.core.pagination import decode_cursor, paginate
@@ -89,14 +89,14 @@ def create_storage(payload: StorageIn, db: DbSession, ws: CurrentWorkspace, user
 
 
 def _get(db, ws_id, sid) -> StorageLocation:
-    s = db.get(StorageLocation, sid)
-    if not s or s.workspace_id != ws_id:
+    try:
+        return assert_in_workspace(db, StorageLocation, sid, ws_id, label="storage")
+    except HTTPException:
         raise_http(
             status.HTTP_404_NOT_FOUND,
             code=ErrorCodes.STORAGE_NOT_FOUND,
             message="storage not found",
         )
-    return s
 
 
 @router.get("/{storage_id}")

--- a/backend/app/api/routes/workspaces.py
+++ b/backend/app/api/routes/workspaces.py
@@ -7,9 +7,10 @@ import secrets
 from datetime import datetime, timezone
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Request, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from sqlalchemy import select
 
+from app.api._helpers import assert_in_workspace
 from app.core.config import settings
 from app.core.cookies import WORKSPACE_COOKIE_NAME, workspace_cookie_attrs
 from app.core.deps import CurrentUser, CurrentWorkspace, DbSession, require_role
@@ -497,8 +498,9 @@ def revoke_catalog_token(token_id: UUID, db: DbSession, ws: CurrentWorkspace):
 
     Sets revoked_at = now(). Cross-workspace access → 404 (never 403).
     """
-    t = db.get(WorkspaceCatalogToken, token_id)
-    if not t or t.workspace_id != ws.id:
+    try:
+        t = assert_in_workspace(db, WorkspaceCatalogToken, token_id, ws.id, label="catalog token")
+    except HTTPException:
         raise_http(
             status.HTTP_404_NOT_FOUND,
             ErrorCodes.RESOURCE_NOT_FOUND,
@@ -559,8 +561,9 @@ def patch_member(
     ws: CurrentWorkspace,
     user: CurrentUser,
 ):
-    m = db.get(WorkspaceMember, member_id)
-    if not m or m.workspace_id != ws.id:
+    try:
+        m = assert_in_workspace(db, WorkspaceMember, member_id, ws.id, label="member")
+    except HTTPException:
         raise_http(
             status.HTTP_404_NOT_FOUND,
             ErrorCodes.WORKSPACE_MEMBER_NOT_FOUND,
@@ -594,8 +597,9 @@ def patch_member(
 
 @router.delete("/members/{member_id}", dependencies=[Depends(require_role("admin"))])
 def remove_member(member_id: UUID, db: DbSession, ws: CurrentWorkspace, user: CurrentUser):
-    m = db.get(WorkspaceMember, member_id)
-    if not m or m.workspace_id != ws.id:
+    try:
+        m = assert_in_workspace(db, WorkspaceMember, member_id, ws.id, label="member")
+    except HTTPException:
         raise_http(
             status.HTTP_404_NOT_FOUND,
             ErrorCodes.WORKSPACE_MEMBER_NOT_FOUND,


### PR DESCRIPTION
Refs #841

## Summary
- Replaced route-level `db.get(...); workspace_id != ...` ownership checks with `assert_in_workspace` lookups.
- Preserved existing route-specific 404 error codes where contract tests assert them.
- Added a minimal `prod-validate` CI guard that fails when `db.get(` is followed within 3 lines by `workspace_id !=` in route Python files.

## Validation
- `cd backend && uv run python -m pytest -q tests/test_workspace_isolation.py` — 56 passed, 2 warnings
- `cd backend && uv run python -m pytest -q tests/test_error_codes.py` — 11 passed, 1 warning
- `cd backend && LINT_CMD="ruff check app --output-format=concise" BASELINE_FILE="../.ruff-baseline.txt" WORK_DIR="." bash ../scripts/lint-delta.sh` — no new violations
- Local CI guard command — passed
- `uv run --project backend python - <<'PY' ... yaml.safe_load('.github/workflows/ci.yml') ... PY` — ci.yml parsed
- `git diff --check` — passed

## Merge Order / Coordination
- Merge after #851.
- Rebase after #852/#853/#845 if `.github/workflows/ci.yml` conflicts.
- Coordinate with #840 if it touches the same route files.
